### PR TITLE
refactor: remove unused mcpSelectorOpen

### DIFF
--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -154,7 +154,7 @@ function onCheckMCPTool(mcpId: string, toolId: string, checked: boolean): void {
                 />
                 <form class="bg-background mx-auto flex w-full gap-2 px-4 pb-4 md:max-w-3xl md:pb-6">
                     {#if !readonly}
-                        <MultimodalInput {attachments} {chatClient} {selectedModel} {selectedMCPTools} bind:mcpSelectorOpen={mcpSelectorOpen} class="flex-1" />
+                        <MultimodalInput {attachments} {chatClient} {selectedModel} {selectedMCPTools} class="flex-1" />
                     {/if}
                 </form>
             </div>

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -25,14 +25,12 @@ let {
   class: c,
   selectedMCPTools,
   selectedModel,
-  mcpSelectorOpen = $bindable(),
 }: {
   attachments: Attachment[];
   chatClient: Chat;
   class?: string;
   selectedMCPTools: SvelteMap<string, Set<string>>;
   selectedModel?: ModelInfo;
-  mcpSelectorOpen: boolean;
 } = $props();
 
 let input = $state('');
@@ -123,7 +121,7 @@ $effect.pre(() => {
 
 <div class="relative flex w-full flex-col gap-4">
 	{#if mounted && chatClient.messages.length === 0 && attachments.length === 0}
-		<SuggestedActions {chatClient} {selectedMCPTools} bind:mcpSelectorOpen={mcpSelectorOpen} />
+		<SuggestedActions {chatClient} {selectedMCPTools} />
 	{/if}
 
 	{#if attachments.length > 0}

--- a/packages/renderer/src/lib/chat/components/suggested-actions.svelte
+++ b/packages/renderer/src/lib/chat/components/suggested-actions.svelte
@@ -13,11 +13,9 @@ import { Button } from './ui/button';
 let {
   chatClient,
   selectedMCPTools,
-  mcpSelectorOpen = $bindable(),
 }: {
   chatClient: Chat;
   selectedMCPTools: SvelteMap<string, Set<string>>;
-  mcpSelectorOpen: boolean;
 } = $props();
 
 type SuggestedAction = {


### PR DESCRIPTION
Follow up of https://github.com/kortex-hub/kortex/pull/661, these are not used anymore and can be removed