### PR TITLE
fix: enable typecheck on ollama extension

### DIFF
--- a/extensions/ollama/src/ollama-extension.ts
+++ b/extensions/ollama/src/ollama-extension.ts
@@ -60,7 +60,12 @@ export class OllamaExtension {
         throw new Error(`HTTP error, status: ${res.status}`);
       }
       const data = await res.json();
-      models = Array.isArray(data.models) ? data.models : [];
+      models =
+        data !== null && typeof data === 'object' && 'models' in data
+          ? Array.isArray(data.models)
+            ? data.models
+            : []
+          : [];
     } catch (_err: unknown) {
       running = false;
       models = [];


### PR DESCRIPTION
While working on extensions, I realize that some of them errored on typecheck.
This fixes the Goose extension

`pnpm exec tsc --noEmit --project extensions/gemini`
