### PR TITLE
chore: changed default location for new chat button

### DIFF
--- a/packages/renderer/src/lib/chat/components/app-sidebar.svelte
+++ b/packages/renderer/src/lib/chat/components/app-sidebar.svelte
@@ -3,7 +3,7 @@ import { router } from 'tinro';
 
 import { currentChatId } from '/@/lib/chat/state/current-chat-id.svelte';
 
-import PenToSquareIcon from './icons/PenToSquareIcon.svelte';
+import Plus from './icons/plus.svelte';
 import { SidebarHistory } from './sidebar-history';
 import { Button } from './ui/button';
 import { Sidebar, SidebarContent, SidebarHeader, SidebarMenu, useSidebar } from './ui/sidebar';
@@ -37,7 +37,7 @@ const context = useSidebar();
 						{#snippet child({ props })}
 							<Button
 								{...props}
-								variant="ghost"
+								variant="default"
 								type="button"
 								class="h-fit p-2"
 								onclick={(): void => {
@@ -50,7 +50,7 @@ const context = useSidebar();
 									}
 								}}
 							>
-								<PenToSquareIcon />
+								<Plus />
 							</Button>
 						{/snippet}
 					</TooltipTrigger>

--- a/packages/renderer/src/lib/chat/components/chat-header.svelte
+++ b/packages/renderer/src/lib/chat/components/chat-header.svelte
@@ -10,7 +10,7 @@ import { currentChatId } from '/@/lib/chat/state/current-chat-id.svelte';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
-import PenToSquareIcon from './icons/PenToSquareIcon.svelte';
+import Plus from './icons/plus.svelte';
 import MCPSelector from './mcp-selector.svelte';
 import SidebarToggle from './sidebar-toggle.svelte';
 import { Button } from './ui/button';
@@ -44,11 +44,11 @@ const noMcps = $derived($mcpRemoteServerInfos.length === 0);
 		<Tooltip>
 			<TooltipTrigger>
 				{#snippet child({ props })}
-					<Button
-						{...props}
-						variant="outline"
-						class="order-2 ml-auto px-2 md:order-1 md:ml-0 md:h-fit md:px-2"
-						onclick={():void => {
+				<Button
+					{...props}
+					variant="default"
+					class="order-0 ml-auto px-2 md:ml-0 md:h-fit md:px-2"
+					onclick={():void => {
             	currentChatId.value = undefined;
               if ($router.path === '/') {
                 router.goto('/chat');
@@ -57,7 +57,7 @@ const noMcps = $derived($mcpRemoteServerInfos.length === 0);
               }
             }}
 					>
-						<PenToSquareIcon />
+						<Plus />
 						<span>New Chat</span>
 					</Button>
 				{/snippet}


### PR DESCRIPTION
Changes `new chat` button location to be default in sidebar & makes the sidebar non-colapsible

Will remove the toggle if needed 

[Screencast_20251118_071746.webm](https://github.com/user-attachments/assets/5c49683e-4f4a-4ac6-83e8-0fdcadce9d00)



Closes #582 