### PR TITLE
chore: use static delta in linux pr check when installing flathub binaries

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -110,7 +110,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+          flatpak install flathub --user -y org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
 
       - name: Run Build
         timeout-minutes: 20


### PR DESCRIPTION
backport from Podman Desktop https://github.com/podman-desktop/podman-desktop/pull/14909