### PR TITLE
fix: enhance MCP registry validation error message

### DIFF
--- a/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
@@ -73,6 +73,8 @@ describe('validateSchemaData', () => {
     expect(result).toBe(false);
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
+      invalidServerList,
+      'errors:',
       expect.anything(),
     );
   });
@@ -92,6 +94,8 @@ describe('validateSchemaData', () => {
     expect(result).toBe(false);
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
+      invalidServerResponse,
+      'errors:',
       expect.anything(),
     );
   });
@@ -111,6 +115,8 @@ describe('validateSchemaData', () => {
     expect(result).toBe(false);
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
+      invalidServerResponse,
+      'errors:',
       expect.arrayContaining([
         expect.objectContaining({
           message: expect.stringContaining('pattern'),
@@ -140,6 +146,8 @@ describe('validateSchemaData', () => {
     expect(result).toBe(false);
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
+      invalidServerResponse,
+      'errors:',
       expect.anything(),
     );
   });
@@ -190,6 +198,8 @@ describe('validateSchemaData', () => {
     expect(result).toBe(false);
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
+      invalidServerDetail,
+      'errors:',
       expect.anything(),
     );
   });
@@ -212,6 +222,8 @@ describe('validateSchemaData', () => {
 
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining(`from 'https://example-registry.com'`),
+      invalidData,
+      'errors:',
       expect.anything(),
     );
   });
@@ -233,6 +245,8 @@ describe('validateSchemaData', () => {
 
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
+      invalidData,
+      'errors:',
       expect.anything(),
     );
     expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining(' from '), expect.anything());

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -46,7 +46,9 @@ export class MCPSchemaValidator {
     if (!isValid && !suppressWarnings) {
       const context = contextName ? ` from '${contextName}'` : '';
       console.warn(
-        `[MCPSchemaValidator] Failed to validate data against schema '${schemaName}'${context}.`,
+        `[MCPSchemaValidator] Failed to validate data against schema '${schemaName}'${context}. Payload:`,
+        jsonData,
+        'errors:',
         validator.errors,
       );
     }


### PR DESCRIPTION
While playing with Kortex, I noticed a lot of messages in the log about the validation of data coming from the MCP registries. But they were to understand as only the errors were printed, I added the original payload