### PR TITLE
chore: use extension name as the same name of the folder

### DIFF
--- a/extensions/openai-compatible/package.json
+++ b/extensions/openai-compatible/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openai",
+  "name": "openai-compatible",
   "displayName": "OpenAI Compatible",
   "description": "Integration for Open AI",
   "version": "0.0.1-next",


### PR DESCRIPTION
it needs to be the same in extensions