### PR TITLE
fix(chat): make prompt generation extensible to further add description, title and parameters

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1141,6 +1141,13 @@ export function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
+    'inferenceGenerateFlowParams',
+    async (params: InferenceParameters): Promise<{ prompt: string }> => {
+      return ipcInvoke('inference:generateFlowParams', params);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'createInferenceProviderConnection',
     async (
       internalProviderId: string,

--- a/packages/renderer/src/lib/chat/components/ExportButton.svelte
+++ b/packages/renderer/src/lib/chat/components/ExportButton.svelte
@@ -36,23 +36,12 @@ const exportAsFlow = async (): Promise<void> => {
 
   try {
     const { providerId, connectionName, label } = selectedModel;
-    const prompt = await window.inferenceGenerate({
+    const { prompt } = await window.inferenceGenerateFlowParams({
       providerId,
       connectionName,
       modelId: label,
       mcp: selectedMCP.map(m => m.id),
-      messages: $state.snapshot(chatClient.messages).concat([
-        {
-          id: crypto.randomUUID(),
-          role: 'user',
-          parts: [
-            {
-              text: `Help me to build a reproducible prompt to achieve the same result as I got in the conversation above. The prompt will be executed by another LLM without any further user input so it must contain all the information on how to get the same result.`,
-              type: 'text',
-            },
-          ],
-        },
-      ]),
+      messages: $state.snapshot(chatClient.messages),
     });
 
     flowCreationData.value = {


### PR DESCRIPTION
In this PR, I keep the same instructions to generate the prompt, but instead of using raw text output, I specify that I want the LLM to return an object. In this PR, it has only one property but we need to add more properties (title, description, parameters...) for next coming issues.

Pre-requisite for https://github.com/kortex-hub/kortex/issues/488 and https://github.com/kortex-hub/kortex/issues/455
 

<img width="2672" height="1432" alt="Screenshot 2025-10-06 at 12 27 34" src="https://github.com/user-attachments/assets/f2f3b5c4-0516-4f3f-b8a4-6408f7a0e099" />
<img width="2672" height="1432" alt="Screenshot 2025-10-06 at 12 27 45" src="https://github.com/user-attachments/assets/69e55c54-aa29-4824-9ffe-6356677d9b8d" />
<img width="747" height="515" alt="Screenshot 2025-10-06 at 12 28 31" src="https://github.com/user-attachments/assets/f323316c-eaa6-4eaa-8af3-8d8613a8180b" />


