### PR TITLE
fix(chat/flow): when creating a flow the model used in the chat shoud be preselected

### DIFF
--- a/packages/renderer/src/lib/flows/FlowCreate.svelte
+++ b/packages/renderer/src/lib/flows/FlowCreate.svelte
@@ -24,7 +24,8 @@ import NoFlowProviders from './components/NoFlowProviders.svelte';
 
 let selectedMCP = $state<MCPRemoteServerInfo[]>(flowCreationData.value?.mcp ?? []);
 let models: Array<ModelInfo> = $derived(getModels($providerInfos));
-let selectedModel = $derived<ModelInfo | undefined>(flowCreationData.value?.model ?? models[0]);
+let flowCreationDataModel = $state<ModelInfo | undefined>(flowCreationData.value?.model);
+let selectedModel = $derived<ModelInfo | undefined>(flowCreationDataModel ?? models[0]);
 
 // error
 let error: string | undefined = $state();


### PR DESCRIPTION
When creating a flow the model used in the chat shoud be preselected:

This PR introduces a local state to keep if the selected a model, because derived was recomputed when flowCreationData was cleared.


<img width="1820" height="1171" alt="Screenshot 2025-10-08 at 12 14 00" src="https://github.com/user-attachments/assets/ecd692a1-5ebe-40fa-a71e-a51fadf7fb6d" />
