### PR TITLE
chore: include API for registering scheduling extensions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -793,6 +793,62 @@ declare module '@kortex-app/api' {
     logo?: string | { light: string; dark: string };
   }
 
+  // details of a scheduled task execution (from getExecution)
+  export interface ProviderScheduleExecution {
+    id: string;
+    lastExecution: Date;
+    output: string;
+    duration: number;
+    exitCode?: number;
+  }
+
+  // item representing a scheduled task (from listing)
+  export interface ProviderScheduleItem {
+    id: string;
+    metadata: Record<string, string>;
+    cronExpression: string;
+  }
+
+  // command to execute for the scheduled task
+  export interface ProviderSchedulerCommand {
+    command: string;
+    env: Record<string, string>;
+    args: string[];
+  }
+
+  // options to schedule a task
+  export interface ProviderSchedulerOptions {
+    command: ProviderSchedulerCommand;
+    cronExpression: string;
+    metadata: Record<string, string>;
+  }
+
+  // result of scheduling a task
+  export interface ProviderScheduleResult {
+    id: string;
+  }
+
+  export interface ProviderSchedulerListOptions {
+    metadataKeys?: string[];
+  }
+
+  // allow to schedule tasks, including listing, canceling and getting execution details
+  export interface ProviderScheduler {
+    name: string;
+
+    // schedule a task and return a schedule id
+    schedule(options: ProviderSchedulerOptions): Promise<ProviderScheduleResult>;
+
+    // cancel a scheduled task by id
+    cancel(id: string): Promise<void>;
+
+    // list scheduled tasks
+    list(options: ProviderSchedulerListOptions): Promise<ProviderScheduleItem[]>;
+
+    // get execution details for a scheduled task
+    getExecution(id: string): Promise<ProviderScheduleExecution | undefined>;
+  }
+
   export interface Provider {
     setContainerProviderConnectionFactory(
       containerProviderConnectionFactory: ContainerProviderConnectionFactory,
@@ -831,6 +887,8 @@ declare module '@kortex-app/api' {
     registerAutostart(autostart: ProviderAutostart): Disposable;
 
     registerCleanup(cleanup: ProviderCleanup): Disposable;
+
+    registerScheduler(scheduler: ProviderScheduler): Disposable;
 
     dispose(): void;
     readonly name: string;
@@ -1155,6 +1213,10 @@ declare module '@kortex-app/api' {
 
   export interface ImageFilesProviderMetadata {
     readonly label: string;
+  }
+
+  export interface SchedulerOptions {
+    name: string;
   }
 
   export namespace provider {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -67,6 +67,7 @@ import { MCPManager } from '/@/plugin/mcp/mcp-manager.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { ExtensionBanner, RecommendedRegistry } from '/@/plugin/recommendations/recommendations-api.js';
+import { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Uri } from '/@/plugin/types/uri.js';
 import { Updater } from '/@/plugin/updater.js';
@@ -542,6 +543,7 @@ export class PluginSystem {
     container.bind<OnboardingRegistry>(OnboardingRegistry).toSelf().inSingletonScope();
     container.bind<KubernetesClient>(KubernetesClient).toSelf().inSingletonScope();
     container.bind<ChatManager>(ChatManager).toSelf().inSingletonScope();
+    container.bind<SchedulerRegistry>(SchedulerRegistry).toSelf().inSingletonScope();
 
     // INIT KUBERNETES
     const kubernetesClient = container.get<KubernetesClient>(KubernetesClient);
@@ -781,11 +783,13 @@ export class PluginSystem {
     const authentication = container.get<AuthenticationImpl>(AuthenticationImpl);
     const imageRegistry = container.get<ImageRegistry>(ImageRegistry);
     const mcpRegistry = container.get<MCPRegistry>(MCPRegistry);
+    const schedulerRegistry = container.get<SchedulerRegistry>(SchedulerRegistry);
     mcpRegistry.init();
 
     const mcpIPCHandler = container.get<MCPIPCHandler>(MCPIPCHandler);
     mcpIPCHandler.init();
 
+    await schedulerRegistry.init();
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 
     this.ipcHandle('tasks:clear-all', async (): Promise<void> => {

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -37,11 +37,14 @@ import type {
   ProviderLifecycle,
   ProviderLinks,
   ProviderOptions,
+  ProviderScheduler,
   ProviderStatus,
   ProviderUpdate,
   VmProviderConnection,
   VmProviderConnectionFactory,
 } from '@kortex-app/api';
+
+import type { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
 
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { Emitter } from './events/emitter.js';
@@ -92,6 +95,7 @@ export class ProviderImpl implements Provider, IDisposable {
     private providerOptions: ProviderOptions,
     private providerRegistry: ProviderRegistry,
     private containerRegistry: ContainerProviderRegistry,
+    private schedulerRegistry: SchedulerRegistry,
   ) {
     this.containerProviderConnectionsStatuses = new Map();
     this.containerProviderConnections = new Set();
@@ -338,6 +342,10 @@ export class ProviderImpl implements Provider, IDisposable {
 
   registerLifecycle(lifecycle: ProviderLifecycle): Disposable {
     return this.providerRegistry.registerLifecycle(this, lifecycle);
+  }
+
+  registerScheduler(scheduler: ProviderScheduler): Disposable {
+    return this.schedulerRegistry.register(this, scheduler);
   }
 
   registerInstallation(installation: ProviderInstallation): Disposable {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -39,6 +39,7 @@ import type {
 } from '@kortex-app/api';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
 import {
   type CheckStatus,
   type PreflightChecksCallback,
@@ -63,6 +64,8 @@ let autostartEngine: AutostartEngine;
 const apiSenderSendMock = vi.fn();
 
 let containerRegistry: ContainerProviderRegistry;
+
+let schedulerRegistry: SchedulerRegistry;
 
 class TestProviderRegistry extends ProviderRegistry {
   getKubernetesProviders(): Map<string, KubernetesProviderConnection> {
@@ -94,7 +97,11 @@ beforeEach(() => {
     isApiAttached: vi.fn(),
     onApiAttached: vi.fn(),
   } as unknown as ContainerProviderRegistry;
-  providerRegistry = new TestProviderRegistry(apiSender, containerRegistry, telemetry);
+  schedulerRegistry = {
+    register: vi.fn(),
+  } as unknown as SchedulerRegistry;
+
+  providerRegistry = new TestProviderRegistry(apiSender, containerRegistry, telemetry, schedulerRegistry);
   autostartEngine = {
     registerProvider: vi.fn(),
   } as unknown as AutostartEngine;

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -62,6 +62,7 @@ import type {
 } from '@kortex-app/api';
 import { inject, injectable } from 'inversify';
 
+import { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
 import type { Event } from '/@api/event.js';
 import {
   LifecycleMethod,
@@ -198,6 +199,8 @@ export class ProviderRegistry {
     private containerRegistry: ContainerProviderRegistry,
     @inject(Telemetry)
     private telemetryService: Telemetry,
+    @inject(SchedulerRegistry)
+    private schedulerRegistry: SchedulerRegistry,
   ) {
     this.providers = new Map();
     this.listeners = [];
@@ -247,6 +250,7 @@ export class ProviderRegistry {
       providerOptions,
       this,
       this.containerRegistry,
+      this.schedulerRegistry,
     );
     this.count++;
     this.providers.set(id, providerImpl);

--- a/packages/main/src/plugin/scheduler/scheduler-registry.spec.ts
+++ b/packages/main/src/plugin/scheduler/scheduler-registry.spec.ts
@@ -1,0 +1,136 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ProviderScheduler } from '@kortex-app/api';
+import { Container } from 'inversify';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ApiSenderType } from '/@/plugin/api.js';
+import type { ProviderImpl } from '/@/plugin/provider-impl.js';
+import { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
+
+const providerImpl1 = {
+  id: 'provider-1',
+  name: 'provider-name-1',
+  internalId: 'internal-1',
+} as unknown as ProviderImpl;
+
+const providerImpl2 = {
+  id: 'provider-2',
+  name: 'provider-name-2',
+  internalId: 'internal-2',
+} as unknown as ProviderImpl;
+
+const scheduler1: ProviderScheduler = {
+  name: 'scheduler-1',
+  schedule: vi.fn(),
+  cancel: vi.fn(),
+  list: vi.fn(),
+  getExecution: vi.fn(),
+};
+
+const scheduler2: ProviderScheduler = {
+  name: 'scheduler-2',
+  schedule: vi.fn(),
+  cancel: vi.fn(),
+  list: vi.fn(),
+  getExecution: vi.fn(),
+};
+
+const apiSenderMock = {
+  send: vi.fn(),
+} as unknown as ApiSenderType;
+
+let schedulerRegistry: SchedulerRegistry;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  const container = new Container();
+  container.bind(SchedulerRegistry).toSelf().inSingletonScope();
+  container.bind(ApiSenderType).toConstantValue(apiSenderMock);
+  schedulerRegistry = container.get(SchedulerRegistry);
+});
+
+test('should initialize without error', async () => {
+  await expect(schedulerRegistry.init()).resolves.toBeUndefined();
+});
+
+test('should register a scheduler and send event', () => {
+  const disposable = schedulerRegistry.register(providerImpl1, scheduler1);
+
+  expect(apiSenderMock.send).toHaveBeenCalledWith('provider-scheduler-change', {
+    providerId: providerImpl1.id,
+    name: scheduler1.name,
+  });
+  expect(apiSenderMock.send).toHaveBeenCalledTimes(1);
+  expect(disposable).toBeDefined();
+  expect(typeof disposable.dispose).toBe('function');
+});
+
+test('should register multiple schedulers', () => {
+  schedulerRegistry.register(providerImpl1, scheduler1);
+  schedulerRegistry.register(providerImpl2, scheduler2);
+
+  expect(apiSenderMock.send).toHaveBeenCalledTimes(2);
+  expect(apiSenderMock.send).toHaveBeenNthCalledWith(1, 'provider-scheduler-change', {
+    providerId: providerImpl1.id,
+    name: scheduler1.name,
+  });
+  expect(apiSenderMock.send).toHaveBeenNthCalledWith(2, 'provider-scheduler-change', {
+    providerId: providerImpl2.id,
+    name: scheduler2.name,
+  });
+});
+
+test('should unregister scheduler when disposable is called', () => {
+  const disposable = schedulerRegistry.register(providerImpl1, scheduler1);
+
+  expect(apiSenderMock.send).toHaveBeenCalledTimes(1);
+
+  // Dispose the scheduler
+  disposable.dispose();
+
+  expect(apiSenderMock.send).toHaveBeenCalledTimes(2);
+  expect(apiSenderMock.send).toHaveBeenNthCalledWith(2, 'provider-scheduler-change', {
+    providerId: providerImpl1.id,
+    name: scheduler1.name,
+  });
+});
+
+test('should dispose and clear all schedulers', () => {
+  schedulerRegistry.register(providerImpl1, scheduler1);
+  schedulerRegistry.register(providerImpl2, scheduler2);
+
+  expect(apiSenderMock.send).toHaveBeenCalledTimes(2);
+
+  // Dispose the registry
+  schedulerRegistry.dispose();
+
+  // No additional events should be sent on dispose
+  expect(apiSenderMock.send).toHaveBeenCalledTimes(2);
+});
+
+test('should handle multiple dispose calls on the same disposable', () => {
+  const disposable = schedulerRegistry.register(providerImpl1, scheduler1);
+
+  disposable.dispose();
+  disposable.dispose(); // Second dispose should not cause issues
+
+  // Should only send 2 events (1 register, 1 unregister)
+  expect(apiSenderMock.send).toHaveBeenCalledTimes(2);
+});

--- a/packages/main/src/plugin/scheduler/scheduler-registry.ts
+++ b/packages/main/src/plugin/scheduler/scheduler-registry.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ProviderScheduler } from '@kortex-app/api';
+import { inject, injectable } from 'inversify';
+
+import { ApiSenderType } from '/@/plugin/api.js';
+import type { ProviderImpl } from '/@/plugin/provider-impl.js';
+import { Disposable } from '/@/plugin/types/disposable.js';
+import type { IDisposable } from '/@api/disposable.js';
+
+// Registry for all schedulers registered there
+@injectable()
+export class SchedulerRegistry implements IDisposable {
+  #schedulers: Map<string, ProviderScheduler> = new Map();
+
+  constructor(
+    @inject(ApiSenderType)
+    private apiSender: ApiSenderType,
+  ) {}
+
+  async init(): Promise<void> {}
+
+  // Register a new scheduler
+  register(providerImpl: ProviderImpl, scheduler: ProviderScheduler): Disposable {
+    this.#schedulers.set(providerImpl.name, scheduler);
+
+    const eventName = 'provider-scheduler-change';
+    const eventPayload = { providerId: providerImpl.id, name: scheduler.name };
+
+    this.apiSender.send(eventName, eventPayload);
+    return Disposable.create(() => {
+      this.#schedulers.delete(providerImpl.internalId);
+      this.apiSender.send(eventName, eventPayload);
+    });
+  }
+
+  dispose(): void {
+    this.#schedulers.clear();
+  }
+}


### PR DESCRIPTION
Add a way to register a scheduler.


related to https://github.com/kortex-hub/kortex/issues/519