### PR TITLE
chore(mcp): deprecate mcp provider connection

### DIFF
--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -34,6 +34,9 @@ export enum ProviderConnectionType {
   KUBERNETES = 'kubernetes',
   VM = 'vm',
   INFERENCE = 'inference',
+  /**
+   * @deprecated
+   */
   MCP = 'mcp',
   FLOW = 'flow',
 }
@@ -71,6 +74,9 @@ export interface ProviderVmConnectionInfo extends ProviderConnectionBase {
   connectionType: ProviderConnectionType.VM;
 }
 
+/**
+ * @deprecated
+ */
 export interface ProviderMCPConnectionInfo extends ProviderConnectionBase {
   connectionType: ProviderConnectionType.MCP;
 }
@@ -108,6 +114,9 @@ export interface ProviderInfo {
   kubernetesConnections: ProviderKubernetesConnectionInfo[];
   vmConnections: ProviderVmConnectionInfo[];
   inferenceConnections: ProviderInferenceConnectionInfo[];
+  /**
+   * @deprecated
+   */
   mcpConnections: ProviderMCPConnectionInfo[];
   flowConnections: ProviderFlowConnectionInfo[];
 
@@ -161,12 +170,24 @@ export interface ProviderInfo {
    * MCP Provider connection
    */
   // can create provider connection from MCPProviderConnectionFactory params
+  /**
+   * @deprecated
+   */
   mcpProviderConnectionCreation: boolean;
   // can initialize provider connection from MCPProviderConnectionFactory params
+  /**
+   * @deprecated
+   */
   mcpProviderConnectionInitialization: boolean;
   // optional creation name (if defined)
+  /**
+   * @deprecated
+   */
   mcpProviderConnectionCreationDisplayName?: string;
   // optional creation button title (if defined)
+  /**
+   * @deprecated
+   */
   mcpProviderConnectionCreationButtonTitle?: string;
 
   // other

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -574,6 +574,9 @@ declare module '@kortex-app/api' {
     status(): ProviderConnectionStatus;
   }
 
+  /**
+   * @deprecated
+   */
   export type MCPProviderConnection = {
     name: string;
     transport: MCPTransport;
@@ -774,6 +777,9 @@ declare module '@kortex-app/api' {
       connectionAuditor?: Auditor,
     ): Disposable;
 
+    /**
+     * @deprecated
+     */
     setMCPProviderConnectionFactory(
       providerProviderConnectionFactory: MCPProviderConnectionFactory,
       connectionAuditor?: Auditor,
@@ -783,6 +789,9 @@ declare module '@kortex-app/api' {
     registerKubernetesProviderConnection(connection: KubernetesProviderConnection): Disposable;
     registerVmProviderConnection(connection: VmProviderConnection): Disposable;
     registerInferenceProviderConnection(connection: InferenceProviderConnection): Disposable;
+    /**
+     * @deprecated
+     */
     registerMCPProviderConnection(connection: MCPProviderConnection): Disposable;
 
     registerFlowProviderConnection(connection: FlowProviderConnection): Disposable;
@@ -934,10 +943,17 @@ declare module '@kortex-app/api' {
     providerId: string;
   }
 
+  /**
+   * @deprecated
+   */
   export interface RegisterMCPConnectionEvent {
     providerId: string;
     connection: MCPProviderConnection;
   }
+
+  /**
+   * @deprecated
+   */
   export interface UnregisterMCPConnectionEvent {
     providerId: string;
     connectionName: string;

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -168,7 +168,13 @@ export class ProviderRegistry {
     this._onDidUnregisterInferenceConnection.event;
 
   // MCP
+  /**
+   * @deprecated
+   */
   private readonly _onDidRegisterMCPConnection = new Emitter<RegisterMCPConnectionEvent>();
+  /**
+   * @deprecated
+   */
   readonly onDidRegisterMCPConnection: Event<RegisterMCPConnectionEvent> = this._onDidRegisterMCPConnection.event;
 
   private readonly _onDidUnregisterMCPConnection = new Emitter<UnregisterMCPConnectionEvent>();
@@ -1324,6 +1330,9 @@ export class ProviderRegistry {
     return 'sdk' in connection;
   }
 
+  /**
+   * @deprecated
+   */
   isMCPConnection(connection: ProviderConnection): connection is MCPProviderConnection {
     return 'transport' in connection;
   }
@@ -1561,6 +1570,9 @@ export class ProviderRegistry {
     this._onDidRegisterInferenceConnection.fire({ providerId: provider.id });
   }
 
+  /**
+   * @deprecated
+   */
   onDidRegisterMCPConnectionCallback(provider: ProviderImpl, mcpProviderConnection: MCPProviderConnection): void {
     this.connectionLifecycleContexts.set(mcpProviderConnection, new LifecycleContextImpl());
     this.apiSender.send('provider-register-mcp-connection', { name: mcpProviderConnection.name });


### PR DESCRIPTION
Following https://github.com/kortex-hub/kortex/issues/54 we don't need individual extensions to register manually MCP