### PR TITLE
fix: tweak UI classes

### DIFF
--- a/packages/renderer/src/lib/chat/components/ui/sidebar/sidebar-provider.svelte
+++ b/packages/renderer/src/lib/chat/components/ui/sidebar/sidebar-provider.svelte
@@ -37,7 +37,7 @@ const sidebar = setSidebar({
 		data-slot="sidebar-wrapper"
 		style="--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
 		class={cn(
-			'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full',
+			'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex w-full',
 			className
 		)}
 		bind:this={ref}

--- a/packages/renderer/src/lib/chat/components/ui/sidebar/sidebar.svelte
+++ b/packages/renderer/src/lib/chat/components/ui/sidebar/sidebar.svelte
@@ -79,7 +79,7 @@ const sidebar = useSidebar();
 			class={cn(
 				'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
 				side === 'left'
-					? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+					? 'group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
 					: 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
 				// Adjust the padding for floating and inset variants.
 				variant === 'floating' || variant === 'inset'


### PR DESCRIPTION
Removing the `min-h-svh` and `left-0` leading to some glitchy UI

<img width="1050" height="700" alt="image" src="https://github.com/user-attachments/assets/473646da-5a90-4351-a487-c991447c0cbe" />

<img width="1050" height="700" alt="image" src="https://github.com/user-attachments/assets/ec80d978-e0e2-466d-ac74-e350961ce61b" />
