### PR TITLE
fix: show reasoning before response and improve streaming indicators

### DIFF
--- a/packages/renderer/src/lib/chat/components/message-reasoning.spec.ts
+++ b/packages/renderer/src/lib/chat/components/message-reasoning.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getLock } from '/@/lib/chat/hooks/lock.svelte';
+
+import MessageReasoning from './message-reasoning.svelte';
+
+vi.mock(import('/@/lib/chat/hooks/lock.svelte'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getLock).mockReturnValue({
+    locked: false,
+    lockTransition: vi.fn(),
+    unlockTransition: vi.fn(),
+    userScrolledAway: false,
+    transitionLockCount: 0,
+  });
+});
+
+describe('MessageReasoning', () => {
+  test('should show "Reasoning..." when loading with no text content yet', () => {
+    render(MessageReasoning, {
+      loading: true,
+      reasoningContent: '',
+      hasText: false,
+    });
+
+    expect(screen.getByText('Reasoning...')).toBeInTheDocument();
+    expect(screen.queryByText(/^Reasoned for/)).not.toBeInTheDocument();
+  });
+
+  test('should show "Reasoning..." when loading with partial reasoning but no text yet', () => {
+    render(MessageReasoning, {
+      loading: true,
+      reasoningContent: 'Some reasoning content',
+      hasText: false,
+    });
+
+    expect(screen.getByText('Reasoning...')).toBeInTheDocument();
+    expect(screen.queryByText(/^Reasoned for/)).not.toBeInTheDocument();
+  });
+
+  test('should show "Reasoned for..." when loading but text has started', () => {
+    const { container } = render(MessageReasoning, {
+      loading: true,
+      reasoningContent: 'Some reasoning content',
+      hasText: true,
+    });
+
+    expect(container.textContent).toMatch(/Reasoned for/);
+    expect(screen.queryByText('Reasoning...', { exact: true })).not.toBeInTheDocument();
+  });
+
+  test('should show "Reasoned for..." when not loading', () => {
+    const { container } = render(MessageReasoning, {
+      loading: false,
+      reasoningContent: 'Some reasoning content',
+      hasText: true,
+    });
+
+    expect(container.textContent).toMatch(/Reasoned for/);
+    expect(screen.queryByText('Reasoning...', { exact: true })).not.toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/chat/components/message-reasoning.svelte
+++ b/packages/renderer/src/lib/chat/components/message-reasoning.svelte
@@ -1,19 +1,44 @@
 <script lang="ts">
+/* eslint-enable simple-import-sort/imports */
+import humanizeDuration from 'humanize-duration';
 import { tick } from 'svelte';
 /* eslint-disable import/no-duplicates */
 import { cubicInOut } from 'svelte/easing';
 import { slide } from 'svelte/transition';
 
-/* eslint-enable simple-import-sort/imports */
 import { getLock } from '/@/lib/chat/hooks/lock.svelte';
 
 import ChevronDownIcon from './icons/chevron-down.svelte';
-import LoaderIcon from './icons/loader.svelte';
 import { Markdown } from './markdown';
 
-let { loading, reasoning }: { loading: boolean; reasoning: string } = $props();
+let { loading, reasoningContent, hasText }: { loading: boolean; reasoningContent: string; hasText: boolean } = $props();
 let expanded = $state(false);
 const scrollLock = getLock('messages-scroll');
+
+// Show "Reasoning..." only during reasoning phase (before text starts)
+// Once text starts, reasoning is complete even if still loading
+const isReasoning = $derived(loading && !hasText);
+
+// Track reasoning duration
+let startTime = $state<number | null>(null);
+let endTime = $state<number | null>(null);
+
+// Track when reasoning starts and ends
+$effect(() => {
+  if (isReasoning && startTime === null) {
+    startTime = Date.now();
+  } else if (!isReasoning && startTime !== null && endTime === null) {
+    endTime = Date.now();
+  }
+});
+
+const durationText = $derived(
+  startTime && endTime ? humanizeDuration(endTime - startTime, { round: true, largest: 2 }) : null,
+);
+
+const reasoningLabel = $derived(
+  isReasoning ? 'Reasoning...' : durationText ? `Reasoned for ${durationText}` : 'Reasoned for a few seconds',
+);
 
 function lockScrolling(): void {
   scrollLock.lockTransition();
@@ -31,31 +56,28 @@ function unlockScrolling(): void {
 </script>
 
 <div class="flex flex-col">
-	{#if loading}
-		<div class="flex flex-row items-center gap-2">
-			<div class="font-medium">Reasoning</div>
-			<div class="animate-spin">
-				<LoaderIcon />
-			</div>
-		</div>
-	{:else}
-		<div class="flex flex-row items-center gap-2">
-			<div class="font-medium">Reasoned for a few seconds</div>
-			<!-- svelte-ignore a11y_click_events_have_key_events -->
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<div
-				class="cursor-pointer"
+	<div class="flex flex-row items-center gap-2">
+		<div class="font-medium">{reasoningLabel}</div>
+		{#if reasoningContent}
+			<button
+				type="button"
+				class="cursor-pointer transition-transform duration-200 -rotate-90"
+				class:rotate-0={expanded}
+				aria-expanded={expanded}
+				aria-controls="reasoning-content"
+				aria-label={expanded ? 'Collapse reasoning details' : 'Expand reasoning details'}
 				onclick={(): void => {
 					expanded = !expanded;
 				}}
 			>
 				<ChevronDownIcon />
-			</div>
-		</div>
-	{/if}
+			</button>
+		{/if}
+	</div>
 
 	{#if expanded}
 		<div
+			id="reasoning-content"
 			transition:slide={{ duration: 200, easing: cubicInOut }}
 			onintrostart={lockScrolling}
 			onintroend={unlockScrolling}
@@ -63,7 +85,7 @@ function unlockScrolling(): void {
 			onoutroend={unlockScrolling}
 			class="mt-4 mb-2 flex flex-col gap-4 border-l pl-4 text-zinc-600 dark:text-zinc-400"
 		>
-			<Markdown md={reasoning} />
+			<Markdown md={reasoningContent} />
 		</div>
 	{/if}
 </div>

--- a/packages/renderer/src/lib/chat/components/messages/preview-message-test.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message-test.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import type { UIMessage } from '@ai-sdk/svelte';
+
+import { TooltipProvider } from '/@/lib/chat/components/ui/tooltip';
+
+import PreviewMessage from './preview-message.svelte';
+
+let {
+  message,
+  messages,
+  readonly,
+  loading,
+}: {
+  message: UIMessage;
+  messages: UIMessage[];
+  readonly: boolean;
+  loading: boolean;
+} = $props();
+</script>
+
+<TooltipProvider>
+  <PreviewMessage {message} {messages} {readonly} {loading} />
+</TooltipProvider>

--- a/packages/renderer/src/lib/chat/components/messages/preview-message.spec.ts
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.spec.ts
@@ -1,0 +1,287 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import type { UIMessage } from '@ai-sdk/svelte';
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { EditState } from '/@/lib/chat/hooks/edit-state.svelte';
+import { getLock } from '/@/lib/chat/hooks/lock.svelte';
+
+import PreviewMessageTest from './preview-message-test.svelte';
+
+vi.mock(import('/@/lib/chat/hooks/edit-state.svelte'));
+vi.mock(import('/@/lib/chat/hooks/lock.svelte'));
+
+// Mock animations
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  // Configure mocked modules
+  vi.mocked(EditState.fromContext).mockReturnValue({
+    isAfterEditingMessage: vi.fn(() => false),
+    isEditing: false,
+    startEditing: vi.fn(),
+    editingMessage: undefined,
+    cancelEditing: vi.fn(),
+  });
+  vi.mocked(getLock).mockReturnValue({
+    locked: false,
+    lockTransition: vi.fn(),
+    unlockTransition: vi.fn(),
+    userScrolledAway: false,
+    transitionLockCount: 0,
+  });
+
+  if (!HTMLElement.prototype.animate) {
+    HTMLElement.prototype.animate = vi.fn(() => ({
+      finished: Promise.resolve(),
+      onfinish: null,
+      cancel: vi.fn(),
+    })) as unknown as typeof HTMLElement.prototype.animate;
+  }
+});
+
+describe('PreviewMessage - Reasoning and Response Display', () => {
+  test('should render reasoning and text content when both are present', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'Reasoning content' },
+        { type: 'text', text: 'Response text' },
+      ],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: false,
+    });
+
+    // Both reasoning and text should be rendered
+    const content = container.textContent ?? '';
+    expect(content).toMatch(/Reasoned for/);
+    expect(content).toContain('Response text');
+
+    // Verify reasoning appears before response text in the DOM
+    const reasoningMatch = /Reasoned for/.exec(content);
+    const reasoningIndex = reasoningMatch ? content.indexOf(reasoningMatch[0]) : -1;
+    const textIndex = content.indexOf('Response text');
+    expect(reasoningIndex).toBeGreaterThan(-1);
+    expect(textIndex).toBeGreaterThan(-1);
+    expect(reasoningIndex).toBeLessThan(textIndex);
+  });
+
+  test('should show spinner when loading last assistant message without reasoning', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Response text' }],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: true,
+    });
+
+    // Check for spinner (LoaderIcon is rendered inside animate-spin div)
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  test('should show generating spinner when loading with reasoning but no text yet', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [{ type: 'reasoning', text: 'Reasoning content' }],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: true,
+    });
+
+    // Should show "Reasoning..." since no text has started yet
+    expect(container.textContent).toContain('Reasoning...');
+    expect(container.textContent).not.toMatch(/Reasoned for/);
+    // Should show global generating spinner
+    const spinners = container.querySelectorAll('.animate-spin');
+    expect(spinners.length).toBe(1);
+  });
+
+  test('should show generating spinner when loading with reasoning and text', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'Reasoning content' },
+        { type: 'text', text: 'Response text' },
+      ],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: true,
+    });
+
+    // Should show "Reasoned for..." since text has started
+    expect(container.textContent).toMatch(/Reasoned for/);
+    // Should show global generating spinner since still loading
+    const spinners = container.querySelectorAll('.animate-spin');
+    expect(spinners.length).toBe(1);
+  });
+
+  test('should not show generating spinner when not loading', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'Reasoning content' },
+        { type: 'text', text: 'Response text' },
+      ],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: false,
+    });
+
+    // Count spinners - the generating response spinner should not be present
+    const spinners = container.querySelectorAll('.animate-spin');
+    // No generating response spinner when not loading
+    expect(spinners.length).toBe(0);
+  });
+
+  test('should not show spinner for earlier assistant messages when loading', () => {
+    const earlierMessage: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Earlier response' }],
+    };
+
+    const laterMessage: UIMessage = {
+      id: 'msg2',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Current response' }],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message: earlierMessage,
+      messages: [earlierMessage, laterMessage],
+      readonly: true,
+      loading: true,
+    });
+
+    // Should not show spinner for earlier assistant messages
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).not.toBeInTheDocument();
+  });
+
+  test('should not show spinner for user messages', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'User question' }],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: true,
+    });
+
+    // Should not show spinner for user messages
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).not.toBeInTheDocument();
+  });
+
+  test('should render only text when no reasoning present', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Response without reasoning' }],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: false,
+    });
+
+    expect(container.textContent).toContain('Response without reasoning');
+    expect(container.textContent).not.toMatch(/Reasoned for/);
+    expect(container.textContent).not.toContain('Reasoning');
+  });
+
+  test('should handle multiple text parts', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'First part' },
+        { type: 'text', text: 'Second part' },
+      ],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: false,
+    });
+
+    expect(container.textContent).toContain('First part');
+    expect(container.textContent).toContain('Second part');
+  });
+
+  test('should handle multiple reasoning parts', () => {
+    const message: UIMessage = {
+      id: 'msg1',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'First reasoning' },
+        { type: 'reasoning', text: 'Second reasoning' },
+        { type: 'text', text: 'Response' },
+      ],
+    };
+
+    const { container } = render(PreviewMessageTest, {
+      message,
+      messages: [message],
+      readonly: true,
+      loading: false,
+    });
+
+    // Should render both reasoning and response text
+    expect(container.textContent).toMatch(/Reasoned for/);
+    expect(container.textContent).toContain('Response');
+  });
+});

