### PR TITLE
fix(chat): reuse export icon in flow create, align

### DIFF
--- a/packages/renderer/src/lib/chat/components/messages/ExportIcon.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/ExportIcon.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
-import Fa from 'svelte-fa';
+import Fa, { type IconSize } from 'svelte-fa';
 
 let {
-  scale,
+  size,
 }: {
-  scale: number;
+  size: IconSize;
 } = $props();
 </script>
 
-<Fa icon={faFileExport} scale={scale}/>
+<Fa icon={faFileExport} size={size}/>

--- a/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
@@ -148,7 +148,7 @@ const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type 
 										variant="ghost"
 										title={$isGooseCliToolInstalled? 'Export as Flow' : 'Install flow provider to enable save.'}
 									>
-										<ExportIcon scale={2}/>
+										<ExportIcon size="2x"/>
 									</Button>
 							{/if}
 						</div>

--- a/packages/renderer/src/lib/flows/FlowCreate.svelte
+++ b/packages/renderer/src/lib/flows/FlowCreate.svelte
@@ -109,7 +109,7 @@ async function generate(): Promise<void> {
             <div>You can create a flow using this form by selecting a model, one or several tools (from MCP servers)
               and specifying instructions.</div>
             <div>A flow can also be created by exporting a chat session. All information's on this page will then automatically be filled.</div>
-            <div class="flex flex-row gap-1 items-center">The export feature in the chat window is available through the <ExportIcon scale={1}/> icon</div>
+            <div class="flex flex-row gap-1 items-center">The export feature in the chat window is available through the <ExportIcon size="1x"/> icon</div>
           </div>
           {#if error}
             <ErrorMessage {error}/>


### PR DESCRIPTION
<img width="1208" height="712" alt="Screenshot 2025-09-04 at 12 16 10" src="https://github.com/user-attachments/assets/92056823-217a-40a3-b726-532d27df3d18" />
<img width="1208" height="712" alt="Screenshot 2025-09-04 at 12 15 41" src="https://github.com/user-attachments/assets/f9651514-8571-4375-9d6d-c54f135bb207" />
