### PR TITLE
fix(mcp): url arg missing in method call

### DIFF
--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -361,8 +361,11 @@ export class MCPRegistry {
 
     let transport: Transport;
     let config: StorageConfigFormat;
+
+    let url: string | undefined;
+
     switch (options.type) {
-      case 'remote':
+      case 'remote': {
         config = {
           remoteId: options.index,
           serverId: serverDetail.serverId,
@@ -373,8 +376,11 @@ export class MCPRegistry {
             ]),
           ),
         };
-        transport = this.setupRemote(serverDetail.remotes?.[options.index], config.headers);
+        const remote = serverDetail.remotes?.[options.index];
+        transport = this.setupRemote(remote, config.headers);
+        url = remote?.url;
         break;
+      }
       case 'package': {
         const pack = serverDetail.packages?.[options.index];
         if (!pack) throw new Error('package not found');
@@ -435,6 +441,7 @@ export class MCPRegistry {
       options.index,
       name,
       transport,
+      url,
       description,
     );
 


### PR DESCRIPTION
This PR fixes #743.


As you can see below, the URI in the goose file is now the url of Github and not the description.

<img width="680" height="338" alt="Screenshot 2025-11-17 at 15 21 37" src="https://github.com/user-attachments/assets/2ff2c3f4-1973-49e6-8697-b4b28d3ba7d2" />

<img width="303" height="405" alt="Screenshot 2025-11-17 at 15 22 36" src="https://github.com/user-attachments/assets/cbefd1df-5843-4981-8559-aaeee0703217" />
