### PR TITLE
feat(backend: mcp): support spawn local mcp

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "packages/main/dist/index.cjs",
   "scripts": {
-    "build": "pnpm run build:main && pnpm run build:mcp-setup && pnpm run build:preload && pnpm run build:preload-webview && npm run build:preload:types && pnpm run build:renderer && pnpm run build:extensions",
+    "build": "pnpm run build:mcp-setup && pnpm run build:main && pnpm run build:preload && pnpm run build:preload-webview && npm run build:preload:types && pnpm run build:renderer && pnpm run build:extensions",
     "build:main": "cd ./packages/main && vite build",
     "build:extensions": "pnpm run build:extensions:gemini && pnpm run build:extensions:goose && pnpm run build:extensions:mcp-registries && pnpm run build:extensions:openai-compatible && pnpm run build:extensions:openshift-ai",
     "build:extensions:gemini": "cd ./extensions/gemini && pnpm run build",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint:check": "node --max-old-space-size=8192 node_modules/eslint/bin/eslint.js --cache . --cache-strategy content",
     "svelte:check": "svelte-check --ignore \"packages/ui/dist,packages/renderer/src/lib/ui/DetailsPage.svelte,packages/renderer/src/lib/ui/EngineFormPage.svelte,packages/renderer/src/lib/ui/FormPage.svelte,storybook\"",
     "typecheck:extension-api": "tsc --noEmit -p packages/extension-api/tsconfig.json",
-    "typecheck:main": "tsc --noEmit -p packages/main/tsconfig.json",
+    "typecheck:main": "pnpm run build:mcp-setup && tsc --noEmit -p packages/main/tsconfig.json",
     "typecheck:preload": "tsc --noEmit -p packages/preload/tsconfig.json",
     "typecheck:preload-webview": "tsc --noEmit -p packages/preload-webview/tsconfig.json",
     "typecheck:renderer": "pnpm run build:preload:types && tsc --noEmit -p packages/renderer/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "packages/main/dist/index.cjs",
   "scripts": {
-    "build": "pnpm run build:main && pnpm run build:preload && pnpm run build:preload-webview && npm run build:preload:types && pnpm run build:renderer && pnpm run build:extensions",
+    "build": "pnpm run build:main && pnpm run build:mcp-setup && pnpm run build:preload && pnpm run build:preload-webview && npm run build:preload:types && pnpm run build:renderer && pnpm run build:extensions",
     "build:main": "cd ./packages/main && vite build",
     "build:extensions": "pnpm run build:extensions:gemini && pnpm run build:extensions:goose && pnpm run build:extensions:mcp-registries && pnpm run build:extensions:openai-compatible && pnpm run build:extensions:openshift-ai",
     "build:extensions:gemini": "cd ./extensions/gemini && pnpm run build",
@@ -23,6 +23,7 @@
     "build:extensions:openshift-ai": "cd ./extensions/openshift-ai && pnpm run build",
     "build:extension-api": "cd ./packages/extension-api && vite build",
     "build:preload": "cd ./packages/preload && vite build",
+    "build:mcp-setup": "cd ./packages/mcp-setup && vite build",
     "build:preload-webview": "cd ./packages/preload-webview && vite build",
     "build:preload:types": "dts-cb -i \"packages/preload/tsconfig.json\" -o \"packages/preload/exposedInMainWorld.d.ts\" && dts-cb -i \"packages/preload-webview/tsconfig.json\" -o \"packages/preload-webview/exposedInWebview.d.ts\"",
     "build:renderer": "cross-env NODE_OPTIONS=--max-old-space-size=4096 vite -c packages/renderer/vite.config.js build",
@@ -35,6 +36,7 @@
     "test:unit:coverage": "pnpm run test:unit --coverage",
     "test:main": "vitest --run --project=main --passWithNoTests",
     "test:preload": "vitest --run --project=preload --passWithNoTests",
+    "test:mcp-setup": "vitest --run --project=mcp-setup --passWithNoTests",
     "test:preload-webview": "vitest --run --project=preload-webview",
     "test:extensions": "vitest --run --project=extensions --passWithNoTests",
     "test:renderer": "pnpm run build:preload:types && vitest --run --project=renderer --passWithNoTests",
@@ -134,6 +136,7 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
+    "mcp-setup": "workspace:*",
     "@docker/extension-api-client-types": "0.4.2",
     "@kubernetes/client-node": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.18.1",

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -219,16 +219,16 @@ export class MCPRegistry {
 
           // client already exists ?
           const existingServers = await this.mcpManager.listMCPRemoteServers();
-          const existing = existingServers.find(srv => srv.id.includes(server.id ?? 'unknown'));
+          const existing = existingServers.find(srv => srv.id.includes(server.serverId ?? 'unknown'));
           if (existing) {
-            console.log(`[MCPRegistry] MCP client for server ${server.id} already exists, skipping`);
+            console.log(`[MCPRegistry] MCP client for server ${server.serverId} already exists, skipping`);
             continue;
           }
 
           const transport = await this.setupPackage(pack, config);
           await this.mcpManager.registerMCPClient(
             INTERNAL_PROVIDER_ID,
-            server.id,
+            server.serverId,
             'package',
             config.packageId,
             server.name,
@@ -384,7 +384,7 @@ export class MCPRegistry {
       case 'package':
         config = {
           packageId: options.index,
-          serverId: serverDetail.id,
+          serverId: serverDetail.serverId,
           runtimeArguments: Object.fromEntries(
             Object.entries(options.runtimeArguments).map(([key, response]) => [key, this.format(response)]),
           ),
@@ -457,17 +457,17 @@ export class MCPRegistry {
 
     const resolved: components['schemas']['Package'] = {
       ...pack,
-      runtime_arguments: (pack.runtime_arguments ?? []).map((argument, index) => ({
+      runtimeArguments: (pack.runtimeArguments ?? []).map((argument, index) => ({
         ...argument,
         value: config.runtimeArguments[index],
         variables: undefined,
       })),
-      package_arguments: (pack.package_arguments ?? []).map((argument, index) => ({
+      packageArguments: (pack.packageArguments ?? []).map((argument, index) => ({
         ...argument,
         value: config.packageArguments[index],
         variables: undefined,
       })),
-      environment_variables: (pack.environment_variables ?? []).map(argument => ({
+      environmentVariables: (pack.environmentVariables ?? []).map(argument => ({
         ...argument,
         value: config.environmentVariables[argument.name],
         variables: undefined,

--- a/packages/mcp-setup/package.json
+++ b/packages/mcp-setup/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "mcp-setup",
+  "version": "0.0.1",
+  "description": "Logic to setup and configure MCP Server - Local and Remote",
+  "repository": "https://github.com/kortex-hub/kortex",
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "test": "vitest run --coverage --passWithNoTests",
+    "build": "vite build",
+    "watch": "vite build --watch"
+  },
+  "devDependencies": {
+    "vite": "^7.1.2",
+    "vitest": "^3.2.4",
+    "ai": "^5.0.11",
+    "vite-plugin-dts": "^4.5.4",
+    "mcp-registry": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.17.1"
+  }
+}

--- a/packages/mcp-setup/src/index.ts
+++ b/packages/mcp-setup/src/index.ts
@@ -16,26 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface InputResponse {
-  value: string;
-}
+import type { MCPSpawner } from './spawner/mcp-spawner';
+import { getMCPSpawner } from './spawner/utils';
 
-export interface InputWithVariableResponse extends InputResponse {
-  variables: Record<string, InputResponse>;
-}
-
-export interface MCPSetupRemoteOptions {
-  type: 'remote';
-  index: number;
-  headers: Record<string, InputWithVariableResponse>;
-}
-
-export interface MCPSetupPackageOptions {
-  type: 'package';
-  index: number;
-  packageArguments: Record<number, InputWithVariableResponse>;
-  runtimeArguments: Record<number, InputWithVariableResponse>;
-  environmentVariables: Record<string, InputWithVariableResponse>;
-}
-
-export type MCPSetupOptions = MCPSetupRemoteOptions | MCPSetupPackageOptions;
+export { getMCPSpawner, type MCPSpawner };

--- a/packages/mcp-setup/src/spawner/mcp-spawner.spec.ts
+++ b/packages/mcp-setup/src/spawner/mcp-spawner.spec.ts
@@ -21,10 +21,10 @@ import { beforeEach, describe, expect, test } from 'vitest';
 
 import { MCPSpawner } from './mcp-spawner';
 
-type MockPack = components['schemas']['Package'] & { registry_type: 'mock' };
+type MockPack = components['schemas']['Package'] & { registryType: 'mock' };
 
 const PACKAGE_MOCK = {
-  registry_type: 'mock',
+  registryType: 'mock',
 } as MockPack;
 
 class McpSpawnerMock extends MCPSpawner<'mock'> {
@@ -73,9 +73,9 @@ describe('MCPSpawner#formatInputWithVariables', () => {
       name: 'input with no variable',
       input: {
         value: '--foo',
-        is_required: true,
+        isRequired: true,
         format: 'string',
-        is_secret: false,
+        isSecret: false,
       },
       expected: '--foo',
     },
@@ -83,15 +83,15 @@ describe('MCPSpawner#formatInputWithVariables', () => {
       name: 'input with one variable containing default',
       input: {
         value: '--foo={bar}',
-        is_required: true,
+        isRequired: true,
         format: 'string',
-        is_secret: false,
+        isSecret: false,
         variables: {
           bar: {
-            is_secret: false,
+            isSecret: false,
             default: 'bar',
             format: 'string',
-            is_required: true,
+            isRequired: true,
           },
         },
       },
@@ -101,15 +101,15 @@ describe('MCPSpawner#formatInputWithVariables', () => {
       name: 'input with one variable containing value and default',
       input: {
         value: '--foo={bar}',
-        is_required: true,
+        isRequired: true,
         format: 'string',
-        is_secret: false,
+        isSecret: false,
         variables: {
           bar: {
-            is_secret: false,
+            isSecret: false,
             default: 'bar',
             format: 'string',
-            is_required: true,
+            isRequired: true,
             value: 'potatoes',
           },
         },
@@ -120,21 +120,21 @@ describe('MCPSpawner#formatInputWithVariables', () => {
       name: 'input with two variables',
       input: {
         value: '--foo={foo},--bar={bar}',
-        is_required: true,
+        isRequired: true,
         format: 'string',
-        is_secret: false,
+        isSecret: false,
         variables: {
           foo: {
-            is_secret: false,
+            isSecret: false,
             default: 'foo',
             format: 'string',
-            is_required: true,
+            isRequired: true,
           },
           bar: {
-            is_secret: false,
+            isSecret: false,
             default: 'bar',
             format: 'string',
-            is_required: true,
+            isRequired: true,
           },
         },
       },
@@ -164,8 +164,8 @@ describe('MCPSpawner#getEnvironments', () => {
       envs: [
         {
           name: 'FOO',
-          is_required: true,
-          is_secret: true,
+          isRequired: true,
+          isSecret: true,
           format: 'string',
           value: 'BAR',
         },
@@ -176,7 +176,7 @@ describe('MCPSpawner#getEnvironments', () => {
     },
   ])('$name', ({ envs, expected }) => {
     const spawner = new McpSpawnerMock({
-      environment_variables: envs,
+      environmentVariables: envs,
     });
     const result = spawner.getEnvironments();
     expect(result).toStrictEqual(expected);

--- a/packages/mcp-setup/src/spawner/mcp-spawner.spec.ts
+++ b/packages/mcp-setup/src/spawner/mcp-spawner.spec.ts
@@ -1,0 +1,184 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { components } from 'mcp-registry';
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { MCPSpawner } from './mcp-spawner';
+
+type MockPack = components['schemas']['Package'] & { registry_type: 'mock' };
+
+const PACKAGE_MOCK = {
+  registry_type: 'mock',
+} as MockPack;
+
+class McpSpawnerMock extends MCPSpawner<'mock'> {
+  constructor(pack?: Partial<MockPack>) {
+    super({
+      ...PACKAGE_MOCK,
+      ...pack,
+    });
+  }
+
+  [Symbol.asyncDispose](): PromiseLike<void> {
+    throw new Error('not implemented');
+  }
+
+  spawn(): Promise<Transport> {
+    throw new Error('not implemented');
+  }
+  enabled(): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+
+  public override formatInputWithVariables(input: components['schemas']['InputWithVariables']): string {
+    return super.formatInputWithVariables(input);
+  }
+
+  public override getEnvironments(): Record<string, string> {
+    return super.getEnvironments();
+  }
+}
+
+interface FormatInputWithVariablesTestCase {
+  name: string;
+  input: components['schemas']['InputWithVariables'];
+  expected: string;
+}
+
+describe('MCPSpawner#formatInputWithVariables', () => {
+  let spawner: McpSpawnerMock;
+
+  beforeEach(() => {
+    spawner = new McpSpawnerMock();
+  });
+
+  test.each<FormatInputWithVariablesTestCase>([
+    {
+      name: 'input with no variable',
+      input: {
+        value: '--foo',
+        is_required: true,
+        format: 'string',
+        is_secret: false,
+      },
+      expected: '--foo',
+    },
+    {
+      name: 'input with one variable containing default',
+      input: {
+        value: '--foo={bar}',
+        is_required: true,
+        format: 'string',
+        is_secret: false,
+        variables: {
+          bar: {
+            is_secret: false,
+            default: 'bar',
+            format: 'string',
+            is_required: true,
+          },
+        },
+      },
+      expected: '--foo=bar',
+    },
+    {
+      name: 'input with one variable containing value and default',
+      input: {
+        value: '--foo={bar}',
+        is_required: true,
+        format: 'string',
+        is_secret: false,
+        variables: {
+          bar: {
+            is_secret: false,
+            default: 'bar',
+            format: 'string',
+            is_required: true,
+            value: 'potatoes',
+          },
+        },
+      },
+      expected: '--foo=potatoes',
+    },
+    {
+      name: 'input with two variables',
+      input: {
+        value: '--foo={foo},--bar={bar}',
+        is_required: true,
+        format: 'string',
+        is_secret: false,
+        variables: {
+          foo: {
+            is_secret: false,
+            default: 'foo',
+            format: 'string',
+            is_required: true,
+          },
+          bar: {
+            is_secret: false,
+            default: 'bar',
+            format: 'string',
+            is_required: true,
+          },
+        },
+      },
+      expected: '--foo=foo,--bar=bar',
+    },
+  ])('$name', ({ input, expected }) => {
+    const formatted = spawner.formatInputWithVariables(input);
+    expect(formatted).toEqual(expected);
+  });
+});
+
+interface GetEnvironmentsTestCase {
+  name: string;
+  envs?: components['schemas']['KeyValueInput'][];
+  expected: Record<string, string>;
+}
+
+describe('MCPSpawner#getEnvironments', () => {
+  test.each<GetEnvironmentsTestCase>([
+    {
+      name: 'empty env array',
+      envs: [],
+      expected: {},
+    },
+    {
+      name: 'simple single env with provided value',
+      envs: [
+        {
+          name: 'FOO',
+          is_required: true,
+          is_secret: true,
+          format: 'string',
+          value: 'BAR',
+        },
+      ],
+      expected: {
+        FOO: 'BAR',
+      },
+    },
+  ])('$name', ({ envs, expected }) => {
+    const spawner = new McpSpawnerMock({
+      environment_variables: envs,
+    });
+    const result = spawner.getEnvironments();
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/packages/mcp-setup/src/spawner/mcp-spawner.ts
+++ b/packages/mcp-setup/src/spawner/mcp-spawner.ts
@@ -19,7 +19,7 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { components } from 'mcp-registry';
 
 export abstract class MCPSpawner<T extends string = string> implements AsyncDisposable {
-  constructor(protected readonly pack: components['schemas']['Package'] & { registry_type: T }) {}
+  constructor(protected readonly pack: components['schemas']['Package'] & { registryType: T }) {}
 
   abstract spawn(): Promise<Transport>;
   abstract [Symbol.asyncDispose](): PromiseLike<void>;
@@ -30,7 +30,7 @@ export abstract class MCPSpawner<T extends string = string> implements AsyncDisp
   ): string {
     const value = argument.value ?? argument.default;
 
-    if (argument.is_required && !value) {
+    if (argument.isRequired && !value) {
       throw new Error(
         `argument '${argument.description}' does not have a default value: user input is not yet supported`,
       );
@@ -53,7 +53,7 @@ export abstract class MCPSpawner<T extends string = string> implements AsyncDisp
 
     for (const [key, content] of Object.entries(input.variables ?? {})) {
       const value = content.value ?? content.default;
-      if (content.is_required && !value)
+      if (content.isRequired && !value)
         throw new Error(`cannot format input with required variable ${key} without any value or default`);
 
       if (value !== undefined) {
@@ -64,7 +64,7 @@ export abstract class MCPSpawner<T extends string = string> implements AsyncDisp
   }
 
   protected getEnvironments(): Record<string, string> {
-    return (this.pack.environment_variables ?? []).reduce(
+    return (this.pack.environmentVariables ?? []).reduce(
       (accumulator, current) => {
         accumulator[current.name] = this.formatInputWithVariables(current);
         return accumulator;

--- a/packages/mcp-setup/src/spawner/mcp-spawner.ts
+++ b/packages/mcp-setup/src/spawner/mcp-spawner.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { components } from 'mcp-registry';
+
+export abstract class MCPSpawner<T extends string = string> implements AsyncDisposable {
+  constructor(protected readonly pack: components['schemas']['Package'] & { registry_type: T }) {}
+
+  abstract spawn(): Promise<Transport>;
+  abstract [Symbol.asyncDispose](): PromiseLike<void>;
+  abstract enabled(): Promise<boolean>;
+
+  protected getArgument(
+    argument: components['schemas']['PositionalArgument'] | components['schemas']['NamedArgument'],
+  ): string {
+    const value = argument.value ?? argument.default;
+
+    if (argument.is_required && !value) {
+      throw new Error(
+        `argument '${argument.description}' does not have a default value: user input is not yet supported`,
+      );
+    }
+
+    // dealing with named argument
+    if ('type' in argument && argument['type'] === 'named') {
+      return `${argument.name}=${value}`;
+    } else {
+      return `${value}`;
+    }
+  }
+
+  protected formatInputWithVariables(input: components['schemas']['InputWithVariables']): string {
+    if (!input.value) {
+      throw new Error('missing value for input');
+    }
+
+    let template = input.value;
+
+    for (const [key, content] of Object.entries(input.variables ?? {})) {
+      const value = content.value ?? content.default;
+      if (content.is_required && !value)
+        throw new Error(`cannot format input with required variable ${key} without any value or default`);
+
+      if (value !== undefined) {
+        template = template.replace(`{${key}}`, value);
+      }
+    }
+    return template;
+  }
+
+  protected getEnvironments(): Record<string, string> {
+    return (this.pack.environment_variables ?? []).reduce(
+      (accumulator, current) => {
+        accumulator[current.name] = this.formatInputWithVariables(current);
+        return accumulator;
+      },
+      {} as Record<string, string>,
+    );
+  }
+}

--- a/packages/mcp-setup/src/spawner/npm-spawner.spec.ts
+++ b/packages/mcp-setup/src/spawner/npm-spawner.spec.ts
@@ -1,0 +1,104 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { experimental_createMCPClient } from 'ai';
+import { assert, expect, onTestFinished, test } from 'vitest';
+
+import { NPMSpawner } from './npm-spawner';
+
+const DUMMY_FILENAME = 'hello.txt';
+const DUMMY_CONTENT = 'Hello World';
+
+test('enabled', async () => {
+  const spawner = new NPMSpawner({
+    registry_type: 'npm',
+    identifier: 'dummy',
+    version: 'fake',
+    runtime_arguments: [],
+    package_arguments: [],
+  });
+  const enabled = await spawner.enabled();
+  expect(enabled).toBeTruthy();
+});
+
+test(
+  'integration',
+  async () => {
+    const tmp = await mkdtemp('npm-spawner');
+
+    // handle cleanup
+    onTestFinished(async () => {
+      await rm(tmp, { recursive: true });
+    });
+
+    const dummyFile = join(tmp, DUMMY_FILENAME);
+    await writeFile(dummyFile, DUMMY_CONTENT);
+
+    const npmSpawner = new NPMSpawner({
+      registry_type: 'npm',
+      identifier: '@modelcontextprotocol/server-filesystem',
+      version: '2025.8.21',
+      runtime_arguments: [
+        {
+          name: '--yes',
+          type: 'named',
+          format: 'boolean',
+          default: 'true',
+          is_required: true,
+          is_secret: false,
+        },
+      ],
+      package_arguments: [
+        {
+          is_required: true,
+          default: tmp,
+          is_secret: false,
+          format: 'filepath',
+        },
+      ],
+    });
+    const transport = await npmSpawner.spawn();
+
+    const client = await experimental_createMCPClient({ transport: transport });
+    const tools = await client.tools();
+    assert('read_text_file' in tools, 'tools should contain read_text_file method');
+
+    const res = await tools['read_text_file'].execute(
+      {
+        path: dummyFile,
+      },
+      {
+        messages: [],
+        toolCallId: '06',
+      },
+    );
+    assert('content' in res);
+    assert(Array.isArray(res.content));
+
+    console.log(res);
+    expect(res.content).toHaveLength(1);
+    expect(res.content[0].isError).toBeFalsy();
+    expect(res.content[0].text).toBe(DUMMY_CONTENT);
+  },
+  {
+    skip: true, // do not run
+  },
+);

--- a/packages/mcp-setup/src/spawner/npm-spawner.spec.ts
+++ b/packages/mcp-setup/src/spawner/npm-spawner.spec.ts
@@ -29,11 +29,11 @@ const DUMMY_CONTENT = 'Hello World';
 
 test('enabled', async () => {
   const spawner = new NPMSpawner({
-    registry_type: 'npm',
+    registryType: 'npm',
     identifier: 'dummy',
     version: 'fake',
-    runtime_arguments: [],
-    package_arguments: [],
+    runtimeArguments: [],
+    packageArguments: [],
   });
   const enabled = await spawner.enabled();
   expect(enabled).toBeTruthy();
@@ -53,24 +53,24 @@ test(
     await writeFile(dummyFile, DUMMY_CONTENT);
 
     const npmSpawner = new NPMSpawner({
-      registry_type: 'npm',
+      registryType: 'npm',
       identifier: '@modelcontextprotocol/server-filesystem',
       version: '2025.8.21',
-      runtime_arguments: [
+      runtimeArguments: [
         {
           name: '--yes',
           type: 'named',
           format: 'boolean',
           default: 'true',
-          is_required: true,
-          is_secret: false,
+          isRequired: true,
+          isSecret: false,
         },
       ],
-      package_arguments: [
+      packageArguments: [
         {
-          is_required: true,
+          isRequired: true,
           default: tmp,
-          is_secret: false,
+          isSecret: false,
           format: 'filepath',
         },
       ],

--- a/packages/mcp-setup/src/spawner/npm-spawner.ts
+++ b/packages/mcp-setup/src/spawner/npm-spawner.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { exec } from 'node:child_process';
+
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+
+import { MCPSpawner } from './mcp-spawner';
+
+const NPX_COMMAND = 'npx';
+
+export class NPMSpawner extends MCPSpawner<'npm'> {
+  #disposables: Array<AsyncDisposable> = [];
+
+  async spawn(): Promise<Transport> {
+    if (!this.pack.identifier) throw new Error('missing identifier in MCP Local Server configuration');
+    if (this.pack.file_sha256) {
+      console.warn('specified file sha256 is not supported with npx spawner');
+    }
+
+    // build arguments
+    const RUNTIME_ARGS: Array<string> = (this.pack.runtime_arguments ?? []).map(this.getArgument.bind(this));
+    const PACKAGE_ARGS: Array<string> = (this.pack.package_arguments ?? []).map(this.getArgument.bind(this));
+
+    // let's use package@version if version is specified
+    const identifier = this.pack.version ? `${this.pack.identifier}@${this.pack.version}` : this.pack.identifier;
+
+    // environments variables
+    const ENVIRONMENTS = this.getEnvironments();
+
+    const transport = new StdioClientTransport({
+      command: NPX_COMMAND,
+      args: [...RUNTIME_ARGS, identifier, ...PACKAGE_ARGS],
+      env: ENVIRONMENTS,
+    });
+    this.#disposables.push({
+      [Symbol.asyncDispose]: () => {
+        return transport.close();
+      },
+    });
+    return transport;
+  }
+
+  async enabled(): Promise<boolean> {
+    const { promise, resolve } = Promise.withResolvers<boolean>();
+
+    // eslint-disable-next-line sonarjs/os-command
+    exec(`${NPX_COMMAND} --version`, error => {
+      if (!error) {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    });
+
+    return promise;
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await Promise.allSettled(this.#disposables.map(disposable => disposable[Symbol.asyncDispose]()));
+  }
+}

--- a/packages/mcp-setup/src/spawner/npm-spawner.ts
+++ b/packages/mcp-setup/src/spawner/npm-spawner.ts
@@ -29,13 +29,13 @@ export class NPMSpawner extends MCPSpawner<'npm'> {
 
   async spawn(): Promise<Transport> {
     if (!this.pack.identifier) throw new Error('missing identifier in MCP Local Server configuration');
-    if (this.pack.file_sha256) {
+    if (this.pack.fileSha256) {
       console.warn('specified file sha256 is not supported with npx spawner');
     }
 
     // build arguments
-    const RUNTIME_ARGS: Array<string> = (this.pack.runtime_arguments ?? []).map(this.getArgument.bind(this));
-    const PACKAGE_ARGS: Array<string> = (this.pack.package_arguments ?? []).map(this.getArgument.bind(this));
+    const RUNTIME_ARGS: Array<string> = (this.pack.runtimeArguments ?? []).map(this.getArgument.bind(this));
+    const PACKAGE_ARGS: Array<string> = (this.pack.packageArguments ?? []).map(this.getArgument.bind(this));
 
     // let's use package@version if version is specified
     const identifier = this.pack.version ? `${this.pack.identifier}@${this.pack.version}` : this.pack.identifier;

--- a/packages/mcp-setup/src/spawner/utils.ts
+++ b/packages/mcp-setup/src/spawner/utils.ts
@@ -26,16 +26,16 @@ import { NPMSpawner } from './npm-spawner';
  * @param registry_type
  * @param rest
  */
-export function getMCPSpawner({ registry_type, ...rest }: components['schemas']['Package']): MCPSpawner {
-  if (!registry_type) throw new Error('cannot determine how to spawn package: registry_type is missing');
+export function getMCPSpawner({ registryType, ...rest }: components['schemas']['Package']): MCPSpawner {
+  if (!registryType) throw new Error('cannot determine how to spawn package: registry_type is missing');
 
-  switch (registry_type) {
+  switch (registryType) {
     case 'npm':
       return new NPMSpawner({
-        registry_type,
+        registryType,
         ...rest,
       });
     default:
-      throw new Error(`unsupported registry type: ${registry_type}`);
+      throw new Error(`unsupported registry type: ${registryType}`);
   }
 }

--- a/packages/mcp-setup/src/spawner/utils.ts
+++ b/packages/mcp-setup/src/spawner/utils.ts
@@ -15,27 +15,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { components } from 'mcp-registry';
 
-export interface InputResponse {
-  value: string;
+import type { MCPSpawner } from './mcp-spawner';
+import { NPMSpawner } from './npm-spawner';
+
+/**
+ * @private By destructuring `registry_type` and reconstructing the object, TypeScript can properly infer the narrowed type in each switch case.
+ *
+ * @param registry_type
+ * @param rest
+ */
+export function getMCPSpawner({ registry_type, ...rest }: components['schemas']['Package']): MCPSpawner {
+  if (!registry_type) throw new Error('cannot determine how to spawn package: registry_type is missing');
+
+  switch (registry_type) {
+    case 'npm':
+      return new NPMSpawner({
+        registry_type,
+        ...rest,
+      });
+    default:
+      throw new Error(`unsupported registry type: ${registry_type}`);
+  }
 }
-
-export interface InputWithVariableResponse extends InputResponse {
-  variables: Record<string, InputResponse>;
-}
-
-export interface MCPSetupRemoteOptions {
-  type: 'remote';
-  index: number;
-  headers: Record<string, InputWithVariableResponse>;
-}
-
-export interface MCPSetupPackageOptions {
-  type: 'package';
-  index: number;
-  packageArguments: Record<number, InputWithVariableResponse>;
-  runtimeArguments: Record<number, InputWithVariableResponse>;
-  environmentVariables: Record<string, InputWithVariableResponse>;
-}
-
-export type MCPSetupOptions = MCPSetupRemoteOptions | MCPSetupPackageOptions;

--- a/packages/mcp-setup/tsconfig.json
+++ b/packages/mcp-setup/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
+    "module": "nodenext",
+    "target": "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/mcp-setup/vite.config.js
+++ b/packages/mcp-setup/vite.config.js
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/* eslint-env node */
+import { join } from 'path';
+import { defineConfig } from 'vite';
+import { builtinModules } from 'module';
+import dts from 'vite-plugin-dts';
+
+const PACKAGE_ROOT = __dirname;
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  mode: process.env.MODE,
+  root: PACKAGE_ROOT,
+  resolve: {
+    alias: {
+      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+    },
+  },
+  plugins: [dts()],
+  build: {
+    target: 'esnext',
+    minify: false,
+    sourcemap: 'inline',
+    outDir: 'dist',
+    assetsDir: '.',
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      external: builtinModules.flatMap(p => [p, `node:${p}`]),
+      output: {
+        entryFileNames: '[name].cjs',
+      },
+    },
+    emptyOutDir: true,
+    reportCompressedSize: false,
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       hpagent:
         specifier: ^1.2.0
         version: 1.2.0
+      mcp-setup:
+        specifier: workspace:*
+        version: link:packages/mcp-setup
       mime-types:
         specifier: ^3.0.1
         version: 3.0.1
@@ -484,6 +487,27 @@ importers:
         specifier: ^7.8.0
         version: 7.9.1(typescript@5.9.2)
 
+  packages/mcp-setup:
+    devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.17.1
+        version: 1.18.1
+      ai:
+        specifier: ^5.0.11
+        version: 5.0.51(zod@3.25.76)
+      mcp-registry:
+        specifier: workspace:*
+        version: link:../mcp-registry
+      vite:
+        specifier: ^7.1.2
+        version: 7.1.2(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.1)
+      vite-plugin-dts:
+        specifier: ^4.5.4
+        version: 4.5.4(@types/node@24.1.0)(rollup@4.46.2)(typescript@5.9.2)(vite@7.1.2(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.1.0)(typescript@5.9.2))(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.1)
+
   packages/preload-webview:
     devDependencies:
       '@podman-desktop/webview-api':
@@ -684,12 +708,6 @@ packages:
   '@adobe/css-tools@4.4.3':
     resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
 
-  '@ai-sdk/gateway@1.0.26':
-    resolution: {integrity: sha512-AfTkubvvHU+soI5IdIpPvXgdnNy56Kt//vBJxYNQ0eGwlVhSQ/SkCVMdQxcVDvdTvlEO46MHKuPaZnQnT5Zgxw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4
-
   '@ai-sdk/gateway@1.0.28':
     resolution: {integrity: sha512-e9RKgWVDYHsd4UkKCgKQpK+nxLSDydN18yXctzgNlmf2R7BR+HqUsTKJdZT6ArSoXBWBGhyZss0cJJnpm6YVfw==}
     engines: {node: '>=18'}
@@ -773,12 +791,21 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.28.4':
+    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.28.2':
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.1':
     resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.4':
+    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
   '@balena/dockerignore@1.0.2':
@@ -1621,6 +1648,19 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
+  '@microsoft/api-extractor-model@7.30.7':
+    resolution: {integrity: sha512-TBbmSI2/BHpfR9YhQA7nH0nqVmGgJ0xH0Ex4D99/qBDAUpnhA2oikGmdXanbw9AWWY/ExBYIpkmY8dBHdla3YQ==}
+
+  '@microsoft/api-extractor@7.52.13':
+    resolution: {integrity: sha512-K6/bBt8zZfn9yc06gNvA+/NlBGJC/iJlObpdufXHEJtqcD4Dln4ITCLZpwP3DNZ5NyBFeTkKdv596go3V72qlA==}
+    hasBin: true
+
+  '@microsoft/tsdoc-config@0.17.1':
+    resolution: {integrity: sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==}
+
+  '@microsoft/tsdoc@0.15.1':
+    resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
   '@modelcontextprotocol/sdk@1.18.1':
     resolution: {integrity: sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==}
     engines: {node: '>=18'}
@@ -2057,6 +2097,28 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@rushstack/node-core-library@5.14.0':
+    resolution: {integrity: sha512-eRong84/rwQUlATGFW3TMTYVyqL1vfW9Lf10PH+mVGfIb9HzU3h5AASNIw+axnBLjnD0n3rT5uQBwu9fvzATrg==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/rig-package@0.5.3':
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
+
+  '@rushstack/terminal@0.16.0':
+    resolution: {integrity: sha512-WEvNuKkoR1PXorr9SxO0dqFdSp1BA+xzDrIm/Bwlc5YHg2FFg6oS+uCTYjerOhFuqCW+A3vKBm6EmKWSHfgx/A==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@5.0.3':
+    resolution: {integrity: sha512-bgPhQEqLVv/2hwKLYv/XvsTWNZ9B/+X1zJ7WgQE9rO5oiLzrOZvkIW4pk13yOQBhHyjcND5qMOa6p83t+Z66iQ==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -2252,6 +2314,9 @@ packages:
 
   '@types/adm-zip@0.5.7':
     resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2798,6 +2863,35 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@volar/language-core@2.4.23':
+    resolution: {integrity: sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==}
+
+  '@volar/source-map@2.4.23':
+    resolution: {integrity: sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==}
+
+  '@volar/typescript@2.4.23':
+    resolution: {integrity: sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==}
+
+  '@vue/compiler-core@3.5.21':
+    resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
+
+  '@vue/compiler-dom@3.5.21':
+    resolution: {integrity: sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/language-core@2.2.0':
+    resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/shared@3.5.21':
+    resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
+
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
@@ -2870,17 +2964,27 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@5.0.49:
-    resolution: {integrity: sha512-7XVcmXbnAqG7waJqNcxKrzVW1Ck5fw4KhWxAyltKxnupOgFxH62ra1zEofym/KO3hPYq4aJ3/gTp1ZeLvlwLkQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4
-
   ai@5.0.51:
     resolution: {integrity: sha512-ToKW099QWUJNqePZbWGg8FSfxTxS3UN9U6yCla8rYdW0EBTDNPnpRwK1N6ER9TfV+dFtdUu+ZgKSlhQnEThriQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -2890,8 +2994,17 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
+  ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
+
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  alien-signals@0.4.14:
+    resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -3464,6 +3577,12 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
   config-file-ts@0.2.8-rc1:
     resolution: {integrity: sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==}
 
@@ -3609,6 +3728,9 @@ packages:
 
   date.js@0.3.3:
     resolution: {integrity: sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==}
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3988,6 +4110,10 @@ packages:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -4311,6 +4437,9 @@ packages:
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
+
+  exsolve@1.0.7:
+    resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
   ext-list@2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
@@ -4650,6 +4779,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -4747,6 +4880,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
 
   import-meta-resolve@4.1.0:
     resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
@@ -5059,6 +5196,9 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
@@ -5174,6 +5314,9 @@ packages:
   known-css-properties@0.37.0:
     resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
@@ -5276,6 +5419,10 @@ packages:
   listr2@9.0.1:
     resolution: {integrity: sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==}
     engines: {node: '>=20.0.0'}
+
+  local-pkg@1.1.2:
+    resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
+    engines: {node: '>=14'}
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -5707,6 +5854,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
   mode-watcher@1.1.0:
     resolution: {integrity: sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==}
     peerDependencies:
@@ -5744,6 +5894,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -6090,6 +6243,12 @@ packages:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
   playwright-core@1.54.2:
     resolution: {integrity: sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==}
     engines: {node: '>=18'}
@@ -6243,6 +6402,9 @@ packages:
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -6528,6 +6690,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.2:
@@ -6836,6 +7003,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -7149,10 +7320,18 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -7285,6 +7464,15 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-plugin-dts@4.5.4:
+    resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
+    peerDependencies:
+      typescript: '*'
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -7405,6 +7593,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -7610,12 +7801,6 @@ snapshots:
 
   '@adobe/css-tools@4.4.3': {}
 
-  '@ai-sdk/gateway@1.0.26(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
-      zod: 3.25.76
-
   '@ai-sdk/gateway@1.0.28(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -7707,9 +7892,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.1
 
+  '@babel/parser@7.28.4':
+    dependencies:
+      '@babel/types': 7.28.4
+
   '@babel/runtime@7.28.2': {}
 
   '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.28.4':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -7953,7 +8147,7 @@ snapshots:
 
   '@electron/notarize@2.5.0':
     dependencies:
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
@@ -7962,7 +8156,7 @@ snapshots:
   '@electron/osx-sign@1.3.1':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -7995,7 +8189,7 @@ snapshots:
       '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       detect-libc: 2.1.0
       fs-extra: 10.1.0
       got: 11.8.6
@@ -8014,7 +8208,7 @@ snapshots:
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       dir-compare: 4.2.0
       fs-extra: 11.3.0
       minimatch: 9.0.5
@@ -8220,7 +8414,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8537,12 +8731,47 @@ snapshots:
 
   '@malept/flatpak-bundler@0.4.0':
     dependencies:
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       fs-extra: 9.1.0
       lodash: 4.17.21
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@microsoft/api-extractor-model@7.30.7(@types/node@24.1.0)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.14.0(@types/node@24.1.0)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.52.13(@types/node@24.1.0)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.7(@types/node@24.1.0)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.14.0(@types/node@24.1.0)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.16.0(@types/node@24.1.0)
+      '@rushstack/ts-command-line': 5.0.3(@types/node@24.1.0)
+      lodash: 4.17.21
+      minimatch: 10.0.3
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/tsdoc-config@0.17.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      ajv: 8.12.0
+      jju: 1.4.0
+      resolve: 1.22.10
+
+  '@microsoft/tsdoc@0.15.1': {}
 
   '@modelcontextprotocol/sdk@1.18.1':
     dependencies:
@@ -8935,6 +9164,40 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@rushstack/node-core-library@5.14.0(@types/node@24.1.0)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@rushstack/rig-package@0.5.3':
+    dependencies:
+      resolve: 1.22.10
+      strip-json-comments: 3.1.1
+
+  '@rushstack/terminal@0.16.0(@types/node@24.1.0)':
+    dependencies:
+      '@rushstack/node-core-library': 5.14.0(@types/node@24.1.0)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 24.1.0
+
+  '@rushstack/ts-command-line@5.0.3(@types/node@24.1.0)':
+    dependencies:
+      '@rushstack/terminal': 0.16.0(@types/node@24.1.0)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@segment/analytics-core@1.8.2':
@@ -9133,6 +9396,8 @@ snapshots:
   '@types/adm-zip@0.5.7':
     dependencies:
       '@types/node': 22.17.0
+
+  '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -9448,7 +9713,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.9.2)
       '@typescript-eslint/types': 8.39.1
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -9572,7 +9837,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.9.2)
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/visitor-keys': 8.35.1
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -9843,6 +10108,51 @@ snapshots:
       loupe: 3.1.4
       tinyrainbow: 2.0.0
 
+  '@volar/language-core@2.4.23':
+    dependencies:
+      '@volar/source-map': 2.4.23
+
+  '@volar/source-map@2.4.23': {}
+
+  '@volar/typescript@2.4.23':
+    dependencies:
+      '@volar/language-core': 2.4.23
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.21':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@vue/shared': 3.5.21
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.21':
+    dependencies:
+      '@vue/compiler-core': 3.5.21
+      '@vue/shared': 3.5.21
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/language-core@2.2.0(typescript@5.9.2)':
+    dependencies:
+      '@volar/language-core': 2.4.23
+      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.21
+      alien-signals: 0.4.14
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@vue/shared@3.5.21': {}
+
   '@xmldom/xmldom@0.8.10': {}
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
@@ -9905,14 +10215,6 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@5.0.49(zod@3.25.76):
-    dependencies:
-      '@ai-sdk/gateway': 1.0.26(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
-      '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
-
   ai@5.0.51(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 1.0.28(zod@3.25.76)
@@ -9920,6 +10222,14 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
+
+  ajv-draft-04@1.0.0(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
+
+  ajv-formats@3.0.1(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -9932,12 +10242,28 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.12.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
+  ajv@8.13.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.0.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@0.4.14: {}
 
   ansi-colors@4.1.3: {}
 
@@ -10383,7 +10709,7 @@ snapshots:
 
   builder-util-runtime@9.3.2:
     dependencies:
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       sax: 1.4.1
     transitivePeerDependencies:
       - supports-color
@@ -10672,6 +10998,10 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  confbox@0.1.8: {}
+
+  confbox@0.2.2: {}
+
   config-file-ts@0.2.8-rc1:
     dependencies:
       glob: 10.4.5
@@ -10824,6 +11154,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  de-indent@1.0.2: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -10952,7 +11284,7 @@ snapshots:
 
   docker-modem@5.0.6:
     dependencies:
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.16.0
@@ -11158,6 +11490,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.2
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -11731,6 +12065,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  exsolve@1.0.7: {}
+
   ext-list@2.2.2:
     dependencies:
       mime-db: 1.54.0
@@ -12135,6 +12471,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   headers-polyfill@4.0.3: {}
 
   hosted-git-info@2.8.9: {}
@@ -12238,6 +12576,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-lazy@4.0.0: {}
 
   import-meta-resolve@4.1.0: {}
 
@@ -12520,6 +12860,8 @@ snapshots:
 
   jiti@2.4.2: {}
 
+  jju@1.4.0: {}
+
   jose@5.10.0: {}
 
   jose@6.0.11: {}
@@ -12654,6 +12996,8 @@ snapshots:
 
   known-css-properties@0.37.0: {}
 
+  kolorist@1.8.0: {}
+
   lazy-val@1.0.5: {}
 
   lazystream@1.0.1:
@@ -12745,6 +13089,12 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
+
+  local-pkg@1.1.2:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 2.3.0
+      quansync: 0.2.11
 
   locate-character@3.0.0: {}
 
@@ -13318,6 +13668,13 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
+
   mode-watcher@1.1.0(svelte@5.38.1):
     dependencies:
       runed: 0.25.0(svelte@5.38.1)
@@ -13390,6 +13747,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
     optional: true
+
+  muggle-string@0.4.1: {}
 
   mustache@4.2.0: {}
 
@@ -13721,6 +14080,18 @@ snapshots:
 
   pkce-challenge@5.0.0: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.7
+      pathe: 2.0.3
+
   playwright-core@1.54.2: {}
 
   playwright@1.54.2:
@@ -13869,6 +14240,8 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+
+  quansync@0.2.11: {}
 
   querystringify@2.2.0: {}
 
@@ -14244,6 +14617,10 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
+
   semver@7.7.2: {}
 
   send@0.19.0:
@@ -14606,7 +14983,7 @@ snapshots:
 
   sumchecker@3.0.1:
     dependencies:
-      debug: 4.4.1(supports-color@10.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14617,6 +14994,10 @@ snapshots:
       has-flag: 3.0.0
 
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -14987,7 +15368,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript@5.8.2: {}
+
   typescript@5.9.2: {}
+
+  ufo@1.6.1: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -15187,6 +15572,25 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-dts@4.5.4(@types/node@24.1.0)(rollup@4.46.2)(typescript@5.9.2)(vite@7.1.2(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.1)):
+    dependencies:
+      '@microsoft/api-extractor': 7.52.13(@types/node@24.1.0)
+      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
+      '@volar/typescript': 2.4.23
+      '@vue/language-core': 2.2.0(typescript@5.9.2)
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.17
+      typescript: 5.9.2
+    optionalDependencies:
+      vite: 7.1.2(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
 
   vite@6.3.5(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:
@@ -15393,6 +15797,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vscode-uri@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -183,6 +183,26 @@ const setupExtensionApiWatcher = name => {
   spawnProcess.on('exit', process.exit);
 };
 
+/**
+ * Watch mcp-setup package
+ */
+const setupMCPSetupWatcher = () => {
+  const spawnProcess = spawn('pnpm', ['watch'], {
+    cwd: resolve('packages', 'mcp-setup'),
+    shell: process.platform === 'win32',
+  });
+
+  spawnProcess.stdout.on('data', d => d.toString().trim() && console.warn(d.toString(), { timestamp: true }));
+  spawnProcess.stderr.on('data', d => {
+    const data = d.toString().trim();
+    if (!data) return;
+    console.error(data, { timestamp: true });
+  });
+
+  // Stops the watch script when the application has been quit
+  spawnProcess.on('exit', process.exit);
+};
+
 (async () => {
   try {
     const extensions = [];
@@ -227,6 +247,7 @@ const setupExtensionApiWatcher = name => {
     }
     await setupPreloadPackageWatcher(viteDevServer);
     await setupPreloadWebviewPackageWatcher(viteDevServer);
+    await setupMCPSetupWatcher();
     await setupMainPackageWatcher(viteDevServer);
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
## Description

_EXPERIMENTAL_

Introducing a `mcp-setup` package, we could find a better name, but the goal would be to move all the logic for connecting (remote) and spawn (local) MCP servers.

> ⚠️ the errors are pretty terrible, currently the stderr of the spawn command is piped into Kortex stderr, this should be displayed in the Ui in the future
> ⚠️ since https://github.com/kortex-hub/kortex/pull/412 is not merged, I haven't tested with persistence, IN THEORY, MCP should reboot at startup, but this is not guaranteed 

## Screenshots

> ℹ️  You can combine this PR with https://github.com/kortex-hub/kortex/pull/436 to have a nice UI and replicate the video bellow
> ⚠️  I used the registry `https://axel7083.github.io/mcp-registry-online-v1.0.0`, and only the `@modelcontextprotocol/server-filesystem` is working, no other have been tested fixed to works.

https://github.com/user-attachments/assets/499d6f02-099e-4b80-a038-775f4295f837

## Testing

- [x] unit tests for the `mcp-setup` package have been adde