### PR TITLE
fix: typo in OpenShift AI token placeholder in OpenShift extension

### DIFF
--- a/extensions/openshift-ai/package.json
+++ b/extensions/openshift-ai/package.json
@@ -27,7 +27,7 @@
         "openshiftai.factory.token": {
           "type": "string",
           "scope": "InferenceProviderConnectionFactory",
-          "description": "Enter your OpenSjift AI token",
+          "description": "Enter your OpenShift AI token",
           "format": "password"
         }
       }


### PR DESCRIPTION
…openshift-ai/sec/package.json from OpenSjift to OpenShift

fixed bug #702 

This PR corrects a minor typo in the OpenShift AI token placeholder — changed OpenSjift to OpenShift, which is located at
extensions/openshift-ai/package.json

<img width="593" height="153" alt="image" src="https://github.com/user-attachments/assets/4e733505-e2f0-44a3-8742-defc6e217c4d" />
