### PR TITLE
feat(chat/flow): add generation of title and description, move type to API

### DIFF
--- a/packages/api/src/chat/flow-generation-parameters-schema.ts
+++ b/packages/api/src/chat/flow-generation-parameters-schema.ts
@@ -13,7 +13,7 @@ export const FlowGenerationParametersSchema = z.object({
   prompt: z
     .string()
     .describe(
-      'Help me to build a reproducible prompt to achieve the same result as I got in the conversation above. The prompt will be executed by another LLM without any further user input so it must contain all the information on how to get the same result.',
+      'Help me create a reproducible prompt that achieves the same result as in the conversation above. The prompt will be executed by another LLM without any further user input, so it must include all the necessary information to reproduce the same outcome.',
     ),
 });
 

--- a/packages/api/src/chat/flow-generation-parameters-schema.ts
+++ b/packages/api/src/chat/flow-generation-parameters-schema.ts
@@ -1,0 +1,20 @@
+import z from 'zod';
+
+export const kubernetesNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+export const FlowGenerationParametersSchema = z.object({
+  name: z
+    .string()
+    .regex(kubernetesNameRegex)
+    .describe(
+      `Name of the flow that will be saved. The name must match the kubernetes name regex /${kubernetesNameRegex.source}/.`,
+    ),
+  description: z.string().describe('Description of the flow, give a short description of what the flow does.'),
+  prompt: z
+    .string()
+    .describe(
+      'Help me to build a reproducible prompt to achieve the same result as I got in the conversation above. The prompt will be executed by another LLM without any further user input so it must contain all the information on how to get the same result.',
+    ),
+});
+
+export type FlowGenerationParameters = z.output<typeof FlowGenerationParametersSchema>;

--- a/packages/main/src/chat/chat-manager.ts
+++ b/packages/main/src/chat/chat-manager.ts
@@ -28,10 +28,13 @@ import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import type { WebContents } from 'electron';
 import { inject } from 'inversify';
-import z from 'zod';
 
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { Directories } from '/@/plugin/directories.js';
+import {
+  FlowGenerationParameters,
+  FlowGenerationParametersSchema,
+} from '/@api/chat/flow-generation-parameters-schema.js';
 import type { InferenceParameters } from '/@api/chat/InferenceParameters.js';
 import type { MessageConfig } from '/@api/chat/message-config.js';
 import type { Chat, Message } from '/@api/chat/schema.js';
@@ -273,16 +276,10 @@ export class ChatManager {
     return result.text;
   }
 
-  async generateFlowParams(params: InferenceParameters): Promise<{ prompt: string }> {
+  async generateFlowParams(params: InferenceParameters): Promise<FlowGenerationParameters> {
     const result = await generateObject({
       ...(await this.getInferenceComponents(params)),
-      schema: z.object({
-        prompt: z
-          .string()
-          .describe(
-            'Help me to build a reproducible prompt to achieve the same result as I got in the conversation above. The prompt will be executed by another LLM without any further user input so it must contain all the information on how to get the same result.',
-          ),
-      }),
+      schema: FlowGenerationParametersSchema,
     });
     return result.object;
   }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -44,6 +44,7 @@ import type {
 import type { DynamicToolUIPart, UIMessageChunk } from 'ai';
 import { contextBridge, ipcRenderer } from 'electron';
 
+import type { FlowGenerationParameters } from '/@api/chat/flow-generation-parameters-schema';
 import type { InferenceParameters } from '/@api/chat/InferenceParameters.js';
 import type { Chat, Message } from '/@api/chat/schema.js';
 import type { CliToolInfo } from '/@api/cli-tool-info';
@@ -1142,7 +1143,7 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'inferenceGenerateFlowParams',
-    async (params: InferenceParameters): Promise<{ prompt: string }> => {
+    async (params: InferenceParameters): Promise<FlowGenerationParameters> => {
       return ipcInvoke('inference:generateFlowParams', params);
     },
   );

--- a/packages/renderer/src/lib/chat/components/ExportButton.svelte
+++ b/packages/renderer/src/lib/chat/components/ExportButton.svelte
@@ -36,7 +36,7 @@ const exportAsFlow = async (): Promise<void> => {
 
   try {
     const { providerId, connectionName, label } = selectedModel;
-    const { prompt } = await window.inferenceGenerateFlowParams({
+    const generatedFlowParams = await window.inferenceGenerateFlowParams({
       providerId,
       connectionName,
       modelId: label,
@@ -45,7 +45,7 @@ const exportAsFlow = async (): Promise<void> => {
     });
 
     flowCreationData.value = {
-      prompt,
+      ...generatedFlowParams,
       model: selectedModel,
       mcp: selectedMCP,
     };

--- a/packages/renderer/src/lib/chat/state/flow-creation-data.svelte.ts
+++ b/packages/renderer/src/lib/chat/state/flow-creation-data.svelte.ts
@@ -1,8 +1,8 @@
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
+import type { FlowGenerationParameters } from '/@api/chat/flow-generation-parameters-schema';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
-export interface FlowCreationData {
-  prompt: string;
+export interface FlowCreationData extends FlowGenerationParameters {
   model: ModelInfo;
   mcp: MCPRemoteServerInfo[];
 }

--- a/packages/renderer/src/lib/flows/FlowCreate.svelte
+++ b/packages/renderer/src/lib/flows/FlowCreate.svelte
@@ -13,6 +13,7 @@ import FormPage from '/@/lib/ui/FormPage.svelte';
 import { handleNavigation } from '/@/navigation';
 import { isFlowConnectionAvailable } from '/@/stores/flow-provider';
 import { providerInfos } from '/@/stores/providers';
+import { kubernetesNameRegex } from '/@api/chat/flow-generation-parameters-schema';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 import { NavigationPage } from '/@api/navigation-page';
 
@@ -30,8 +31,8 @@ let error: string | undefined = $state();
 let loading: boolean = $state(false);
 
 // form field
-let name: string = $state(`flow-${generateWords({ exactly: 2, join: '-' })}`);
-let description: string = $state('');
+let name: string = $state(flowCreationData.value?.name ?? `flow-${generateWords({ exactly: 2, join: '-' })}`);
+let description: string = $state(flowCreationData.value?.description ?? '');
 let instruction: string = $state('You are a helpful assistant.');
 let prompt: string = $state(flowCreationData.value?.prompt ?? '');
 let flowProviderConnectionKey: string | undefined = $state<string>();
@@ -54,8 +55,6 @@ onMount(() => {
     console.error('Flow auto-select skipped:', e);
   }
 });
-
-const kubernetesNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
 
 const formValidContent = $derived(
   !!flowProviderConnectionKey &&


### PR DESCRIPTION
In this PR, I move the zod schemas to the API package to be reused in types around the application.

And I added the name and description of the flow to be generated.

I also applied @benoitf suggestion to change to fix the formulation of the prompt.


Example:

<img width="1840" height="1191" alt="Screenshot 2025-10-06 at 15 13 54" src="https://github.com/user-attachments/assets/16c7df32-09a7-4bbc-9384-faeaa217af4e" />


