### PR TITLE
test: add e2e test for adding a MCP registry

### DIFF
--- a/tests/playwright/src/model/navigation/pages/mcp-base-tab-page.ts
+++ b/tests/playwright/src/model/navigation/pages/mcp-base-tab-page.ts
@@ -20,7 +20,7 @@ import { type Locator, type Page } from '@playwright/test';
 
 import { BasePage } from './base-page';
 
-export abstract class McpTabPage extends BasePage {
+export abstract class McpBaseTabPage extends BasePage {
   readonly content: Locator;
   readonly table: Locator;
   readonly noMcpServersAvailableHeading: Locator;

--- a/tests/playwright/src/model/navigation/pages/mcp-edit-registries-tab-page.ts
+++ b/tests/playwright/src/model/navigation/pages/mcp-edit-registries-tab-page.ts
@@ -18,9 +18,9 @@
 
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import { McpTabPage } from './mcp-base-tab-page';
+import { McpBaseTabPage } from './mcp-base-tab-page';
 
-export class McpEditRegistriesTabPage extends McpTabPage {
+export class McpEditRegistriesTabPage extends McpBaseTabPage {
   readonly addMcpRegistryButton: Locator;
   readonly addMcpRegistryDialog: Locator;
 

--- a/tests/playwright/src/model/navigation/pages/mcp-install-tab-page.ts
+++ b/tests/playwright/src/model/navigation/pages/mcp-install-tab-page.ts
@@ -18,9 +18,9 @@
 
 import { expect, type Page } from '@playwright/test';
 
-import { McpTabPage } from './mcp-base-tab-page';
+import { McpBaseTabPage } from './mcp-base-tab-page';
 
-export class McpInstallTabPage extends McpTabPage {
+export class McpInstallTabPage extends McpBaseTabPage {
   constructor(page: Page) {
     super(page, 'mcpServer');
   }

--- a/tests/playwright/src/model/navigation/pages/mcp-page.ts
+++ b/tests/playwright/src/model/navigation/pages/mcp-page.ts
@@ -22,7 +22,7 @@ import { BasePage } from './base-page';
 import { McpEditRegistriesTabPage } from './mcp-edit-registries-tab-page';
 import { McpInstallTabPage } from './mcp-install-tab-page';
 
-export class McpServersPage extends BasePage {
+export class McpPage extends BasePage {
   readonly searchMcpServersField: Locator;
   readonly editRegistriesTabButton: Locator;
   readonly installTabButton: Locator;

--- a/tests/playwright/src/specs/mcp-smoke.spec.ts
+++ b/tests/playwright/src/specs/mcp-smoke.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { McpServersPage } from 'src/model/navigation/pages/mcp-page';
+import { McpPage } from 'src/model/navigation/pages/mcp-page';
 
 import { test } from '../fixtures/electron-app';
 import { NavigationBar } from '../model/navigation/navigation';
@@ -25,11 +25,11 @@ import { waitForNavigationReady } from '../utils/app-ready';
 const DEFAULT_REGISTRY: string = 'MCP Registry example';
 const REGISTRY_URL: string = 'https://registry.modelcontextprotocol.io';
 let navigationBar: NavigationBar;
-let mcpServersPage: McpServersPage;
+let mcpServersPage: McpPage;
 
 test.beforeEach(async ({ page }) => {
   navigationBar = new NavigationBar(page);
-  mcpServersPage = new McpServersPage(page);
+  mcpServersPage = new McpPage(page);
   await waitForNavigationReady(page);
   await navigationBar.mcpLink.click();
   await mcpServersPage.waitForLoad();


### PR DESCRIPTION
This pr adds an e2e test for the “Add a new MCP Registry” flow on the MCP Page.

It is part of the issue: https://github.com/kortex-hub/kortex/issues/545