### PR TITLE
fix(chat): explicit type for exposedInMainWorld.d.ts which had any

### DIFF
--- a/packages/api/src/chat/flow-generation-parameters-schema.ts
+++ b/packages/api/src/chat/flow-generation-parameters-schema.ts
@@ -16,9 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ZodType } from 'zod';
 import z from 'zod';
 
-export const FlowGenerationParametersSchema = z.object({
+export type FlowGenerationParameters = {
+  name: string;
+  description: string;
+  prompt: string;
+};
+
+export const FlowGenerationParametersSchema: ZodType<FlowGenerationParameters> = z.object({
   name: z
     .string()
     .describe(
@@ -40,5 +47,3 @@ export const FlowGenerationParametersSchema = z.object({
       'Help me create a reproducible prompt that achieves the same result as in the conversation above. The prompt will be executed by another LLM without any further user input, so it must include all the necessary information to reproduce the same outcome.',
     ),
 });
-
-export type FlowGenerationParameters = z.output<typeof FlowGenerationParametersSchema>;


### PR DESCRIPTION
fix(chat): explicit type for exposedInMainWorld.d.ts which had any

after:
<img width="1037" height="578" alt="Screenshot 2025-10-08 at 15 06 37" src="https://github.com/user-attachments/assets/d3e63a11-422e-4c42-b15d-ebd6a3ce3601" />



before:
<img width="766" height="524" alt="Screenshot 2025-10-08 at 15 07 57" src="https://github.com/user-attachments/assets/5470143e-fb3c-486a-a28c-f6b79f3dd1cd" />

