### PR TITLE
chore(ci): add workflow for nightly e2e tests

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1,0 +1,175 @@
+#
+# Copyright (C) 2022-2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: nightly e2e tests
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to run tests on'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - windows
+          - macos
+
+permissions:
+  contents: read
+
+jobs:
+  windows-e2e-tests:
+    name: ${{ matrix.os }} - ${{ matrix.mode }} e2e tests
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'windows' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2025, windows-11-arm]
+        mode: [prod, dev]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Run Smoke E2E tests in ${{ matrix.mode == 'production' && 'Production' || 'Development' }} Mode
+        shell: bash
+        run: |
+          if [ ${{ matrix.mode }} == 'prod' ]; then
+            echo "Compiling Kortex in production mode"
+            export ELECTRON_ENABLE_INSPECT=true
+            pnpm compile:current --win dir
+            # Determine binary path based on OS
+            case "${{ matrix.os }}" in
+              *arm*)
+                BINARY_PATH="./dist/win-arm64-unpacked/Kortex.exe"
+                ;;
+              *)
+                BINARY_PATH="./dist/win-unpacked/Kortex.exe"
+                ;;
+            esac
+            path=$(realpath $BINARY_PATH)
+            echo "Kortex built binary: $path"
+            export KORTEX_BINARY=$path
+          fi
+          pnpm test:e2e
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          annotate_only: true
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          require_tests: true
+          report_paths: '**/*results.xml'
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: results-e2e-${{ matrix.os }}-${{ matrix.mode }}
+          path: |
+            tests/**/output/*
+
+  macos-e2e-tests:
+    name: ${{ matrix.os }} - ${{ matrix.mode }} e2e tests
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'macos' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15-intel, macos-26]
+        mode: [prod, dev]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Run Smoke E2E tests in ${{ matrix.mode == 'production' && 'Production' || 'Development' }} Mode
+        shell: bash
+        run: |
+          if [ ${{ matrix.mode }} == 'prod' ]; then
+            echo "Compiling Kortex in production mode"
+            export ELECTRON_ENABLE_INSPECT=true
+            pnpm compile:current --mac dir
+            # Determine binary path based on OS architecture
+            case "${{ matrix.os }}" in
+              *intel*)
+                BINARY_PATH="./dist/mac/Kortex.app/Contents/MacOS/Kortex"
+                ;;
+              *)
+                BINARY_PATH="./dist/mac-arm64/Kortex.app/Contents/MacOS/Kortex"
+                ;;
+            esac
+            path=$(realpath $BINARY_PATH)
+            echo "Kortex built binary: $path"
+            export KORTEX_BINARY=$path
+          fi
+          pnpm test:e2e
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          annotate_only: true
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          require_tests: true
+          report_paths: '**/*results.xml'
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: results-e2e-${{ matrix.os }}-${{ matrix.mode }}
+          path: |
+            tests/**/output/*

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2025 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,9 +31,6 @@ on:
           - all
           - windows
           - macos
-
-permissions:
-  contents: read
 
 jobs:
   windows-e2e-tests:


### PR DESCRIPTION
Add workflow for scheduled test runs.

- Scheduled runs: Automatically executes daily at 2:00 AM
- Manual triggers: Supports manual execution with platform selection
- Matrix testing: Runs on Windows and macOS (x64 and arm64 runners)
- Test reporting: Generates and publishes JUnit test reports with summaries
- Artifacts: Uploads build and test artifacts for review

Closes #491 
Closes #492 

Tested in my fork:
<img width="1154" height="792" alt="Screenshot 2025-10-07 at 10 49 55 AM" src="https://github.com/user-attachments/assets/3abc5785-870f-47be-b74e-040239a97cd7" />

