### PR TITLE
refactor: remove hardcoded dependency on goose cli

### DIFF
--- a/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
@@ -5,10 +5,11 @@ import { fly } from 'svelte/transition';
 import { toast } from 'svelte-sonner';
 import { router } from 'tinro';
 
+import { fileUIPart2Attachment } from '/@/lib/chat/utils/chat';
 import { cn } from '/@/lib/chat/utils/shadcn';
 import { flowCreationStore } from '/@/lib/flows/flowCreationStore';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
-import { isGooseCliToolInstalled } from '/@/stores/goose-cli-tool';
+import { isFlowConnectionAvailable } from '/@/stores/flow-provider';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
 import PencilEditIcon from '../icons/pencil-edit.svelte';
@@ -20,7 +21,6 @@ import { Button } from '../ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import ExportIcon from './ExportIcon.svelte';
 import ToolParts from './tool-parts.svelte';
-import { fileUIPart2Attachment } from '/@/lib/chat/utils/chat';
 
 let {
   message,
@@ -147,7 +147,7 @@ const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type 
 										}}
 										disabled={loading}
 										variant="ghost"
-										title={$isGooseCliToolInstalled? 'Export as Flow' : 'Install flow provider to enable save.'}
+										title={$isFlowConnectionAvailable? 'Export as Flow' : 'Install flow provider to enable save.'}
 									>
 										<ExportIcon size="2x"/>
 									</Button>

--- a/packages/renderer/src/lib/flows/FlowCreate.svelte
+++ b/packages/renderer/src/lib/flows/FlowCreate.svelte
@@ -11,7 +11,7 @@ import { flowCreationStore } from '/@/lib/flows/flowCreationStore';
 import { getModels } from '/@/lib/models/models-utils';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import { handleNavigation } from '/@/navigation';
-import { isGooseCliToolInstalled } from '/@/stores/goose-cli-tool';
+import { isFlowConnectionAvailable } from '/@/stores/flow-provider';
 import { providerInfos } from '/@/stores/providers';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 import { NavigationPage } from '/@api/navigation-page';
@@ -60,7 +60,8 @@ const kubernetesNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
 const formValidContent = $derived(
   !!flowProviderConnectionKey &&
     !!selectedModel &&
-    !!name && name.length <= 63 &&
+    !!name &&
+    name.length <= 63 &&
     kubernetesNameRegex.test(name) &&
     !!prompt &&
     !!instruction
@@ -110,7 +111,7 @@ async function generate(): Promise<void> {
 <FormPage title="Flow Create" inProgress={loading}>
   {#snippet content()}
     <div class="px-5 pb-5 min-w-full">
-    {#if $isGooseCliToolInstalled}
+    {#if $isFlowConnectionAvailable}
         <div class="bg-[var(--pd-content-card-bg)] px-6 py-4">
           <div class="flex flex-col">
             <div>You can create a flow using this form by selecting a model, one or several tools (from MCP servers)

--- a/packages/renderer/src/lib/flows/FlowList.svelte
+++ b/packages/renderer/src/lib/flows/FlowList.svelte
@@ -4,8 +4,8 @@ import { Button, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/u
 
 import FlowName from '/@/lib/flows/columns/FlowName.svelte';
 import { handleNavigation } from '/@/navigation';
+import { isFlowConnectionAvailable } from '/@/stores/flow-provider';
 import { flowsInfos } from '/@/stores/flows';
-import { isGooseCliToolInstalled } from '/@/stores/goose-cli-tool';
 import type { FlowInfo } from '/@api/flow-info';
 import { NavigationPage } from '/@api/navigation-page';
 
@@ -51,7 +51,7 @@ function navigateToCreateFlow(): void {
 
 <NavPage searchEnabled={false} title="Flows">
   {#snippet additionalActions()}
-    {#if $isGooseCliToolInstalled}
+    {#if $isFlowConnectionAvailable}
       <Button icon={faPencil} onclick={navigateToCreateFlow}>
         Create
       </Button>
@@ -63,7 +63,7 @@ function navigateToCreateFlow(): void {
 
   {#snippet content()}
     <div class="w-full flex justify-center">
-      {#if $isGooseCliToolInstalled}
+      {#if $isFlowConnectionAvailable}
         {#if $flowsInfos.length === 0}
           <EmptyFlowScreen onclick={navigateToCreateFlow} />
         {:else}

--- a/packages/renderer/src/stores/flow-provider.ts
+++ b/packages/renderer/src/stores/flow-provider.ts
@@ -1,0 +1,13 @@
+import { derived } from 'svelte/store';
+
+import { providerInfos } from './providers';
+
+export const flowConnectionCount = derived(providerInfos, $providerInfos => {
+  return $providerInfos.reduce((accumulator, current) => {
+    return accumulator + current.flowConnections.length;
+  }, 0);
+});
+
+export const isFlowConnectionAvailable = derived(flowConnectionCount, $flowConnectionCount => {
+  return $flowConnectionCount > 0;
+});

--- a/packages/renderer/src/stores/goose-cli-tool.ts
+++ b/packages/renderer/src/stores/goose-cli-tool.ts
@@ -7,7 +7,3 @@ const gooseCliToolId = 'kortex.goose.goose';
 export const gooseCliTool = derived(cliToolInfos, $cliToolInfos => {
   return $cliToolInfos.find(c => c.id === gooseCliToolId);
 });
-
-export const isGooseCliToolInstalled = derived(cliToolInfos, $cliToolInfos => {
-  return !!$cliToolInfos.find(c => c.path && c.id === gooseCliToolId);
-});


### PR DESCRIPTION
## Description

The FlowList, FlowCreate, and the button to export chat to the FlowCreate was hidden being a `$isGooseCliToolInstalled`. As per requested in https://github.com/kortex-hub/kortex/issues/280 : removing the hardcoded and uses the flow connections as metric to display or not those components.

## Related issues

Following 
- https://github.com/kortex-hub/kortex/pull/339
- https://github.com/kortex-hub/kortex/pull/338
- https://github.com/kortex-hub/kortex/pull/337


Fixes https://github.com/kortex-hub/kortex/issues/280