### PR TITLE
fix(chat/flow): make prompt from whole conversation

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1116,8 +1116,14 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'inferenceGenerate',
-    async (internalProviderId: string, connectionName: string, model: string, prompt: string): Promise<string> => {
-      return ipcInvoke('inference:generate', internalProviderId, connectionName, model, prompt);
+    async (
+      providerId: string,
+      connectionName: string,
+      modelId: string,
+      mcp: Array<string>,
+      messages: UIMessage[],
+    ): Promise<string> => {
+      return ipcInvoke('inference:generate', providerId, connectionName, modelId, mcp, messages);
     },
   );
 

--- a/packages/renderer/src/lib/chat/components/ExportButton.svelte
+++ b/packages/renderer/src/lib/chat/components/ExportButton.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+import { type Chat } from '@ai-sdk/svelte';
+import { toast } from 'svelte-sonner';
+
+import { flowCreationStore } from '/@/lib/flows/flowCreationStore';
+import { handleNavigation } from '/@/navigation';
+import { isGooseCliToolInstalled } from '/@/stores/goose-cli-tool';
+import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
+import { NavigationPage } from '/@api/navigation-page';
+
+import ExportIcon from './messages/ExportIcon.svelte';
+import type { ModelInfo } from './model-info';
+import { Button } from './ui/button';
+
+let {
+  selectedModel,
+  selectedMCP,
+  loading,
+  chatClient,
+}: {
+  selectedModel?: ModelInfo;
+  selectedMCP: MCPRemoteServerInfo[];
+  loading: boolean;
+  chatClient: Chat;
+} = $props();
+
+let loadingExportAsFlow = $state(false);
+
+const exportAsFlow = async (): Promise<void> => {
+  if (!selectedModel) {
+    toast.error(`There's no selected model to export as a flow.`);
+    return;
+  }
+
+  loadingExportAsFlow = true;
+
+  try {
+    const prompt = await window.inferenceGenerate(
+      selectedModel.providerId,
+      selectedModel.connectionName,
+      selectedModel.label,
+      selectedMCP.map(m => m.id),
+      $state.snapshot(chatClient.messages).concat([
+        {
+          id: crypto.randomUUID(),
+          role: 'user',
+          parts: [
+            {
+              text: 'Use the conversation to make a unique prompt, only return the prompt it will be executed automatically.',
+              type: 'text',
+            },
+          ],
+        },
+      ]),
+    );
+
+    flowCreationStore.set({
+      prompt,
+      model: selectedModel,
+      mcp: selectedMCP,
+    });
+
+    handleNavigation({ page: NavigationPage.FLOW_CREATE });
+  } catch (e) {
+    console.error(e);
+  } finally {
+    loadingExportAsFlow = false;
+  }
+};
+</script>
+
+<Button
+	class="h-fit rounded-md p-[7px] hover:bg-zinc-200 dark:border-zinc-700 hover:dark:bg-zinc-900"
+	onclick={async(event): Promise<void> => {
+		event.preventDefault();
+		await exportAsFlow();
+	}}
+	disabled={loading || !chatClient.messages.length || loadingExportAsFlow}
+	variant="ghost"
+	title={$isGooseCliToolInstalled? 'Export as Flow' : 'Install flow provider to enable save.'}
+>
+	<ExportIcon size="2x"/>
+</Button>

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -102,7 +102,7 @@ const hasModels = $derived(models && models.length > 0);
                 />
                 <form class="bg-background mx-auto flex w-full gap-2 px-4 pb-4 md:max-w-3xl md:pb-6">
                     {#if !readonly}
-                        <MultimodalInput {attachments} {chatClient} {selectedMCP} bind:mcpSelectorOpen={mcpSelectorOpen} class="flex-1" />
+                        <MultimodalInput {attachments} {chatClient} {selectedModel} {selectedMCP} bind:mcpSelectorOpen={mcpSelectorOpen} class="flex-1" />
                     {/if}
                 </form>
             </div>

--- a/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
@@ -2,63 +2,32 @@
 import type { UIMessage } from '@ai-sdk/svelte';
 import type { DynamicToolUIPart } from 'ai';
 import { fly } from 'svelte/transition';
-import { toast } from 'svelte-sonner';
-import { router } from 'tinro';
 
 import { fileUIPart2Attachment } from '/@/lib/chat/utils/chat';
 import { cn } from '/@/lib/chat/utils/shadcn';
-import { flowCreationStore } from '/@/lib/flows/flowCreationStore';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
-import { isFlowConnectionAvailable } from '/@/stores/flow-provider';
+import { isGooseCliToolInstalled } from '/@/stores/goose-cli-tool';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
 import PencilEditIcon from '../icons/pencil-edit.svelte';
 import SparklesIcon from '../icons/sparkles.svelte';
 import MessageReasoning from '../message-reasoning.svelte';
-import type { ModelInfo } from '../model-info';
 import PreviewAttachment from '../preview-attachment.svelte';
 import { Button } from '../ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-import ExportIcon from './ExportIcon.svelte';
 import ToolParts from './tool-parts.svelte';
 
 let {
   message,
   readonly,
   loading,
-  selectedModel,
-  selectedMCP,
 }: {
   message: UIMessage;
   readonly: boolean;
   loading: boolean;
-  selectedModel?: ModelInfo;
-  selectedMCP: MCPRemoteServerInfo[];
 } = $props();
 
 let mode = $state<'view' | 'edit'>('view');
-
-const exportAsFlow = (): void => {
-  if (!selectedModel) {
-    toast.error(`There's no selected model to export as a flow.`);
-    return;
-  }
-
-  const prompt = message.parts?.find(p => p.type === 'text')?.text;
-
-  if (!prompt) {
-    toast.error(`There's no user message to export as a flow.`);
-    return;
-  }
-
-  flowCreationStore.set({
-    prompt,
-    model: selectedModel,
-    mcp: selectedMCP,
-  });
-
-  router.goto('/flows/create');
-};
 
 const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type === 'dynamic-tool') ?? [];
 </script>
