### PR TITLE
feat(ui-agent-workspace): added agent workspace list view

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -60,4 +60,5 @@ export enum NavigationPage {
   NETWORK_CREATE = 'network-create',
   EXTENSIONS_CATALOG = 'extensions-catalog',
   MCP_DETAILS = 'mcp-details',
+  AGENT_WORKSPACES = 'agent-workspaces',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -76,6 +76,7 @@ export interface NavigationParameters {
   [NavigationPage.MCP_INSTALL_FROM_REGISTRY]: {
     serverId: string;
   };
+  [NavigationPage.AGENT_WORKSPACES]: never;
 }
 
 // the parameters property is optional when the NavigationParameters say it is

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -5,6 +5,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import { tablePersistence } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
+import AgentWorkspaceList from '/@/lib/agent-workspaces/AgentWorkspaceList.svelte';
 import { parseExtensionListRequest } from '/@/lib/extensions/extension-list';
 import FlowCreate from '/@/lib/flows/FlowCreate.svelte';
 import FlowDetails from '/@/lib/flows/FlowDetails.svelte';
@@ -170,6 +171,10 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
         <Route path="/chat/:chatId/*" let:meta breadcrumb="Chat">
           <CustomChat chatId={meta.params.chatId} />
+        </Route>
+
+        <Route path="/agent-workspaces" breadcrumb="Agent Workspaces" navigationHint="root">
+          <AgentWorkspaceList />
         </Route>
 
         <Route path="/flows/*" breadcrumb="Flows" navigationHint="root" firstmatch>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+
+import AgentWorkspaceCard from './AgentWorkspaceCard.svelte';
+
+const workspace: AgentWorkspaceSummary = {
+  id: 'ws-1',
+  name: 'api-refactor',
+  paths: {
+    source: '/home/user/projects/backend',
+    configuration: '/home/user/.config/kortex/workspaces/api-refactor.yaml',
+  },
+};
+
+test('Expect card displays workspace name', () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  expect(screen.getByText('api-refactor')).toBeInTheDocument();
+});
+
+test('Expect card displays source path', () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  expect(screen.getByText('/home/user/projects/backend')).toBeInTheDocument();
+});
+
+test('Expect card displays configuration path', () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  expect(screen.getByText('/home/user/.config/kortex/workspaces/api-refactor.yaml')).toBeInTheDocument();
+});
+
+test('Expect card has aria label with workspace name', () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  expect(screen.getByRole('region', { name: 'workspace api-refactor' })).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import { faFolder, faGear } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+
+interface Props {
+  workspace: AgentWorkspaceSummary;
+}
+
+let { workspace }: Props = $props();
+</script>
+
+<div
+  class="flex flex-col gap-3 p-4 bg-(--pd-content-card-carousel-card-bg) hover:bg-(--pd-content-card-carousel-card-hover-bg) rounded-md"
+  role="region"
+  aria-label="workspace {workspace.name}">
+  <div class="text-start">
+    <span class="text-(--pd-invert-content-card-text) font-semibold text-base">{workspace.name}</span>
+  </div>
+  <div class="flex flex-col gap-2 text-sm">
+    <div class="flex items-center gap-2 text-(--pd-invert-content-card-text)" title={workspace.paths.source}>
+      <Icon icon={faFolder} class="shrink-0 opacity-70" />
+      <span class="truncate">{workspace.paths.source}</span>
+    </div>
+    <div class="flex items-center gap-2 text-(--pd-invert-content-card-text)" title={workspace.paths.configuration}>
+      <Icon icon={faGear} class="shrink-0 opacity-70" />
+      <span class="truncate">{workspace.paths.configuration}</span>
+    </div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceEmptyScreen.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceEmptyScreen.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import { faRobot } from '@fortawesome/free-solid-svg-icons/faRobot';
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+</script>
+
+<EmptyScreen title="No agent workspaces" icon={faRobot}>
+  <span class="text-(--pd-content-text)">
+    Agent workspaces will appear here once created.
+  </span>
+</EmptyScreen>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { agentWorkspaces } from '/@/stores/agent-workspaces';
+import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+
+import AgentWorkspaceList from './AgentWorkspaceList.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  agentWorkspaces.set([]);
+});
+
+test('Expect empty screen when no workspaces', () => {
+  render(AgentWorkspaceList);
+
+  expect(screen.getByText('No agent workspaces')).toBeInTheDocument();
+});
+
+test('Expect total count displayed as 0 total sessions when empty', () => {
+  render(AgentWorkspaceList);
+
+  expect(screen.getByText('0 total sessions')).toBeInTheDocument();
+});
+
+test('Expect workspace cards displayed with total count', () => {
+  const workspaces: AgentWorkspaceSummary[] = [
+    {
+      id: 'ws-1',
+      name: 'api-refactor',
+      paths: {
+        source: '/home/user/projects/backend',
+        configuration: '/home/user/.config/kortex/workspaces/api-refactor.yaml',
+      },
+    },
+    {
+      id: 'ws-2',
+      name: 'frontend-redesign',
+      paths: {
+        source: '/home/user/projects/frontend',
+        configuration: '/home/user/.config/kortex/workspaces/frontend-redesign.yaml',
+      },
+    },
+  ];
+  agentWorkspaces.set(workspaces);
+
+  render(AgentWorkspaceList);
+
+  expect(screen.getByText('api-refactor')).toBeInTheDocument();
+  expect(screen.getByText('frontend-redesign')).toBeInTheDocument();
+  expect(screen.getByText('/home/user/projects/backend')).toBeInTheDocument();
+  expect(screen.getByText('/home/user/projects/frontend')).toBeInTheDocument();
+  expect(screen.getByText('2 total sessions')).toBeInTheDocument();
+});
+
+test('Expect page title to be Agent Workspaces', () => {
+  render(AgentWorkspaceList);
+
+  expect(screen.getByText('Agent Workspaces')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import { NavPage } from '@podman-desktop/ui-svelte';
+
+import { agentWorkspaces } from '/@/stores/agent-workspaces';
+
+import AgentWorkspaceCard from './AgentWorkspaceCard.svelte';
+import AgentWorkspaceEmptyScreen from './AgentWorkspaceEmptyScreen.svelte';
+</script>
+
+<NavPage searchEnabled={false} title="Agent Workspaces">
+  {#snippet additionalActions()}
+    <span class="text-(--pd-content-text)">{$agentWorkspaces.length} total sessions</span>
+  {/snippet}
+
+  {#snippet content()}
+    <div class="flex w-full h-full overflow-auto">
+      {#if $agentWorkspaces.length === 0}
+        <AgentWorkspaceEmptyScreen />
+      {:else}
+        <div class="grid grid-cols-3 gap-4 p-5 w-full h-fit">
+          {#each $agentWorkspaces as workspace (workspace.id)}
+            <AgentWorkspaceCard {workspace} />
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/snippet}
+</NavPage>

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -308,3 +308,9 @@ test(`Test navigationHandle for ${NavigationPage.EXTENSIONS_CATALOG}`, () => {
     '/extensions?screen=catalog&searchTerm=not%3Ainstalled%20category%3Afoo%20keyword%3Abar%20red%20hat',
   );
 });
+
+test(`Test navigationHandle for ${NavigationPage.AGENT_WORKSPACES}`, () => {
+  handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/agent-workspaces');
+});

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -176,5 +176,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.MCP_DETAILS:
       router.goto(`/mcps/${encodeURIComponent(request.parameters.id)}/summary`);
       break;
+    case NavigationPage.AGENT_WORKSPACES:
+      router.goto('/agent-workspaces');
+      break;
   }
 };

--- a/packages/renderer/src/stores/agent-workspaces.ts
+++ b/packages/renderer/src/stores/agent-workspaces.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+
+export const agentWorkspaces: Writable<AgentWorkspaceSummary[]> = writable([]);
+
+export async function fetchAgentWorkspaces(): Promise<void> {
+  const data = await window.listAgentWorkspaces();
+  agentWorkspaces.set(data);
+}
+
+window.addEventListener('system-ready', () => {
+  fetchAgentWorkspaces().catch((error: unknown) => {
+    console.error('Failed to fetch agent workspaces', error);
+  });
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry-agent-workspaces.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-agent-workspaces.svelte.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { faRobot } from '@fortawesome/free-solid-svg-icons/faRobot';
+
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+export function createNavigationAgentWorkspacesEntry(): NavigationRegistryEntry {
+  const registry: NavigationRegistryEntry = {
+    name: 'Agents',
+    icon: { faIcon: { definition: faRobot, size: 'lg' } },
+    link: '/agent-workspaces',
+    tooltip: 'Agent Workspaces',
+    type: 'entry',
+    get counter() {
+      return 0;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -25,6 +25,7 @@ import { configurationProperties } from '/@/stores/configurationProperties';
 import { EventStore } from '/@/stores/event-store';
 import { createNavigationFlowsEntry } from '/@/stores/navigation/navigation-registry-flows.svelte';
 
+import { createNavigationAgentWorkspacesEntry } from './navigation-registry-agent-workspaces.svelte';
 import { createNavigationExtensionEntry, createNavigationExtensionGroup } from './navigation-registry-extension.svelte';
 import { createNavigationMcpEntry } from './navigation-registry-mcp.svelte';
 
@@ -68,6 +69,7 @@ const init = (): void => {
   values.push(createNavigationNetworkEntry());
   values.push(createNavigationKubernetesGroup());
   */
+  values.push(createNavigationAgentWorkspacesEntry());
   values.push(createNavigationMcpEntry());
   values.push(createNavigationFlowsEntry());
   values.push(createNavigationExtensionEntry());


### PR DESCRIPTION
Added agent workspace list view with the current attributes for workspaces list from the CLI. Agent workspaces are mocked in `agent-workspace-mock-data.ts`

<img width="1038" height="695" alt="Captura de pantalla 2026-03-11 a las 17 44 46" src="https://github.com/user-attachments/assets/79d84603-9615-42ef-95ba-a37260fb5ae2" />

Part of #1040 

Basic unit tests provided.