### PR TITLE
fix: allow creation for RAG connections

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -167,6 +167,22 @@ onMount(async () => {
           });
         }
       });
+
+      provider.ragConnections.forEach(connection => {
+        const ragConnectionName = getProviderConnectionName(provider, connection);
+        connectionNames.push(ragConnectionName);
+        // update the map only if the container state is different from last time
+        if (
+          !containerConnectionStatus.has(ragConnectionName) ||
+          containerConnectionStatus.get(ragConnectionName)?.status !== connection.status
+        ) {
+          containerConnectionStatus.set(ragConnectionName, {
+            inProgress: false,
+            action: undefined,
+            status: connection.status,
+          });
+        }
+      });
     });
     // if a machine has been deleted we need to clean its old stored status
     containerConnectionStatus.forEach((v, k) => {
@@ -404,6 +420,7 @@ $effect(() => {
                   || provider.kubernetesProviderConnectionCreation
                   || provider.vmProviderConnectionCreation
                   || provider.inferenceProviderConnectionCreation
+                  || provider.ragProviderConnectionCreation
                   }
                     {@const providerDisplayName =
                       (provider.containerProviderConnectionCreation
@@ -414,7 +431,9 @@ $effect(() => {
                             ? provider.vmProviderConnectionCreationDisplayName
                             : provider.inferenceProviderConnectionCreation
                               ? provider.inferenceProviderConnectionCreationDisplayName
-                              : undefined) ?? provider.name}
+                              : provider.ragProviderConnectionCreation
+                                ? provider.ragProviderConnectionCreationDisplayName
+                                : undefined) ?? provider.name}
                     {@const buttonTitle =
                       (provider.containerProviderConnectionCreation
                         ? (provider.containerProviderConnectionCreationButtonTitle ?? undefined)
@@ -424,7 +443,9 @@ $effect(() => {
                             ? provider.vmProviderConnectionCreationButtonTitle
                             : provider.inferenceProviderConnectionCreation
                               ? provider.inferenceProviderConnectionCreationButtonTitle
-                              : undefined) ?? 'Create new'}
+                              : provider.ragProviderConnectionCreation
+                                ? provider.ragProviderConnectionCreationButtonTitle
+                                : undefined) ?? 'Create new'}
                     <!-- create new provider button -->
                     <CreateProviderConnectionButton {provider} {providerDisplayName} {buttonTitle} bind:preflightChecks={preflightChecks} />
                   {/if}
@@ -666,6 +687,18 @@ $effect(() => {
             />
           </div>
         {/each}
+          {#each provider.ragConnections as ragConnection, index (index)}
+            <div class="px-5 py-2 w-[240px]" role="region" aria-label={ragConnection.name}>
+              <span>{ragConnection.name} (RAG)</span>
+              <PreferencesConnectionActions
+                provider={provider}
+                connection={ragConnection}
+                connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, ragConnection))}
+                updateConnectionStatus={updateContainerStatus}
+                addConnectionToRestartingQueue={addConnectionToRestartingQueue}
+              />
+            </div>
+          {/each}
         </div>
       </div>
     {/each}


### PR DESCRIPTION
In a previous PR (#746) support for RAG extension points were added but UI was not updaded thus it was not possible to create a new RAG connection.