@@ -138,20 +107,6 @@ const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type 
 							>
 								<Markdown markdown={part.text} />
 							</div>
-								{#if message.role === 'user' }
-									<Button
-										class="h-fit rounded-md p-[7px] hover:bg-zinc-200 dark:border-zinc-700 hover:dark:bg-zinc-900"
-										onclick={(event): void => {
-											event.preventDefault();
-											exportAsFlow();
-										}}
-										disabled={loading}
-										variant="ghost"
-										title={$isFlowConnectionAvailable? 'Export as Flow' : 'Install flow provider to enable save.'}
-									>
-										<ExportIcon size="2x"/>
-									</Button>
-							{/if}
 						</div>
 					{:else if mode === 'edit'}
 						<div class="flex flex-row items-start gap-2">

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -9,9 +9,11 @@ import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
 import { cn } from '/@/lib/chat/utils/shadcn';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
+import ExportButton from './ExportButton.svelte';
 import ArrowUpIcon from './icons/arrow-up.svelte';
 import PaperclipIcon from './icons/paperclip.svelte';
 import StopIcon from './icons/stop.svelte';
+import type { ModelInfo } from './model-info';
 import PreviewAttachment from './preview-attachment.svelte';
 import SuggestedActions from './suggested-actions.svelte';
 import { Button } from './ui/button';
@@ -22,12 +24,14 @@ let {
   chatClient,
   class: c,
   selectedMCP,
+  selectedModel,
   mcpSelectorOpen = $bindable(),
 }: {
   attachments: Attachment[];
   chatClient: Chat;
   class?: string;
   selectedMCP: MCPRemoteServerInfo[];
+  selectedModel?: ModelInfo;
   mcpSelectorOpen: boolean;
 } = $props();
 
@@ -169,7 +173,7 @@ $effect.pre(() => {
 		</Button>
 	</div>
 
-	<div class="absolute right-0 bottom-0 flex w-fit flex-row justify-end p-2">
+	<div class="absolute right-0 bottom-0 flex w-fit flex-row items-center justify-end p-2">
 		{#if loading}
 			<Button
 				class="h-fit rounded-full border p-1.5 dark:border-zinc-600"
@@ -193,5 +197,7 @@ $effect.pre(() => {
 				<ArrowUpIcon size={14} />
 			</Button>
 		{/if}
+
+		<ExportButton {chatClient} {selectedModel} {selectedMCP} {loading}/>
 	</div>
 </div>


### PR DESCRIPTION
Instead of creating a flow from a given user prompt, use LLM to generate a prompt from the whole conversation, and store in the flow. So it can be executed automatically.

Demo:

https://github.com/user-attachments/assets/469a7923-766e-4752-8692-7abe87413726




Fixes #268 