### PR TITLE
feat(chat): implement edit message functionality

### DIFF
--- a/packages/main/src/chat/chat-manager.ts
+++ b/packages/main/src/chat/chat-manager.ts
@@ -110,6 +110,7 @@ export class ChatManager {
     this.ipcHandle('inference:getChatMessagesById', (_, id: string) => this.getChatMessagesById(id));
     this.ipcHandle('inference:deleteChat', (_, id: string) => this.deleteChat(id));
     this.ipcHandle('inference:deleteAllChats', () => this.deleteAllChats());
+    this.ipcHandle('inference:deleteTrailingMessages', (_, id: string) => this.deleteTrailingMessages(id));
   }
 
   private async getExchanges(mcpId: string): Promise<DynamicToolUIPart[]> {
@@ -148,6 +149,13 @@ export class ChatManager {
 
   private async deleteAllChats(): Promise<undefined> {
     await this.chatQueries.deleteAllChatsForUser({ userId: this.userId });
+  }
+
+  private async deleteTrailingMessages(id: string): Promise<undefined> {
+    const result = await this.chatQueries.deleteTrailingMessages({ id });
+    if (result.isErr()) {
+      throw result.error;
+    }
   }
 
   private async convertMessages(messages: UIMessage[]): Promise<UIMessage[]> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1318,6 +1318,10 @@ export function initExposure(): void {
     return ipcInvoke('inference:deleteAllChats');
   });
 
+  contextBridge.exposeInMainWorld('inferenceDeleteTrailingMessages', async (id: string): Promise<undefined> => {
+    return ipcInvoke('inference:deleteTrailingMessages', id);
+  });
+
   contextBridge.exposeInMainWorld('inferenceGenerate', async (params: InferenceParameters): Promise<string> => {
     return ipcInvoke('inference:generate', params);
   });

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -18,6 +18,7 @@ import { toast } from 'svelte-sonner';
 
 import { LAST_USED_MODEL_KEY } from '/@/lib/chat/ai/models';
 import { ChatHistory } from '/@/lib/chat/hooks/chat-history.svelte';
+import { EditState } from '/@/lib/chat/hooks/edit-state.svelte';
 import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
 import { convertToUIMessages } from '/@/lib/chat/utils/chat';
 import { getModels } from '/@/lib/models/models-utils';
@@ -137,6 +138,8 @@ const chatClient = $derived(
     },
   }),
 );
+
+EditState.toContext();
 
 let attachments = $state<Attachment[]>([]);
 let mcpSelectorOpen = $state(false);