--- a/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
@@ -8,6 +8,7 @@ import { fileUIPart2Attachment } from '/@/lib/chat/utils/chat';
 import { cn } from '/@/lib/chat/utils/shadcn';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 
+import LoaderIcon from '../icons/loader.svelte';
 import PencilEditIcon from '../icons/pencil-edit.svelte';
 import SparklesIcon from '../icons/sparkles.svelte';
 import MessageReasoning from '../message-reasoning.svelte';
@@ -33,6 +34,15 @@ const editState = EditState.fromContext();
 const isGrayed = $derived(editState.isAfterEditingMessage(messages, message));
 
 const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type === 'dynamic-tool') ?? [];
+
+// Separate reasoning and text parts for proper ordering
+const reasoningParts = $derived(message.parts.filter(part => part.type === 'reasoning'));
+const textParts = $derived(message.parts.filter(part => part.type === 'text'));
+const hasText = $derived(textParts.some(part => part.text.trim().length > 0));
+
+// Show spinner only for the last assistant message while loading (during reasoning or text generation)
+const isLastMessage = $derived(messages.length > 0 && messages[messages.length - 1].id === message.id);
+const isGeneratingResponse = $derived(loading && message.role === 'assistant' && isLastMessage);
 </script>
 
 <div
@@ -75,86 +85,57 @@ const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type 
         </div>
       {/if}
 
