### PR TITLE
fix: mcp already started error

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -885,9 +885,11 @@ declare module '@kortex-app/api' {
 
   export interface RegisterMCPConnectionEvent {
     providerId: string;
+    connection: MCPProviderConnection;
   }
   export interface UnregisterMCPConnectionEvent {
     providerId: string;
+    connectionName: string;
   }
 
   export interface RegisterContainerConnectionEvent {

--- a/packages/main/src/plugin/mcp/mcp-manager.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.ts
@@ -1,0 +1,96 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { MCPProviderConnection } from '@kortex-app/api';
+import type { ToolSet } from 'ai';
+import { experimental_createMCPClient } from 'ai';
+import { inject, injectable } from 'inversify';
+
+import { ProviderRegistry } from '/@/plugin/provider-registry.js';
+
+/**
+ * experimental_createMCPClient return `Promise<MCPClient>` but they did not exported this type...
+ */
+type ExtractedMCPClient = Awaited<ReturnType<typeof experimental_createMCPClient>>;
+
+@injectable()
+export class MCPManager implements AsyncDisposable {
+  #client: Map<string, ExtractedMCPClient> = new Map<string, ExtractedMCPClient>();
+
+  constructor(
+    @inject(ProviderRegistry)
+    private provider: ProviderRegistry,
+  ) {}
+
+  /**
+   * Cleanup all clients
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await Promise.all(Array.from(this.#client.values().map(({ close }) => close())));
+  }
+
+  protected getKey(internalProviderId: string, connectionName: string): string {
+    return `${internalProviderId}:${connectionName}`;
+  }
+
+  public async getToolSet(): Promise<ToolSet> {
+    const tools = await Promise.all(Array.from(this.#client.values()).map(client => client.tools()));
+
+    return tools.reduce((acc, current) => {
+      return { ...acc, ...current };
+    }, {});
+  }
+
+  protected async registerMCPClient(internalProviderId: string, connection: MCPProviderConnection): Promise<void> {
+    const client = await experimental_createMCPClient({ transport: connection.transport });
+
+    console.log('[MCPManager] Registering MCP client for ', internalProviderId, ' with name ', connection.name);
+    this.#client.set(this.getKey(internalProviderId, connection.name), client);
+  }
+
+  init(): void {
+    console.log('[MCPManager] Init');
+
+    // register listener for new MCP connections
+    this.provider.onDidRegisterMCPConnection(async ({ providerId, connection }) => {
+      const internalProviderId = this.provider.getMatchingProviderInternalId(providerId);
+
+      await this.registerMCPClient(internalProviderId, connection);
+    });
+
+    // register listener for unregistered MCP connections
+    this.provider.onDidUnregisterMCPConnection(({ providerId, connectionName }) => {
+      const client = this.#client.get(this.getKey(providerId, connectionName));
+      if (client) {
+        client.close().catch(console.error);
+        this.#client.delete(this.getKey(providerId, connectionName));
+      }
+    });
+
+    // Get all providers
+    const providers = this.provider.getProviderInfos();
+
+    // try to register all clients
+    Promise.allSettled(
+      providers.flatMap(({ internalId }) => {
+        const connections = this.provider.getMCPProviderConnection(internalId);
+        return connections.map(connection => this.registerMCPClient(internalId, connection));
+      }),
+    ).catch(console.error);
+  }
+}

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -176,8 +176,7 @@ export class ProviderRegistry {
   readonly onDidRegisterMCPConnection: Event<RegisterMCPConnectionEvent> = this._onDidRegisterMCPConnection.event;
 
   private readonly _onDidUnregisterMCPConnection = new Emitter<UnregisterMCPConnectionEvent>();
-  readonly onDidUnregisterMCPConnection: Event<UnregisterMCPConnectionEvent> =
-    this._onDidUnregisterInferenceConnection.event;
+  readonly onDidUnregisterMCPConnection: Event<UnregisterMCPConnectionEvent> = this._onDidUnregisterMCPConnection.event;
 
   private readonly _onDidRegisterContainerConnection = new Emitter<RegisterContainerConnectionEvent>();
   readonly onDidRegisterContainerConnection: Event<RegisterContainerConnectionEvent> =
@@ -1444,7 +1443,7 @@ export class ProviderRegistry {
   onDidRegisterMCPConnectionCallback(provider: ProviderImpl, mcpProviderConnection: MCPProviderConnection): void {
     this.connectionLifecycleContexts.set(mcpProviderConnection, new LifecycleContextImpl());
     this.apiSender.send('provider-register-mcp-connection', { name: mcpProviderConnection.name });
-    this._onDidRegisterMCPConnection.fire({ providerId: provider.id });
+    this._onDidRegisterMCPConnection.fire({ providerId: provider.id, connection: mcpProviderConnection });
   }
 
   onDidChangeContainerProviderConnectionStatus(
@@ -1499,7 +1498,7 @@ export class ProviderRegistry {
 
   onDidUnregisterMCPConnectionCallback(provider: ProviderImpl, mcpProviderConnection: MCPProviderConnection): void {
     this.apiSender.send('provider-unregister-mcp-connection', { name: mcpProviderConnection.name });
-    this._onDidUnregisterMCPConnection.fire({ providerId: provider.id });
+    this._onDidUnregisterMCPConnection.fire({ providerId: provider.id, connectionName: mcpProviderConnection.name });
   }
 
   onDidUnregisterVmConnectionCallback(provider: ProviderImpl, vmProviderConnection: VmProviderConnection): void {
@@ -1734,6 +1733,13 @@ export class ProviderRegistry {
     return Array.from(this.providers.values()).flatMap(({ mcpConnections }) =>
       mcpConnections.map(({ transport }) => transport),
     );
+  }
+
+  getMCPProviderConnection(internalProviderId: string): Array<MCPProviderConnection> {
+    const provider = this.providers.get(internalProviderId);
+    if (!provider) throw new Error('Provider not found');
+
+    return provider.mcpConnections;
   }
 
   protected fireUpdateContainerConnectionEvents(


### PR DESCRIPTION
Follow-up of https://github.com/kortex-hub/kortex/pull/2

An extension can register MCP connections, through a `Transport` instance, but a transport can only be connected once. The existing code was trying to reconnect everytime we make a chat request.

This PR introduce a `MCPManager`, creating and caching `MCPClient`