### PR TITLE
fix: start/stop MCP server linked to RAG connection using update events

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1124,6 +1124,11 @@ declare module '@kortex-app/api' {
     providerId: string;
     connection: RagProviderConnection;
   }
+  export interface UpdateRagConnectionEvent {
+    providerId: string;
+    connection: RagProviderConnection;
+    status: ProviderConnectionStatus;
+  }
   export interface UnregisterRagConnectionEvent {
     providerId: string;
     connection: RagProviderConnection;

--- a/packages/main/src/plugin/mcp/mcp-registry.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.spec.ts
@@ -62,6 +62,7 @@ const originalConsoleError = console.error;
 const providerRegistry = {
   onDidRegisterRagConnection: vi.fn(),
   onDidUnregisterRagConnection: vi.fn(),
+  onDidUpdateRagConnection: vi.fn(),
 } as unknown as ProviderRegistry;
 
 beforeEach(() => {

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -132,16 +132,23 @@ export class MCPRegistry {
       this.proxySettings = this.proxy.proxy;
     }
 
-    this.providerRegistry.onDidRegisterRagConnection(e =>
-      this.setupMCPServer(e.connection.mcpServer.serverId, e.connection.mcpServer.config),
-    );
-    this.providerRegistry.onDidUnregisterRagConnection(e =>
-      this.resetMCPServer(
-        e.connection.mcpServer.serverId,
-        e.connection.mcpServer.config.type,
-        e.connection.mcpServer.config.index,
-      ),
-    );
+    this.providerRegistry.onDidRegisterRagConnection(e => {
+      if (e.connection.status() === 'started') {
+        this.setupMCPServer(e.connection.mcpServer.serverId, e.connection.mcpServer.config).catch(console.error);
+      }
+    });
+
+    this.providerRegistry.onDidUpdateRagConnection(e => {
+      if (e.status === 'started') {
+        this.setupMCPServer(e.connection.mcpServer.serverId, e.connection.mcpServer.config).catch(console.error);
+      } else if (e.status === 'stopped') {
+        this.resetMCPServer(
+          e.connection.mcpServer.serverId,
+          e.connection.mcpServer.config.type,
+          e.connection.mcpServer.config.index,
+        ).catch(console.error);
+      }
+    });
 
     const mcpRegistriesConfiguration: IConfigurationNode = {
       id: 'preferences.mcp',

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -64,6 +64,7 @@ import type {
   UnregisterVmConnectionEvent,
   UpdateContainerConnectionEvent,
   UpdateKubernetesConnectionEvent,
+  UpdateRagConnectionEvent,
   UpdateVmConnectionEvent,
   VmProviderConnection,
 } from '@kortex-app/api';
@@ -184,6 +185,9 @@ export class ProviderRegistry {
 
   private readonly _onDidRegisterRagConnection = new Emitter<RegisterRagConnectionEvent>();
   readonly onDidRegisterRagConnection: Event<RegisterRagConnectionEvent> = this._onDidRegisterRagConnection.event;
+
+  private readonly _onDidUpdateRagConnection = new Emitter<UpdateRagConnectionEvent>();
+  readonly onDidUpdateRagConnection: Event<UpdateRagConnectionEvent> = this._onDidUpdateRagConnection.event;
 
   private readonly _onDidUnregisterRagConnection = new Emitter<UnregisterRagConnectionEvent>();
   readonly onDidUnregisterRagConnection: Event<UnregisterRagConnectionEvent> = this._onDidUnregisterRagConnection.event;
@@ -1324,7 +1328,7 @@ export class ProviderRegistry {
   }
 
   isRagConnectionInfo(
-    connection: ProviderConnectionInfo | ContainerProviderConnection,
+    connection: ProviderConnectionInfo | RagProviderConnection,
   ): connection is ProviderRagConnectionInfo {
     return (connection as ProviderRagConnectionInfo).connectionType === 'rag';
   }
@@ -1403,6 +1407,15 @@ export class ProviderRegistry {
           },
           status: 'started',
         });
+      } else if (this.isRagConnectionInfo(providerConnectionInfo)) {
+        const connection = this.ragProviders.get(provider.id + '.' + providerConnectionInfo.name);
+        if (connection !== undefined) {
+          this._onDidUpdateRagConnection.fire({
+            providerId: provider.id,
+            connection,
+            status: 'started',
+          });
+        }
       } else {
         this._onDidUpdateVmConnection.fire({
           providerId: provider.id,
@@ -1518,6 +1531,15 @@ export class ProviderRegistry {
           },
           status: 'stopped',
         });
+      } else if (this.isRagConnectionInfo(providerConnectionInfo)) {
+        const connection = this.ragProviders.get(provider.id + '.' + providerConnectionInfo.name);
+        if (connection !== undefined) {
+          this._onDidUpdateRagConnection.fire({
+            providerId: provider.id,
+            connection,
+            status: 'stopped',
+          });
+        }
       } else {
         this._onDidUpdateVmConnection.fire({
           providerId: provider.id,


### PR DESCRIPTION
To test:

- create a RAG environment
- verify it is listed as connected
- stop the Milvus resource
- verify the RAG environment is listed as disconnected
- start the Milvus resource
- verify the RAG environment is listed as connected

Fixes #1144