### PR TITLE
chore(ramalama-extension): add container model extractor

### DIFF
--- a/extensions/ramalama/src/api/model-info.ts
+++ b/extensions/ramalama/src/api/model-info.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ModelInfo {
+  name: string;
+  port: number;
+}

--- a/extensions/ramalama/src/api/ramalama-container-info.ts
+++ b/extensions/ramalama/src/api/ramalama-container-info.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ContainerInfo } from 'dockerode';
+
+export type RamalamaContainerInfo = ContainerInfo & {
+  Labels: {
+    'ai.ramalama.model': string;
+  } & Record<string, string>;
+};

--- a/extensions/ramalama/src/helper/container-model-extractor.spec.ts
+++ b/extensions/ramalama/src/helper/container-model-extractor.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { RamalamaContainerInfo } from '/@/api/ramalama-container-info';
+
+import { ContainerModelExtractor } from './container-model-extractor';
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+});
+
+test('extractModelInfo ', async () => {
+  const containerModelExtractor = new ContainerModelExtractor();
+
+  // test the extraction of model info from a RamalamaContainerInfo
+  const container = {
+    Id: '1',
+    Names: ['/container1'],
+    Labels: {
+      'ai.ramalama': 'true',
+      'ai.ramalama.model': 'granite-4',
+      'ai.ramalama.port': '8080',
+    },
+  } as unknown as RamalamaContainerInfo;
+
+  const modelInfo = await containerModelExtractor.extractModelInfo(container);
+  expect(modelInfo.name).toBe('granite-4');
+  expect(modelInfo.port).toBe(8080);
+});
+
+test('extractModelInfo without port ', async () => {
+  const containerModelExtractor = new ContainerModelExtractor();
+
+  // test the extraction of model info from a RamalamaContainerInfo
+  const container = {
+    Id: '1',
+    Names: ['/container1'],
+    Labels: {
+      'ai.ramalama': 'true',
+      'ai.ramalama.model': 'granite-4',
+    },
+  } as unknown as RamalamaContainerInfo;
+
+  const modelInfo = await containerModelExtractor.extractModelInfo(container);
+  expect(modelInfo.name).toBe('granite-4');
+  // port should default to 0 if not specified
+  expect(modelInfo.port).toBe(0);
+});

--- a/extensions/ramalama/src/helper/container-model-extractor.ts
+++ b/extensions/ramalama/src/helper/container-model-extractor.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { injectable } from 'inversify';
+
+import type { ModelInfo } from '/@/api/model-info';
+import type { RamalamaContainerInfo } from '/@/api/ramalama-container-info';
+
+@injectable()
+export class ContainerModelExtractor {
+  async extractModelInfo(container: RamalamaContainerInfo): Promise<ModelInfo> {
+    const modelName = container.Labels['ai.ramalama.model'];
+    const portLabel = container.Labels['ai.ramalama.port'];
+    const port = portLabel ? Number.parseInt(portLabel, 10) : 0;
+
+    return {
+      name: modelName,
+      port: port,
+    };
+  }
+}


### PR DESCRIPTION
extract name of the model and its port from ContainerInfo metadata

Signed-off-by: Florent Benoit <fbenoit@redhat.com>