### PR TITLE
chore: add methods to interact from IPC with scheduler/flow manager

### DIFF
--- a/packages/api/src/flow-schedule-info.ts
+++ b/packages/api/src/flow-schedule-info.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface FlowScheduleInfo {
+  id: string;
+  flowId: string;
+  schedulerName: string;
+  cronExpression: string;
+}

--- a/packages/api/src/scheduler/scheduler-api-info.ts
+++ b/packages/api/src/scheduler/scheduler-api-info.ts
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+export interface ProviderScheduleItemInfo {
+  schedulerName: string;
+  id: string;
+  metadata: Record<string, string>;
+  cronExpression: string;
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -71,6 +71,7 @@ import type { ExtensionInfo } from '/@api/extension-info';
 import type { FeedbackProperties, GitHubIssue } from '/@api/feedback';
 import type { FlowExecuteInfo } from '/@api/flow-execute-info';
 import type { FlowInfo } from '/@api/flow-info';
+import type { FlowScheduleInfo } from '/@api/flow-schedule-info';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
@@ -296,10 +297,40 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('listFlows', async (): Promise<Array<FlowInfo>> => {
     return ipcInvoke('flows:list');
   });
+  contextBridge.exposeInMainWorld(
+    'scheduleFlow',
+    async (
+      schedulerName: string,
+      flowId: string,
+      providerId: string,
+      connectionName: string,
+      cronExpression: string,
+    ): Promise<void> => {
+      return ipcInvoke('flows:schedule', schedulerName, flowId, providerId, connectionName, cronExpression);
+    },
+  );
 
   contextBridge.exposeInMainWorld('listExecuteFlows', async (): Promise<Array<FlowExecuteInfo>> => {
     return ipcInvoke('flows:listExecute');
   });
+
+  contextBridge.exposeInMainWorld('listScheduledFlows', async (): Promise<Array<FlowScheduleInfo>> => {
+    return ipcInvoke('flows:listSchedules');
+  });
+
+  contextBridge.exposeInMainWorld(
+    'deleteSchedule',
+    async (schedulerName: string, scheduleId: string): Promise<void> => {
+      return ipcInvoke('scheduler:delete-schedule', schedulerName, scheduleId);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'getSchedulerExecution',
+    async (schedulerName: string, id: string): Promise<containerDesktopAPI.ProviderScheduleExecution | undefined> => {
+      return ipcInvoke('scheduler:get-execution', schedulerName, id);
+    },
+  );
 
   contextBridge.exposeInMainWorld(
     'readFlow',


### PR DESCRIPTION
Scheduler-registry is handling the registration of schedulers, but it was missing methods from IPC to interact with schedulers

like, remotely asking to schedule a job, list the jobs, get the scheduler names. This PR is adding those "IPC" commands

it also adds the IPC commands at the flow level (so that flow manager can ask the scheduler-registry to delegate the execution of jobs)


SchedulerRegistry : interact with the scheduler-extensions (low-level)

FlowManager: allow to schedule Flows delegating to the "internal" scheduler-registry. (it adds the metadata 'flow-scheduler' on all jobs to be able to later retrieve all of them (filter out other jobs that may have been scheduled that are not flows)





related to https://github.com/kortex-hub/kortex/issues/519