### PR TITLE
feat: export flow button

### DIFF
--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -117,10 +117,12 @@ let attachments = $state<Attachment[]>([]);
 			{readonly}
 			loading={chatClient.status === 'streaming' || chatClient.status === 'submitted'}
 			messages={chatClient.messages}
+      {selectedModel}
+      {selectedMCP}
 		/>
      <form class="bg-background mx-auto flex w-full gap-2 px-4 pb-4 md:max-w-3xl md:pb-6">
        {#if !readonly}
-         <MultimodalInput {attachments} {user} {chatClient} selectedModel={selectedModel} selectedMCP={selectedMCP} class="flex-1" />
+         <MultimodalInput {attachments} {user} {chatClient} class="flex-1" />
        {/if}
      </form>
    </div>

--- a/packages/renderer/src/lib/chat/components/messages.svelte
+++ b/packages/renderer/src/lib/chat/components/messages.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
-import ThinkingMessage from './messages/thinking-message.svelte';
-import Overview from './messages/overview.svelte';
-import { onMount } from 'svelte';
-import PreviewMessage from './messages/preview-message.svelte';
 import type { UIMessage } from '@ai-sdk/svelte';
+import { onMount } from 'svelte';
+import type { SvelteSet } from 'svelte/reactivity';
+
 import { getLock } from '/@/lib/chat/hooks/lock';
+
+import Overview from './messages/overview.svelte';
+import PreviewMessage from './messages/preview-message.svelte';
+import ThinkingMessage from './messages/thinking-message.svelte';
+import type { ModelInfo } from './model-info';
 
 let containerRef = $state<HTMLDivElement | null>(null);
 let endRef = $state<HTMLDivElement | null>(null);
@@ -13,10 +17,14 @@ let {
   readonly,
   loading,
   messages,
+  selectedModel,
+  selectedMCP,
 }: {
   readonly: boolean;
   loading: boolean;
   messages: UIMessage[];
+  selectedModel?: ModelInfo;
+  selectedMCP: SvelteSet<string>;
 } = $props();
 
 let mounted = $state(false);
@@ -41,7 +49,7 @@ $effect(() => {
     characterData: true,
   });
 
-  return () => observer.disconnect();
+  return (): void => observer.disconnect();
 });
 </script>
 
@@ -51,7 +59,7 @@ $effect(() => {
 	{/if}
 
 	{#each messages as message (message.id)}
-		<PreviewMessage {message} {readonly} {loading} />
+		<PreviewMessage {message} {readonly} {loading} {selectedModel} {selectedMCP} />
 	{/each}
 
 	{#if loading && messages.length > 0 && messages[messages.length - 1].role === 'user'}

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -2,21 +2,16 @@
 import { type Chat } from '@ai-sdk/svelte';
 import type { Attachment } from '@ai-sdk/ui-utils';
 import { onMount } from 'svelte';
-import type { SvelteSet } from 'svelte/reactivity';
 import { innerWidth } from 'svelte/reactivity/window';
 import { toast } from 'svelte-sonner';
-import { router } from 'tinro';
 
 import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
 import { cn } from '/@/lib/chat/utils/shadcn';
-import { flowCreationStore } from '/@/lib/flows/flowCreationStore';
 
 import type { User } from '../../../../../main/src/chat/db/schema';
 import ArrowUpIcon from './icons/arrow-up.svelte';
 import PaperclipIcon from './icons/paperclip.svelte';
-import PlusIcon from './icons/plus.svelte';
 import StopIcon from './icons/stop.svelte';
-import type { ModelInfo } from './model-info';
 import PreviewAttachment from './preview-attachment.svelte';
 import SuggestedActions from './suggested-actions.svelte';
 import { Button } from './ui/button';
@@ -27,15 +22,11 @@ let {
   user,
   chatClient,
   class: c,
-  selectedModel,
-  selectedMCP,
 }: {
   attachments: Attachment[];
   user: User | undefined;
   chatClient: Chat;
   class?: string;
-  selectedModel?: ModelInfo;
-  selectedMCP: SvelteSet<string>;
 } = $props();
 
 let input = $state('');
@@ -45,30 +36,6 @@ let fileInputRef = $state<HTMLInputElement | null>(null);
 let uploadQueue = $state<string[]>([]);
 const storedInput = new LocalStorage('input', '');
 const loading = $derived(chatClient.status === 'streaming' || chatClient.status === 'submitted');
-
-const exportAsFlow = (): void => {
-  if (!selectedModel) {
-    toast.error("There's no selected model to export as a flow.");
-    return;
-  }
-
-  const lastUserMessage = chatClient.messages
-    .findLast(m => m.role === 'user')
-    ?.parts.find(p => p.type === 'text')?.text;
-
-  if (!lastUserMessage) {
-    toast.error("There's no user message to export as a flow.");
-    return;
-  }
-
-  flowCreationStore.set({
-    lastUserMessage,
-    model: selectedModel,
-    mcp: selectedMCP,
-  });
-
-  router.goto('/flows/create');
-};
 
 const adjustHeight = (): void => {
   if (textareaRef) {
@@ -245,18 +212,6 @@ $effect.pre(() => {
 		>
 			<PaperclipIcon size={14} />
 		</Button>
-		<Button
-            class="h-fit rounded-md p-[7px] hover:bg-zinc-200 dark:border-zinc-700 hover:dark:bg-zinc-900"
-            onclick={(event): void => {
-                event.preventDefault();
-                exportAsFlow();
-            }}
-            disabled={loading || chatClient.messages.filter(m => m.role === 'user').length === 0}
-            variant="ghost"
-            title="Export as Flow"
-        >
-            <PlusIcon size={14} />
-        </Button>
 	</div>
 
 	<div class="absolute right-0 bottom-0 flex w-fit flex-row justify-end p-2">

--- a/packages/renderer/src/lib/flows/FlowCreate.svelte
+++ b/packages/renderer/src/lib/flows/FlowCreate.svelte
@@ -18,7 +18,7 @@ let error: string | undefined = $state();
 // form field
 let name: string = $state('');
 let description: string = $state('');
-let prompt: string = $state($flowCreationStore?.lastUserMessage ?? '');
+let prompt: string = $state($flowCreationStore?.prompt ?? '');
 let flowProviderConnectionKey: string | undefined = $state<string>();
 let result: string | undefined = $state(undefined);
 

--- a/packages/renderer/src/lib/flows/flowCreationStore.ts
+++ b/packages/renderer/src/lib/flows/flowCreationStore.ts
@@ -3,7 +3,7 @@ import { writable } from 'svelte/store';
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
 
 export interface FlowCreationData {
-  lastUserMessage: string;
+  prompt: string;
   model: ModelInfo;
   mcp: Set<string>;
 }


### PR DESCRIPTION
This PR adds a button to the chat UI that redirects users to the flow creation page.

It passes a data object containing the model, MCP, and last user prompt. For now, only the prompt field is pre-populated, but the other information is available in the object for future use.

This is the first step toward a fully functional end-to-end flow creation.


Partial fix of https://github.com/kortex-hub/kortex/issues/85