### PR TITLE
fix: enable typecheck on Goose extension

### DIFF
--- a/extensions/goose/src/kube-template.spec.ts
+++ b/extensions/goose/src/kube-template.spec.ts
@@ -26,6 +26,8 @@ import { KubeTemplate } from './kube-template';
 test.each<KubeTemplateOptions & { testName: string }>([
   {
     testName: 'gemini',
+    job: { name: 'job-1' },
+    namespace: 'ns1',
     recipe: {
       flowId: 'demo-flow-id',
       name: 'echo',
@@ -44,7 +46,6 @@ instructions: |
     },
     provider: {
       name: 'google',
-      model: 'gemini-2.5-pro',
       credentials: {
         env: [{ key: 'GOOGLE_API_KEY', value: 'dummy' }],
       },

--- a/extensions/goose/src/recipe-template.spec.ts
+++ b/extensions/goose/src/recipe-template.spec.ts
@@ -28,9 +28,14 @@ test.each<RecipeTemplateOptions & { testName: string }>([
     recipe: {
       name: 'echo',
       prompt: 'echo the user prompt',
+      description: '',
       title: 'Echo',
       instructions: 'echo the user prompt',
       extensions: [],
+      settings: {
+        goose_provider: '',
+        goose_model: '',
+      },
     },
   },
   {
@@ -38,6 +43,7 @@ test.each<RecipeTemplateOptions & { testName: string }>([
     recipe: {
       name: 'paris-trip',
       prompt: 'make a trip to paris',
+      description: '',
       title: 'Echo',
       instructions: 'echo the user prompt',
       extensions: [
@@ -53,6 +59,10 @@ test.each<RecipeTemplateOptions & { testName: string }>([
           ],
         },
       ],
+      settings: {
+        goose_provider: '',
+        goose_model: '',
+      },
     },
   },
 ])('$testName', async options => {

--- a/extensions/goose/src/test-snapshots/recipe-with-extensions.yaml
+++ b/extensions/goose/src/test-snapshots/recipe-with-extensions.yaml
@@ -1,9 +1,11 @@
 title: Echo
 name: paris-trip
-description: 
+description: |
+    
 
 # Required for headless mode
-prompt: make a trip to paris
+prompt: |
+    make a trip to paris
 
 instructions: |
     echo the user prompt
@@ -14,3 +16,8 @@ extensions:
     uri: "https://api.githubcopilot.com/mcp/"
     headers:
       Authorization: "Dummy"
+
+
+settings:
+  goose_provider: 
+  goose_model: 

--- a/extensions/goose/src/test-snapshots/simple-recipe.yaml
+++ b/extensions/goose/src/test-snapshots/simple-recipe.yaml
@@ -1,11 +1,19 @@
 title: Echo
 name: echo
-description: 
+description: |
+    
 
 # Required for headless mode
-prompt: echo the user prompt
+prompt: |
+    echo the user prompt
 
 instructions: |
     echo the user prompt
 
 extensions:
+  []
+
+
+settings:
+  goose_provider: 
+  goose_model: 

--- a/extensions/goose/tsconfig.json
+++ b/extensions/goose/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
-    "lib": ["ES2024", "webworker"],
+    "module": "esnext",
+    "lib": ["ES2024"],
     "sourceMap": true,
     "rootDir": "src",
     "outDir": "dist",
+    "target": "esnext",
+    "moduleResolution": "node",
     "skipLibCheck": true,
     "types": ["node"],
     "esModuleInterop": true


### PR DESCRIPTION
While working on extensions, I realize that some of them errored on typecheck.
This fixes the Goose extension

`pnpm exec tsc --noEmit --project extensions/gemini`