-      {#each message.parts as part, i (`${message.id}-${i}`)}
-        {@const { type } = part}
-        {#if type === 'reasoning'}
-          <MessageReasoning {loading} reasoning={part.text} />
-        {:else if type === 'text'}
-          <div class="flex flex-row items-center gap-2">
-            {#if message.role === 'user' && !readonly}
-              <Tooltip>
-                <TooltipTrigger>
-                  {#snippet child({ props })}
-                    <Button
-                      {...props}
-                      variant="ghost"
-                      class={cn(
-                        'text-muted-foreground h-fit rounded-full px-2 opacity-0 group-hover/message:opacity-100',
-                        { 'invisible': editState.isEditing }
-                      )}
-                      aria-label="Edit message"
-                      onclick={(): void => {
-                        editState.startEditing(message);
-                      }}
-                      disabled={editState.isEditing}
-                    >
-                      <PencilEditIcon />
-                    </Button>
-                  {/snippet}
-                </TooltipTrigger>
-                <TooltipContent>Edit message</TooltipContent>
-              </Tooltip>
-            {/if}
-            <div
-              class={cn('flex flex-col gap-4', {
-                'bg-primary text-primary-foreground rounded-xl px-3 pt-4': message.role === 'user',
-                'animate-fade-in': message.role === 'assistant',
-              })}
-            >
-              <Markdown markdown={part.text} allowDangerousHtml={message.role !== 'user'} />
-            </div>
-          </div>
-
-          <!-- TODO -->
-          <!-- {:else if type === 'tool-invocation'}
-          {@const { toolInvocation } = part}
-          {@const { toolName, state } = toolInvocation}
-
-          {#if state === 'call'}
-            {@const { args } = toolInvocation}
-            <div
-              class={cn({
-                skeleton: ['getWeather'].includes(toolName)
-              })}
-            >
-              {#if toolName === 'getWeather'}
-                <Weather />
-              {:else if toolName === 'createDocument'}
-                <DocumentPreview {readonly} {args} />
-              {:else if toolName === 'updateDocument'}
-                <DocumentToolCall type="update" {args} {readonly} />
-              {:else if toolName === 'requestSuggestions'}
-                <DocumentToolCall type="request-suggestions" {args} {readonly} />
-              {/if}
-            </div>
-          {:else if state === 'result'}
-          {@const { result } = toolInvocation}
-            <div>
-              {#if toolName === 'getWeather'}
-                <Weather weatherAtLocation={result} />
-              {:else if toolName === 'createDocument'}
-                <DocumentPreview {readonly} {result} />
-              {:else if toolName === 'updateDocument'}
-                <DocumentToolResult type="update" {result} {readonly} />
-              {:else if toolName === 'requestSuggestions'}
-                <DocumentToolResult type="request-suggestions" {result} {readonly} />
-              {:else}
-                <pre>{JSON.stringify(result, null, 2)}</pre>
-              {/if}
-            </div>
-          {/if} -->
-        {/if}
+      <!-- Show reasoning first -->
+      {#each reasoningParts as part, i (`${message.id}-reasoning-${i}`)}
+        <MessageReasoning {loading} reasoningContent={part.text} {hasText} />
       {/each}
+
+      <!-- Show text parts after reasoning -->
+      {#each textParts as part, i (`${message.id}-text-${i}`)}
+        <div class="flex flex-row items-center gap-2">
+          {#if message.role === 'user' && !readonly}
+            <Tooltip>
+              <TooltipTrigger>
+                {#snippet child({ props })}
+                  <Button
+                    {...props}
+                    variant="ghost"
+                    class={cn(
+                      'text-muted-foreground h-fit rounded-full px-2 opacity-0 group-hover/message:opacity-100',
+                      { 'invisible': editState.isEditing }
+                    )}
+                    aria-label="Edit message"
+                    onclick={(): void => {
+                      editState.startEditing(message);
+                    }}
+                    disabled={editState.isEditing}
+                  >
+                    <PencilEditIcon />
+                  </Button>
+                {/snippet}
+              </TooltipTrigger>
+              <TooltipContent>Edit message</TooltipContent>
+            </Tooltip>
+          {/if}
+          <div
+            class={cn('flex flex-col gap-4', {
+              'bg-primary text-primary-foreground rounded-xl px-3 pt-4': message.role === 'user',
+              'animate-fade-in': message.role === 'assistant',
+            })}
+          >
+            <Markdown markdown={part.text} allowDangerousHtml={message.role !== 'user'} />
+          </div>
+        </div>
+      {/each}
+
+      <!-- Show spinner at the end while response is streaming (after reasoning completes) -->
+      {#if isGeneratingResponse}
+        <div class="flex">
+          <div class="animate-spin">
+            <LoaderIcon size={16} />
+          </div>
+        </div>
+      {/if}
 
       <!-- TODO -->
       <!-- {#if !readonly}


### PR DESCRIPTION
fix: show reasoning before response and improve streaming indicators

Previously, the "Reasoning..." indicator displayed during the entire
message streaming process, even after reasoning was complete. This was
confusing as users expect reasoning to happen before the answer.

Changes:
- "Reasoning..." shows only during reasoning phase (before text starts)
- Once text starts streaming, shows "Reasoned for X" with actual duration
  using humanize-duration library (e.g., "2 seconds", "1 minute, 30 seconds")
- Reasoning component always renders before text content
- Single global spinner shows at end of message during both reasoning
  and text generation (simplified from having separate spinners)
- Only the last assistant message shows a spinner during generation
- Chevron to expand reasoning rotates: points right when collapsed,
  down when expanded, with smooth transition animation
- Users can expand reasoning during streaming to view content in real-time

https://github.com/user-attachments/assets/881c6f8f-0b42-434b-8cec-a00774e0071a

Fixes #1168