### PR TITLE
fix(extensions/container): remove duplicated "extension" in displayed name

### DIFF
--- a/extensions/container/packages/extension/package.json
+++ b/extensions/container/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "container",
-  "displayName": "Container Extension",
+  "displayName": "Container",
   "description": "Allows to interact with container engines (docker, podman, etc.)",
   "version": "0.0.1-next",
   "icon": "icon.png",


### PR DESCRIPTION
Follow up of https://github.com/kortex-hub/kortex/pull/829, there was one extension missing to be consistent in the namings