### PR TITLE
chore(scheduler-extension): generate a macos plist file for a given scheduling expression

### DIFF
--- a/extensions/scheduler/src/helper/macos/plist-generator.spec.ts
+++ b/extensions/scheduler/src/helper/macos/plist-generator.spec.ts
@@ -1,0 +1,426 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { PlistOptions } from './plist-generator';
+import { PlistGenerator } from './plist-generator';
+
+let plistGenerator: PlistGenerator;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  plistGenerator = new PlistGenerator();
+});
+
+test('generates valid plist with required fields', () => {
+  const options: PlistOptions = {
+    id: 'test-job-123',
+    metadata: {},
+    executorScript: '/usr/local/bin/executor.sh',
+    storageDir: '/var/lib/kortex/storage',
+    command: {
+      command: 'docker',
+      args: ['ps', '-a'],
+      env: {},
+    },
+    outputFile: '/var/log/test-job.log',
+    cronComponents: {
+      minute: '0',
+      hour: '12',
+      day: '*',
+      month: '*',
+      weekday: '*',
+    },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+  expect(result).toContain('<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"');
+  expect(result).toContain('<plist version="1.0">');
+  expect(result).toContain('<key>Label</key>');
+  expect(result).toContain('<string>io.github.kortex-hub.kortex.schedule.test-job-123</string>');
+  expect(result).toContain('<key>ProgramArguments</key>');
+  expect(result).toContain('<string>/usr/local/bin/executor.sh</string>');
+  expect(result).toContain('<string>/var/lib/kortex/storage</string>');
+  expect(result).toContain('<string>test-job-123</string>');
+  expect(result).toContain('<string>docker</string>');
+  expect(result).toContain('<string>ps</string>');
+  expect(result).toContain('<string>-a</string>');
+  expect(result).toContain('<key>StandardOutPath</key>');
+  expect(result).toContain('<string>/var/log/test-job.log</string>');
+  expect(result).toContain('<key>StandardErrorPath</key>');
+  expect(result).toContain('<string>/var/log/test-job.log.err</string>');
+});
+
+test('includes metadata in ProgramArguments', () => {
+  const options: PlistOptions = {
+    id: 'job-with-metadata',
+    metadata: {
+      type: 'foo',
+      hello: 'bar',
+    },
+    executorScript: '/usr/local/bin/executor.sh',
+    storageDir: '/var/lib/kortex',
+    command: { command: 'echo', args: ['hello'], env: {} },
+    outputFile: '/var/log/job.log',
+    cronComponents: { minute: '*', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<string>--metadata</string>');
+  expect(result).toContain('<string>type=foo</string>');
+  expect(result).toContain('<string>--metadata</string>');
+  expect(result).toContain('<string>hello=bar</string>');
+});
+
+test('includes metadata dictionary in plist', () => {
+  const options: PlistOptions = {
+    id: 'job-with-metadata-dict',
+    metadata: {
+      jobType: 'backup',
+      version: '1.0',
+    },
+    executorScript: '/usr/local/bin/executor.sh',
+    storageDir: '/var/lib/kortex',
+    command: { command: 'backup', args: [], env: {} },
+    outputFile: '/var/log/backup.log',
+    cronComponents: { minute: '0', hour: '2', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>metadata</key>');
+  expect(result).toContain('<dict>');
+  expect(result).toContain('<key>jobType</key>');
+  expect(result).toContain('<string>backup</string>');
+  expect(result).toContain('<key>version</key>');
+  expect(result).toContain('<string>1.0</string>');
+});
+
+test('escapes special XML characters in command arguments', () => {
+  const options: PlistOptions = {
+    id: 'escape-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: {
+      command: 'echo',
+      args: ['<tag>', 'a&b', '"quoted"', `'single'`],
+      env: {},
+    },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '*', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('&lt;tag&gt;');
+  expect(result).toContain('a&amp;b');
+  expect(result).toContain('&quot;quoted&quot;');
+  expect(result).toContain('&apos;single&apos;');
+});
+
+test('escapes special characters in metadata values', () => {
+  const options: PlistOptions = {
+    id: 'metadata-escape',
+    metadata: {
+      description: 'Job with <special> & "chars"',
+    },
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '*', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('description=Job with &lt;special&gt; &amp; &quot;chars&quot;');
+  expect(result).toContain('<key>description</key>');
+  expect(result).toContain('<string>Job with &lt;special&gt; &amp; &quot;chars&quot;</string>');
+});
+
+test('includes environment variables when provided', () => {
+  const options: PlistOptions = {
+    id: 'env-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: {
+      command: 'node',
+      args: ['script.js'],
+      env: {
+        NODE_ENV: 'production',
+        API_KEY: 'secret123',
+      },
+    },
+    outputFile: '/var/log/node.log',
+    cronComponents: { minute: '*/5', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>EnvironmentVariables</key>');
+  expect(result).toContain('<key>NODE_ENV</key>');
+  expect(result).toContain('<string>production</string>');
+  expect(result).toContain('<key>API_KEY</key>');
+  expect(result).toContain('<string>secret123</string>');
+});
+
+test('omits EnvironmentVariables section when env is empty', () => {
+  const options: PlistOptions = {
+    id: 'no-env',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '*', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).not.toContain('<key>EnvironmentVariables</key>');
+});
+
+test('escapes special characters in environment variable values', () => {
+  const options: PlistOptions = {
+    id: 'env-escape',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: {
+      command: 'test',
+      args: [],
+      env: {
+        PATH: '/usr/bin:/bin',
+        MESSAGE: 'Hello & <world>',
+      },
+    },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '*', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<string>Hello &amp; &lt;world&gt;</string>');
+});
+
+test('generates StartInterval for minute-only wildcard expressions', () => {
+  const options: PlistOptions = {
+    id: 'interval-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '*/5', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>StartInterval</key>');
+  expect(result).toContain('<integer>300</integer>'); // 5 minutes = 300 seconds
+  expect(result).not.toContain('<key>StartCalendarInterval</key>');
+});
+
+test('generates StartCalendarInterval for specific time', () => {
+  const options: PlistOptions = {
+    id: 'calendar-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '30', hour: '14', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>StartCalendarInterval</key>');
+  expect(result).toContain('<key>Hour</key>');
+  expect(result).toContain('<integer>14</integer>');
+  expect(result).toContain('<key>Minute</key>');
+  expect(result).toContain('<integer>30</integer>');
+});
+
+test('generates multiple calendar intervals for range expressions', () => {
+  const options: PlistOptions = {
+    id: 'range-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '0', hour: '9-17/2', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>StartCalendarInterval</key>');
+  expect(result).toContain('<array>');
+  // Should generate intervals for hours: 9, 11, 13, 15, 17
+  const hourMatches = result.match(/<key>Hour<\/key>/g);
+  expect(hourMatches).toHaveLength(5);
+});
+
+test('includes day in calendar interval', () => {
+  const options: PlistOptions = {
+    id: 'day-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '0', hour: '0', day: '1', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>Day</key>');
+  expect(result).toContain('<integer>1</integer>');
+});
+
+test('includes month in calendar interval', () => {
+  const options: PlistOptions = {
+    id: 'month-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '0', hour: '0', day: '1', month: '6', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>Month</key>');
+  expect(result).toContain('<integer>6</integer>');
+});
+
+test('includes weekday in calendar interval', () => {
+  const options: PlistOptions = {
+    id: 'weekday-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '0', hour: '9', day: '*', month: '*', weekday: '1' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<key>Weekday</key>');
+  expect(result).toContain('<integer>1</integer>');
+});
+
+test('handles all wildcards', () => {
+  const options: PlistOptions = {
+    id: 'wildcard-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '*', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  // All wildcards should produce a single empty interval
+  expect(result).toContain('<key>StartCalendarInterval</key>');
+  expect(result).toContain('<array>');
+  expect(result).toContain('<dict>');
+});
+
+test('handles empty command args', () => {
+  const options: PlistOptions = {
+    id: 'no-args',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'uptime', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '0', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).toContain('<string>uptime</string>');
+  expect(result).toContain('<key>ProgramArguments</key>');
+});
+
+test('handles no metadata', () => {
+  const options: PlistOptions = {
+    id: 'no-metadata',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '*', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  expect(result).not.toContain('<key>metadata</key>');
+  expect(result).toContain('<key>Label</key>');
+});
+
+test('generates valid plist structure', () => {
+  const options: PlistOptions = {
+    id: 'structure-test',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: '0', hour: '12', day: '*', month: '*', weekday: '*' },
+  };
+
+  const result = plistGenerator.generate(options);
+
+  // Check proper XML structure
+  const openDicts = (result.match(/<dict>/g) ?? []).length;
+  const closeDicts = (result.match(/<\/dict>/g) ?? []).length;
+  expect(openDicts).toBe(closeDicts);
+
+  const openArrays = (result.match(/<array>/g) ?? []).length;
+  const closeArrays = (result.match(/<\/array>/g) ?? []).length;
+  expect(openArrays).toBe(closeArrays);
+
+  expect(result).toContain('</plist>');
+});
+
+test('throws error for unsupported cron field format', () => {
+  const options: PlistOptions = {
+    id: 'invalid-cron',
+    metadata: {},
+    executorScript: '/bin/sh',
+    storageDir: '/storage',
+    command: { command: 'test', args: [], env: {} },
+    outputFile: '/dev/null',
+    cronComponents: { minute: 'invalid-format', hour: '*', day: '*', month: '*', weekday: '*' },
+  };
+
+  expect(() => plistGenerator.generate(options)).toThrow('Unsupported cron field: invalid-format');
+});

--- a/extensions/scheduler/src/helper/macos/plist-generator.ts
+++ b/extensions/scheduler/src/helper/macos/plist-generator.ts
@@ -1,0 +1,202 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ProviderSchedulerCommand } from '@kortex-app/api';
+import { injectable } from 'inversify';
+
+import type { CronComponents } from '/@/helper/cron-parser';
+
+export interface PlistOptions {
+  id: string;
+  metadata: Record<string, string>;
+  executorScript: string;
+  storageDir: string;
+  command: ProviderSchedulerCommand;
+  outputFile: string;
+  cronComponents: CronComponents;
+}
+
+@injectable()
+export class PlistGenerator {
+  generate(options: PlistOptions): string {
+    const { id, executorScript, storageDir, command, outputFile, cronComponents } = options;
+
+    // create --metadata key=value arguments for each metadata entry
+    const metadataEntries = Object.entries(options.metadata)
+      .map(
+        ([key, value]) =>
+          `        <string>--metadata</string>\n        <string>${this.escapeXml(key)}=${this.escapeXml(value)}</string>`,
+      )
+      .join('\n');
+
+    const calendarInterval = this.buildCalendarInterval(cronComponents);
+    const environmentVariables = this.buildEnvironmentVariables(command.env);
+
+    // create metadata dictionary for plist
+    const metadataDict = this.buildMetadataDict(options.metadata);
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.github.kortex-hub.kortex.schedule.${id}</string>
+${metadataDict}
+    <key>ProgramArguments</key>
+    <array>
+        <string>${executorScript}</string>
+        <string>${storageDir}</string>
+        <string>${id}</string>
+${metadataEntries}
+        <string>${command.command}</string>
+${command.args.map(arg => `        <string>${this.escapeXml(arg)}</string>`).join('\n')}
+    </array>
+${environmentVariables}
+${calendarInterval}
+    <key>StandardOutPath</key>
+    <string>${outputFile}</string>
+    <key>StandardErrorPath</key>
+    <string>${outputFile}.err</string>
+</dict>
+</plist>`;
+  }
+
+  private escapeXml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  private buildCalendarInterval(components: CronComponents): string {
+    // Helper: expand expressions like "2-22/4" or "*/5" into numbers
+    const expandField = (field: string, max: number): number[] => {
+      if (field === '*') return []; // empty means "wildcard, ignore in calendar interval"
+
+      if (field.startsWith('*/')) {
+        const step = Number.parseInt(field.slice(2), 10);
+        const result: number[] = [];
+        for (let i = 0; i <= max; i += step) result.push(i);
+        return result;
+      }
+
+      const rangeMatch = RegExp(/^(\d+)-(\d+)\/(\d+)$/).exec(field);
+      if (rangeMatch) {
+        const start = Number.parseInt(rangeMatch[1], 10);
+        const end = Number.parseInt(rangeMatch[2], 10);
+        const step = Number.parseInt(rangeMatch[3], 10);
+        const result: number[] = [];
+        for (let i = start; i <= end; i += step) result.push(i);
+        return result;
+      }
+
+      // single integer
+      if (/^\d+$/.test(field)) return [Number.parseInt(field, 10)];
+
+      throw new Error(`Unsupported cron field: ${field}`);
+    };
+
+    // Expand all components
+    const minutes = expandField(components.minute, 59);
+    const hours = expandField(components.hour, 23);
+    const days = expandField(components.day, 31);
+    const months = expandField(components.month, 12);
+    const weekdays = expandField(components.weekday, 7);
+
+    // If only minute uses "*/n" and everything else is wildcard, use StartInterval
+    if (
+      components.minute.startsWith('*/') &&
+      components.hour === '*' &&
+      components.day === '*' &&
+      components.month === '*' &&
+      components.weekday === '*'
+    ) {
+      const intervalSeconds = Number.parseInt(components.minute.slice(2), 10) * 60;
+      return `    <key>StartInterval</key>\n    <integer>${intervalSeconds}</integer>`;
+    }
+
+    // Generate all combinations for StartCalendarInterval
+    const arrayEntries: string[] = [];
+
+    const hoursList = hours.length ? hours : [undefined];
+    const minutesList = minutes.length ? minutes : [undefined];
+    const daysList = days.length ? days : [undefined];
+    const monthsList = months.length ? months : [undefined];
+    const weekdaysList = weekdays.length ? weekdays : [undefined];
+
+    for (const h of hoursList) {
+      for (const m of minutesList) {
+        for (const d of daysList) {
+          for (const mo of monthsList) {
+            for (const w of weekdaysList) {
+              const dictEntries: string[] = [];
+              if (h !== undefined) dictEntries.push(`        <key>Hour</key>\n        <integer>${h}</integer>`);
+              if (m !== undefined) dictEntries.push(`        <key>Minute</key>\n        <integer>${m}</integer>`);
+              if (d !== undefined) dictEntries.push(`        <key>Day</key>\n        <integer>${d}</integer>`);
+              if (mo !== undefined) dictEntries.push(`        <key>Month</key>\n        <integer>${mo}</integer>`);
+              if (w !== undefined) dictEntries.push(`        <key>Weekday</key>\n        <integer>${w}</integer>`);
+              arrayEntries.push(`    <dict>\n${dictEntries.join('\n')}\n    </dict>`);
+            }
+          }
+        }
+      }
+    }
+
+    return `    <key>StartCalendarInterval</key>\n    <array>\n${arrayEntries.join('\n')}\n    </array>`;
+  }
+
+  private buildEnvironmentVariables(env?: Record<string, string>): string {
+    if (!env || Object.keys(env).length === 0) {
+      return '';
+    }
+
+    const entries = Object.entries(env)
+      .map(
+        ([key, value]) =>
+          `        <key>${this.escapeXml(key)}</key>\n        <string>${this.escapeXml(value)}</string>`,
+      )
+      .join('\n');
+
+    return `    <key>EnvironmentVariables</key>
+    <dict>
+${entries}
+    </dict>
+`;
+  }
+
+  private buildMetadataDict(metadata: Record<string, string>): string {
+    if (!metadata || Object.keys(metadata).length === 0) {
+      return '';
+    }
+
+    const entries = Object.entries(metadata)
+      .map(
+        ([key, value]) =>
+          `        <key>${this.escapeXml(key)}</key>\n        <string>${this.escapeXml(value)}</string>`,
+      )
+      .join('\n');
+
+    return `    <key>metadata</key>
+    <dict>
+${entries}
+    </dict>
+`;
+  }
+}


### PR DESCRIPTION
Generates the launchagent file that can be used to schedule jobs on macOS

related to https://github.com/kortex-hub/kortex/issues/519

