### PR TITLE
chore: updated mcp-registry-types dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.33.0",
     "@kortex-app/api": "workspace:",
-    "@kortex-hub/mcp-registry-types": "^1.2.3",
+    "@kortex-hub/mcp-registry-types": "^1.4.0-next.20251210140818.04eeb13",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -461,7 +461,7 @@ export class MCPRegistry {
   }
 
   protected setupRemote(
-    remote: components['schemas']['Remote'] | undefined,
+    remote: components['schemas']['StreamableHttpTransport'] | components['schemas']['SseTransport'] | undefined,
     headers: Record<string, string>,
   ): Transport {
     if (!remote) throw new Error('remote not found');

--- a/packages/renderer/src/lib/mcp/setup/RemoteSetupForm.svelte
+++ b/packages/renderer/src/lib/mcp/setup/RemoteSetupForm.svelte
@@ -9,7 +9,7 @@ import { createInputWithVariables } from '/@/lib/mcp/setup/input-with-variable-r
 import type { InputWithVariableResponse, MCPSetupRemoteOptions } from '/@api/mcp/mcp-setup';
 
 interface Props {
-  object: components['schemas']['Remote'];
+  object: components['schemas']['SseTransport'] | components['schemas']['StreamableHttpTransport'];
   loading: boolean;
   remoteIndex: number;
   submit: (options: MCPSetupRemoteOptions) => Promise<void>;

--- a/packages/renderer/src/lib/mcp/setup/mcp-target.ts
+++ b/packages/renderer/src/lib/mcp/setup/mcp-target.ts
@@ -18,4 +18,8 @@
 
 import type { components } from '@kortex-hub/mcp-registry-types';
 
-export type MCPTarget = (components['schemas']['Remote'] | components['schemas']['Package']) & { index: number };
+export type MCPTarget = (
+  | components['schemas']['StreamableHttpTransport']
+  | components['schemas']['SseTransport']
+  | components['schemas']['Package']
+) & { index: number };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: 'workspace:'
         version: link:packages/extension-api
       '@kortex-hub/mcp-registry-types':
-        specifier: ^1.2.3
-        version: 1.2.3
+        specifier: ^1.4.0-next.20251210140818.04eeb13
+        version: 1.4.0-next.20251210140818.04eeb13
       '@rollup/plugin-commonjs':
         specifier: ^28.0.6
         version: 28.0.6(rollup@4.46.2)
@@ -1633,8 +1633,8 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@kortex-hub/mcp-registry-types@1.2.3':
-    resolution: {integrity: sha512-vNVgNt10al3RZsIUwf3VrZl+7qeyDhoNU3VSTLS5K0caXbbuP3KZWzNBDUHZ891oHOX2glXjJSnReOuD5GO/Dw==}
+  '@kortex-hub/mcp-registry-types@1.4.0-next.20251210140818.04eeb13':
+    resolution: {integrity: sha512-xYO35mnv6qtwIC3+1WJHUet94w3C2CWwu9GdxM0jSSG763OMuOoyPTirsXDNeiPE7pYUwr1rR9Ea1WVcHT+1pA==}
 
   '@kubernetes/client-node@1.3.0':
     resolution: {integrity: sha512-IE0yrIpOT97YS5fg2QpzmPzm8Wmcdf4ueWMn+FiJSI3jgTTQT1u+LUhoYpdfhdHAVxdrNsaBg2C0UXSnOgMoCQ==}
@@ -8556,7 +8556,9 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kortex-hub/mcp-registry-types@1.2.3': {}
+  '@kortex-hub/mcp-registry-types@1.4.0-next.20251210140818.04eeb13':
+    dependencies:
+      ajv: 8.17.1
 
   '@kubernetes/client-node@1.3.0(patch_hash=1c34691b2a4cf5f4fdeb73244fb59dccceee5642ddca2ac6c41fe86d9fde86e5)(encoding@0.1.13)':
     dependencies:


### PR DESCRIPTION
Updates mcp-registry-types dependency version


We are using Remote type https://github.com/kortex-hub/kortex/blob/main/packages/main/src/plugin/mcp/mcp-registry.ts#L464 but it is deprecated in newer version of openapi spec see https://raw.githubusercontent.com/modelcontextprotocol/registry/refs/tags/v1.3.10/docs/reference/api/openapi.yaml

So this PR changes Remote type to StreamableHttpTransport and SseTransport