### PR TITLE
fix: avoid svelte-check error

### DIFF
--- a/packages/renderer/src/lib/flows/FlowActions.svelte
+++ b/packages/renderer/src/lib/flows/FlowActions.svelte
@@ -11,7 +11,7 @@ import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 
 interface Props {
   object: FlowInfo;
-  onLocalRun: (flowExecuteId: string) => void;
+  onLocalRun?: (flowExecuteId: string) => void;
 }
 
 const { object, onLocalRun }: Props = $props();
@@ -33,7 +33,8 @@ async function executeFlow(): Promise<void> {
   // execute the flow
   const flow = { providerId: object.providerId, connectionName: object.connectionName, flowId: object.id };
   const taskId: string = await window.flowExecute(flow);
-  onLocalRun(taskId);
+  // execute callback if any
+  onLocalRun?.(taskId);
 
   // redirect to the run tab
   navigateToRunFlow();


### PR DESCRIPTION
before: if you click on the run icon from Flow list, it starts the flow but you're not redirected to the flow's run tab and you see an error in the console
after:
you can click, you're redirected and no error in the console

Signed-off-by: Florent Benoit <fbenoit@redhat.com>