### PR TITLE
refactor(ipc): introduce MCPIPCHandler

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -62,6 +62,7 @@ import type {
 } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { MCPExchanges } from '/@/plugin/mcp/mcp-exchanges.js';
+import { MCPIPCHandler } from '/@/plugin/mcp/mcp-ipc-handler.js';
 import { MCPManager } from '/@/plugin/mcp/mcp-manager.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
@@ -526,6 +527,7 @@ export class PluginSystem {
     container.bind<KubeGeneratorRegistry>(KubeGeneratorRegistry).toSelf().inSingletonScope();
     container.bind<ImageRegistry>(ImageRegistry).toSelf().inSingletonScope();
     container.bind<MCPRegistry>(MCPRegistry).toSelf().inSingletonScope();
+    container.bind<MCPIPCHandler>(MCPIPCHandler).toSelf().inSingletonScope();
     container.bind<ViewRegistry>(ViewRegistry).toSelf().inSingletonScope();
     container.bind<Context>(Context).toSelf().inSingletonScope();
     container.bind<ContainerProviderRegistry>(ContainerProviderRegistry).toSelf().inSingletonScope();
@@ -782,6 +784,9 @@ export class PluginSystem {
     const imageRegistry = container.get<ImageRegistry>(ImageRegistry);
     const mcpRegistry = container.get<MCPRegistry>(MCPRegistry);
     mcpRegistry.init();
+
+    const mcpIPCHandler = container.get<MCPIPCHandler>(MCPIPCHandler);
+    mcpIPCHandler.init();
 
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 
@@ -2153,13 +2158,6 @@ export class PluginSystem {
         registryCreateOptions: containerDesktopAPI.RegistryCreateOptions,
       ): Promise<void> => {
         await imageRegistry.createRegistry(providerName, registryCreateOptions);
-      },
-    );
-
-    this.ipcHandle(
-      'mcp-registry:createMCPRegistry',
-      async (_listener, registryCreateOptions: containerDesktopAPI.MCPRegistryCreateOptions): Promise<void> => {
-        await mcpRegistry.createRegistry(registryCreateOptions);
       },
     );
 

--- a/packages/main/src/plugin/mcp/mcp-ipc-handler.ts
+++ b/packages/main/src/plugin/mcp/mcp-ipc-handler.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type containerDesktopAPI from '@kortex-app/api';
+import type { IpcMainInvokeEvent } from 'electron/main';
+import { inject, injectable } from 'inversify';
+
+import { IPCHandle } from '/@/plugin/api.js';
+import { MCPRegistry } from '/@/plugin/mcp/mcp-registry.js';
+
+@injectable()
+export class MCPIPCHandler {
+  constructor(
+    @inject(IPCHandle)
+    private readonly ipcHandle: IPCHandle,
+    @inject(MCPRegistry)
+    private readonly mcpRegistry: MCPRegistry,
+  ) {}
+
+  init(): void {
+    this.ipcHandle('mcp-registry:createMCPRegistry', this.createMCPRegistry.bind(this));
+  }
+
+  protected async createMCPRegistry(
+    _: IpcMainInvokeEvent,
+    registryCreateOptions: containerDesktopAPI.MCPRegistryCreateOptions,
+  ): Promise<void> {
+    await this.mcpRegistry.createRegistry(registryCreateOptions);
+  }
+}


### PR DESCRIPTION
## Description

Similar to https://github.com/kortex-hub/kortex/pull/381 introducing `mcp-ipc-handler` file with a dedicated `MCPIPCHandler`.

I only moved one method in this PR, because I cannot create an empty class (getting eslint errors) but each method will be moved individually to ease review.

## Related issues

Split of https://github.com/kortex-hub/kortex/pull/483