### PR TITLE
feat(chat): add inline rename for chat history

### DIFF
--- a/packages/main/src/chat/chat-manager.spec.ts
+++ b/packages/main/src/chat/chat-manager.spec.ts
@@ -136,20 +136,30 @@ describe('ChatManager', () => {
       >);
 
       const chatManager = createChatManager();
-      const mockUpdateChatTitleById = vi.fn().mockReturnValue({ isOk: () => true });
-      (chatManager as unknown as { chatQueries: { updateChatTitleById: MockInstance } }).chatQueries = {
-        updateChatTitleById: mockUpdateChatTitleById,
+      const mockUpdateChatTitleIfMatches = vi.fn(
+        async (): Promise<{ isOk: () => boolean; isErr: () => boolean; value: boolean }> => ({
+          isOk: () => true,
+          isErr: () => false,
+          value: true, // Row was updated
+        }),
+      );
+      (chatManager as unknown as { chatQueries: { updateChatTitleIfMatches: MockInstance } }).chatQueries = {
+        updateChatTitleIfMatches: mockUpdateChatTitleIfMatches,
       } as never;
 
       const mockModel = 'mock-model';
       const userMessage = { role: 'user', parts: [{ type: 'text', text: 'Hello' }] };
 
       (
-        chatManager as unknown as { generateTitleInBackground: (m: unknown, u: unknown, id: string) => void }
-      ).generateTitleInBackground(mockModel, userMessage, 'chat-123');
+        chatManager as unknown as { generateTitleInBackground: (m: unknown, u: unknown, id: string, p: string) => void }
+      ).generateTitleInBackground(mockModel, userMessage, 'chat-123', 'Hello');
 
       await vi.waitFor(() => {
-        expect(mockUpdateChatTitleById).toHaveBeenCalledWith({ chatId: 'chat-123', title: 'Generated Title' });
+        expect(mockUpdateChatTitleIfMatches).toHaveBeenCalledWith({
+          chatId: 'chat-123',
+          expectedTitle: 'Hello',
+          newTitle: 'Generated Title',
+        });
       });
 
       expect(vi.mocked(mockWebContents.send)).toHaveBeenCalledWith('api-sender', 'chat-list-updated');
@@ -165,17 +175,23 @@ describe('ChatManager', () => {
 
       const chatManager = createChatManager();
       const dbError = new Error('DB write failed');
-      const mockUpdateChatTitleById = vi.fn().mockReturnValue({ isOk: () => false, error: dbError });
-      (chatManager as unknown as { chatQueries: { updateChatTitleById: MockInstance } }).chatQueries = {
-        updateChatTitleById: mockUpdateChatTitleById,
+      const mockUpdateChatTitleIfMatches = vi.fn(
+        async (): Promise<{ isOk: () => boolean; isErr: () => boolean; error: Error }> => ({
+          isOk: () => false,
+          isErr: () => true,
+          error: dbError,
+        }),
+      );
+      (chatManager as unknown as { chatQueries: { updateChatTitleIfMatches: MockInstance } }).chatQueries = {
+        updateChatTitleIfMatches: mockUpdateChatTitleIfMatches,
       } as never;
 
       const mockModel = 'mock-model';
       const userMessage = { role: 'user', parts: [{ type: 'text', text: 'Hello' }] };
 
       (
-        chatManager as unknown as { generateTitleInBackground: (m: unknown, u: unknown, id: string) => void }
-      ).generateTitleInBackground(mockModel, userMessage, 'chat-123');
+        chatManager as unknown as { generateTitleInBackground: (m: unknown, u: unknown, id: string, p: string) => void }
+      ).generateTitleInBackground(mockModel, userMessage, 'chat-123', 'Hello');
 
       await vi.waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('Failed to update chat title in database', dbError);
@@ -197,14 +213,52 @@ describe('ChatManager', () => {
       const userMessage = { role: 'user', parts: [{ type: 'text', text: 'Hello' }] };
 
       (
-        chatManager as unknown as { generateTitleInBackground: (m: unknown, u: unknown, id: string) => void }
-      ).generateTitleInBackground(mockModel, userMessage, 'chat-123');
+        chatManager as unknown as { generateTitleInBackground: (m: unknown, u: unknown, id: string, p: string) => void }
+      ).generateTitleInBackground(mockModel, userMessage, 'chat-123', 'Hello');
 
       await vi.waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('Failed to generate chat title', expect.any(Error));
       });
 
       consoleSpy.mockRestore();
+    });
+
+    it('should not update title if user has manually renamed the chat', async () => {
+      const { generateText } = await import('ai');
+      vi.mocked(generateText).mockResolvedValue({ text: 'Generated Title' } as Awaited<
+        ReturnType<typeof generateText>
+      >);
+
+      const chatManager = createChatManager();
+      // Simulate user has renamed the chat - atomic update returns false (no rows updated)
+      const mockUpdateChatTitleIfMatches = vi.fn(
+        async (): Promise<{ isOk: () => boolean; isErr: () => boolean; value: boolean }> => ({
+          isOk: () => true,
+          isErr: () => false,
+          value: false, // No rows updated - title didn't match
+        }),
+      );
+      (chatManager as unknown as { chatQueries: { updateChatTitleIfMatches: MockInstance } }).chatQueries = {
+        updateChatTitleIfMatches: mockUpdateChatTitleIfMatches,
+      } as never;
+
+      const mockModel = 'mock-model';
+      const userMessage = { role: 'user', parts: [{ type: 'text', text: 'Hello' }] };
+
+      (
+        chatManager as unknown as { generateTitleInBackground: (m: unknown, u: unknown, id: string, p: string) => void }
+      ).generateTitleInBackground(mockModel, userMessage, 'chat-123', 'Hello');
+
+      await vi.waitFor(() => {
+        expect(mockUpdateChatTitleIfMatches).toHaveBeenCalledWith({
+          chatId: 'chat-123',
+          expectedTitle: 'Hello',
+          newTitle: 'Generated Title',
+        });
+      });
+
+      // Should NOT emit event because no rows were updated (title was changed by user)
+      expect(vi.mocked(mockWebContents.send)).not.toHaveBeenCalledWith('api-sender', 'chat-list-updated');
     });
   });
 });

