### PR TITLE
feat: add description of mcp server

### DIFF
--- a/packages/renderer/src/lib/mcp/MCPServerListRegistryInstall.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerListRegistryInstall.svelte
@@ -6,6 +6,7 @@ import { mcpRegistriesServerInfos } from '/@/stores/mcp-registry-servers';
 import type { MCPServerDetail } from '/@api/mcp/mcp-server-info';
 
 import McpIcon from '../images/MCPIcon.svelte';
+import { MCPServerDescriptionColumn } from './mcp-server-columns';
 import McpEmptyScreen from './MCPRegistryEmptyScreen.svelte';
 import McpServerListActions from './MCPServerRegistryListActions.svelte';
 
@@ -36,17 +37,10 @@ const nameColumn = new TableColumn<MCPServerDetail, string>('Name', {
   comparator: (a, b): number => b.name.localeCompare(a.name),
 });
 
-const descriptionColumn = new TableColumn<MCPServerDetail, string>('Description', {
-  width: '3fr',
-  renderMapping: (obj): string => obj.description,
-  renderer: SimpleColumn,
-  comparator: (a, b): number => b.description.localeCompare(a.description),
-});
-
 const columns = [
   statusColumn,
   nameColumn,
-  descriptionColumn,
+  new MCPServerDescriptionColumn(),
   new TableColumn<MCPServerDetail>('Actions', {
     align: 'right',
     renderer: McpServerListActions,

--- a/packages/renderer/src/lib/mcp/MCPServerListRemoteReady.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerListRemoteReady.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
-import SimpleColumn from '@podman-desktop/ui-svelte/TableSimpleColumn';
 
 import MCPNameColumn from '/@/lib/mcp/column/MCPNameColumn.svelte';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
 import McpIcon from '../images/MCPIcon.svelte';
+import { MCPServerDescriptionColumn } from './mcp-server-columns';
 import MCPServerEmptyScreen from './MCPServerEmptyScreen.svelte';
 import McpServerRemoteListActions from './MCPServerRemoteListActions.svelte';
 
@@ -32,20 +32,13 @@ const nameColumn = new TableColumn<MCPRemoteServerInfo>('Name', {
   comparator: (a, b): number => b.name.localeCompare(a.name),
 });
 
-const descriptionColumn = new TableColumn<MCPRemoteServerInfo, string>('Description', {
-  width: '3fr',
-  renderMapping: (obj): string => obj.description,
-  renderer: SimpleColumn,
-  comparator: (a, b): number => b.description.localeCompare(a.description),
-});
-
 const actionsColumn = new TableColumn<MCPRemoteServerInfo>('Actions', {
   align: 'right',
   renderer: McpServerRemoteListActions,
   overflow: true,
 });
 
-const columns = [statusColumn, nameColumn, descriptionColumn, actionsColumn];
+const columns = [statusColumn, nameColumn, new MCPServerDescriptionColumn(), actionsColumn];
 
 const row = new TableRow<MCPRemoteServerInfo>({});
 </script>

--- a/packages/renderer/src/lib/mcp/mcp-server-columns.ts
+++ b/packages/renderer/src/lib/mcp/mcp-server-columns.ts
@@ -1,0 +1,31 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { TableColumn } from '@podman-desktop/ui-svelte';
+import SimpleColumn from '@podman-desktop/ui-svelte/TableSimpleColumn';
+
+export class MCPServerDescriptionColumn extends TableColumn<{ description: string }, string> {
+  constructor() {
+    super('Description', {
+      width: '3fr',
+      renderMapping: (mcpServerDetail): string => mcpServerDetail.description,
+      renderer: SimpleColumn,
+      comparator: (a, b): number => b.description.localeCompare(a.description),
+    });
+  }
+}


### PR DESCRIPTION
when listing mcp servers from the official mcp registry the id is not meaningful. Having the description helps.

depends on:
- [x] https://github.com/kortex-hub/kortex/pull/374

Signed-off-by: Florent Benoit <fbenoit@redhat.com>