### PR TITLE
fix(extensions/goose): explicit label to avoid error on kubernetes deploy

### DIFF
--- a/extensions/goose/src/templates/kube.mustache
+++ b/extensions/goose/src/templates/kube.mustache
@@ -23,6 +23,8 @@ metadata:
     {{& annotations.flowId }}: {{{ recipe.flowId }}}
 spec:
   template:
+    labels:
+      app: goose
     metadata:
       annotations:
         {{& annotations.version }}: {{ kortex.version }}


### PR DESCRIPTION
WIP cannot reproduce issue

fix(extensions/goose): explicit label to avoid error on kubernetes deploy

Fixes https://github.com/kortex-hub/kortex/issues/543