### PR TITLE
fix: preserve text following colons in markdown rendering

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -263,6 +263,22 @@ test('Expect to render a markdown table as an HTML table', async () => {
   expect(table).toContainHTML('<td>Cell 1</td>');
 });
 
+describe('Unrecognized directives', () => {
+  test('Expect text with colon-separated words to be preserved', async () => {
+    await waitRender({ markdown: 'look at that:poof!' });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent.textContent).toContain('look at that:poof!');
+  });
+
+  test('Expect unrecognized directive with label to be preserved', async () => {
+    await waitRender({ markdown: ':unknown[some label]' });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent.textContent).toContain(':unknown[some label]');
+  });
+});
+
 describe('jump to TOC section', () => {
   test('Expect TOC to be clickable', async () => {
     await waitRender({

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -78,6 +78,7 @@ import { gfmTable, gfmTableHtml } from 'micromark-extension-gfm-table';
 import { onDestroy, onMount } from 'svelte';
 
 import { button } from './micromark-button-directive';
+import { fallback } from './micromark-fallback-directive';
 import { image } from './micromark-image-directive';
 import { link } from './micromark-link-directive';
 import { createListener } from './micromark-listener-handler';
@@ -115,7 +116,11 @@ function renderMarkdown(source: string): string {
   // Provide micromark + extensions
   const rendered = micromark(source, {
     extensions: [gfmAutolinkLiteral(), gfmTable(), directive()],
-    htmlExtensions: [gfmAutolinkLiteralHtml(), gfmTableHtml(), directiveHtml({ button, image, link, warnings })],
+    htmlExtensions: [
+      gfmAutolinkLiteralHtml(),
+      gfmTableHtml(),
+      directiveHtml({ button, image, link, warnings, '*': fallback }),
+    ],
   });
 
   // remove href values in each anchor using # for links

--- a/packages/renderer/src/lib/markdown/micromark-fallback-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-fallback-directive.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import type { Directive } from 'micromark-extension-directive';
+
+/**
+ * Fallback handler for unrecognized directives.
+ * Preserves the original text so that content like `:poof:` in
+ * "look at that:poof!" is not silently stripped.
+ *
+ * @this {import('micromark-util-types').CompileContext}
+ * @type {import('micromark-extension-directive').Handle}
+ */
+export function fallback(d: Directive): void {
+  if (d.type === 'textDirective') {
+    // Reconstruct the original text: :name[label]{attributes}
+    this.raw(':' + (d.name ?? ''));
+    if (d.label) {
+      this.raw('[' + d.label + ']');
+    }
+    if (d.attributes && Object.keys(d.attributes).length > 0) {
+      const attrs = Object.entries(d.attributes)
+        .map(([key, value]) => `${key}="${value}"`)
+        .join(' ');
+      this.raw('{' + attrs + '}');
+    }
+  }
+}


### PR DESCRIPTION
Unrecognized micromark directives (e.g. :2b in "granite3.2:2b")
were silently stripped. Add a wildcard fallback handler that outputs the
raw text for any directive not handled by button, image, link, or warnings.

Before the change:
<img width="860" height="125" alt="Screenshot 2026-03-17 at 14 15 36" src="https://github.com/user-attachments/assets/def22db7-d0ae-4517-a030-42314b1d8444" />

After, the same message is rendered properly:
<img width="688" height="120" alt="Screenshot 2026-03-17 at 14 16 23" src="https://github.com/user-attachments/assets/a9fef5a2-5ec3-465a-a3d2-99557ff087de" />

Fixes #1107