### PR TITLE
feat: remember last used model in chat 

### DIFF
--- a/packages/renderer/src/lib/chat/ai/models.ts
+++ b/packages/renderer/src/lib/chat/ai/models.ts
@@ -1,0 +1,1 @@
+export const LAST_USED_MODEL_KEY: string = 'last-used-model';

--- a/packages/renderer/src/lib/chat/components/chat.spec.ts
+++ b/packages/renderer/src/lib/chat/components/chat.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ModelInfo } from '/@/lib/chat/components/model-info';
+
+import { findModel } from './chat.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('findModel', () => {
+  const models: ModelInfo[] = [
+    { providerId: 'ollama', connectionName: 'local', label: 'llama3' },
+    { providerId: 'ollama', connectionName: 'local', label: 'mistral' },
+    { providerId: 'gemini', connectionName: 'cloud', label: 'gemini-pro' },
+  ];
+
+  test('should return matching model when all fields match', () => {
+    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'mistral' };
+    const result = findModel(models, target);
+    expect(result).toEqual(target);
+  });
+
+  test('should return undefined when model is undefined', () => {
+    const result = findModel(models, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  test('should return undefined when no model matches', () => {
+    const target: ModelInfo = { providerId: 'openai', connectionName: 'remote', label: 'gpt-4' };
+    const result = findModel(models, target);
+    expect(result).toBeUndefined();
+  });
+
+  test('should return undefined when label does not match', () => {
+    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'nonexistent' };
+    const result = findModel(models, target);
+    expect(result).toBeUndefined();
+  });
+
+  test('should return undefined when providerId does not match', () => {
+    const target: ModelInfo = { providerId: 'wrong-provider', connectionName: 'local', label: 'llama3' };
+    const result = findModel(models, target);
+    expect(result).toBeUndefined();
+  });
+
+  test('should return undefined when connectionName does not match', () => {
+    const target: ModelInfo = { providerId: 'ollama', connectionName: 'wrong-connection', label: 'llama3' };
+    const result = findModel(models, target);
+    expect(result).toBeUndefined();
+  });
+
+  test('should return undefined when models list is empty', () => {
+    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'llama3' };
+    const result = findModel([], target);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -1,3 +1,14 @@
+<script lang="ts" module>
+import type { ModelInfo } from '/@/lib/chat/components/model-info';
+
+export function findModel(models: ModelInfo[], model: ModelInfo | undefined): ModelInfo | undefined {
+  if (!model) return undefined;
+  return models.find(
+    m => m.label === model.label && m.providerId === model.providerId && m.connectionName === model.connectionName,
+  );
+}
+</script>
+
 <script lang="ts">
 import { Chat } from '@ai-sdk/svelte';
 import type { Attachment } from '@ai-sdk/ui-utils';
@@ -5,8 +16,9 @@ import { untrack } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { toast } from 'svelte-sonner';
 
-import type { ModelInfo } from '/@/lib/chat/components/model-info';
+import { LAST_USED_MODEL_KEY } from '/@/lib/chat/ai/models';
 import { ChatHistory } from '/@/lib/chat/hooks/chat-history.svelte';
+import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
 import { convertToUIMessages } from '/@/lib/chat/utils/chat';
 import { getModels } from '/@/lib/models/models-utils';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
@@ -35,6 +47,8 @@ let models: Array<ModelInfo> = $derived(getModels($providerInfos));
 
 const config = MessageConfigSchema.safeParse(messages[messages.length - 1]?.config).data;
 
+const lastUsedModel = new LocalStorage<ModelInfo | undefined>(LAST_USED_MODEL_KEY, undefined);
+
 let selectedModel = $derived<ModelInfo | undefined>(
   config
     ? {
@@ -42,8 +56,14 @@ let selectedModel = $derived<ModelInfo | undefined>(
         label: config.modelId,
         providerId: config.providerId,
       }
-    : models[0],
+    : findModel(models, lastUsedModel.value) ?? models[0],
 );
+
+$effect(() => {
+  if (selectedModel) {
+    lastUsedModel.value = selectedModel;
+  }
+});
 
 /**
  * Here we store the list of tools selected

--- a/tests/playwright/src/model/pages/chat-page.ts
+++ b/tests/playwright/src/model/pages/chat-page.ts
@@ -286,4 +286,9 @@ export class ChatPage extends BasePage {
   getToolByName(name: string): Locator {
     return this.page.getByText(name, { exact: true });
   }
+
+  async clearLastUsedModel(): Promise<void> {
+    // Must match LAST_USED_MODEL_KEY from packages/renderer/src/lib/chat/ai/models.ts
+    await this.page.evaluate(() => localStorage.removeItem('last-used-model'));
+  }
 }

--- a/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
@@ -30,8 +30,9 @@ test.use({
 
 test.describe
   .serial('Chat page navigation', { tag: '@smoke' }, () => {
-    test.beforeEach(async ({ page, navigationBar }) => {
+    test.beforeEach(async ({ page, navigationBar, chatPage }) => {
       await waitForNavigationReady(page);
+      await chatPage.clearLastUsedModel();
       await navigationBar.navigateToChatPage();
     });
 
@@ -265,5 +266,24 @@ test.describe
 
       await chatPage.verifySendButtonVisible(TIMEOUTS.MODEL_RESPONSE);
       await chatPage.verifyStopButtonHidden();
+    });
+
+    test('[CHAT-11] Last used model is remembered when starting a new chat', async ({ chatPage }) => {
+      const modelCount = await chatPage.getAvailableModelsCount();
+
+      if (modelCount < 2) {
+        test.skip(true, 'Skipping test: Less than 2 models available');
+        return;
+      }
+
+      // Select the second model
+      await chatPage.selectModelByIndex(1);
+      const selectedModelName = await chatPage.getSelectedModelName();
+      expect(selectedModelName).toBeTruthy();
+
+      // Start a new chat and verify the last used model is still selected
+      await chatPage.clickNewChat();
+      const modelAfterNewChat = await chatPage.getSelectedModelName();
+      expect(modelAfterNewChat).toBe(selectedModelName);
     });
   });


### PR DESCRIPTION
Store the selected provider:model in localStorage so new chats
default to the last used model instead of always picking the first
alphabetically. Reset the stored model before each e2e test to
prevent state leaking between tests.

Fixes #1099