--- a/packages/main/src/chat/chat-manager.ts
+++ b/packages/main/src/chat/chat-manager.ts
@@ -111,6 +111,7 @@ export class ChatManager {
     this.ipcHandle('inference:deleteChat', (_, id: string) => this.deleteChat(id));
     this.ipcHandle('inference:deleteAllChats', () => this.deleteAllChats());
     this.ipcHandle('inference:deleteTrailingMessages', (_, id: string) => this.deleteTrailingMessages(id));
+    this.ipcHandle('inference:renameChat', (_, id: string, title: string) => this.renameChat(id, title));
   }
 
   private async getExchanges(mcpId: string): Promise<DynamicToolUIPart[]> {
@@ -156,6 +157,14 @@ export class ChatManager {
     if (result.isErr()) {
       throw result.error;
     }
+  }
+
+  private async renameChat(id: string, title: string): Promise<undefined> {
+    const result = await this.chatQueries.updateChatTitleById({ chatId: id, title });
+    if (result.isErr()) {
+      throw result.error;
+    }
+    this.webContents.send('api-sender', 'chat-list-updated');
   }
 
   private async convertMessages(messages: UIMessage[]): Promise<UIMessage[]> {
@@ -223,8 +232,14 @@ export class ChatManager {
 
   /**
    * Asynchronously generates an AI-powered chat title and persists it, notifying the UI on success.
+   * Only updates the title if it hasn't been manually changed from the placeholder.
    */
-  private generateTitleInBackground(model: LanguageModelV2, userMessage: UIMessage, chatId: string): void {
+  private generateTitleInBackground(
+    model: LanguageModelV2,
+    userMessage: UIMessage,
+    chatId: string,
+    placeholderTitle: string,
+  ): void {
     generateText({
       model,
       prompt: userMessage.parts
@@ -238,11 +253,21 @@ export class ChatManager {
       - do not use quotes or colons`,
     })
       .then(async result => {
-        const updateResult = await this.chatQueries.updateChatTitleById({ chatId, title: result.text });
-        if (updateResult.isOk()) {
-          this.webContents.send('api-sender', 'chat-list-updated');
-        } else {
+        // Atomically update title only if it still matches the placeholder
+        const updateResult = await this.chatQueries.updateChatTitleIfMatches({
+          chatId,
+          expectedTitle: placeholderTitle,
+          newTitle: result.text,
+        });
+
+        if (updateResult.isErr()) {
           console.error('Failed to update chat title in database', updateResult.error);
+          return;
+        }
+
+        // Only emit event if a row was actually updated
+        if (updateResult.value) {
+          this.webContents.send('api-sender', 'chat-list-updated');
         }
       })
       .catch((error: unknown) => {
@@ -270,7 +295,7 @@ export class ChatManager {
       const internalProviderId = this.providerRegistry.getMatchingProviderInternalId(params.providerId);
       const sdk = this.providerRegistry.getInferenceSDK(internalProviderId, params.connectionName);
       const model = sdk.languageModel(params.modelId);
-      this.generateTitleInBackground(model, userMessage, chatId);
+      this.generateTitleInBackground(model, userMessage, chatId, placeholderTitle);
     }
 
     const inferenceComponents = await this.getInferenceComponents(params);

--- a/packages/main/src/chat/db/queries.ts
+++ b/packages/main/src/chat/db/queries.ts
@@ -448,4 +448,31 @@ export class ChatQueries {
       return ok(undefined);
     });
   };
+
+  /**
+   * Atomically updates chat title only if it matches the expected current title.
+   * Returns true if a row was updated, false if no match was found.
+   */
+  updateChatTitleIfMatches = ({
+    chatId,
+    expectedTitle,
+    newTitle,
+  }: {
+    chatId: string;
+    expectedTitle: string;
+    newTitle: string;
+  }): ResultAsync<boolean, DbError> => {
+    const db = this.db;
+    return safeTry(async function* () {
+      const result = yield* fromPromise(
+        db
+          .update(chat)
+          .set({ title: newTitle })
+          .where(and(eq(chat.id, chatId), eq(chat.title, expectedTitle))),
+        e => new DbInternalError({ cause: e }),
+      );
+      // Check if any rows were affected
+      return ok(result.changes > 0);
+    });
+  };
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1314,6 +1314,10 @@ export function initExposure(): void {
     return ipcInvoke('inference:deleteChat', chatId);
   });
 
+  contextBridge.exposeInMainWorld('inferenceRenameChat', async (chatId: string, title: string): Promise<undefined> => {
+    return ipcInvoke('inference:renameChat', chatId, title);
+  });
+
   contextBridge.exposeInMainWorld('inferenceDeleteAllChats', async (): Promise<undefined> => {
     return ipcInvoke('inference:deleteAllChats');
   });

--- a/packages/renderer/src/lib/chat/components/sidebar-history/history.svelte
+++ b/packages/renderer/src/lib/chat/components/sidebar-history/history.svelte
@@ -159,6 +159,12 @@ async function handleDeleteAllChats(): Promise<void> {
 									chatIdToDelete = chatId;
 									withConfirmation(handleDeleteChat, 'This action cannot be undone. This will permanently delete your chat');
 								}}
+								onrename={(chatId, newTitle): void => {
+									const chatToUpdate = chatHistory.chats.find(c => c.id === chatId);
+									if (chatToUpdate) {
+										chatToUpdate.title = newTitle;
+									}
+								}}
 							/>
 						{/each}
 					{/if}

--- a/packages/renderer/src/lib/chat/components/sidebar-history/item.svelte
+++ b/packages/renderer/src/lib/chat/components/sidebar-history/item.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+import { tick } from 'svelte';
+import { toast } from 'svelte-sonner';
 import { router } from 'tinro';
 
 import { currentChatId } from '/@/lib/chat/state/current-chat-id.svelte';
 import type { Chat } from '/@api/chat/schema.js';
 
 import MoreHorizontalIcon from '../icons/more-horizontal.svelte';
+import PencilEditIcon from '../icons/pencil-edit.svelte';
 import TrashIcon from '../icons/trash.svelte';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu';
 import { SidebarMenuAction, SidebarMenuButton, SidebarMenuItem, useSidebar } from '../ui/sidebar';
@@ -13,28 +16,103 @@ let {
   chat,
   active,
   ondelete,
+  onrename,
 }: {
   chat: Chat;
   active: boolean;
   ondelete: (chatId: string) => void;
+  onrename: (chatId: string, newTitle: string) => void;
 } = $props();
 
 const context = useSidebar();
+let isRenaming = $state(false);
+let renameInFlight = $state(false);
+let newTitle = $state(chat.title);
+let inputElement: HTMLInputElement | undefined = $state();
+
+async function startRenaming(): Promise<void> {
+  isRenaming = true;
+  newTitle = chat.title;
+  // Focus the input after it renders
+  await tick();
+  inputElement?.focus();
+  inputElement?.select();
+}
+
+async function saveRename(): Promise<void> {
+  // Guard against duplicate calls (e.g., Enter + blur)
+  if (renameInFlight) {
+    return;
+  }
+  const normalizedTitle = newTitle.trim();
+  if (normalizedTitle && normalizedTitle !== chat.title) {
+    renameInFlight = true;
+    try {
+      await window.inferenceRenameChat(chat.id, normalizedTitle);
+      onrename(chat.id, normalizedTitle);
+      toast.success('Chat renamed successfully');
+    } catch (error) {
+      console.error('Failed to rename chat', error);
+      toast.error('Failed to rename chat');
+      newTitle = chat.title;
+    } finally {
+      renameInFlight = false;
+    }
+  }
+  isRenaming = false;
+}
+
+function cancelRename(): void {
+  newTitle = chat.title;
+  isRenaming = false;
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    saveRename().catch((err: unknown) => {
+      console.error('Failed to save rename', err);
+    });
+  } else if (event.key === 'Escape') {
+    event.preventDefault();
+    cancelRename();
+  }
+}
+
+function handleBlur(): void {
+  saveRename().catch((err: unknown) => {
+    console.error('Failed to save rename on blur', err);
+  });
+}
+
+function handleClick(): void {
+  currentChatId.value = chat.id;
+  router.goto(`/chat/${chat.id}`);
+  context.setOpenMobile(false);
+}
 </script>
 
 <SidebarMenuItem>
 	<SidebarMenuButton isActive={active}>
 		{#snippet child({ props })}
-			<button
-				{...props}
-				onclick={(): void => {
-					currentChatId.value = chat.id;
-					router.goto(`/chat/${chat.id}`);
-					context.setOpenMobile(false);
-				}}
-			>
-				<span>{chat.title}</span>
-			</button>
+			{#if isRenaming}
+				<input
+					bind:this={inputElement}
+					bind:value={newTitle}
+					onkeydown={handleKeydown}
+					onblur={handleBlur}
+					aria-label="Rename conversation"
+					class="bg-sidebar-accent text-sidebar-accent-foreground flex h-8 w-full rounded-md px-2 text-sm outline-none"
+					type="text"
+				/>
+			{:else}
+				<button
+					{...props}
+					onclick={handleClick}
+				>
+					<span>{chat.title}</span>
+				</button>
+			{/if}
 		{/snippet}
 	</SidebarMenuButton>
 
@@ -93,6 +171,11 @@ const context = useSidebar();
 					</DropdownMenuItem>
 				</DropdownMenuSubContent>
 			</DropdownMenuSub> -->
+
+			<DropdownMenuItem class="cursor-pointer" onclick={startRenaming}>
+				<PencilEditIcon />
+				<span>Rename</span>
+			</DropdownMenuItem>
 
 			<DropdownMenuItem
 				class="text-destructive focus:bg-destructive/15 focus:text-destructive cursor-pointer dark:text-red-500"

--- a/tests/playwright/src/model/pages/chat-page.ts
+++ b/tests/playwright/src/model/pages/chat-page.ts
@@ -40,6 +40,7 @@ export class ChatPage extends BasePage {
   readonly chatHistoryItem: Locator;
   readonly chatHistoryItemMenuAction: Locator;
   readonly chatHistoryItemDeleteButton: Locator;
+  readonly chatHistoryItemRenameButton: Locator;
   readonly chatHistoryEmptyMessage: Locator;
   readonly toasts: Locator;
   readonly modelDropdownContent: Locator;
@@ -73,6 +74,7 @@ export class ChatPage extends BasePage {
     this.chatHistoryItem = page.locator('button[data-sidebar="menu-button"]');
     this.chatHistoryItemMenuAction = page.locator('button[data-sidebar="menu-action"]');
     this.chatHistoryItemDeleteButton = page.getByRole('menuitem', { name: 'Delete' });
+    this.chatHistoryItemRenameButton = page.getByRole('menuitem', { name: 'Rename' });
     this.chatHistoryEmptyMessage = page.getByText('Your conversations will appear here once you start chatting!');
     this.toasts = page.locator('[data-sonner-toast]');
     this.modelDropdownContent = page.locator('[data-slot="dropdown-menu-content"]');
@@ -182,6 +184,44 @@ export class ChatPage extends BasePage {
   async deleteAllChatHistoryItems(): Promise<void> {
     await this.deleteAllChatsButton.click();
     await handleDialogIfPresent(this.page);
+  }
+
+  async renameChatHistoryItemByIndex(index: number, newTitle: string): Promise<void> {
+    const item = this.chatHistoryItems.nth(index);
+    await item.locator(this.chatHistoryItemMenuAction).click();
+    await this.chatHistoryItemRenameButton.click();
+
+    // Find the input field using accessible label
+    const inputField = item.getByLabel('Rename conversation');
+    await expect(inputField).toBeVisible();
+    await inputField.fill(newTitle);
+    await inputField.press('Enter');
+  }
+
+  async cancelRenameChatHistoryItemByIndex(index: number, textBeforeCancel?: string): Promise<void> {
+    const item = this.chatHistoryItems.nth(index);
+    await item.locator(this.chatHistoryItemMenuAction).click();
+    await this.chatHistoryItemRenameButton.click();
+
+    // Find the input field using accessible label
+    const inputField = item.getByLabel('Rename conversation');
+    await expect(inputField).toBeVisible();
+
+    // Optionally fill text before canceling (to test that changes are discarded)
+    if (textBeforeCancel) {
+      await inputField.fill(textBeforeCancel);
+    }
+
+    await inputField.press('Escape');
+
+    // Verify the input is no longer visible
+    await expect(inputField).not.toBeVisible();
+  }
+
+  async getChatHistoryItemTitle(index: number): Promise<string> {
+    const item = this.chatHistoryItems.nth(index);
+    const title = await item.locator(this.chatHistoryItem).textContent();
+    return title?.trim() ?? '';
   }
 
   async waitForChatHistoryCount(expectedCount: number, timeout = 10_000): Promise<void> {

--- a/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
@@ -391,4 +391,72 @@ test.describe
       await expect(chatPage.getConversationMessage(originalMessage)).not.toBeVisible();
       await chatPage.waitForModelResponse();
     });
+
+    test('[CHAT-15] Rename chat from history sidebar', async ({ chatPage }) => {
+      await chatPage.ensureChatSidebarVisible();
+      await chatPage.clickNewChat();
+
+      const message = 'Test message for renaming';
+      await chatPage.sendMessage(message);
+      await chatPage.waitForModelResponse();
+
+      // Wait for chat to appear in history
+      const initialCount = await chatPage.getChatHistoryCount();
+      expect(initialCount).toBeGreaterThan(0);
+
+      // Get the original title (should be auto-generated from the message)
+      await expect
+        .poll(
+          async () => {
+            const title = await chatPage.getChatHistoryItemTitle(0);
+            return title.trim().length > 0;
+          },
+          { timeout: TIMEOUTS.MODEL_RESPONSE },
+        )
+        .toBeTruthy();
+
+      // Rename the chat
+      const newTitle = 'My Renamed Chat';
+      await chatPage.renameChatHistoryItemByIndex(0, newTitle);
+
+      // Verify the title has been updated
+      await expect
+        .poll(async () => await chatPage.getChatHistoryItemTitle(0), { timeout: TIMEOUTS.SHORT })
+        .toBe(newTitle);
+
+      await chatPage.ensureNotificationsAreNotVisible();
+    });
+
+    test('[CHAT-16] Cancel rename with Escape key preserves original title', async ({ chatPage }) => {
+      await chatPage.ensureChatSidebarVisible();
+      await chatPage.clickNewChat();
+
+      const message = 'Test message for cancel rename';
+      await chatPage.sendMessage(message);
+      await chatPage.waitForModelResponse();
+
+      // Wait for chat to appear in history with auto-generated title
+      await expect
+        .poll(
+          async () => {
+            const title = await chatPage.getChatHistoryItemTitle(0);
+            return title.trim().length > 0;
+          },
+          { timeout: TIMEOUTS.MODEL_RESPONSE },
+        )
+        .toBeTruthy();
+
+      // Capture the original title
+      const originalTitle = await chatPage.getChatHistoryItemTitle(0);
+      expect(originalTitle).toBeTruthy();
+
+      // Open rename UI, type a new title, but press Escape to cancel
+      await chatPage.cancelRenameChatHistoryItemByIndex(0, 'This should not be saved');
+
+      // Verify the title remains unchanged
+      const titleAfterCancel = await chatPage.getChatHistoryItemTitle(0);
+      expect(titleAfterCancel).toBe(originalTitle);
+
+      await chatPage.ensureNotificationsAreNotVisible();
+    });
   });


### PR DESCRIPTION
## Summary

Implements inline chat rename functionality in the sidebar history, allowing users to rename chats directly from the history list similar to Ollama and Claude Desktop.

- Adds "Rename" option to chat dropdown menu with inline text input field
- Keyboard shortcuts: Enter to save, Escape to cancel
- Auto-focus and text selection when entering rename mode
- Toast notifications for success/error feedback
- Exposes `inferenceRenameChat` API and IPC handler
- **Race condition fix**: Prevents AI-generated title from overwriting user's manual rename
- Adds E2E test `[CHAT-15] Rename chat from history sidebar`

## Test plan

- [x] Unit tests pass (including new test for race condition fix)
- [x] E2E test added and verified
- [ ] Manual testing:
  - [ ] Create a new chat
  - [ ] Click the "More" (⋯) button on the chat in sidebar
  - [ ] Select "Rename" from dropdown
  - [ ] Edit the title inline
  - [ ] Press Enter to save (verify success toast appears)
  - [ ] Press Escape to cancel rename
  - [ ] Verify AI-generated title doesn't overwrite manual rename

Fixes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)