### PR TITLE
fix(chat/flow): make prompt from whole conversation 

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2795,13 +2795,13 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
         connectionName: string,
-        modelId: string,
+        model: string,
         mcp: Array<string>,
         messages: UIMessage[],
       ): Promise<string> => {
         const internalProviderId = providerRegistry.getMatchingProviderInternalId(providerId);
         const sdk = providerRegistry.getInferenceSDK(internalProviderId, connectionName);
-        const languageModel = sdk.languageModel(modelId);
+        const languageModel = sdk.languageModel(model);
 
         const userMessage = getMostRecentUserMessage(messages);
 


### PR DESCRIPTION
Instead of creating a flow from a given user prompt, use LLM to generate a prompt from the whole conversation, and store in the flow. So it can be executed automatically.

Demo:

https://github.com/user-attachments/assets/469a7923-766e-4752-8692-7abe87413726




Fixes #268 