### PR TITLE
ci: enable nightly e2e workflow to run from branches/forks

### DIFF
--- a/.github/workflows/e2e-test-job.yaml
+++ b/.github/workflows/e2e-test-job.yaml
@@ -32,6 +32,16 @@ on:
         description: 'Arguments for pnpm compile:current (e.g., --win dir, --linux dir, --mac dir)'
         required: true
         type: string
+      repo:
+        description: 'Repository to checkout (e.g., owner/repo for forks). Defaults to the current repository.'
+        required: false
+        type: string
+        default: ''
+      ref:
+        description: 'Branch, tag, or SHA to checkout. Defaults to the default branch.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   e2e-test:
@@ -43,6 +53,9 @@ jobs:
       GEMINI_API_KEY: ${{ !startsWith(inputs.instance, 'ubuntu') && secrets.GEMINI_API_KEY || '' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         name: Install pnpm

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -32,6 +32,16 @@ on:
           - windows
           - macos
           - linux
+      repo:
+        description: 'Repository to checkout (e.g., owner/repo for forks)'
+        required: false
+        default: ''
+        type: string
+      ref:
+        description: 'Branch, tag, or SHA to checkout'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   windows-e2e-tests:
@@ -46,6 +56,8 @@ jobs:
       instance: ${{ matrix.os }}
       mode: ${{ matrix.mode }}
       compile_args: '--win dir'
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
     secrets: inherit
 
   linux-e2e-tests:
@@ -60,6 +72,8 @@ jobs:
       instance: ${{ matrix.os }}
       mode: ${{ matrix.mode }}
       compile_args: '--linux dir'
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
     secrets: inherit
 
   macos-e2e-tests:
@@ -74,4 +88,6 @@ jobs:
       instance: ${{ matrix.os }}
       mode: ${{ matrix.mode }}
       compile_args: '--mac dir'
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
     secrets: inherit


### PR DESCRIPTION
- Add repo and ref inputs to the nightly e2e workflow for testing code from forks or specific branches
- Update the reusable e2e-test-job.yaml to accept and use these parameters in the checkout step
- Defaults preserve existing behavior when inputs are not provided

Closes #1011 