### PR TITLE
fix(chat): implement stop generation button functionality

### DIFF
--- a/packages/main/src/chat/chat-manager.ts
+++ b/packages/main/src/chat/chat-manager.ts
@@ -55,6 +55,7 @@ import { ParameterExtractor } from './parameter-extraction.js';
 export class ChatManager {
   private chatQueries!: ChatQueries;
   private userId!: string;
+  private activeStreams = new Map<number, { controller: AbortController; chatId: string }>();
 
   constructor(
     @inject(ProviderRegistry)
@@ -102,6 +103,7 @@ export class ChatManager {
     this.userId = await getOrCreateUserId();
 
     this.ipcHandle('inference:streamText', (_, params) => this.streamText(params));
+    this.ipcHandle('inference:stopStream', (_, onDataId: number) => this.stopStream(onDataId));
     this.ipcHandle('inference:generate', (_, params) => this.generate(params));
     this.ipcHandle('inference:generateFlowParams', (_, params) => this.generateFlowParams(params));
     this.ipcHandle('inference:detectFlowFields', (_, params) => this.detectFlowFields(params));
@@ -145,10 +147,16 @@ export class ChatManager {
   }
 
   private async deleteChat(id: string): Promise<undefined> {
+    this.stopStreamsByChat(id);
     await this.chatQueries.deleteChatById({ id });
   }
 
   private async deleteAllChats(): Promise<undefined> {
+    // Abort all active streams
+    for (const [onDataId, stream] of this.activeStreams.entries()) {
+      stream.controller.abort();
+      this.activeStreams.delete(onDataId);
+    }
     await this.chatQueries.deleteAllChatsForUser({ userId: this.userId });
   }
 
@@ -277,81 +285,112 @@ export class ChatManager {
 
   async streamText(params: InferenceParameters & { onDataId: number; chatId: string }): Promise<number> {
     const { chatId } = params;
-    const chatGetter = await this.chatQueries.getChatById({ id: chatId });
+    const abortController = new AbortController();
+    this.activeStreams.set(params.onDataId, { controller: abortController, chatId });
 
-    if (!chatGetter.isOk()) {
-      const userMessage = this.getMostRecentUserMessage(params.messages);
-      if (!userMessage) {
-        throw new Error('No user message found');
+    try {
+      const chatGetter = await this.chatQueries.getChatById({ id: chatId });
+      if (abortController.signal.aborted) return params.onDataId;
+
+      if (!chatGetter.isOk()) {
+        const userMessage = this.getMostRecentUserMessage(params.messages);
+        if (!userMessage) {
+          throw new Error('No user message found');
+        }
+        const placeholderTitle = this.extractPlaceholderTitle(userMessage);
+        await this.chatQueries.saveChat({
+          id: chatId,
+          userId: this.userId,
+          title: placeholderTitle,
+        });
+        if (abortController.signal.aborted) return params.onDataId;
+
+        this.webContents.send('api-sender', 'chat-list-updated');
+
+        const internalProviderId = this.providerRegistry.getMatchingProviderInternalId(params.providerId);
+        const sdk = this.providerRegistry.getInferenceSDK(internalProviderId, params.connectionName);
+        const model = sdk.languageModel(params.modelId);
+        this.generateTitleInBackground(model, userMessage, chatId, placeholderTitle);
       }
-      const placeholderTitle = this.extractPlaceholderTitle(userMessage);
-      await this.chatQueries.saveChat({
-        id: chatId,
-        userId: this.userId,
-        title: placeholderTitle,
+
+      const inferenceComponents = await this.getInferenceComponents(params);
+      if (abortController.signal.aborted) return params.onDataId;
+
+      const config: MessageConfig = {
+        tools: params.tools,
+        modelId: params.modelId,
+        connectionName: params.connectionName,
+        providerId: params.providerId,
+      };
+      await this.chatQueries.saveMessages({
+        messages: [
+          {
+            chatId,
+            id: inferenceComponents.userMessage.id,
+            role: 'user',
+            parts: inferenceComponents.userMessage.parts,
+            createdAt: new Date(),
+            attachments: [],
+            config,
+          },
+        ],
       });
-      this.webContents.send('api-sender', 'chat-list-updated');
+      if (abortController.signal.aborted) return params.onDataId;
 
-      const internalProviderId = this.providerRegistry.getMatchingProviderInternalId(params.providerId);
-      const sdk = this.providerRegistry.getInferenceSDK(internalProviderId, params.connectionName);
-      const model = sdk.languageModel(params.modelId);
-      this.generateTitleInBackground(model, userMessage, chatId, placeholderTitle);
-    }
+      const streaming = streamText({
+        ...inferenceComponents,
+        abortSignal: abortController.signal,
+      });
 
-    const inferenceComponents = await this.getInferenceComponents(params);
+      const reader = streaming
+        .toUIMessageStream({
+          onFinish: async ({ messages }): Promise<void> => {
+            await this.chatQueries.saveMessages({
+              messages: messages.map(message => ({
+                id: randomUUID().toString(),
+                role: message.role,
+                parts: message.parts,
+                createdAt: new Date(),
+                chatId,
+                attachments: [],
+                config,
+              })),
+            });
+          },
+        })
+        .getReader();
 
-    const config: MessageConfig = {
-      tools: params.tools,
-      modelId: params.modelId,
-      connectionName: params.connectionName,
-      providerId: params.providerId,
-    };
-    await this.chatQueries.saveMessages({
-      messages: [
-        {
-          chatId,
-          id: inferenceComponents.userMessage.id,
-          role: 'user',
-          parts: inferenceComponents.userMessage.parts,
-          createdAt: new Date(),
-          attachments: [],
-          config,
-        },
-      ],
-    });
-
-    const streaming = streamText(inferenceComponents);
-
-    const reader = streaming
-      .toUIMessageStream({
-        onFinish: async ({ messages }): Promise<void> => {
-          await this.chatQueries.saveMessages({
-            messages: messages.map(message => ({
-              id: randomUUID().toString(),
-              role: message.role,
-              parts: message.parts,
-              createdAt: new Date(),
-              chatId,
-              attachments: [],
-              config,
-            })),
-          });
-        },
-      })
-      .getReader();
-
-    // loop to wait for the stream to finish
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        // end
-        this.webContents.send('inference:streamText-onEnd', params.onDataId);
-        break;
+      // loop to wait for the stream to finish
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        this.webContents.send('inference:streamText-onChunk', params.onDataId, value);
       }
-      this.webContents.send('inference:streamText-onChunk', params.onDataId, value);
+    } finally {
+      this.activeStreams.delete(params.onDataId);
+      this.webContents.send('inference:streamText-onEnd', params.onDataId);
     }
 
     return params.onDataId;
+  }
+
+  private stopStream(onDataId: number): void {
+    const stream = this.activeStreams.get(onDataId);
+    if (stream) {
+      stream.controller.abort();
+      this.activeStreams.delete(onDataId);
+    }
+  }
+
+  private stopStreamsByChat(chatId: string): void {
+    for (const [onDataId, stream] of this.activeStreams.entries()) {
+      if (stream.chatId === chatId) {
+        stream.controller.abort();
+        this.activeStreams.delete(onDataId);
+      }
+    }
   }
 
   async generate(params: InferenceParameters): Promise<string> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1400,17 +1400,33 @@ export function initExposure(): void {
   >();
   contextBridge.exposeInMainWorld(
     'inferenceStreamText',
-    async (
+    (
       params: InferenceParameters & { chatId: string },
       onChunk: (data: UIMessageChunk) => void,
       onError: (error: string) => void,
       onEnd: () => void,
-    ): Promise<number> => {
+    ): number => {
       onDataCallbacksStreamTextId++;
-      onDataCallbacksStreamText.set(onDataCallbacksStreamTextId, { onChunk, onError, onEnd });
-      return ipcInvoke('inference:streamText', { ...params, onDataId: onDataCallbacksStreamTextId });
+      const id = onDataCallbacksStreamTextId;
+      onDataCallbacksStreamText.set(id, { onChunk, onError, onEnd });
+      ipcInvoke('inference:streamText', { ...params, onDataId: id }).catch((err: unknown) => {
+        const callback = onDataCallbacksStreamText.get(id);
+        if (callback) {
+          onDataCallbacksStreamText.delete(id);
+          try {
+            callback.onError(String(err));
+          } finally {
+            callback.onEnd();
+          }
+        }
+      });
+      return id;
     },
   );
+
+  contextBridge.exposeInMainWorld('inferenceStopStream', async (onDataId: number): Promise<void> => {
+    return ipcInvoke('inference:stopStream', onDataId);
+  });
 
   ipcRenderer.on('inference:streamText-onChunk', (_, callbackId: number, chunk: UIMessageChunk) => {
     // grab callback from the map

--- a/packages/renderer/src/lib/chat/components/ipc-chat-transport.ts
+++ b/packages/renderer/src/lib/chat/components/ipc-chat-transport.ts
@@ -25,10 +25,12 @@ export class IPCChatTransport<T extends UIMessage> implements ChatTransport<T> {
 
     const tools = this.dependencies.getMCPTools();
 
+    const abortSignal = options.abortSignal;
+
     return new ReadableStream<UIMessageChunk>({
-      async start(controller): Promise<void> {
+      start(controller): void {
         const { providerId, connectionName, label } = model;
-        await window.inferenceStreamText(
+        const onDataId = window.inferenceStreamText(
           {
             chatId: options.chatId,
             providerId,
@@ -50,6 +52,20 @@ export class IPCChatTransport<T extends UIMessage> implements ChatTransport<T> {
             controller.close();
           },
         );
+
+        if (abortSignal) {
+          if (abortSignal.aborted) {
+            window.inferenceStopStream(onDataId).catch(console.error);
+          } else {
+            abortSignal.addEventListener(
+              'abort',
+              () => {
+                window.inferenceStopStream(onDataId).catch(console.error);
+              },
+              { once: true },
+            );
+          }
+        }
       },
     });
   }

--- a/tests/playwright/src/model/pages/chat-page.ts
+++ b/tests/playwright/src/model/pages/chat-page.ts
@@ -318,6 +318,11 @@ export class ChatPage extends BasePage {
     await expect(this.stopButton).not.toBeVisible({ timeout });
   }
 
+  async clickStopButton(): Promise<void> {
+    await expect(this.stopButton).toBeVisible();
+    await this.stopButton.click();
+  }
+
   async exportAsFlow(): Promise<FlowsCreatePage> {
     await expect(this.exportAsFlowButton).toBeEnabled({ timeout: TIMEOUTS.STANDARD });
     await this.exportAsFlowButton.click();

--- a/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
@@ -459,4 +459,26 @@ test.describe
 
       await chatPage.ensureNotificationsAreNotVisible();
     });
+
+    test('[CHAT-17] Stop generation cancels the AI response stream', async ({ chatPage }) => {
+      await chatPage.clickNewChat();
+
+      // Send a message that should generate a long response
+      const message = 'Write a very detailed and long essay about the history of container orchestration systems';
+      await chatPage.sendMessage(message, { waitForMessage: false });
+
+      // Verify the stop button appears during generation
+      await chatPage.verifyStopButtonVisible();
+      await chatPage.verifySendButtonHidden();
+
+      // Click the stop button to cancel generation
+      await chatPage.clickStopButton();
+
+      // Verify the UI returns to the ready state
+      await chatPage.verifyStopButtonHidden(TIMEOUTS.SHORT);
+      await chatPage.verifySendButtonVisible(TIMEOUTS.SHORT);
+
+      // Verify the user message is still visible in the conversation
+      await chatPage.verifyConversationMessage(message);
+    });
   });


### PR DESCRIPTION
- Wire abort signal through IPC layer to cancel AI response streams
- Make inferenceStreamText return onDataId synchronously for immediate abort listener registration
- Store AbortController per stream with chatId tracking
- Abort active streams when chat is deleted
- Add E2E test [CHAT-17] for stop generation

https://github.com/user-attachments/assets/a21e31f2-d6d7-4002-b5a7-20008680a062

Fixes #535

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