--- a/packages/renderer/src/lib/chat/components/messages.svelte
+++ b/packages/renderer/src/lib/chat/components/messages.svelte
@@ -53,7 +53,7 @@ $effect(() => {
 	{/if}
 
 	{#each messages as message (message.id)}
-		<PreviewMessage {message} {readonly} {loading}/>
+		<PreviewMessage {message} {messages} {readonly} {loading}/>
 	{/each}
 
 	{#if loading && messages.length > 0 && messages[messages.length - 1].role === 'user'}

--- a/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
@@ -3,6 +3,7 @@ import type { UIMessage } from '@ai-sdk/svelte';
 import type { DynamicToolUIPart } from 'ai';
 import { fly } from 'svelte/transition';
 
+import { EditState } from '/@/lib/chat/hooks/edit-state.svelte';
 import { fileUIPart2Attachment } from '/@/lib/chat/utils/chat';
 import { cn } from '/@/lib/chat/utils/shadcn';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
@@ -17,21 +18,27 @@ import ToolParts from './tool-parts.svelte';
 
 let {
   message,
+  messages,
   readonly,
   loading,
 }: {
   message: UIMessage;
+  messages: UIMessage[];
   readonly: boolean;
   loading: boolean;
 } = $props();
 
-let mode = $state<'view' | 'edit'>('view');
+const editState = EditState.fromContext();
+
+const isGrayed = $derived(editState.isAfterEditingMessage(messages, message));
 
 const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type === 'dynamic-tool') ?? [];
 </script>
 
 <div
-	class="group/message mx-auto w-full max-w-3xl px-4"
+	class={cn('group/message mx-auto w-full max-w-3xl px-4', {
+		'opacity-40 pointer-events-none': isGrayed,
+	})}
 	data-role={message.role}
 	in:fly|global={{ opacity: 0, y: 5 }}
 >
@@ -39,10 +46,7 @@ const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type 
 	<div
 		class={cn(
 			'flex w-full gap-4 group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-2xl',
-			{
-				'w-full': mode === 'edit',
-				'group-data-[role=user]/message:w-fit': mode !== 'edit',
-			}
+			'group-data-[role=user]/message:w-fit',
 		)}
 	>
 		{#if message.role === 'assistant'}
@@ -76,44 +80,36 @@ const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type 
 				{#if type === 'reasoning'}
 					<MessageReasoning {loading} reasoning={part.text} />
 				{:else if type === 'text'}
-					{#if mode === 'view'}
-						<div class="flex flex-row items-center gap-2">
-							{#if message.role === 'user' && !readonly}
-								<Tooltip>
-									<TooltipTrigger>
-										{#snippet child({ props })}
-											<Button
-												{...props}
-												variant="ghost"
-												class="text-muted-foreground h-fit rounded-full px-2 opacity-0 group-hover/message:opacity-100"
-												onclick={(): void => {
-													mode = 'edit';
-												}}
-											>
-												<PencilEditIcon />
-											</Button>
-										{/snippet}
-									</TooltipTrigger>
-									<TooltipContent>Edit message</TooltipContent>
-								</Tooltip>
-							{/if}
-							<div
-								class={cn('flex flex-col gap-4', {
-									'bg-primary text-primary-foreground rounded-xl px-3 pt-4': message.role === 'user',
-   									'animate-fade-in': message.role === 'assistant',
-								})}
-							>
-								<Markdown markdown={part.text} />
-							</div>
+					<div class="flex flex-row items-center gap-2">
+						{#if message.role === 'user' && !readonly && !editState.isEditing}
+							<Tooltip>
+								<TooltipTrigger>
+									{#snippet child({ props })}
+										<Button
+											{...props}
+											variant="ghost"
+											class="text-muted-foreground h-fit rounded-full px-2 opacity-0 group-hover/message:opacity-100"
+											aria-label="Edit message"
+											onclick={(): void => {
+												editState.startEditing(message);
+											}}
+										>
+											<PencilEditIcon />
+										</Button>
+									{/snippet}
+								</TooltipTrigger>
+								<TooltipContent>Edit message</TooltipContent>
+							</Tooltip>
+						{/if}
+						<div
+							class={cn('flex flex-col gap-4', {
+								'bg-primary text-primary-foreground rounded-xl px-3 pt-4': message.role === 'user',
+								'animate-fade-in': message.role === 'assistant',
+							})}
+						>
+							<Markdown markdown={part.text} />
 						</div>
-					{:else if mode === 'edit'}
-						<div class="flex flex-row items-start gap-2">
-							<div class="size-8"></div>
-
-							<!-- TODO -->
-							<!-- <MessageEditor key={message.id} {message} {setMode} {setMessages} {reload} /> -->
-						</div>
-					{/if}
+					</div>
 
 					<!-- TODO -->
 					<!-- {:else if type === 'tool-invocation'}

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 import { type Chat } from '@ai-sdk/svelte';
 import type { Attachment } from '@ai-sdk/ui-utils';
-import { onMount } from 'svelte';
+import { onMount, untrack } from 'svelte';
 import type { SvelteMap } from 'svelte/reactivity';
 import { innerWidth } from 'svelte/reactivity/window';
 import { toast } from 'svelte-sonner';
 
+import { EditState } from '/@/lib/chat/hooks/edit-state.svelte';
 import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
 import { cn } from '/@/lib/chat/utils/shadcn';
 
@@ -33,11 +34,34 @@ let {
   selectedModel?: ModelInfo;
 } = $props();
 
+const editState = EditState.fromContext();
+
 let input = $state('');
+let savedInput = $state('');
 let mounted = $state(false);
 let textareaRef = $state<HTMLTextAreaElement | null>(null);
 const storedInput = new LocalStorage('input', '');
 const loading = $derived(chatClient.status === 'streaming' || chatClient.status === 'submitted');
+
+$effect(() => {
+  if (editState.editingMessage) {
+    const text = editState.editingMessage.parts
+      .filter(part => part.type === 'text')
+      .map(part => (part as { type: 'text'; text: string }).text)
+      .join('');
+    untrack(() => {
+      savedInput = input;
+      setInput(text);
+      textareaRef?.focus();
+    });
+  }
+});
+
+function cancelEditing(): void {
+  editState.cancelEditing();
+  setInput(savedInput);
+  savedInput = '';
+}
 
 const adjustHeight = (): void => {
   if (textareaRef) {
@@ -60,6 +84,29 @@ function setInput(value: string): void {
 
 async function submitForm(): Promise<void> {
   const text = input;
+
+  if (editState.editingMessage) {
+    const editingMessage = editState.editingMessage;
+    setInput('');
+    savedInput = '';
+    editState.cancelEditing();
+
+    await window.inferenceDeleteTrailingMessages(editingMessage.id);
+
+    const index = chatClient.messages.findIndex(m => m.id === editingMessage.id);
+    if (index !== -1) {
+      const updatedMessage = {
+        ...editingMessage,
+        parts: [{ type: 'text' as const, text }],
+      };
+      chatClient.messages = [...chatClient.messages.slice(0, index), updatedMessage];
+    }
+
+    resetHeight();
+    await chatClient.regenerate();
+    return;
+  }
+
   setInput('');
   await chatClient.sendMessage({
     text,
@@ -133,6 +180,10 @@ $effect.pre(() => {
 		</div>
 	{/if}
 
+	{#if editState.isEditing}
+		<div class="text-muted-foreground px-3 pt-2 text-sm">Press ESC to cancel editing</div>
+	{/if}
+
 	<Textarea
 		bind:ref={textareaRef}
 		placeholder="Send a message..."
@@ -144,6 +195,12 @@ $effect.pre(() => {
 		rows={2}
 		autofocus
 		onkeydown={async(event): Promise<void> => {
+			if (event.key === 'Escape' && editState.isEditing) {
+				event.preventDefault();
+				cancelEditing();
+				return;
+			}
+
 			if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
 				event.preventDefault();
 

--- a/packages/renderer/src/lib/chat/hooks/edit-state.svelte.ts
+++ b/packages/renderer/src/lib/chat/hooks/edit-state.svelte.ts
@@ -1,0 +1,37 @@
+import type { UIMessage } from '@ai-sdk/svelte';
+import { getContext, setContext } from 'svelte';
+
+const contextKey = Symbol('EditState');
+
+export class EditState {
+  editingMessage = $state<UIMessage | undefined>(undefined);
+
+  get isEditing(): boolean {
+    return this.editingMessage !== undefined;
+  }
+
+  startEditing(message: UIMessage): void {
+    this.editingMessage = message;
+  }
+
+  cancelEditing(): void {
+    this.editingMessage = undefined;
+  }
+
+  isAfterEditingMessage(messages: UIMessage[], message: UIMessage): boolean {
+    if (!this.editingMessage) return false;
+    const editIndex = messages.findIndex(m => m.id === this.editingMessage!.id);
+    const messageIndex = messages.findIndex(m => m.id === message.id);
+    return messageIndex > editIndex;
+  }
+
+  static fromContext(): EditState {
+    return getContext<EditState>(contextKey);
+  }
+
+  static toContext(): EditState {
+    const state = new EditState();
+    setContext(contextKey, state);
+    return state;
+  }
+}

--- a/tests/playwright/src/model/pages/chat-page.ts
+++ b/tests/playwright/src/model/pages/chat-page.ts
@@ -35,6 +35,7 @@ export class ChatPage extends BasePage {
   readonly chatHistoryItems: Locator;
   readonly conversationMessages: Locator;
   readonly conversationMessageParagraphs: Locator;
+  readonly userConversationMessages: Locator;
   readonly modelConversationMessages: Locator;
   readonly chatHistoryItem: Locator;
   readonly chatHistoryItemMenuAction: Locator;
@@ -52,6 +53,7 @@ export class ChatPage extends BasePage {
   readonly showMcpPanelButton: Locator;
   readonly filterToolsInput: Locator;
   readonly toolCheckboxes: Locator;
+  readonly editCancelHint: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -66,6 +68,7 @@ export class ChatPage extends BasePage {
     this.chatHistoryItems = page.locator('li[data-sidebar="menu-item"]');
     this.conversationMessages = page.locator('div[data-role]');
     this.conversationMessageParagraphs = this.conversationMessages.getByRole('paragraph');
+    this.userConversationMessages = page.locator('div[data-role="user"]');
     this.modelConversationMessages = page.locator('div[data-role="assistant"]');
     this.chatHistoryItem = page.locator('button[data-sidebar="menu-button"]');
     this.chatHistoryItemMenuAction = page.locator('button[data-sidebar="menu-action"]');
@@ -83,6 +86,7 @@ export class ChatPage extends BasePage {
     this.showMcpPanelButton = page.getByRole('button', { name: 'Show MCP panel' });
     this.filterToolsInput = page.getByLabel('filter Tools');
     this.toolCheckboxes = page.getByRole('checkbox');
+    this.editCancelHint = page.getByText('Press ESC to cancel editing');
   }
 
   async waitForLoad(): Promise<void> {
@@ -319,5 +323,55 @@ export class ChatPage extends BasePage {
   async clearLastUsedModel(): Promise<void> {
     // Must match LAST_USED_MODEL_KEY from packages/renderer/src/lib/chat/ai/models.ts
     await this.page.evaluate(() => localStorage.removeItem('last-used-model'));
+  }
+
+  getEditButtonForUserMessage(index: number): Locator {
+    return this.userConversationMessages.nth(index).getByLabel('Edit message');
+  }
+
+  async clickEditOnUserMessage(index: number): Promise<void> {
+    const messageLocator = this.userConversationMessages.nth(index);
+    await messageLocator.hover();
+    const editButton = messageLocator.getByLabel('Edit message');
+    // The button is opacity-0 until CSS group-hover takes effect, so force the click
+    await editButton.click({ force: true });
+  }
+
+  async verifyEditingMode(originalText: string): Promise<void> {
+    await expect(this.editCancelHint).toBeVisible();
+    await expect(this.messageField).toHaveValue(originalText);
+  }
+
+  async cancelEditing(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await expect(this.editCancelHint).not.toBeVisible();
+  }
+
+  async verifyMessagesGrayedAfterIndex(userMessageIndex: number): Promise<void> {
+    const allMessages = await this.conversationMessages.all();
+    const userMessages = await this.userConversationMessages.all();
+    const editedMessage = userMessages[userMessageIndex];
+
+    // Find the position of the edited user message in all messages
+    let editedGlobalIndex = -1;
+    for (let i = 0; i < allMessages.length; i++) {
+      const el = allMessages[i];
+      if ((await el.innerHTML()) === (await editedMessage.innerHTML())) {
+        editedGlobalIndex = i;
+        break;
+      }
+    }
+
+    // Messages after the edited one should have reduced opacity
+    for (let i = editedGlobalIndex + 1; i < allMessages.length; i++) {
+      await expect(allMessages[i]).toHaveClass(/opacity-40/);
+    }
+  }
+
+  async submitEditedMessage(newText: string): Promise<void> {
+    await this.messageField.clear();
+    await this.messageField.fill(newText);
+    await expect(this.sendButton).toBeEnabled();
+    await this.sendButton.click();
   }
 }

--- a/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
@@ -34,6 +34,12 @@ test.describe
       await waitForNavigationReady(page);
       await chatPage.clearLastUsedModel();
       await navigationBar.navigateToChatPage();
+      const existingCount = await chatPage.getChatHistoryCount();
+      if (existingCount > 0) {
+        await chatPage.deleteAllChatHistoryItems();
+        await chatPage.verifyChatHistoryEmpty();
+        await chatPage.ensureNotificationsAreNotVisible();
+      }
     });
 
     test('[CHAT-01] All chat UI elements are visible', async ({ chatPage }) => {
@@ -319,6 +325,9 @@ test.describe
       // Verify delete all button is visible in viewport without scrolling
       await expect(chatPage.deleteAllChatsButton).toBeInViewport();
 
+      // Wait for send button to ensure all pending model generations have completed
+      await chatPage.verifySendButtonVisible(TIMEOUTS.MODEL_RESPONSE);
+
       // Clean up - delete all chats
       await chatPage.deleteAllChatHistoryItems();
       await chatPage.verifyChatHistoryEmpty();
@@ -342,5 +351,61 @@ test.describe
       await chatPage.clickNewChat();
       const modelAfterNewChat = await chatPage.getSelectedModelName();
       expect(modelAfterNewChat).toBe(selectedModelName);
+    });
+
+    test('[CHAT-12] Edit button enters editing mode and ESC cancels it', async ({ chatPage }) => {
+      test.slow();
+      await chatPage.clickNewChat();
+      await chatPage.verifySendButtonVisible();
+
+      const message = 'Hello, this is a test message';
+      await chatPage.sendMessage(message);
+      await chatPage.verifyConversationMessage(message);
+
+      // Wait for model response before editing
+      await expect(chatPage.modelConversationMessages.first()).toBeVisible({ timeout: TIMEOUTS.MODEL_RESPONSE });
+
+      await chatPage.clickEditOnUserMessage(0);
+      await chatPage.verifyEditingMode(message);
+
+      // Messages after the edited one should be grayed out
+      await chatPage.verifyMessagesGrayedAfterIndex(0);
+
+      // Cancel editing with ESC
+      await chatPage.cancelEditing();
+
+      // Input should be restored to empty (or previous value)
+      await expect(chatPage.messageField).toHaveValue('');
+      // Original message should still be visible
+      await chatPage.verifyConversationMessage(message);
+    });
+
+    test('[CHAT-13] Edit message and submit triggers regeneration', async ({ chatPage }) => {
+      test.slow();
+      await chatPage.clickNewChat();
+      await chatPage.verifySendButtonVisible();
+
+      const originalMessage = 'What is 2 + 2?';
+      await chatPage.sendMessage(originalMessage);
+      await chatPage.verifyConversationMessage(originalMessage);
+
+      // Wait for model response
+      await expect(chatPage.modelConversationMessages.first()).toBeVisible({ timeout: TIMEOUTS.MODEL_RESPONSE });
+
+      // Edit the message
+      await chatPage.clickEditOnUserMessage(0);
+      await chatPage.verifyEditingMode(originalMessage);
+
+      const editedMessage = 'What is 3 + 3?';
+      await chatPage.submitEditedMessage(editedMessage);
+
+      // The edited message should appear in the conversation
+      await chatPage.verifyConversationMessage(editedMessage);
+
+      // The original message should no longer be visible
+      await expect(chatPage.getConversationMessage(originalMessage)).not.toBeVisible({ timeout: TIMEOUTS.SHORT });
+
+      // A new model response should be generated
+      await expect(chatPage.modelConversationMessages.first()).toBeVisible({ timeout: TIMEOUTS.MODEL_RESPONSE });
     });
   });


### PR DESCRIPTION
This PR provides support for editing chat messages. In the original Vercel Chatbot UI, the message was edited in place (Claude Desktop does it too), but I prefer Ollama client's approach, where editing happens in a single place, the input box at the bottom, providing a consistent UI (includes all existing and future buttons).

Clicking the edit button on a user message populates the input box with the message text, shows a "Press ESC to cancel editing" hint, and grays out all messages after the edited one. Submitting the edit deletes trailing messages from the database and regenerates the AI response. Just like in Ollama client.

- Add EditState context for shared editing state across components
- Add deleteTrailingMessages IPC endpoint and preload exposure
- Update multimodal-input to handle edit mode (ESC cancel, submit edit)
- Update preview-message to gray out messages and hide edit buttons
  during editing

~~Includes the fix from #1134~~  edit: was merged in main first

See it in action:

https://github.com/user-attachments/assets/0e531f65-e1be-42d2-ac67-863718f4291b

Admittedly, there's one thing Claude Desktop does better, which is, instead of deleting trailing messages, it just forks the conversation and allows the user to switch between different branches. But it's a more complex approach that'll certainly require database schema changes. Not impossible to do but I think the current approach is a good starting point. We can certainly implement conversation forking in a subsequent PR, if needed. cc @slemeur

Fixes #1081 

