### PR TITLE
chore(scheduler-extension): register scheduler if there is one

### DIFF
--- a/extensions/scheduler/src/api/native-scheduler-api.ts
+++ b/extensions/scheduler/src/api/native-scheduler-api.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ProviderScheduler } from '@kortex-app/api';
+
+export const NativeScheduler = Symbol.for('NativeScheduler');
+export interface NativeScheduler extends ProviderScheduler {
+  init(): Promise<void>;
+}


### PR DESCRIPTION
it will allow to have a native macOS scheduler (using LaunchAgents) or a Windows scheduler (using schtasks) to be registered

related to https://github.com/kortex-hub/kortex/issues/519