### PR TITLE
chore: rename Podman Desktop

### DIFF
--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
-    <title>Podman Desktop</title>
+    <title>Kortex</title>
   </head>
   <body class="overflow-hidden text-[var(--pd-default-text)] text-base bg-[var(--pd-titlebar-bg)]">
     <div id="app"></div>


### PR DESCRIPTION
when sharing a window in google meet, the window is now named "Kortex"

Signed-off-by: Florent Benoit <fbenoit@redhat.com>