### PR TITLE
fix: navigation in flows was displaying wrong breadcrumb

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -163,7 +163,7 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
           <CustomChat />
         </Route>
 
-        <Route path="/flows" breadcrumb="Flows">
+        <Route path="/flows" breadcrumb="Flows"  navigationHint="root">
           <FlowList/>
         </Route>
 


### PR DESCRIPTION
fix breadcrumb for flows

before: 
<img width="1840" height="1191" alt="Screenshot 2025-08-29 at 15 40 23" src="https://github.com/user-attachments/assets/c507e097-da76-4bfd-a1b2-99f877691d5c" />
after: 

<img width="1840" height="1191" alt="Screenshot 2025-08-29 at 15 39 11" src="https://github.com/user-attachments/assets/2cfadfaf-f35d-4f22-aad7-2390d47d5b4b" />
