### PR TITLE
chore(ramalama-extension): make helpers available in the inversify world

### DIFF
--- a/extensions/ramalama/src/helper/_module.ts
+++ b/extensions/ramalama/src/helper/_module.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+import { ContainerModelExtractor } from './container-model-extractor';
+import { ContainerRamaLamaFinder } from './container-ramalama-finder';
+
+const helpersModule = new ContainerModule(options => {
+  options.bind<ContainerModelExtractor>(ContainerModelExtractor).toSelf().inSingletonScope();
+  options.bind<ContainerRamaLamaFinder>(ContainerRamaLamaFinder).toSelf().inSingletonScope();
+});
+
+export { helpersModule };

--- a/extensions/ramalama/src/inject/inversify-binding.spec.ts
+++ b/extensions/ramalama/src/inject/inversify-binding.spec.ts
@@ -21,6 +21,7 @@ import type { ContainerExtensionAPI } from '@kortex-app/container-extension-api'
 import { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { helpersModule } from '/@/helper/_module';
 import { managersModule } from '/@/manager/_manager-module';
 import { InferenceModelManager } from '/@/manager/inference-model-manager';
 
@@ -64,6 +65,7 @@ describe('InversifyBinding', () => {
     expect(vi.mocked(Container.prototype.bind)).toHaveBeenCalledWith(RamalamaProvider);
 
     // expect load of modules
+    expect(vi.mocked(Container.prototype.load)).toHaveBeenCalledWith(helpersModule);
     expect(vi.mocked(Container.prototype.load)).toHaveBeenCalledWith(managersModule);
   });
 

--- a/extensions/ramalama/src/inject/inversify-binding.ts
+++ b/extensions/ramalama/src/inject/inversify-binding.ts
@@ -20,6 +20,7 @@ import type { ExtensionContext as PodmanDesktopExtensionContext, Provider, Telem
 import type { ContainerExtensionAPI } from '@kortex-app/container-extension-api';
 import { Container } from 'inversify';
 
+import { helpersModule } from '/@/helper/_module';
 import {
   ContainerExtensionAPISymbol,
   ExtensionContextSymbol,
@@ -57,6 +58,7 @@ export class InversifyBinding {
     this.#container.bind(TelemetryLoggerSymbol).toConstantValue(this.#telemetryLogger);
     this.#container.bind(RamalamaProvider).toConstantValue(this.#provider);
 
+    await this.#container.load(helpersModule);
     await this.#container.load(managersModule);
 
     // Get inference model manager


### PR DESCRIPTION
define the helper module and bind it

Signed-off-by: Florent Benoit <fbenoit@redhat.com>