### PR TITLE
chore: update publish step to use Node.js v24

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -191,7 +191,7 @@ jobs:
 
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Execute pnpm


### PR DESCRIPTION
OIDC publication requires npm > 11.5.1 while Node.js v22 has 10.9.2

https://docs.npmjs.com/trusted-publishers
<img width="859" height="83" alt="image" src="https://github.com/user-attachments/assets/ca497862-2fbe-4335-b0b5-27531be06170" />
