### PR TITLE
refactor(flows): use object with all options instead of multiple parameters

### DIFF
--- a/extensions/goose/src/goose-recipe.ts
+++ b/extensions/goose/src/goose-recipe.ts
@@ -22,13 +22,13 @@ import { basename, dirname, join } from 'node:path';
 import type {
   Disposable,
   Flow,
+  FlowExecuteParams,
   FlowGenerateCommandLineOptions,
   FlowGenerateCommandLineResult,
   FlowGenerateKubernetesOptions,
   FlowGenerateKubernetesResult,
   FlowGenerateOptions,
   FlowParameter,
-  Logger,
   Provider,
   provider as ProviderAPI,
   ProviderConnectionStatus,
@@ -136,7 +136,7 @@ export class GooseRecipe implements Disposable {
     return Buffer.from(fullPath).toString('base64');
   }
 
-  protected async execute(flowId: string, logger: Logger, params?: Record<string, string>): Promise<void> {
+  protected async execute({ flowId, logger, params }: FlowExecuteParams): Promise<void> {
     const { env, flowPath } = await this.getFlowInfos(flowId);
     // execute goose recipe using run
     await this.gooseCLI.run(flowPath, logger, { path: this.getBasePath(), env, params });

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -431,6 +431,12 @@ declare module '@kortex-app/api' {
     flowId: string;
   }
 
+  export interface FlowExecuteParams {
+    flowId: string;
+    logger: Logger;
+    params?: Record<string, string>;
+  }
+
   export interface FlowGenerateCommandLineResult {
     command: string;
     args: string[];
@@ -497,7 +503,7 @@ declare module '@kortex-app/api' {
       /**
        * @experimental expect change
        */
-      execute(flowId: string, logger: Logger, params?: Record<string, string>): Promise<void>;
+      execute(options: FlowExecuteParams): Promise<void>;
     };
   }
 

--- a/packages/main/src/plugin/flow/flow-manager.ts
+++ b/packages/main/src/plugin/flow/flow-manager.ts
@@ -135,7 +135,7 @@ export class FlowManager implements Disposable {
     task.status = 'in-progress';
 
     flowConnection.flow
-      .execute(flowId, logger, params)
+      .execute({ flowId, logger, params })
       .then(() => {
         task.state = 'completed';
         task.status = 'success';


### PR DESCRIPTION
Follow up of comment https://github.com/kortex-hub/kortex/pull/715#discussion_r2517482395,
introducing a `FlowExecuteOptions` interface to allow adding more parameters in the future.