### PR TITLE
fix(navigation): encode parameters

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -177,9 +177,9 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
 
         <Route path="/flows/:providerId/:connectionName/:flowId/*" let:meta breadcrumb="Flow Details">
           <FlowDetails
-            providerId={meta.params.providerId}
-            connectionName={meta.params.connectionName}
-            flowId={meta.params.flowId}
+            providerId={decodeURIComponent(meta.params.providerId)}
+            connectionName={decodeURIComponent(meta.params.connectionName)}
+            flowId={decodeURIComponent(meta.params.flowId)}
           />
         </Route>
 

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -50,12 +50,12 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       break;
     case NavigationPage.FLOW_DETAILS:
       router.goto(
-        `/flows/${request.parameters.providerId}/${request.parameters.connectionName}/${request.parameters.flowId}/summary`,
+        `/flows/${encodeURIComponent(request.parameters.providerId)}/${encodeURIComponent(request.parameters.connectionName)}/${encodeURIComponent(request.parameters.flowId)}/summary`,
       );
       break;
     case NavigationPage.FLOW_RUN:
       router.goto(
-        `/flows/${request.parameters.providerId}/${request.parameters.connectionName}/${request.parameters.flowId}/run`,
+        `/flows/${encodeURIComponent(request.parameters.providerId)}/${encodeURIComponent(request.parameters.connectionName)}/${encodeURIComponent(request.parameters.flowId)}/run`,
       );
       break;
     case NavigationPage.MCP_INSTALL_FROM_REGISTRY:


### PR DESCRIPTION
The flowId may contains is some edge cases an `/`  leading to invalid routing

<img width="403" height="660" alt="Image" src="https://github.com/user-attachments/assets/1ff6cecc-6eb9-4614-bc83-50e68a556d9b" />

This is a problem when navigating to the flow details

https://github.com/kortex-hub/kortex/blob/fa1f68307eea61088bb73c95ced9465d6fca748e/packages/renderer/src/navigation.ts#L53

We should use `encodeURIComponent` & `decodeURIComponent` to ensure we don't have issue with potential `/`