### PR TITLE
fix(mcp-types): update mcp types, use server name as id without registry

### DIFF
--- a/extensions/mcp-registries/src/extension.spec.ts
+++ b/extensions/mcp-registries/src/extension.spec.ts
@@ -40,7 +40,7 @@ test('activate is registering 1 registry', async () => {
   // should be called with the right parameters
   expect(vi.mocked(extensionApi.mcpRegistry.suggestRegistry)).toHaveBeenCalledWith({
     name: 'MCP Registry example',
-    url: 'https://kortex-hub.github.io/mcp-registry-online-v1.2.3',
+    url: 'https://kortex-hub.github.io/mcp-registry-online/v1.2.3/',
     icon: '/src/images/quay.io.png',
   });
 

--- a/extensions/mcp-registries/src/extension.spec.ts
+++ b/extensions/mcp-registries/src/extension.spec.ts
@@ -40,7 +40,7 @@ test('activate is registering 1 registry', async () => {
   // should be called with the right parameters
   expect(vi.mocked(extensionApi.mcpRegistry.suggestRegistry)).toHaveBeenCalledWith({
     name: 'MCP Registry example',
-    url: 'https://kortex-hub.github.io/mcp-registry-online-v1.1.0',
+    url: 'https://kortex-hub.github.io/mcp-registry-online-v1.2.3',
     icon: '/src/images/quay.io.png',
   });
 

--- a/extensions/mcp-registries/src/extension.ts
+++ b/extensions/mcp-registries/src/extension.ts
@@ -38,7 +38,7 @@ export function deactivate(): void {
 const defaultRegistries: extensionApi.RegistrySuggestedProvider[] = [
   {
     name: 'MCP Registry example',
-    url: 'https://kortex-hub.github.io/mcp-registry-online-v1.2.3',
+    url: 'https://kortex-hub.github.io/mcp-registry-online/v1.2.3/',
     icon: quayIoImage,
   },
 ];

--- a/extensions/mcp-registries/src/extension.ts
+++ b/extensions/mcp-registries/src/extension.ts
@@ -38,7 +38,7 @@ export function deactivate(): void {
 const defaultRegistries: extensionApi.RegistrySuggestedProvider[] = [
   {
     name: 'MCP Registry example',
-    url: 'https://kortex-hub.github.io/mcp-registry-online-v1.1.0',
+    url: 'https://kortex-hub.github.io/mcp-registry-online-v1.2.3',
     icon: quayIoImage,
   },
 ];

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.33.0",
     "@kortex-app/api": "workspace:",
-    "@kortex-hub/mcp-registry-types": "^1.1.0",
+    "@kortex-hub/mcp-registry-types": "^1.2.3",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/packages/renderer/src/lib/chat/components/suggested-actions.svelte
+++ b/packages/renderer/src/lib/chat/components/suggested-actions.svelte
@@ -32,7 +32,7 @@ const suggestedActions: SuggestedAction[] = [
     title: 'What are the last 5 issues of GitHub',
     label: 'repository podman-desktop/podman-desktop?',
     action: 'What are the last 5 issues of GitHub repository podman-desktop/podman-desktop?',
-    requiredMcp: ['123e4567-e89b-12d3-a456-426614172000'],
+    requiredMcp: ['com.github.mcp'],
   },
   {
     title: 'Write code to',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: 'workspace:'
         version: link:packages/extension-api
       '@kortex-hub/mcp-registry-types':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.3
+        version: 1.2.3
       '@rollup/plugin-commonjs':
         specifier: ^28.0.6
         version: 28.0.6(rollup@4.46.2)
@@ -1597,8 +1597,8 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@kortex-hub/mcp-registry-types@1.1.0':
-    resolution: {integrity: sha512-V1z/J8MXajEb/UFBYgS8QWVj4+X3KoSSSMkehziJU2j3rDkQkO7J9vfqgesze46mpuu7LJ0yFAkUcTlZ2xrY+A==}
+  '@kortex-hub/mcp-registry-types@1.2.3':
+    resolution: {integrity: sha512-vNVgNt10al3RZsIUwf3VrZl+7qeyDhoNU3VSTLS5K0caXbbuP3KZWzNBDUHZ891oHOX2glXjJSnReOuD5GO/Dw==}
 
   '@kubernetes/client-node@1.3.0':
     resolution: {integrity: sha512-IE0yrIpOT97YS5fg2QpzmPzm8Wmcdf4ueWMn+FiJSI3jgTTQT1u+LUhoYpdfhdHAVxdrNsaBg2C0UXSnOgMoCQ==}
@@ -8455,7 +8455,7 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kortex-hub/mcp-registry-types@1.1.0': {}
+  '@kortex-hub/mcp-registry-types@1.2.3': {}
 
   '@kubernetes/client-node@1.3.0(patch_hash=1c34691b2a4cf5f4fdeb73244fb59dccceee5642ddca2ac6c41fe86d9fde86e5)(encoding@0.1.13)':
     dependencies:


### PR DESCRIPTION
- Update to new spec of mcp types 1.2.3 to make it work with the registry https://registry.modelcontextprotocol.io

