### PR TITLE
chore(scheduler-extension): parse macOS plist file to extract scheduling

### DIFF
--- a/extensions/scheduler/src/helper/macos/cron-plist-parser.spec.ts
+++ b/extensions/scheduler/src/helper/macos/cron-plist-parser.spec.ts
@@ -1,0 +1,134 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { Container } from 'inversify';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { CronParser } from '/@/helper/cron-parser';
+
+import { CronPListParser } from './cron-plist-parser';
+
+const cronParserMock = {
+  toCronExpression: vi.fn(),
+  parse: vi.fn(),
+} as unknown as CronParser;
+
+let cronPListParser: CronPListParser;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  const container = new Container();
+  container.bind<CronParser>(CronParser).toConstantValue(cronParserMock);
+  container.bind<CronPListParser>(CronPListParser).toSelf().inSingletonScope();
+  cronPListParser = container.get(CronPListParser);
+});
+
+test('parses all fields and forwards to CronParser', () => {
+  const plist = `
+    <plist version="1.0">
+      <dict>
+        <key>Minute</key><integer>5</integer>
+        <key>Hour</key><integer>12</integer>
+        <key>Day</key><integer>31</integer>
+        <key>Month</key><integer>7</integer>
+        <key>Weekday</key><integer>1</integer>
+      </dict>
+    </plist>
+  `;
+  vi.mocked(cronParserMock.toCronExpression).mockReturnValue('CRON_ALL_FIELDS');
+
+  const result = cronPListParser.extractFromPlist(plist);
+
+  expect(cronParserMock.toCronExpression).toHaveBeenCalledTimes(1);
+  expect(cronParserMock.toCronExpression).toHaveBeenCalledWith({
+    minute: '5',
+    hour: '12',
+    day: '31',
+    month: '7',
+    weekday: '1',
+  });
+  expect(result).toBe('CRON_ALL_FIELDS');
+});
+
+test('defaults to * when fields are missing', () => {
+  const plist = `
+    <plist version="1.0">
+      <dict>
+        <key>Hour</key><integer>8</integer>
+      </dict>
+    </plist>
+  `;
+  vi.mocked(cronParserMock.toCronExpression).mockReturnValue('CRON_DEFAULTS');
+
+  const result = cronPListParser.extractFromPlist(plist);
+
+  expect(cronParserMock.toCronExpression).toHaveBeenCalledWith({
+    minute: '*',
+    hour: '8',
+    day: '*',
+    month: '*',
+    weekday: '*',
+  });
+  expect(result).toBe('CRON_DEFAULTS');
+});
+
+test('uses the first occurrence when multiple keys exist', () => {
+  const plist = `
+    <plist version="1.0">
+      <dict>
+        <key>Minute</key><integer>5</integer>
+        <key>Minute</key><integer>10</integer>
+        <key>Hour</key><integer>6</integer>
+      </dict>
+    </plist>
+  `;
+  vi.mocked(cronParserMock.toCronExpression).mockReturnValue('CRON_FIRST_MATCH');
+
+  const result = cronPListParser.extractFromPlist(plist);
+
+  expect(cronParserMock.toCronExpression).toHaveBeenCalledWith({
+    minute: '5', // first occurrence only
+    hour: '6',
+    day: '*',
+    month: '*',
+    weekday: '*',
+  });
+  expect(result).toBe('CRON_FIRST_MATCH');
+});
+
+test('returns defaults when no schedule keys are present', () => {
+  const plist = `
+    <plist version="1.0">
+      <dict>
+        <key>Label</key><string>com.example.job</string>
+      </dict>
+    </plist>
+  `;
+  vi.mocked(cronParserMock.toCronExpression).mockReturnValue('CRON_ALL_DEFAULTS');
+
+  const result = cronPListParser.extractFromPlist(plist);
+
+  expect(cronParserMock.toCronExpression).toHaveBeenCalledWith({
+    minute: '*',
+    hour: '*',
+    day: '*',
+    month: '*',
+    weekday: '*',
+  });
+  expect(result).toBe('CRON_ALL_DEFAULTS');
+});

--- a/extensions/scheduler/src/helper/macos/cron-plist-parser.ts
+++ b/extensions/scheduler/src/helper/macos/cron-plist-parser.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { CronParser } from '/@/helper/cron-parser';
+
+@injectable()
+export class CronPListParser {
+  @inject(CronParser)
+  private readonly cronParser: CronParser;
+
+  extractFromPlist(plistContent: string): string {
+    const minuteRegex = /<key>Minute<\/key>\s*<integer>(\d+)<\/integer>/;
+    const hourRegex = /<key>Hour<\/key>\s*<integer>(\d+)<\/integer>/;
+    const dayRegex = /<key>Day<\/key>\s*<integer>(\d+)<\/integer>/;
+    const monthRegex = /<key>Month<\/key>\s*<integer>(\d+)<\/integer>/;
+    const weekdayRegex = /<key>Weekday<\/key>\s*<integer>(\d+)<\/integer>/;
+
+    const minuteMatch = minuteRegex.exec(plistContent);
+    const hourMatch = hourRegex.exec(plistContent);
+    const dayMatch = dayRegex.exec(plistContent);
+    const monthMatch = monthRegex.exec(plistContent);
+    const weekdayMatch = weekdayRegex.exec(plistContent);
+
+    return this.cronParser.toCronExpression({
+      minute: minuteMatch?.[1] ?? '*',
+      hour: hourMatch?.[1] ?? '*',
+      day: dayMatch?.[1] ?? '*',
+      month: monthMatch?.[1] ?? '*',
+      weekday: weekdayMatch?.[1] ?? '*',
+    });
+  }
+}


### PR DESCRIPTION
it extracts a cron expression from the scheduling part of a macOS launchagent plist file

related to https://github.com/kortex-hub/kortex/issues/519