### PR TITLE
chore: display tooltips at the bottom

### DIFF
--- a/packages/renderer/src/lib/chat/components/app-sidebar.svelte
+++ b/packages/renderer/src/lib/chat/components/app-sidebar.svelte
@@ -47,7 +47,7 @@ const context = useSidebar();
 							</Button>
 						{/snippet}
 					</TooltipTrigger>
-					<TooltipContent align="end">New Chat</TooltipContent>
+					<TooltipContent side="bottom" align="end">New Chat</TooltipContent>
 				</Tooltip>
 			</div>
 		</SidebarMenu>

--- a/packages/renderer/src/lib/chat/components/chat-header.svelte
+++ b/packages/renderer/src/lib/chat/components/chat-header.svelte
@@ -55,7 +55,7 @@ const sidebar = useSidebar();
 					</Button>
 				{/snippet}
 			</TooltipTrigger>
-			<TooltipContent>New Chat</TooltipContent>
+			<TooltipContent side="bottom" >New Chat</TooltipContent>
 		</Tooltip>
 	{/if}
 

--- a/packages/renderer/src/lib/chat/components/sidebar-toggle.svelte
+++ b/packages/renderer/src/lib/chat/components/sidebar-toggle.svelte
@@ -22,5 +22,5 @@ const sidebar = useSidebar();
 			</Button>
 		{/snippet}
 	</TooltipTrigger>
-	<TooltipContent align="start">Toggle Sidebar</TooltipContent>
+	<TooltipContent side="bottom" align="start">Toggle Sidebar</TooltipContent>
 </Tooltip>


### PR DESCRIPTION
today they're at the top but I don't see them (they're under the titlebar)