### PR TITLE
fix: enable typecheck on Gemini extension

### DIFF
--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -108,7 +108,7 @@ beforeEach(() => {
   } as unknown as Pager<Model>;
 
   const mockList = vi.fn().mockResolvedValue(mockPager);
-  vi.mocked(GoogleGenAI).prototype.models = { list: mockList };
+  vi.mocked(GoogleGenAI).mockReturnValue({ models: { list: mockList } } as unknown as GoogleGenAI);
 });
 
 test('constructor should not do anything', async () => {


### PR DESCRIPTION
While working on extensions, I realize that some of them errored on typecheck.
This fixes the Gemini extension

`pnpm exec tsc --noEmit --project extensions/gemini`