### PR TITLE
fix(goose/kubernetes): empty extension array in recipe in case no MCP

### DIFF
--- a/extensions/goose/src/templates/recipe.mustache
+++ b/extensions/goose/src/templates/recipe.mustache
@@ -20,6 +20,9 @@ extensions:
       {{ key }}: "{{ value }}"
     {{/headers }}
   {{/recipe.extensions }}
+  {{^recipe.extensions}}
+  []
+  {{/recipe.extensions}}
 
 
 settings:


### PR DESCRIPTION
fixes #216 

The extension list was not provided when no extension, leading to the default extensions (Jira etc...)