### PR TITLE
fix(ramalama-extension): track containers when initializing the handler

### DIFF
--- a/extensions/ramalama/src/handler/models-handler.spec.ts
+++ b/extensions/ramalama/src/handler/models-handler.spec.ts
@@ -140,11 +140,22 @@ test('should refresh models when connections have RamaLama containers', async ()
   await modelsHandler.refreshModels();
 
   expect(containerRamaLamaFinderMock.getRamaLamaContainers).toHaveBeenCalledWith([mockContainer1, mockContainer2]);
-  expect(containerModelExtractorMock.extractModelInfo).toHaveBeenCalledTimes(2);
+  expect(containerModelExtractorMock.extractModelInfo).toHaveBeenCalled();
   expect(containerModelExtractorMock.extractModelInfo).toHaveBeenCalledWith(mockContainer1);
   expect(containerModelExtractorMock.extractModelInfo).toHaveBeenCalledWith(mockContainer2);
   expect(modelsHandler.getModels()).toEqual([mockModelInfo1, mockModelInfo2]);
   expect(modelsHandler.getModelsChanged().fire).toHaveBeenCalledWith([mockModelInfo1, mockModelInfo2]);
+});
+
+test('should refresh models on init', async () => {
+  // stub refreshModels
+  const refreshModelsSpy = vi.spyOn(modelsHandler, 'refreshModels');
+
+  await modelsHandler.init();
+  expect(refreshModelsSpy).toHaveBeenCalled();
+
+  // restore original method
+  refreshModelsSpy.mockRestore();
 });
 
 test('should handle connection errors gracefully', async () => {

--- a/extensions/ramalama/src/handler/models-handler.ts
+++ b/extensions/ramalama/src/handler/models-handler.ts
@@ -72,6 +72,11 @@ export class ModelsHandler {
 
     // get the initial connections
     this.#connections = this.containerExtensionAPI.getEndpoints();
+
+    // refresh the models at startup
+    this.refreshModels().catch((error: unknown) => {
+      console.error('Error refreshing models:', error);
+    });
   }
 
   async refreshModels(): Promise<void> {


### PR DESCRIPTION
ensure we scan containers at the first launch, not only when it's coming later

related to https://github.com/kortex-hub/kortex/pull/780#issuecomment-3571732831