### PR TITLE
fix(chat): prevent scroll jump when hovering edit button

### DIFF
--- a/packages/renderer/src/lib/chat/components/messages.svelte
+++ b/packages/renderer/src/lib/chat/components/messages.svelte
@@ -40,7 +40,6 @@ $effect(() => {
   observer.observe(containerRef, {
     childList: true,
     subtree: true,
-    attributes: true,
     characterData: true,
   });
 


### PR DESCRIPTION
if there's a very long conversation, larger than the viewport, then when the mouse hovers over the edit button on top of the convo, the page automatically scrolls down to the end of the page.

Fix involves removing `attributes` from MutationObserver config so CSS class changes
(like hover opacity transitions) no longer trigger auto-scroll to bottom.