### PR TITLE
feat(skills): add skill details view page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -63,5 +63,6 @@ export enum NavigationPage {
   AGENT_WORKSPACES = 'agent-workspaces',
   AGENT_WORKSPACE_CREATE = 'agent-workspace-create',
   SKILLS = 'skills',
+  SKILL_DETAILS = 'skill-details',
   RAG_ENVIRONMENT_DETAILS = 'rag-environment-details',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -79,6 +79,9 @@ export interface NavigationParameters {
   [NavigationPage.AGENT_WORKSPACES]: never;
   [NavigationPage.AGENT_WORKSPACE_CREATE]: never;
   [NavigationPage.SKILLS]: never;
+  [NavigationPage.SKILL_DETAILS]: {
+    name: string;
+  };
   [NavigationPage.RAG_ENVIRONMENT_DETAILS]: {
     name: string;
   };

--- a/packages/main/src/plugin/skill/skill-manager.spec.ts
+++ b/packages/main/src/plugin/skill/skill-manager.spec.ts
@@ -494,13 +494,15 @@ test('listSkillFolderContent should return folder entries for a registered skill
   const skillManager = createSkillManager();
   const skill = await skillManager.registerSkill(join(SKILLS_DIR, 'my-test-skill'));
 
-  vi.mocked(readdir).mockResolvedValue(['SKILL.md', 'utils.ts', 'templates'] as unknown as Awaited<
-    ReturnType<typeof readdir>
-  >);
+  vi.mocked(readdir).mockResolvedValue([
+    { name: 'SKILL.md', isDirectory: (): boolean => false },
+    { name: 'utils.ts', isDirectory: (): boolean => false },
+    { name: 'templates', isDirectory: (): boolean => true },
+  ] as unknown as Awaited<ReturnType<typeof readdir>>);
 
   const entries = await skillManager.listSkillFolderContent('my-test-skill');
-  expect(entries).toEqual(['SKILL.md', 'utils.ts', 'templates']);
-  expect(readdir).toHaveBeenCalledWith(skill.path);
+  expect(entries).toEqual(['SKILL.md', 'utils.ts', 'templates/']);
+  expect(readdir).toHaveBeenCalledWith(skill.path, { withFileTypes: true });
 });
 
 test('listSkillFolderContent should throw when skill name not found', async () => {

--- a/packages/main/src/plugin/skill/skill-manager.ts
+++ b/packages/main/src/plugin/skill/skill-manager.ts
@@ -376,10 +376,11 @@ export class SkillManager {
     return { name: metadata.name, description: metadata.description, content: body };
   }
 
-  /** Lists all file/directory names inside the skill's folder. */
+  /** Lists all file/directory names inside the skill's folder. Directories have a trailing slash. */
   async listSkillFolderContent(name: string): Promise<string[]> {
     const skill = this.findSkillByName(name);
-    return readdir(skill.path);
+    const entries = await readdir(skill.path, { withFileTypes: true });
+    return entries.map(entry => (entry.isDirectory() ? `${entry.name}/` : entry.name));
   }
 
   private findSkillByName(name: string): SkillInfo {

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -83,6 +83,7 @@ import PVCDetails from './lib/pvc/PVCDetails.svelte';
 import PVCList from './lib/pvc/PVCList.svelte';
 import ServiceDetails from './lib/service/ServiceDetails.svelte';
 import ServicesList from './lib/service/ServicesList.svelte';
+import SkillDetails from './lib/skills/SkillDetails.svelte';
 import SkillsList from './lib/skills/SkillsList.svelte';
 import StatusBar from './lib/statusbar/StatusBar.svelte';
 import IconsStyle from './lib/style/IconsStyle.svelte';
@@ -223,6 +224,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/skills/*" breadcrumb="Skills" navigationHint="root" firstmatch>
           <Route path="/" breadcrumb="Skills" navigationHint="root">
             <SkillsList />
+          </Route>
+          <Route path="/:name/*" let:meta breadcrumb="Skill Details" navigationHint="details">
+            <SkillDetails name={decodeURIComponent(meta.params.name)} />
           </Route>
         </Route>
         <!-- Knowledge Databases -->

--- a/packages/renderer/src/lib/skills/SkillDetailRow.svelte
+++ b/packages/renderer/src/lib/skills/SkillDetailRow.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+interface Props {
+  label: string;
+  value: string;
+  title?: string;
+  truncate?: boolean;
+}
+
+let { label, value, title, truncate = false }: Props = $props();
+</script>
+
+<div class="flex justify-between py-3">
+  <span class="text-sm text-[var(--pd-content-card-text)]">{label}</span>
+  <span
+    class={`text-sm font-medium text-[var(--pd-content-text)] ${truncate ? 'max-w-[200px] text-right truncate' : 'text-right break-all'}`}
+    title={title}>
+    {value}
+  </span>
+</div>

--- a/packages/renderer/src/lib/skills/SkillDetails.svelte
+++ b/packages/renderer/src/lib/skills/SkillDetails.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+import { faFile, faFolder } from '@fortawesome/free-regular-svg-icons';
+import { Checkbox, EmptyScreen, Tab } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { toast } from 'svelte-sonner';
+import { router } from 'tinro';
+
+import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
+import Route from '/@/Route.svelte';
+import { skillInfos } from '/@/stores/skills';
+import type { SkillInfo } from '/@api/skill/skill-info';
+
+import SkillActions from './SkillActions.svelte';
+import SkillDetailRow from './SkillDetailRow.svelte';
+
+interface Props {
+  name: string;
+}
+
+let { name }: Props = $props();
+
+let skillInfo: SkillInfo | undefined = $derived($skillInfos.find(s => s.name === name));
+let skillContent: string | undefined = $state(undefined);
+let folderContents: string[] = $state([]);
+
+$effect(() => {
+  if (!skillInfo) {
+    skillContent = undefined;
+    folderContents = [];
+    return;
+  }
+  const currentName = name;
+  Promise.allSettled([window.getSkillContent(currentName), window.listSkillFolderContent(currentName)])
+    .then(([contentResult, folderResult]) => {
+      if (contentResult.status === 'fulfilled') {
+        skillContent = contentResult.value;
+      } else {
+        console.error('Error loading skill instructions:', contentResult.reason);
+        toast.error('Failed to load skill instructions');
+      }
+      if (folderResult.status === 'fulfilled') {
+        folderContents = folderResult.value;
+      } else {
+        console.error('Error loading skill resources:', folderResult.reason);
+        toast.error('Failed to load skill resources');
+      }
+    })
+    .catch((err: unknown) => console.error('Unexpected error loading skill details:', err));
+});
+
+function formatTokenCount(text: string | undefined): string {
+  if (!text) return 'N/A';
+  const tokens = Math.ceil(text.length / 3.5);
+  if (tokens >= 1000) {
+    return `~${(tokens / 1000).toFixed(1)}k tokens`;
+  }
+  return `~${tokens} tokens`;
+}
+
+let toggling = $state(false);
+
+function onToggle(): void {
+  if (!skillInfo || toggling) return;
+  toggling = true;
+  const promise = skillInfo.enabled ? window.disableSkill(skillInfo.name) : window.enableSkill(skillInfo.name);
+  promise
+    .catch((err: unknown) => {
+      console.error('Error toggling skill:', err);
+      toast.error('Failed to toggle skill');
+    })
+    .finally(() => {
+      toggling = false;
+    });
+}
+</script>
+
+<DetailsPage title={name}>
+  {#snippet subtitleSnippet()}
+    <div class="flex items-center gap-3">
+      <span
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
+        bg-[var(--pd-label-bg)] text-[var(--pd-label-text)]">
+        {skillInfo?.managed ? 'Custom' : 'Pre-built'}
+      </span>
+      <span
+        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium"
+        class:text-[var(--pd-status-running)]={skillInfo?.enabled}
+        class:text-[var(--pd-status-stopped)]={!skillInfo?.enabled}>
+        <span
+          class="w-1.5 h-1.5 rounded-full"
+          class:bg-[var(--pd-status-running)]={skillInfo?.enabled}
+          class:bg-[var(--pd-status-stopped)]={!skillInfo?.enabled}>
+        </span>
+        {skillInfo?.enabled ? 'Enabled' : 'Disabled'}
+      </span>
+    </div>
+  {/snippet}
+
+  {#snippet actionsSnippet()}
+    <div class="flex items-center gap-2">
+      {#if skillInfo}
+        <Checkbox
+          checked={skillInfo.enabled}
+          onclick={onToggle}
+          title={skillInfo.enabled ? 'Disable skill' : 'Enable skill'} />
+        <SkillActions object={skillInfo} detailed={true} />
+      {/if}
+    </div>
+  {/snippet}
+
+  {#snippet tabsSnippet()}
+    <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
+    <Tab title="Instructions" selected={isTabSelected($router.path, 'instructions')} url={getTabUrl($router.path, 'instructions')} />
+    <Tab title="Resources" selected={isTabSelected($router.path, 'resources')} url={getTabUrl($router.path, 'resources')} />
+  {/snippet}
+
+  {#snippet contentSnippet()}
+    <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+      {#if skillInfo}
+        <!-- About Section -->
+        <div class="px-5 py-4 h-full overflow-auto">
+          <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg p-5 mb-6">
+            <h3 class="text-sm font-semibold text-[var(--pd-content-card-header-text)] uppercase tracking-wider mb-4">About This Skill</h3>
+            <p class="text-sm text-[var(--pd-content-text)] leading-relaxed">
+              {skillInfo.description || 'No description available.'}
+            </p>
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- General Information -->
+            <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg p-5">
+              <h3 class="text-sm font-semibold text-[var(--pd-content-card-header-text)] uppercase tracking-wider mb-4">General Information</h3>
+              <div class="divide-y divide-[var(--pd-content-card-border)]">
+                <SkillDetailRow label="Name" value={skillInfo.name} />
+                <SkillDetailRow label="Type" value={skillInfo.managed ? 'Custom' : 'Pre-built'} />
+                <SkillDetailRow label="Status" value={skillInfo.enabled ? 'Enabled' : 'Disabled'} />
+                <SkillDetailRow label="Path" value={skillInfo.path || 'N/A'} />
+              </div>
+            </div>
+
+            <!-- Metadata -->
+            <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg p-5">
+              <h3 class="text-sm font-semibold text-[var(--pd-content-card-header-text)] uppercase tracking-wider mb-4">Metadata</h3>
+              <div class="divide-y divide-[var(--pd-content-card-border)]">
+                <SkillDetailRow label="Instructions Size" value={formatTokenCount(skillContent)} />
+                <SkillDetailRow label="Bundled Resources" value="{folderContents.length} items" />
+              </div>
+            </div>
+          </div>
+        </div>
+      {:else}
+        <EmptyScreen title="Skill not found" message="Skill '{name}' could not be found" icon={NoLogIcon} />
+      {/if}
+    </Route>
+
+    <Route path="/instructions" breadcrumb="Instructions" navigationHint="tab">
+      <div class="px-5 py-4 h-full overflow-auto">
+        <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg overflow-hidden">
+          <div class="flex justify-between items-center px-4 py-3 bg-[var(--pd-content-bg)] border-b border-[var(--pd-content-card-border)]">
+            <span class="text-sm font-medium text-[var(--pd-content-text)] font-mono">SKILL.md</span>
+          </div>
+          <div class="p-5">
+            <pre class="text-sm text-[var(--pd-content-text)] leading-relaxed whitespace-pre-wrap font-mono">{skillContent ?? 'No content available.'}</pre>
+          </div>
+        </div>
+      </div>
+    </Route>
+
+    <Route path="/resources" breadcrumb="Resources" navigationHint="tab">
+      <div class="px-5 py-4 h-full overflow-auto">
+        <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg overflow-hidden">
+          <div class="px-5 py-4 border-b border-[var(--pd-content-card-border)] bg-[var(--pd-content-bg)]">
+            <span class="text-base font-semibold text-[var(--pd-content-text)]">Bundled Resources ({folderContents.length})</span>
+          </div>
+          {#if folderContents.length === 0}
+            <div class="px-6 py-12 text-center">
+              <p class="text-sm text-[var(--pd-content-card-text)]">No bundled resources.</p>
+            </div>
+          {:else}
+            {#each folderContents as item (item)}
+              <div class="flex items-center gap-3 px-5 py-3 border-b border-[var(--pd-content-card-border)] last:border-b-0 hover:bg-[var(--pd-content-card-hover-bg)]">
+                <div class="w-8 h-8 rounded-md flex items-center justify-center bg-[var(--pd-content-bg)]">
+                  <Icon icon={item.endsWith('/') ? faFolder : faFile} class="text-[var(--pd-content-card-text)]" />
+                </div>
+                <span class="text-sm font-medium text-[var(--pd-content-text)] font-mono">{item}</span>
+              </div>
+            {/each}
+          {/if}
+        </div>
+      </div>
+    </Route>
+  {/snippet}
+</DetailsPage>

--- a/packages/renderer/src/lib/skills/columns/SkillNameColumn.spec.ts
+++ b/packages/renderer/src/lib/skills/columns/SkillNameColumn.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { SkillInfo } from '/@api/skill/skill-info';
 
@@ -33,6 +33,11 @@ const skill: SkillInfo = {
   managed: true,
 };
 
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+});
+
 test('should display the skill name', () => {
   render(SkillNameColumn, { object: skill });
 
@@ -43,15 +48,16 @@ test('should display the skill name', () => {
 test('should have correct styling', () => {
   render(SkillNameColumn, { object: skill });
 
-  const text = screen.getByText('my-test-skill');
-  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
-  expect(text).toHaveClass('overflow-hidden');
-  expect(text).toHaveClass('text-ellipsis');
+  const button = screen.getByRole('button', { name: 'my-test-skill' });
+  expect(button).toBeInTheDocument();
+  const label = screen.getByText('my-test-skill');
+  expect(label).toHaveClass('overflow-hidden');
+  expect(label).toHaveClass('text-ellipsis');
 });
 
 test('should have the skill name as title attribute', () => {
   render(SkillNameColumn, { object: skill });
 
-  const text = screen.getByTitle('my-test-skill');
-  expect(text).toBeInTheDocument();
+  const button = screen.getByTitle('my-test-skill');
+  expect(button).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/skills/columns/SkillNameColumn.svelte
+++ b/packages/renderer/src/lib/skills/columns/SkillNameColumn.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 import type { SkillInfo } from '/@api/skill/skill-info';
 
 interface Props {
@@ -6,10 +8,19 @@ interface Props {
 }
 
 let { object }: Props = $props();
+
+function openDetails(): void {
+  handleNavigation({
+    page: NavigationPage.SKILL_DETAILS,
+    parameters: { name: object.name },
+  });
+}
 </script>
 
-<div
-  class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis whitespace-nowrap max-w-full"
-  title={object.name}>
-  {object.name}
-</div>
+<button class="flex flex-col whitespace-nowrap max-w-full" onclick={openDetails}>
+  <div
+    class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-[var(--pd-link)]"
+    title={object.name}>
+    {object.name}
+  </div>
+</button>

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -182,6 +182,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.AGENT_WORKSPACE_CREATE:
       router.goto('/agent-workspaces/create');
       break;
+    case NavigationPage.SKILL_DETAILS:
+      router.goto(`/skills/${encodeURIComponent(request.parameters.name)}/summary`);
+      break;
     case NavigationPage.RAG_ENVIRONMENT_DETAILS:
       router.goto(`/rag-environments/${encodeURIComponent(request.parameters.name)}/summary`);
       break;


### PR DESCRIPTION
## Summary

- Adds a skill details view page with Summary, Instructions, and Resources tabs
- Skill names in the list are now clickable, navigating to the detail view
- `listSkillFolderContent` now distinguishes files from directories with a trailing `/`

Fixes https://github.com/openkaiden/kaiden/issues/1043

## Test plan

1. Download the `SKILL.md` from https://github.com/bmahabirbu/kdn/tree/main/skills/add-alias-command
2. Upload it in Kaiden as a skill
3. Click the skill name in the skills list to open the details page
4. Verify the **Summary** tab shows skill info (name, type, status, token estimate, resource count)
5. Verify the **Instructions** tab displays the SKILL.md content
6. Verify the **Resources** tab lists the bundled files/directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)