### PR TITLE
feat: add a new tab on mcp details to list tools calls

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -42,7 +42,7 @@ import type {
   V1Secret,
   V1Service,
 } from '@kubernetes/client-node';
-import type { ToolSet, UIMessage } from 'ai';
+import type { DynamicToolUIPart, ToolSet, UIMessage } from 'ai';
 import { convertToModelMessages, generateText, stepCountIs, streamText } from 'ai';
 import checkDiskSpacePkg from 'check-disk-space';
 import type Dockerode from 'dockerode';
@@ -2173,6 +2173,10 @@ export class PluginSystem {
         );
       },
     );
+
+    this.ipcHandle('mcp-manager:getExchanges', async (_listener, mcpId: string): Promise<DynamicToolUIPart[]> => {
+      return mcpManager.getExchanges(mcpId);
+    });
 
     this.ipcHandle(
       'image-registry:updateRegistry',

--- a/packages/main/src/plugin/mcp/mcp-transport-delegate.ts
+++ b/packages/main/src/plugin/mcp/mcp-transport-delegate.ts
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Transport, TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { JSONRPCMessage, MessageExtraInfo } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * A transport delegate that wraps an MCP Transport and allows intercepting
+ * outgoing (send) and incoming (onmessage) JSON-RPC messages.
+ */
+export class MCPTransportDelegate implements Transport {
+  private readonly onSendHook?: (message: JSONRPCMessage, options?: TransportSendOptions) => void;
+  private readonly onReceiveHook?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+
+  // Consumers of this delegate may assign these handlers as usual
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+
+  constructor(
+    private readonly inner: Transport,
+    hooks: {
+      onSend?: (message: JSONRPCMessage, options?: TransportSendOptions) => void;
+      onReceive?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+    } = {},
+  ) {
+    this.onSendHook = hooks.onSend;
+    this.onReceiveHook = hooks.onReceive;
+
+    // Wire inner transport callbacks to delegate and hooks
+    this.inner.onmessage = (message: JSONRPCMessage, extra?: MessageExtraInfo): void => {
+      try {
+        this.onReceiveHook?.(message, extra);
+      } catch (e) {
+        // Swallow logging errors to avoid breaking transport
+        // eslint-disable-next-line no-console
+        console.error('[MCPTransportDelegate] onReceive hook error', e);
+      }
+      this.onmessage?.(message, extra);
+    };
+
+    this.inner.onerror = (error: Error): void => {
+      this.onerror?.(error);
+    };
+
+    this.inner.onclose = (): void => {
+      this.onclose?.();
+    };
+  }
+
+  async start(): Promise<void> {
+    return this.inner.start();
+  }
+
+  async send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void> {
+    try {
+      this.onSendHook?.(message, options);
+    } catch (e) {
+      // Do not prevent sending if logging fails
+      console.error('[MCPTransportDelegate] onSend hook error', e);
+    }
+    return this.inner.send(message, options);
+  }
+
+  async close(): Promise<void> {
+    return this.inner.close();
+  }
+
+  // Proxy session related fields if present on inner transport
+  get sessionId(): string | undefined {
+    return this.inner.sessionId;
+  }
+  set sessionId(id: string | undefined) {
+    this.inner.sessionId = id;
+  }
+
+  setProtocolVersion?(version: string): void {
+    if (this.inner.setProtocolVersion) {
+      this.inner.setProtocolVersion(version);
+    }
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -41,7 +41,7 @@ import type {
   V1Secret,
   V1Service,
 } from '@kubernetes/client-node';
-import type { UIMessage, UIMessageChunk } from 'ai';
+import type { DynamicToolUIPart, UIMessage, UIMessageChunk } from 'ai';
 import { contextBridge, ipcRenderer } from 'electron';
 import type { components } from 'mcp-registry';
 
@@ -1693,6 +1693,10 @@ export function initExposure(): void {
       return ipcInvoke('mcp-manager:getTools', mcpId);
     },
   );
+
+  contextBridge.exposeInMainWorld('getMcpExchanges', async (mcpId: string): Promise<DynamicToolUIPart[]> => {
+    return ipcInvoke('mcp-manager:getExchanges', mcpId);
+  });
 
   contextBridge.exposeInMainWorld(
     'createMCPServerFromRemoteRegistry',

--- a/packages/renderer/src/lib/mcp/MCPDetails.svelte
+++ b/packages/renderer/src/lib/mcp/MCPDetails.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import { Tab } from '@podman-desktop/ui-svelte';
+import type { DynamicToolUIPart } from 'ai';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
+import ToolParts from '/@/lib/chat/components/messages/tool-parts.svelte';
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
@@ -14,6 +16,15 @@ interface Props {
 let { id }: Props = $props();
 
 let toolSet: string | undefined = $state(undefined);
+let messages: Array<DynamicToolUIPart> = $state([]);
+
+async function refreshMessages(): Promise<void> {
+  try {
+    messages = await window.getMcpExchanges(id);
+  } catch (e) {
+    console.error('Failed to fetch MCP exchanges', e);
+  }
+}
 
 onMount(() => {
   window
@@ -22,6 +33,14 @@ onMount(() => {
       toolSet = JSON.stringify(content, undefined, 2);
     })
     .catch(console.error);
+
+  // Initial load of messages
+  refreshMessages().catch(console.error);
+
+  // Subscribe to updates from main process
+  return window.events?.receive('mcp-manager-update', () => {
+    refreshMessages().catch(console.error);
+  });
 });
 </script>
 
@@ -29,6 +48,7 @@ onMount(() => {
   {#snippet tabsSnippet()}
     <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
     <Tab title="Tools" selected={isTabSelected($router.path, 'tools')} url={getTabUrl($router.path, 'tools')} />
+    <Tab title="Messages" selected={isTabSelected($router.path, 'messages')} url={getTabUrl($router.path, 'messages')} />
   {/snippet}
   {#snippet contentSnippet()}
     <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -37,6 +57,13 @@ onMount(() => {
     <Route path="/tools" breadcrumb="Tools" navigationHint="tab">
       {#if toolSet}
         <MonacoEditor readOnly content={toolSet} language="json"/>
+      {/if}
+    </Route>
+    <Route path="/messages" breadcrumb="Messages" navigationHint="tab">
+      {#if messages.length > 0}
+        <ToolParts tools={messages} />
+      {:else}
+        <div class="text-sm text-zinc-600 dark:text-zinc-400">No messages recorded yet.</div>
       {/if}
     </Route>
   {/snippet}


### PR DESCRIPTION
Fixes #74

Add a new tab to MCPDetails to list all tools call for the MCP server

![mcpmessages](https://github.com/user-attachments/assets/d1f9d13a-2b76-405c-a71a-a6ad91406356)

