### PR TITLE
feat(FlowGenerateOptions): adding `sse` type for the MCP object

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -432,7 +432,7 @@ declare module '@kortex-app/api' {
     };
     mcp: Array<{
       name: string;
-      type: 'streamable_http';
+      type: 'streamable_http' | 'sse';
       uri: string;
       headers?: {
         [key: string]: string;


### PR DESCRIPTION
## Description

Adding missing `sse` type for MCP

## Related issues

Part of https://github.com/kortex-hub/kortex/pull/483

