### PR TITLE
feat(flow): add modal for params

### DIFF
--- a/packages/renderer/src/lib/flows/RunFlowModal.svelte
+++ b/packages/renderer/src/lib/flows/RunFlowModal.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+import { Button, Input } from '@podman-desktop/ui-svelte';
+
+import Dialog from '/@/lib/dialogs/Dialog.svelte';
+import type { FlowInfo } from '/@api/flow-info';
+
+interface Props {
+  flow: FlowInfo;
+  onRun: (inputValues: Record<string, string>) => void;
+  onCancel: () => void;
+}
+
+let { flow, onRun, onCancel }: Props = $props();
+
+let inputValues = $state<Record<string, string>>(
+  flow.parameters
+    ? flow.parameters.reduce<Record<string, string>>((acc, param) => {
+        acc[param.name] = param.default ?? '';
+        return acc;
+      }, {})
+    : {},
+);
+
+const valid = $derived.by(() => {
+  if (flow.parameters) {
+    return flow.parameters.every(param => inputValues[param.name] && inputValues[param.name].trim() !== '');
+  }
+  return true;
+});
+
+function handleInputChange(paramName: string, event: Event): void {
+  inputValues = {
+    ...inputValues,
+    [paramName]: (event.target as HTMLInputElement).value,
+  };
+}
+
+function handleRun(): void {
+  onRun(inputValues);
+}
+</script>
+
+<Dialog
+  title={`Run Flow: ${flow.name}`}
+  onclose={onCancel}
+>
+  {#snippet content()}
+    {#each flow.parameters ?? [] as param (param.name)}
+      <div class="pb-4">
+        <label for={`param-${param.name}`}>
+          {param.name}
+        </label>
+        {#if param.description}
+          <p class="text-sm mb-1">{param.description}</p>
+        {/if}
+        <Input
+          id={`param-${param.name}`}
+          value={inputValues[param.name]}
+          oninput={(e): void => handleInputChange(param.name, e)}
+        />
+      </div>
+    {/each}
+  {/snippet}
+
+  {#snippet buttons()}
+    <div class="flex justify-end space-x-2 p-4">
+      <Button onclick={onCancel}>Cancel</Button>
+      <Button onclick={handleRun} disabled={!valid}>Run</Button>
+    </div>
+  {/snippet}
+</Dialog>


### PR DESCRIPTION
This PR adds a modal before running a flow locally when it has parameters. The modal displays for each parameters:
- name
- description
- an input to fill it
- the default value of the input is set if given in the flow definition

The Cancel button closes the modal, the Run button is disabled if one of the fields is empty, and it can be clicked otherwise.

When no parameters, we keep the same behavior as before : no modal, the flow runs.

I have not added UT yet but they can be added after getting some feedback here.

Closes https://github.com/kortex-hub/kortex/issues/518

<img width="1373" height="1000" alt="Screenshot 2025-11-13 at 11 57 02" src="https://github.com/user-attachments/assets/cae1dca8-bb2d-4ae8-87c3-c7d875990e6a" />
<img width="1373" height="1000" alt="Screenshot 2025-11-13 at 11 57 04" src="https://github.com/user-attachments/assets/70488127-59fd-44c3-987f-59fcb0d78f66" />
<img width="1373" height="1000" alt="Screenshot 2025-11-13 at 11 57 10" src="https://github.com/user-attachments/assets/c417b277-c962-488d-a910-0584055aa259" />
<img width="1373" height="1000" alt="Screenshot 2025-11-13 at 11 56 58" src="https://github.com/user-attachments/assets/e7a0b886-88fc-4dad-a119-810d3dcba7a8" />

Example yaml for Goose recipe:

```yaml
title: flow-pr
name: flow-pr
description: Analyse a pr

prompt: |
     Your job is to analyse and explain PR {{ pr }} of repo {{ repo }}
instructions: Your job is to analyse and explain a PR

parameters:
  - key: pr
    input_type: string
    requirement: required
    description: name of the pull request
  - key: repo
    input_type: string
    requirement: optional
    default: podman-desktop/podman-desktop
    description: name of the repo


extensions:
  - name: "com.github.mcp"
    type: "streamable_http"
    uri: "GitHub's official MCP Server"
    headers:
      Authorization: "Bearer ***************************"


settings:
  goose_provider: google
  goose_model: gemini-flash-latest

```
