### PR TITLE
fix(svelte): migrate HMR configuration for Svelte 5 compatibility

### DIFF
--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -38,7 +38,7 @@ export default defineConfig({
       '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
-  plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],
+  plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js' }), svelteTesting()],
   optimizeDeps: {
     exclude: ['tinro', '@kortex-app/api'],
   },

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,6 +19,7 @@
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   compilerOptions: {
+    hmr: !process.env.VITEST,
     experimental: {
       async: true,
     },


### PR DESCRIPTION
Moved HMR configuration from vite plugin's 'hot' option to compilerOptions.hmr
in svelte.config.js as required by Svelte 5, which has HMR integrated in core.

This fixes the warning: "[vite-plugin-svelte] svelte 5 has hmr integrated in
core. Please remove the vitePlugin.hot option and use compilerOptions.hmr instead"

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
