### PR TITLE
chore: group updates of dependabot for ai sdk and its mcp part

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,9 @@ updates:
           dependency-type: "all"
         - dependency-name: "random-words"
           dependency-type: "all"
+    groups:
+      ai-sdk:
+        applies-to: version-updates
+        patterns:
+          - "@ai-sdk/mcp"
+          - "ai"


### PR DESCRIPTION
Updating only the `ai` library or `@ai-sdk/mcp` doesn’t work
both need to be updated together.

Signed-off-by: Florent Benoit <fbenoit@redhat.com>