### PR TITLE
fix: hide empty onboarding container when no providers available

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -115,9 +115,9 @@ function startOnboardingQueue(): void {
       <div class="flex justify-center text-lg font-bold p-2">
         <span class="mr-2">🎉</span>{welcomeMessages?.welcomeMessage} v{podmanDesktopVersion} !
       </div>
-      <div class="flex flex-row justify-center">
-        <div class="bg-[var(--pd-content-card-inset-bg)] px-4 pb-4 pt-2 rounded-sm">
-          {#if onboardingProviders && onboardingProviders.length > 0}
+      {#if onboardingProviders && onboardingProviders.length > 0}
+        <div class="flex flex-row justify-center">
+          <div class="bg-[var(--pd-content-card-inset-bg)] px-4 pb-4 pt-2 rounded-sm">
             <div class="flex justify-center text-sm text-[var(--pd-content-card-text)] pb-2">
               <div>Choose the extensions to include:</div>
             </div>
@@ -148,12 +148,12 @@ function startOnboardingQueue(): void {
                 </div>
               {/each}
             </div>
-          {/if}
+          </div>
         </div>
-      </div>
-      <div class="flex justify-center p-2 text-sm items-center">
-        Configure these and more under Settings.
-      </div>
+        <div class="flex justify-center p-2 text-sm items-center">
+          Configure these and more under Settings.
+        </div>
+      {/if}
     </div>
 
     <!-- Telemetry -->


### PR DESCRIPTION
Hide the blue container and related text on the welcome page when there
are no onboarding providers, preventing an empty blue rectangle from
appearing during initial onboarding.

<img width="1162" height="812" alt="Screenshot 2026-03-13 at 12 36 55" src="https://github.com/user-attachments/assets/5875080b-e6bb-4eaf-bc98-8c98729daa10" />

Fixes #1097

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
