### PR TITLE
fix(chat): position cursor at end when editing messages

### DIFF
--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -55,7 +55,11 @@ $effect(() => {
       // Wait for DOM to update before adjusting height
       requestAnimationFrame(() => {
         adjustHeight();
-        textareaRef?.focus();
+        if (textareaRef) {
+          textareaRef.focus();
+          // Set cursor to the end of the text
+          textareaRef.setSelectionRange(textareaRef.value.length, textareaRef.value.length);
+        }
       });
     });
   }


### PR DESCRIPTION
When editing a chat message, the cursor now correctly positions at the
end of the text instead of the beginning, improving UX.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
