### PR TITLE
fix(FlowCreate): mixed up prompt and instructions

### DIFF
--- a/packages/renderer/src/lib/flows/FlowCreate.svelte
+++ b/packages/renderer/src/lib/flows/FlowCreate.svelte
@@ -157,7 +157,7 @@ async function generate(): Promise<void> {
 
               <!-- prompt -->
               <div>
-                <span>Prompt (System prompt)</span>
+                <span>Prompt</span>
                 <Textarea
                   placeholder="Prompt"
                   bind:value={prompt}
@@ -167,7 +167,7 @@ async function generate(): Promise<void> {
                 />
               </div>
 
-              <!-- system prompt -->
+              <!-- instruction -->
               <div>
                 <span>Instruction</span>
                 <Textarea


### PR DESCRIPTION
Fix issue introduced in https://github.com/kortex-hub/kortex/commit/c8f581624ea59ac3a718660282ef7102a3722e8f#diff-cd800358983d97fa154a80ce13f94cc5ef3df954ae81a339c1272d2aeadf29d8R25

Sometimes the assistant would not answer the instructions



https://github.com/user-attachments/assets/ceaba6b4-7714-439c-86bd-8048ef72b35d

