### PR TITLE
chore: allow to give plain http://foo links for markdown

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -36,6 +36,7 @@
     "jsdom": "^27.0.0-beta.2",
     "micromark": "^4.0.2",
     "micromark-extension-directive": "^4.0.0",
+    "micromark-extension-gfm-autolink-literal": "^2.1.0",
     "moment": "^2.30.1",
     "monaco-editor": "^0.52.2",
     "svelte": "5.38.1",

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -47,6 +47,7 @@ UI guidelines -->
 <script lang="ts">
 import { micromark } from 'micromark';
 import { directive, directiveHtml } from 'micromark-extension-directive';
+import { gfmAutolinkLiteral, gfmAutolinkLiteralHtml } from 'micromark-extension-gfm-autolink-literal';
 import { onDestroy, onMount } from 'svelte';
 
 import { button } from './micromark-button-directive';
@@ -76,8 +77,8 @@ const eventListeners: EventListener[] = [];
 // Render the markdown or the html+micromark markdown reactively
 $: markdown
   ? (html = micromark(markdown, {
-      extensions: [directive()],
-      htmlExtensions: [directiveHtml({ button, link, warnings })],
+      extensions: [gfmAutolinkLiteral(), directive()],
+      htmlExtensions: [gfmAutolinkLiteralHtml(), directiveHtml({ button, link, warnings })],
     }))
   : undefined;
 
@@ -88,8 +89,8 @@ onMount(() => {
 
   // Provide micromark + extensions
   html = micromark(text, {
-    extensions: [directive()],
-    htmlExtensions: [directiveHtml({ button, link, warnings })],
+    extensions: [gfmAutolinkLiteral(), directive()],
+    htmlExtensions: [gfmAutolinkLiteralHtml(), directiveHtml({ button, link, warnings })],
   });
 
   // remove href values in each anchor using # for links

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,9 @@ importers:
       micromark-extension-directive:
         specifier: ^4.0.0
         version: 4.0.0
+      micromark-extension-gfm-autolink-literal:
+        specifier: ^2.1.0
+        version: 2.1.0
       moment:
         specifier: ^2.30.1
         version: 2.30.1


### PR DESCRIPTION
transform such links into HTML links