### PR TITLE
feat(workspace-manager): add start and stop functions in the backend

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -26,7 +26,13 @@ import type {
 } from '/@api/agent-workspace-info.js';
 
 import { AgentWorkspaceManager } from './agent-workspace-manager.js';
-import { mockGetWorkspaceConfiguration, mockListWorkspaces, mockRemoveWorkspace } from './agent-workspace-mock-data.js';
+import {
+  mockGetWorkspaceConfiguration,
+  mockListWorkspaces,
+  mockRemoveWorkspace,
+  mockStartWorkspace,
+  mockStopWorkspace,
+} from './agent-workspace-mock-data.js';
 
 vi.mock(import('./agent-workspace-mock-data.js'));
 
@@ -64,6 +70,14 @@ describe('init', () => {
 
   test('registers IPC handler for getConfiguration', () => {
     expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:getConfiguration', expect.any(Function));
+  });
+
+  test('registers IPC handler for start', () => {
+    expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:start', expect.any(Function));
+  });
+
+  test('registers IPC handler for stop', () => {
+    expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:stop', expect.any(Function));
   });
 });
 
@@ -128,5 +142,45 @@ describe('getConfiguration', () => {
     });
 
     expect(() => manager.getConfiguration('unknown-id')).toThrow('workspace "unknown-id" not found');
+  });
+});
+
+describe('start', () => {
+  test('delegates to mockStartWorkspace and returns the workspace id', () => {
+    const expected: AgentWorkspaceId = { id: 'ws-1' };
+    vi.mocked(mockStartWorkspace).mockReturnValue(expected);
+
+    const result = manager.start('ws-1');
+
+    expect(mockStartWorkspace).toHaveBeenCalledWith('ws-1');
+    expect(result).toEqual(expected);
+  });
+
+  test('throws when mockStartWorkspace throws for unknown id', () => {
+    vi.mocked(mockStartWorkspace).mockImplementation(() => {
+      throw new Error('workspace "unknown-id" not found. Use "workspace list" to see available workspaces.');
+    });
+
+    expect(() => manager.start('unknown-id')).toThrow('workspace "unknown-id" not found');
+  });
+});
+
+describe('stop', () => {
+  test('delegates to mockStopWorkspace and returns the workspace id', () => {
+    const expected: AgentWorkspaceId = { id: 'ws-1' };
+    vi.mocked(mockStopWorkspace).mockReturnValue(expected);
+
+    const result = manager.stop('ws-1');
+
+    expect(mockStopWorkspace).toHaveBeenCalledWith('ws-1');
+    expect(result).toEqual(expected);
+  });
+
+  test('throws when mockStopWorkspace throws for unknown id', () => {
+    vi.mocked(mockStopWorkspace).mockImplementation(() => {
+      throw new Error('workspace "unknown-id" not found. Use "workspace list" to see available workspaces.');
+    });
+
+    expect(() => manager.stop('unknown-id')).toThrow('workspace "unknown-id" not found');
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -26,7 +26,13 @@ import type {
   AgentWorkspaceSummary,
 } from '/@api/agent-workspace-info.js';
 
-import { mockGetWorkspaceConfiguration, mockListWorkspaces, mockRemoveWorkspace } from './agent-workspace-mock-data.js';
+import {
+  mockGetWorkspaceConfiguration,
+  mockListWorkspaces,
+  mockRemoveWorkspace,
+  mockStartWorkspace,
+  mockStopWorkspace,
+} from './agent-workspace-mock-data.js';
 
 /**
  * Manages agent workspaces.
@@ -57,6 +63,16 @@ export class AgentWorkspaceManager implements Disposable {
     return mockGetWorkspaceConfiguration(id);
   }
 
+  // Future: exec('kortex', ['workspace', 'start', id, '--format', 'json'])
+  start(id: string): AgentWorkspaceId {
+    return mockStartWorkspace(id);
+  }
+
+  // Future: exec('kortex', ['workspace', 'stop', id, '--format', 'json'])
+  stop(id: string): AgentWorkspaceId {
+    return mockStopWorkspace(id);
+  }
+
   init(): void {
     this.ipcHandle('agent-workspace:list', async (): Promise<AgentWorkspaceSummary[]> => {
       return this.list();
@@ -72,6 +88,14 @@ export class AgentWorkspaceManager implements Disposable {
         return this.getConfiguration(id);
       },
     );
+
+    this.ipcHandle('agent-workspace:start', async (_listener: unknown, id: string): Promise<AgentWorkspaceId> => {
+      return this.start(id);
+    });
+
+    this.ipcHandle('agent-workspace:stop', async (_listener: unknown, id: string): Promise<AgentWorkspaceId> => {
+      return this.stop(id);
+    });
   }
 
   @preDestroy()

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-mock-data.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-mock-data.ts
@@ -97,3 +97,22 @@ export function mockGetWorkspaceConfiguration(id: string): AgentWorkspaceConfigu
   }
   return structuredClone(config);
 }
+
+function assertWorkspaceExists(id: string): void {
+  const ws = store.find(ws => ws.id === id);
+  if (!ws) {
+    throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
+  }
+}
+
+// Future: exec('kortex', ['workspace', 'start', id, '--format', 'json'])
+export function mockStartWorkspace(id: string): AgentWorkspaceId {
+  assertWorkspaceExists(id);
+  return { id };
+}
+
+// Future: exec('kortex', ['workspace', 'stop', id, '--format', 'json'])
+export function mockStopWorkspace(id: string): AgentWorkspaceId {
+  assertWorkspaceExists(id);
+  return { id };
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -329,6 +329,14 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('startAgentWorkspace', async (id: string): Promise<AgentWorkspaceId> => {
+    return ipcInvoke('agent-workspace:start', id);
+  });
+
+  contextBridge.exposeInMainWorld('stopAgentWorkspace', async (id: string): Promise<AgentWorkspaceId> => {
+    return ipcInvoke('agent-workspace:stop', id);
+  });
+
   contextBridge.exposeInMainWorld('listFlows', async (): Promise<Array<FlowInfo>> => {
     return ipcInvoke('flows:list');
   });


### PR DESCRIPTION
Add start and stop commands to the agent workspace backend, following the same mock-delegate pattern used by the existing list, remove, and getConfiguration commands.

Closes #1122 