### PR TITLE
chore(workspace-manager): refactor worskspace store to use sveltemap for statuses

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
@@ -19,11 +19,10 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces';
+import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 import AgentWorkspaceCard from './AgentWorkspaceCard.svelte';
@@ -46,7 +45,7 @@ beforeEach(() => {
   vi.mocked(window.listAgentWorkspaces).mockResolvedValue([]);
   vi.mocked(window.startAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
   vi.mocked(window.stopAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
-  agentWorkspaceStatuses.set(new Map());
+  agentWorkspaceStatuses.clear();
 });
 
 test('Expect card displays workspace name', () => {
@@ -134,12 +133,12 @@ test('Expect clicking start button calls startAgentWorkspace', async () => {
   await fireEvent.click(startButton);
 
   await vi.waitFor(() => {
-    expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('running');
+    expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
   });
 });
 
 test('Expect stop button is rendered when workspace is running', async () => {
-  agentWorkspaceStatuses.set(new Map([['ws-1', 'running']]));
+  agentWorkspaceStatuses.set('ws-1', 'running');
 
   render(AgentWorkspaceCard, { workspace });
 
@@ -147,7 +146,7 @@ test('Expect stop button is rendered when workspace is running', async () => {
 });
 
 test('Expect clicking stop button calls stopAgentWorkspace', async () => {
-  agentWorkspaceStatuses.set(new Map([['ws-1', 'running']]));
+  agentWorkspaceStatuses.set('ws-1', 'running');
 
   render(AgentWorkspaceCard, { workspace });
 
@@ -155,6 +154,6 @@ test('Expect clicking stop button calls stopAgentWorkspace', async () => {
   await fireEvent.click(stopButton);
 
   await vi.waitFor(() => {
-    expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('stopped');
+    expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
   });
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
@@ -5,13 +5,13 @@ import { router } from 'tinro';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import LoadingIcon from '/@/lib/ui/LoadingIcon.svelte';
-import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces';
+import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces.svelte';
 import {
   agentWorkspaceStatuses,
   fetchAgentWorkspaces,
   startAgentWorkspace,
   stopAgentWorkspace,
-} from '/@/stores/agent-workspaces';
+} from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 interface Props {
@@ -20,7 +20,7 @@ interface Props {
 
 let { workspace }: Props = $props();
 
-const status: AgentWorkspaceStatus = $derived($agentWorkspaceStatuses.get(workspace.id) ?? 'stopped');
+const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspace.id) ?? 'stopped');
 const isRunning = $derived(status === 'running' || status === 'stopping');
 const inProgress = $derived(status === 'starting' || status === 'stopping');
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -19,11 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { get, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces';
+import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
 
 import AgentWorkspaceDetails from './AgentWorkspaceDetails.svelte';
@@ -49,7 +49,7 @@ beforeEach(() => {
   vi.mocked(window.getAgentWorkspaceConfiguration).mockResolvedValue(configuration);
   vi.mocked(window.startAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
   vi.mocked(window.stopAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
-  agentWorkspaceStatuses.set(new Map());
+  agentWorkspaceStatuses.clear();
 });
 
 test('Expect page title to use configuration name', async () => {
@@ -103,12 +103,12 @@ test('Expect clicking start button transitions workspace to running', async () =
   await fireEvent.click(startButton);
 
   await waitFor(() => {
-    expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('running');
+    expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
   });
 });
 
 test('Expect stop button is rendered when workspace is running', async () => {
-  agentWorkspaceStatuses.set(new Map([['ws-1', 'running']]));
+  agentWorkspaceStatuses.set('ws-1', 'running');
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 
@@ -118,7 +118,7 @@ test('Expect stop button is rendered when workspace is running', async () => {
 });
 
 test('Expect clicking stop button transitions workspace to stopped', async () => {
-  agentWorkspaceStatuses.set(new Map([['ws-1', 'running']]));
+  agentWorkspaceStatuses.set('ws-1', 'running');
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 
@@ -130,6 +130,6 @@ test('Expect clicking stop button transitions workspace to stopped', async () =>
   await fireEvent.click(stopButton);
 
   await waitFor(() => {
-    expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('stopped');
+    expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
   });
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -10,8 +10,8 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
-import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces';
-import { agentWorkspaceStatuses, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces';
+import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaceStatuses, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
 
 interface Props {
   workspaceId: string;
@@ -21,7 +21,7 @@ let { workspaceId }: Props = $props();
 
 const configurationPromise = $derived(window.getAgentWorkspaceConfiguration(workspaceId));
 
-const status: AgentWorkspaceStatus = $derived($agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
+const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
 const isRunning = $derived(status === 'running' || status === 'stopping');
 const inProgress = $derived(status === 'starting' || status === 'stopping');
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaces } from '/@/stores/agent-workspaces';
+import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 import AgentWorkspaceList from './AgentWorkspaceList.svelte';

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -3,7 +3,7 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { Button, NavPage } from '@podman-desktop/ui-svelte';
 
 import { handleNavigation } from '/@/navigation';
-import { agentWorkspaces } from '/@/stores/agent-workspaces';
+import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import { NavigationPage } from '/@api/navigation-page';
 
 import AgentWorkspaceCard from './AgentWorkspaceCard.svelte';

--- a/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
@@ -16,14 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaceStatuses, startAgentWorkspace, stopAgentWorkspace } from './agent-workspaces';
+import { agentWorkspaceStatuses, startAgentWorkspace, stopAgentWorkspace } from './agent-workspaces.svelte';
 
 beforeEach(() => {
   vi.resetAllMocks();
-  agentWorkspaceStatuses.set(new Map());
+  agentWorkspaceStatuses.clear();
 });
 
 test('startAgentWorkspace should transition status from stopped to running', async () => {
@@ -32,7 +31,7 @@ test('startAgentWorkspace should transition status from stopped to running', asy
   await startAgentWorkspace('ws-1');
 
   expect(window.startAgentWorkspace).toHaveBeenCalledWith('ws-1');
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('running');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
 });
 
 test('startAgentWorkspace should set starting status during the call', async () => {
@@ -45,12 +44,12 @@ test('startAgentWorkspace should set starting status during the call', async () 
 
   const promise = startAgentWorkspace('ws-1');
 
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('starting');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('starting');
 
   resolveStart({ id: 'ws-1' });
   await promise;
 
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('running');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
 });
 
 test('startAgentWorkspace should revert to stopped on failure', async () => {
@@ -58,21 +57,21 @@ test('startAgentWorkspace should revert to stopped on failure', async () => {
 
   await startAgentWorkspace('ws-1');
 
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('stopped');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
 });
 
 test('stopAgentWorkspace should transition status from running to stopped', async () => {
-  agentWorkspaceStatuses.set(new Map([['ws-1', 'running']]));
+  agentWorkspaceStatuses.set('ws-1', 'running');
   vi.mocked(window.stopAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
 
   await stopAgentWorkspace('ws-1');
 
   expect(window.stopAgentWorkspace).toHaveBeenCalledWith('ws-1');
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('stopped');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
 });
 
 test('stopAgentWorkspace should set stopping status during the call', async () => {
-  agentWorkspaceStatuses.set(new Map([['ws-1', 'running']]));
+  agentWorkspaceStatuses.set('ws-1', 'running');
 
   let resolveStop: (value: { id: string }) => void = () => {};
   vi.mocked(window.stopAgentWorkspace).mockReturnValue(
@@ -83,19 +82,19 @@ test('stopAgentWorkspace should set stopping status during the call', async () =
 
   const promise = stopAgentWorkspace('ws-1');
 
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('stopping');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopping');
 
   resolveStop({ id: 'ws-1' });
   await promise;
 
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('stopped');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
 });
 
 test('stopAgentWorkspace should revert to running on failure', async () => {
-  agentWorkspaceStatuses.set(new Map([['ws-1', 'running']]));
+  agentWorkspaceStatuses.set('ws-1', 'running');
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop failed'));
 
   await stopAgentWorkspace('ws-1');
 
-  expect(get(agentWorkspaceStatuses).get('ws-1')).toBe('running');
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
 });

--- a/packages/renderer/src/stores/agent-workspaces.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.ts
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Writable } from 'svelte/store';
-import { get, writable } from 'svelte/store';
+import { SvelteMap } from 'svelte/reactivity';
+import { type Writable, writable } from 'svelte/store';
 
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 export type AgentWorkspaceStatus = 'stopped' | 'running' | 'starting' | 'stopping';
 
 export const agentWorkspaces: Writable<AgentWorkspaceSummary[]> = writable([]);
-export const agentWorkspaceStatuses: Writable<Map<string, AgentWorkspaceStatus>> = writable(new Map());
+export const agentWorkspaceStatuses = new SvelteMap<string, AgentWorkspaceStatus>();
 
 export async function fetchAgentWorkspaces(): Promise<void> {
   const data = await window.listAgentWorkspaces();
@@ -32,40 +32,25 @@ export async function fetchAgentWorkspaces(): Promise<void> {
 }
 
 export async function startAgentWorkspace(id: string): Promise<void> {
-  agentWorkspaceStatuses.update(statuses => {
-    const next = new Map(statuses);
-    next.set(id, 'starting');
-    return next;
-  });
+  agentWorkspaceStatuses.set(id, 'starting');
   try {
     await window.startAgentWorkspace(id);
-    agentWorkspaceStatuses.update(statuses => {
-      const next = new Map(statuses);
-      next.set(id, 'running');
-      return next;
-    });
+    agentWorkspaceStatuses.set(id, 'running');
   } catch (error: unknown) {
-    agentWorkspaceStatuses.update(statuses => {
-      const next = new Map(statuses);
-      next.set(id, 'stopped');
-      return next;
-    });
+    agentWorkspaceStatuses.set(id, 'stopped');
     console.error('Failed to start agent workspace', error);
   }
 }
 
 export async function stopAgentWorkspace(id: string): Promise<void> {
-  const statuses = get(agentWorkspaceStatuses);
-  statuses.set(id, 'stopping');
-  agentWorkspaceStatuses.set(new Map(statuses));
+  agentWorkspaceStatuses.set(id, 'stopping');
   try {
     await window.stopAgentWorkspace(id);
-    statuses.set(id, 'stopped');
+    agentWorkspaceStatuses.set(id, 'stopped');
   } catch (error: unknown) {
-    statuses.set(id, 'running');
+    agentWorkspaceStatuses.set(id, 'running');
     console.error('Failed to stop agent workspace', error);
   }
-  agentWorkspaceStatuses.set(new Map(statuses));
 }
 
 window.addEventListener('system-ready', () => {


### PR DESCRIPTION
Replace Writable<Map<string, AgentWorkspaceStatus>> with a SvelteMap from svelte/reactivity. This removes the need to clone the entire map on every status update, simplifies the start/stop functions, and aligns with the reactive primitives already used elsewhere in the codebase. The store file is renamed to .svelte.ts to enable runes support.

Closes #1146 