### PR TITLE
refactor: (goose) extract the command line to a separate method from run

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -418,6 +418,12 @@ declare module '@kortex-app/api' {
     namespace: string;
   }
 
+  export interface FlowGenerateCommandLineResult {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+  }
+
   export interface FlowGenerateOptions {
     name: string;
     description: string;


### PR DESCRIPTION
will help when a scheduler will need to know the command to run