### PR TITLE
fix: hide headers secrets when hide secrets option is selected

### DIFF
--- a/extensions/goose/src/goose-recipe.spec.ts
+++ b/extensions/goose/src/goose-recipe.spec.ts
@@ -163,3 +163,24 @@ describe('cliAPI#onDidChange', () => {
     expect(DISPOSE_MOCK.dispose).toHaveBeenCalledOnce();
   });
 });
+
+describe('goose recipe secrets hiding', () => {
+  test('should hide secrets in headers', async () => {
+    const recipe = new GooseRecipe(PROVIDER_API_MOCK, GOOSE_CLI_MOCK, KORTEX_VERSION);
+    const recipeContent = `
+    title: test-flow
+    extensions:
+      - name: github-mcp
+        type: streamable_http
+        uri: GitHub's official MCP Server
+        headers:
+          Authorization: "Bearer real-github-token-67890"
+    `;
+
+    const result = recipe.hideSecretsInRecipeContent(recipeContent);
+
+    expect(result).toContain('Authorization: "******************************"');
+    expect(result).not.toContain('real-github-token-67890');
+    expect(result).not.toContain('Bearer');
+  });
+});

--- a/extensions/goose/src/goose-recipe.ts
+++ b/extensions/goose/src/goose-recipe.ts
@@ -32,7 +32,7 @@ import type {
 } from '@kortex-app/api';
 import { EventEmitter } from '@kortex-app/api';
 import { generate } from 'random-words';
-import { parse } from 'yaml';
+import { parse, stringify } from 'yaml';
 
 import type { GooseCLI } from './goose-cli';
 import { KubeTemplate } from './kube-template';
@@ -46,6 +46,17 @@ function goose2KortexProvider(gooseprovider: string): string {
   const entry = Object.entries(gooseProviderMap).find(([, v]) => v === gooseprovider);
   if (!entry) throw new Error(`cannot find inference provider for goose provider ${gooseprovider}`);
   return entry[0];
+}
+
+export interface RecipeExtension {
+  name: string;
+  type: string;
+  uri: string;
+  headers?: Record<string, string>;
+}
+
+export interface RecipeWithExtensions {
+  extensions?: Array<RecipeExtension>;
 }
 
 export class GooseRecipe implements Disposable {
@@ -249,6 +260,7 @@ export class GooseRecipe implements Disposable {
     if (!providerId) {
       throw new Error('cannot find provider for this recipe, cannot deploy to kubernetes');
     }
+    const processedContent = options.hideSecrets ? this.hideSecretsInRecipeContent(content) : content;
 
     const template = new KubeTemplate({
       job: {
@@ -260,7 +272,7 @@ export class GooseRecipe implements Disposable {
       recipe: {
         flowId: options.flowId,
         name: recipeName,
-        content: content,
+        content: processedContent,
       },
       provider: {
         name: providerId,
@@ -276,6 +288,65 @@ export class GooseRecipe implements Disposable {
     return {
       resources: template.render(),
     };
+  }
+
+  hideSecretsInRecipeContent(content: string): string {
+    try {
+      const parsed = parse(content);
+
+      if (parsed.extensions) {
+        parsed.extensions = this.processExtensions(parsed.extensions);
+      }
+
+      return this.stringifyRecipe(parsed);
+    } catch (error) {
+      console.warn('Failed to parse recipe content for secret hiding:', error);
+      return content;
+    }
+  }
+
+  private processExtensions(extensions: RecipeExtension[]): RecipeExtension[] {
+    return extensions.map(extension => {
+      if (extension.headers) {
+        const processedHeaders = this.processHeaders(extension.headers);
+        if (processedHeaders !== extension.headers) {
+          return {
+            ...extension,
+            headers: processedHeaders,
+          };
+        }
+      }
+      return extension;
+    });
+  }
+
+  private processHeaders(headers: Record<string, string>): Record<string, string> {
+    const hasSensitiveHeaders = Object.keys(headers).some(key => this.isSensitiveHeader(key));
+
+    if (!hasSensitiveHeaders) {
+      return headers;
+    }
+
+    const processed: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(headers)) {
+      const isSensitive = this.isSensitiveHeader(key);
+      processed[key] = isSensitive ? '*'.repeat(value.length) : value;
+    }
+
+    return processed;
+  }
+
+  private isSensitiveHeader(key: string): boolean {
+    const sensitiveKeys = ['authorization', 'x-api-key', 'api-key', 'token'];
+    return sensitiveKeys.includes(key.toLowerCase());
+  }
+
+  private stringifyRecipe(parsed: RecipeWithExtensions): string {
+    return stringify(parsed, {
+      indent: 2,
+      lineWidth: -1,
+    });
   }
 
   dispose(): void {


### PR DESCRIPTION
This PR checks if inside the recipe YAML in flows section and hides header secrets if the "hide secrets" option is selected.

Before:
<img width="1506" height="944" alt="Captura de pantalla 2025-10-13 a las 12 08 49" src="https://github.com/user-attachments/assets/52bfee76-f41b-4d3c-ae50-0117471da2bd" />

After:
<img width="1513" height="942" alt="Captura de pantalla 2025-10-13 a las 12 06 54" src="https://github.com/user-attachments/assets/1b05ca4f-83c0-43fe-951d-d0e9f3b7cd6a" />

Closes #277 