### PR TITLE
chore: use OIDC for publishing npmjs package

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -176,3 +176,29 @@ jobs:
           repo: prereleases
           owner: kortex-hub
 
+  publish:
+    needs: [tag, release]
+    name: Publish
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Publish @kortex-app/api to npmjs
+        run: |
+          echo "Using version ${{ needs.tag.outputs.kortexVersion }}"
+          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.kortexVersion }}\",#g" packages/extension-api/package.json
+          cd packages/extension-api && pnpm publish --provenance --tag next --no-git-checks --access public


### PR DESCRIPTION
avoid using tokens

https://github.blog/security/supply-chain-security/our-plan-for-a-more-secure-npm-supply-chain/

Signed-off-by: Florent Benoit <fbenoit@redhat.com>