### PR TITLE
feat: allow deletion inference provider connection

### DIFF
--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -1,0 +1,202 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { createGoogleGenerativeAI, type GoogleGenerativeAIProvider } from '@ai-sdk/google';
+import type {
+  CancellationToken,
+  Disposable,
+  Logger,
+  Provider,
+  provider as ProviderAPI,
+  SecretStorage,
+} from '@kortex-app/api';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { Gemini, TOKENS_KEY } from './gemini';
+
+vi.mock('@kortex-app/api', () => ({
+  Disposable: {
+    create: (func: () => void): Disposable => {
+      return {
+        dispose: func,
+      };
+    },
+    from: vi.fn(),
+  },
+}));
+
+vi.mock(import('@ai-sdk/google'), () => ({
+  createGoogleGenerativeAI: vi.fn(),
+}));
+
+const GOOGLE_AI_PROVIDER_MOCK: GoogleGenerativeAIProvider = {} as unknown as GoogleGenerativeAIProvider;
+
+const PROVIDER_API_MOCK: typeof ProviderAPI = {
+  createProvider: vi.fn(),
+} as unknown as typeof ProviderAPI;
+
+const PROVIDER_MOCK: Provider = {
+  id: 'gemini',
+  name: 'Gemini',
+  setInferenceProviderConnectionFactory: vi.fn(),
+  registerInferenceProviderConnection: vi.fn(),
+} as unknown as Provider;
+
+const SAFE_STORAGE_MOCK: SecretStorage = {
+  get: vi.fn(),
+  store: vi.fn(),
+  delete: vi.fn(),
+  onDidChange: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(PROVIDER_API_MOCK.createProvider).mockReturnValue(PROVIDER_MOCK as Provider);
+  vi.mocked(createGoogleGenerativeAI).mockReturnValue(GOOGLE_AI_PROVIDER_MOCK);
+});
+
+test('constructor should not do anything', async () => {
+  const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+  expect(gemini).instanceof(Gemini);
+
+  expect(PROVIDER_API_MOCK.createProvider).not.toHaveBeenCalled();
+});
+
+describe('init', () => {
+  test('should register provider', async () => {
+    const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    expect(PROVIDER_API_MOCK.createProvider).toHaveBeenCalledOnce();
+    expect(PROVIDER_API_MOCK.createProvider).toHaveBeenCalledWith({
+      name: 'Gemini',
+      status: 'unknown',
+      id: 'gemini',
+    });
+  });
+
+  test('should register inference factory', async () => {
+    const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      create: expect.any(Function),
+    });
+  });
+});
+
+describe('factory', () => {
+  let create: (params: { [key: string]: unknown }, logger?: Logger, token?: CancellationToken) => Promise<void>;
+  beforeEach(async () => {
+    const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    const mock = vi.mocked(PROVIDER_MOCK.setInferenceProviderConnectionFactory);
+    assert(mock, 'setInferenceProviderConnectionFactory must be defined');
+    create = mock.mock.calls[0][0].create;
+  });
+
+  test('calling create without params should throw', async () => {
+    await expect(() => {
+      return create({});
+    }).rejects.toThrowError('invalid apiKey');
+  });
+
+  test('calling create with proper params should save token', async () => {
+    await create({
+      'gemini.factory.apiKey': 'dummyKey',
+    });
+
+    // ensure store has been updated
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledOnce();
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey');
+  });
+
+  test('calling create with proper params should register inference connection', async () => {
+    await create({
+      'gemini.factory.apiKey': 'dummyKey',
+    });
+
+    // ensure the key is used to create a google client
+    expect(createGoogleGenerativeAI).toHaveBeenCalledOnce();
+    expect(createGoogleGenerativeAI).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
+    });
+
+    // ensure the connection has been registered
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
+      name: 'dum*****',
+      status: expect.any(Function),
+      lifecycle: {
+        delete: expect.any(Function),
+      },
+      sdk: GOOGLE_AI_PROVIDER_MOCK,
+    });
+  });
+});
+
+describe('connection delete lifecycle', () => {
+  let gemini: Gemini;
+  let mDelete: (logger?: Logger) => Promise<void>;
+  const disposeMock = vi.fn();
+
+  beforeEach(async () => {
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockReturnValue({
+      dispose: disposeMock,
+    });
+
+    gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    // Get the create factory
+    const mock = vi.mocked(PROVIDER_MOCK.setInferenceProviderConnectionFactory);
+    const create = mock.mock.calls[0][0].create;
+
+    await create({
+      'gemini.factory.apiKey': 'dummyKey',
+    });
+
+    const registerMock = vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection);
+    const lifecycle = registerMock.mock.calls[0][0].lifecycle;
+    assert(lifecycle?.delete, 'delete method of lifecycle must be defined');
+
+    mDelete = lifecycle.delete;
+  });
+
+  test('calling delete should delete the token', async () => {
+    await mDelete();
+
+    // should have been called twice
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
+
+    // first time when registering the connection
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, 'dummyKey');
+
+    // second time when unregistering the connection
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, '');
+  });
+
+  test('calling delete should dispose provider inference connection', async () => {
+    await mDelete();
+
+    expect(disposeMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -29,14 +29,26 @@ import type {
 
 export type LifecycleMethod = 'start' | 'stop' | 'delete' | 'edit';
 
-export interface ProviderContainerConnectionInfo {
+export enum ProviderConnectionType {
+  CONTAINER = 'container',
+  KUBERNETES = 'kubernetes',
+  VM = 'vm',
+  INFERENCE = 'inference',
+  MCP = 'mcp',
+}
+
+export interface ProviderConnectionBase {
   name: string;
-  displayName: string;
   status: ProviderConnectionStatus;
+  lifecycleMethods?: LifecycleMethod[];
+  connectionType: ProviderConnectionType;
+}
+
+export interface ProviderContainerConnectionInfo extends ProviderConnectionBase {
+  displayName: string;
   endpoint: {
     socketPath: string;
   };
-  lifecycleMethods?: LifecycleMethod[];
   /**
    * Specify if the corresponding {@link import('@kortex-app/api').ProviderContainerConnection} instance
    * has a shellAccess available
@@ -44,33 +56,26 @@ export interface ProviderContainerConnectionInfo {
   shellAccess?: boolean;
   type: 'docker' | 'podman';
   vmType?: { id: string; name: string };
+  connectionType: ProviderConnectionType.CONTAINER;
 }
 
-export interface ProviderKubernetesConnectionInfo {
-  name: string;
-  status: ProviderConnectionStatus;
+export interface ProviderKubernetesConnectionInfo extends ProviderConnectionBase {
   endpoint: {
     apiURL: string;
   };
-  lifecycleMethods?: LifecycleMethod[];
+  connectionType: ProviderConnectionType.KUBERNETES;
 }
 
-export interface ProviderVmConnectionInfo {
-  name: string;
-  status: ProviderConnectionStatus;
-  lifecycleMethods?: LifecycleMethod[];
+export interface ProviderVmConnectionInfo extends ProviderConnectionBase {
+  connectionType: ProviderConnectionType.VM;
 }
 
-export interface ProviderMCPConnectionInfo {
-  name: string;
-  status: ProviderConnectionStatus;
-  lifecycleMethods?: LifecycleMethod[];
+export interface ProviderMCPConnectionInfo extends ProviderConnectionBase {
+  connectionType: ProviderConnectionType.MCP;
 }
 
-export interface ProviderInferenceConnectionInfo {
-  name: string;
-  status: ProviderConnectionStatus;
-  lifecycleMethods?: LifecycleMethod[];
+export interface ProviderInferenceConnectionInfo extends ProviderConnectionBase {
+  connectionType: ProviderConnectionType.INFERENCE;
 }
 
 export type ProviderConnectionInfo =

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -63,11 +63,12 @@ import type { Transport as MCPTransport } from '@modelcontextprotocol/sdk/shared
 import { inject, injectable } from 'inversify';
 
 import type { Event } from '/@api/event.js';
-import type {
+import {
   LifecycleMethod,
   PreflightChecksCallback,
   ProviderCleanupActionInfo,
   ProviderConnectionInfo,
+  ProviderConnectionType,
   ProviderContainerConnectionInfo,
   ProviderInferenceConnectionInfo,
   ProviderInfo,
@@ -732,6 +733,7 @@ export class ProviderRegistry {
               name: connection.vmTypeDisplayName ?? connection.vmType,
             }
           : undefined,
+        connectionType: ProviderConnectionType.CONTAINER,
       };
     } else if (this.isKubernetesConnection(connection)) {
       providerConnection = {
@@ -740,11 +742,25 @@ export class ProviderRegistry {
         endpoint: {
           apiURL: connection.endpoint.apiURL,
         },
+        connectionType: ProviderConnectionType.KUBERNETES,
+      };
+    } else if (this.isInferenceConnection(connection)) {
+      providerConnection = {
+        name: connection.name,
+        status: connection.status(),
+        connectionType: ProviderConnectionType.INFERENCE,
+      };
+    } else if (this.isMCPConnection(connection)) {
+      providerConnection = {
+        name: connection.name,
+        status: connection.status(),
+        connectionType: ProviderConnectionType.MCP,
       };
     } else {
       providerConnection = {
         name: connection.name,
         status: connection.status(),
+        connectionType: ProviderConnectionType.VM,
       };
     }
 
@@ -1165,16 +1181,56 @@ export class ProviderRegistry {
     return vmConnection;
   }
 
+  protected getMatchingInferenceConnectionFromProvider(
+    internalProviderId: string,
+    providerInferenceConnectionInfo: ProviderInferenceConnectionInfo,
+  ): InferenceProviderConnection {
+    // grab the correct provider
+    const provider = this.getMatchingProvider(internalProviderId);
+
+    // grab the correct kubernetes connection
+    const connection = provider.inferenceConnections.find(
+      connection => connection.name === providerInferenceConnectionInfo.name,
+    );
+    if (!connection) {
+      throw new Error(`no kubernetes connection matching provider id ${internalProviderId}`);
+    }
+    return connection;
+  }
+
+  protected getMatchingMCPConnectionFromProvider(
+    internalProviderId: string,
+    providerMCPConnectionInfo: ProviderMCPConnectionInfo,
+  ): MCPProviderConnection {
+    // grab the correct provider
+    const provider = this.getMatchingProvider(internalProviderId);
+
+    // grab the correct kubernetes connection
+    const connection = provider.mcpConnections.find(connection => connection.name === providerMCPConnectionInfo.name);
+    if (!connection) {
+      throw new Error(`no kubernetes connection matching provider id ${internalProviderId}`);
+    }
+    return connection;
+  }
+
   getMatchingConnectionFromProvider(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderConnectionInfo | ContainerProviderConnection,
   ): ProviderConnection {
+    // if provider container connection
     if (this.isProviderContainerConnection(providerContainerConnectionInfo)) {
       return this.getMatchingContainerConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
-    } else if (this.isProviderKubernetesConnectionInfo(providerContainerConnectionInfo)) {
-      return this.getMatchingKubernetesConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
-    } else {
-      return this.getMatchingVmConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
+    }
+
+    switch (providerContainerConnectionInfo.connectionType) {
+      case ProviderConnectionType.VM:
+        return this.getMatchingVmConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
+      case ProviderConnectionType.KUBERNETES:
+        return this.getMatchingKubernetesConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
+      case ProviderConnectionType.INFERENCE:
+        return this.getMatchingInferenceConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
+      case ProviderConnectionType.MCP:
+        return this.getMatchingMCPConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
     }
   }
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -165,6 +165,22 @@ onMount(async () => {
           }
         }
       });
+
+      provider.inferenceConnections.forEach(connection => {
+        const inferenceConnectionName = getProviderConnectionName(provider, connection);
+        connectionNames.push(inferenceConnectionName);
+        // update the map only if the container state is different from last time
+        if (
+          !containerConnectionStatus.has(inferenceConnectionName) ||
+          containerConnectionStatus.get(inferenceConnectionName)?.status !== connection.status
+        ) {
+          containerConnectionStatus.set(inferenceConnectionName, {
+            inProgress: false,
+            action: undefined,
+            status: connection.status,
+          });
+        }
+      });
     });
     // if a machine has been deleted we need to clean its old stored status
     containerConnectionStatus.forEach((v, k) => {
@@ -724,6 +740,13 @@ $effect(() => {
         {#each provider.inferenceConnections as inferenceConnection, index (index)}
           <div class="px-5 py-2 w-[240px]" role="region" aria-label={inferenceConnection.name}>
             <span>{inferenceConnection.name} (Inference)</span>
+            <PreferencesConnectionActions
+              provider={provider}
+              connection={inferenceConnection}
+              connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, inferenceConnection))}
+              updateConnectionStatus={updateContainerStatus}
+              addConnectionToRestartingQueue={addConnectionToRestartingQueue}
+            />
           </div>
         {/each}
           {#each provider.mcpConnections as mcpConnection, index (index)}


### PR DESCRIPTION
## Description

Big problem currently, you may add a connection, but cannot delete it.

Another problem: the provider registry code is complicated and messy, do not provide any way to properly differentiate VMProviderConnection, this has been added has fallback condition everywhere.

Kubernetes & Container has specific field, allowing us to differentiate them, but not VM, adding a `connectionType` field to `Info` interfaces.

## Screenshots

<img width="681" height="421" alt="image" src="https://github.com/user-attachments/assets/fa0cae5c-e9ee-445a-819b-178642035f57" />


## Related issues

Fixes https://github.com/kortex-hub/kortex/issues/10