### PR TITLE
chore: remove experimentalConfigManager field

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -21,7 +21,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '../api.js';
 import type { ConfigurationRegistry } from '../configuration-registry.js';
-import type { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';
 import { FilesystemMonitoring } from '../filesystem-monitoring.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
 import { KubernetesClient } from './kubernetes-client.js';
@@ -58,9 +57,6 @@ describe('context tests', () => {
   let client: TestKubernetesClient;
 
   const apiSendMock = vi.fn();
-  const experimentalConfigurationManager: ExperimentalConfigurationManager = {
-    isExperimentalConfigurationEnabled: vi.fn(),
-  } as unknown as ExperimentalConfigurationManager;
 
   function createClient(): TestKubernetesClient {
     const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
@@ -73,13 +69,7 @@ describe('context tests', () => {
       receive: vi.fn(),
     };
 
-    const client = new TestKubernetesClient(
-      apiSender,
-      configurationRegistry,
-      fileSystemMonitoring,
-      telemetry,
-      experimentalConfigurationManager,
-    );
+    const client = new TestKubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
 
     client.setUsers(originalUsers);
     client.setClusters(originalClusters);

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -54,7 +54,6 @@ import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
 import { Emitter } from '../events/emitter.js';
-import type { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';
 import { FilesystemMonitoring } from '../filesystem-monitoring.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
 import { Uri } from '../types/uri.js';
@@ -79,9 +78,6 @@ const telemetry: Telemetry = {
     // do nothing
   }),
 } as unknown as Telemetry;
-const experimentalConfigurationManager: ExperimentalConfigurationManager = {
-  isExperimentalConfigurationEnabled: vi.fn(),
-} as unknown as ExperimentalConfigurationManager;
 const makeApiClientMock = vi.fn();
 const getContextObjectMock = vi.fn();
 
@@ -262,13 +258,7 @@ class TestKubernetesClient extends KubernetesClient {
 }
 
 function createTestClient(namespace?: string): TestKubernetesClient {
-  const client = new TestKubernetesClient(
-    apiSender,
-    configurationRegistry,
-    fileSystemMonitoring,
-    telemetry,
-    experimentalConfigurationManager,
-  );
+  const client = new TestKubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
   if (namespace) {
     client.setInitialNamespace(namespace);
   }
@@ -480,13 +470,7 @@ test('Check connection to Kubernetes cluster', async () => {
   vi.mocked(clientNode.Health).mockReturnValue({
     readyz: vi.fn().mockResolvedValue(true),
   } as unknown as clientNode.Health);
-  const client = new KubernetesClient(
-    {} as ApiSenderType,
-    configurationRegistry,
-    fileSystemMonitoring,
-    telemetry,
-    experimentalConfigurationManager,
-  );
+  const client = new KubernetesClient({} as ApiSenderType, configurationRegistry, fileSystemMonitoring, telemetry);
   const result = await client.checkConnection();
   expect(result).toBeTruthy();
 });
@@ -496,13 +480,7 @@ test('Check connection to Kubernetes cluster in error', async () => {
     readyz: vi.fn().mockRejectedValue(undefined),
   } as unknown as clientNode.Health);
 
-  const client = new KubernetesClient(
-    {} as ApiSenderType,
-    configurationRegistry,
-    fileSystemMonitoring,
-    telemetry,
-    experimentalConfigurationManager,
-  );
+  const client = new KubernetesClient({} as ApiSenderType, configurationRegistry, fileSystemMonitoring, telemetry);
   const result = await client.checkConnection();
   expect(result).toBeFalsy();
 });
@@ -514,13 +492,7 @@ test('Check update with empty kubeconfig file', async () => {
   // provide empty kubeconfig file
   readFileMock.mockResolvedValue('');
 
-  const client = new KubernetesClient(
-    {} as ApiSenderType,
-    configurationRegistry,
-    fileSystemMonitoring,
-    telemetry,
-    experimentalConfigurationManager,
-  );
+  const client = new KubernetesClient({} as ApiSenderType, configurationRegistry, fileSystemMonitoring, telemetry);
   await client.refresh();
   expect(consoleErrorSpy).toBeCalledWith(expect.stringContaining('is empty. Skipping'));
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -87,7 +87,6 @@ import type { V1Route } from '/@api/openshift-types.js';
 
 import { ApiSenderType } from '../api.js';
 import { Emitter } from '../events/emitter.js';
-import { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';
 import { FilesystemMonitoring } from '../filesystem-monitoring.js';
 import { Telemetry } from '../telemetry/telemetry.js';
 import { Uri } from '../types/uri.js';
@@ -215,8 +214,6 @@ export class KubernetesClient {
     private readonly fileSystemMonitoring: FilesystemMonitoring,
     @inject(Telemetry)
     private readonly telemetry: Telemetry,
-    @inject(ExperimentalConfigurationManager)
-    private readonly experimentalConfigurationManager: ExperimentalConfigurationManager,
   ) {
     this.kubeConfig = new KubeConfig();
     this.contextsState = new ContextsManager(this.apiSender);

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -33,8 +33,6 @@ import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 import { type IDisposable } from '/@/plugin/types/disposable.js';
 import { type ForwardConfig, type PortMapping, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
-import type { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';
-
 const mockKubeConfig = {
   makeApiClient: vi.fn(),
 };
@@ -57,9 +55,6 @@ const apiSender: ApiSenderType = {} as unknown as ApiSenderType;
 const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
 const fileSystemMonitoring: FilesystemMonitoring = new FilesystemMonitoring();
 const telemetry: Telemetry = {} as unknown as Telemetry;
-const experimentalConfigurationManager: ExperimentalConfigurationManager = {
-  isExperimentalConfigurationEnabled: vi.fn(),
-} as unknown as ExperimentalConfigurationManager;
 vi.mock('@kubernetes/client-node', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await vi.importActual<typeof import('@kubernetes/client-node')>('@kubernetes/client-node');
@@ -170,13 +165,7 @@ describe('PortForwardConnectionService', () => {
 
   beforeEach(() => {
     service = new TestablePortForwardConnectionService(
-      new KubernetesClient(
-        apiSender,
-        configurationRegistry,
-        fileSystemMonitoring,
-        telemetry,
-        experimentalConfigurationManager,
-      ),
+      new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry),
     );
     global.fetch = vi.fn();
     mockKubeConfig.makeApiClient.mockImplementation(api => {
@@ -250,13 +239,7 @@ describe('PortForwardConnectionService', () => {
     );
 
     service = new TestablePortForwardConnectionService(
-      new KubernetesClient(
-        apiSender,
-        configurationRegistry,
-        fileSystemMonitoring,
-        telemetry,
-        experimentalConfigurationManager,
-      ),
+      new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry),
     );
 
     const createdServer = service.createServer(forwardSetup as never);


### PR DESCRIPTION
I was not able to run the command typecheck when checking other changes

fix typecheck error as there is a private field being unused. 

```ts
    @inject(ExperimentalConfigurationManager)
    private readonly experimentalConfigurationManager: ExperimentalConfigurationManager,
```

But then, as the field is removed, need to remove it in all the clients calling the code