### PR TITLE
feat(agent-workspaces): add remove button to workspace detail view

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -191,3 +191,23 @@ test('Expect workspace not removed when user cancels', async () => {
   expect(window.removeAgentWorkspace).not.toHaveBeenCalled();
   expect(router.goto).not.toHaveBeenCalled();
 });
+
+test('Expect no navigation when removal fails', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.removeAgentWorkspace).mockRejectedValue(new Error('removal failed'));
+
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Remove Workspace' })).toBeInTheDocument();
+  });
+
+  const removeButton = screen.getByRole('button', { name: 'Remove Workspace' });
+  await fireEvent.click(removeButton);
+
+  await waitFor(() => {
+    expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1');
+  });
+
+  expect(router.goto).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -36,9 +36,13 @@ function handleStartStop(): void {
 }
 
 function handleRemove(name: string): void {
-  withConfirmation(() => {
-    window.removeAgentWorkspace(workspaceId).catch(console.error);
-    router.goto('/agent-workspaces');
+  withConfirmation(async () => {
+    try {
+      await window.removeAgentWorkspace(workspaceId);
+      router.goto('/agent-workspaces');
+    } catch (error: unknown) {
+      console.error('Failed to remove agent workspace', error);
+    }
   }, `remove workspace ${name}`);
 }
 </script>


### PR DESCRIPTION
Allow users to remove a workspace directly from the detail page with a confirmation dialog, then navigate back to the workspace list.

Closes #1164



Made-with: Claude-4.6-opus-high