### PR TITLE
fix(chat): try to provide clearer instructions how to build prompt

### DIFF
--- a/packages/renderer/src/lib/chat/components/ExportButton.svelte
+++ b/packages/renderer/src/lib/chat/components/ExportButton.svelte
@@ -47,7 +47,7 @@ const exportAsFlow = async (): Promise<void> => {
           role: 'user',
           parts: [
             {
-              text: 'Use the conversation to make a unique prompt, only return the prompt it will be executed automatically.',
+              text: `Help me to build a reproducible prompt to achieve the same result as I got in the conversation above. The prompt will be executed by another LLM without any further user input so it must contain all the information on how to get the same result.`,
               type: 'text',
             },
           ],


### PR DESCRIPTION
Trying to provide a fix for https://github.com/kortex-hub/kortex/issues/409

<img width="1203" height="913" alt="Screenshot 2025-09-26 at 11 01 02" src="https://github.com/user-attachments/assets/201a1857-38b5-4170-bf8f-c05936923b89" />
<img width="1203" height="913" alt="Screenshot 2025-09-26 at 11 00 58" src="https://github.com/user-attachments/assets/118ef431-a479-4fe6-98c0-85f253c926a6" />

the generated prompt includes instructions on how to call MCP tools:
```
        *   Call the `list_issues` tool for `owner='podman-desktop'` and `repo='podman-desktop'`.
        *   Set `perPage=5`, `orderBy='CREATED_AT'`, and `direction='DESC'` to get the most recent issues.
```
```
        *   Call the `get_file_contents` tool for `owner='podman-desktop'`, `repo='podman-desktop'`, and `path='MAINTAINERS.md'`.
```
remark: here it appears that we could call the server without the chatbot in a future workflow process.
<img width="1203" height="913" alt="Screenshot 2025-09-26 at 11 00 45" src="https://github.com/user-attachments/assets/476afcce-b31c-4ce4-88f4-1d40cd376262" />
