### PR TITLE
fix: prevent TypeError in PinActions when outsideWindow is undefined

### DIFF
--- a/packages/renderer/src/lib/statusbar/PinActions.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinActions.spec.ts
@@ -132,6 +132,21 @@ test('escape should hide the menu', async () => {
   });
 });
 
+test('clicking outside the menu should close it', async () => {
+  const { queryByTitle } = await getOpenedPinActions();
+
+  // verify the menu is open
+  expect(queryByTitle('Pin Menu')).toBeInTheDocument();
+
+  // click outside the component (on document body)
+  await fireEvent.click(document.body);
+
+  // menu should be closed
+  await vi.waitFor(() => {
+    expect(queryByTitle('Pin Menu')).toBeNull();
+  });
+});
+
 describe('pin / unpin', () => {
   beforeEach(() => {
     // pin podman

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -38,7 +38,7 @@ function onWindowClick(e: Event): void {
   const target = e.target as HTMLElement;
   // Listen to anything **but** the button that has "data-task-button" attribute with a value of "Help"
   if (target && target.getAttribute('data-task-button') !== 'Pin') {
-    showMenu = outsideWindow.contains(target);
+    showMenu = outsideWindow?.contains(target) ?? false;
   }
 }
 


### PR DESCRIPTION
This PR fixes an error reported in the logs, when clicking anywhere in the UI

> PinActions.svelte:41 Uncaught TypeError: Cannot read properties of undefined (reading 'contains')
    at onWindowClick (PinActions.svelte:41:30)