### PR TITLE
feat(agent-workspaces): display project field in workspace UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
     "@kortex-app/api": "workspace:",
-    "@kortex-hub/kortex-cli-api": "^0.1.4",
+    "@kortex-hub/kortex-cli-api": "^0.1.6",
     "@kortex-hub/kortex-workspace-configuration": "^0.1.4",
     "@kortex-hub/mcp-registry-types": "^1.4.0-next.20251210140818.04eeb13",
     "@rollup/plugin-json": "^6.1.0",

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -41,11 +41,13 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
   {
     id: 'ws-1',
     name: 'test-workspace-1',
+    project: 'project-alpha',
     paths: { source: '/tmp/ws1', configuration: '/tmp/ws1/.kortex.yaml' },
   },
   {
     id: 'ws-2',
     name: 'test-workspace-2',
+    project: 'project-beta',
     paths: { source: '/tmp/ws2', configuration: '/tmp/ws2/.kortex.yaml' },
   },
 ];
@@ -104,6 +106,7 @@ describe('list', () => {
 
     expect(summary).toHaveProperty('id');
     expect(summary).toHaveProperty('name');
+    expect(summary).toHaveProperty('project');
     expect(summary).toHaveProperty('paths');
     expect(summary.paths).toHaveProperty('source');
     expect(summary.paths).toHaveProperty('configuration');

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-mock-data.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-mock-data.ts
@@ -33,6 +33,7 @@ const INITIAL_SUMMARIES: AgentWorkspaceSummary[] = [
   {
     id: 'mock-ws-api-refactor',
     name: 'api-refactor',
+    project: 'backend',
     paths: {
       source: '/home/user/projects/backend',
       configuration: '/home/user/.config/kortex/workspaces/api-refactor.yaml',
@@ -41,6 +42,7 @@ const INITIAL_SUMMARIES: AgentWorkspaceSummary[] = [
   {
     id: 'mock-ws-test-suite',
     name: 'test-suite-fix',
+    project: 'backend',
     paths: {
       source: '/home/user/projects/backend',
       configuration: '/home/user/.config/kortex/workspaces/test-suite-fix.yaml',
@@ -49,6 +51,7 @@ const INITIAL_SUMMARIES: AgentWorkspaceSummary[] = [
   {
     id: 'mock-ws-frontend',
     name: 'frontend-redesign',
+    project: 'frontend',
     paths: {
       source: '/home/user/projects/frontend',
       configuration: '/home/user/.config/kortex/workspaces/frontend-redesign.yaml',

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
@@ -32,6 +32,7 @@ vi.mock(import('tinro'));
 const workspace: AgentWorkspaceSummary = {
   id: 'ws-1',
   name: 'api-refactor',
+  project: 'backend',
   paths: {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kortex/workspaces/api-refactor.yaml',
@@ -52,6 +53,12 @@ test('Expect card displays workspace name', () => {
   render(AgentWorkspaceCard, { workspace });
 
   expect(screen.getByText('api-refactor')).toBeInTheDocument();
+});
+
+test('Expect card displays project name', () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  expect(screen.getByText('backend')).toBeInTheDocument();
 });
 
 test('Expect card displays source path', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faFolder, faGear, faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCubes, faFolder, faGear, faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
 
@@ -70,8 +70,12 @@ function handleRemove(): void {
   onclick={handleOpen}
   onkeydown={handleKeydown}
   tabindex="0">
-  <div class="text-start">
+  <div class="flex items-center justify-between text-start">
     <span class="text-(--pd-invert-content-card-text) font-semibold text-base">{workspace.name}</span>
+    <span class="flex items-center gap-1 text-xs text-(--pd-invert-content-card-text) opacity-70">
+      <Icon icon={faCubes} class="shrink-0" />
+      {workspace.project}
+    </span>
   </div>
   <div class="flex flex-col gap-2 text-sm">
     <div class="flex items-center gap-2 text-(--pd-invert-content-card-text)" title={workspace.paths.source}>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -19,12 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
-import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
+import { agentWorkspaces, agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
+import type { AgentWorkspaceConfiguration, AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 import AgentWorkspaceDetails from './AgentWorkspaceDetails.svelte';
 
@@ -42,6 +42,16 @@ const configuration: AgentWorkspaceConfiguration = {
   name: 'api-refactor',
 };
 
+const workspaceSummary: AgentWorkspaceSummary = {
+  id: 'ws-1',
+  name: 'api-refactor',
+  project: 'backend',
+  paths: {
+    source: '/home/user/projects/backend',
+    configuration: '/home/user/.config/kortex/workspaces/api-refactor.yaml',
+  },
+};
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -51,6 +61,7 @@ beforeEach(() => {
   vi.mocked(window.stopAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
   vi.mocked(window.removeAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
+  agentWorkspaces.set([workspaceSummary]);
   agentWorkspaceStatuses.clear();
 });
 
@@ -74,6 +85,16 @@ test('Expect Summary tab is present', async () => {
   await waitFor(() => {
     expect(screen.getByText('Summary')).toBeInTheDocument();
   });
+});
+
+test('Expect workspace summary with project is resolved from the store', () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  const storeValue = [workspaceSummary];
+  agentWorkspaces.set(storeValue);
+
+  const resolved = get(agentWorkspaces);
+  expect(resolved.find(ws => ws.id === 'ws-1')?.project).toBe('backend');
 });
 
 test('Expect error message displayed when configuration fetch fails', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -12,7 +12,12 @@ import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces.svelte';
-import { agentWorkspaceStatuses, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
+import {
+  agentWorkspaces,
+  agentWorkspaceStatuses,
+  startAgentWorkspace,
+  stopAgentWorkspace,
+} from '/@/stores/agent-workspaces.svelte';
 
 interface Props {
   workspaceId: string;
@@ -21,6 +26,7 @@ interface Props {
 let { workspaceId }: Props = $props();
 
 const configurationPromise = $derived(window.getAgentWorkspaceConfiguration(workspaceId));
+const workspaceSummary = $derived($agentWorkspaces.find(ws => ws.id === workspaceId));
 
 const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
 const isRunning = $derived(status === 'running' || status === 'stopping');
@@ -71,6 +77,15 @@ function handleRemove(name: string): void {
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <div class="h-min">
           <DetailsTable>
+            <tr>
+              <DetailsTitle>Workspace</DetailsTitle>
+            </tr>
+            {#if workspaceSummary?.project}
+              <tr>
+                <DetailsCell>Project</DetailsCell>
+                <DetailsCell>{workspaceSummary.project}</DetailsCell>
+              </tr>
+            {/if}
             <tr>
               <DetailsTitle>Configuration</DetailsTitle>
             </tr>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -48,6 +48,7 @@ test('Expect workspace cards displayed with total count', () => {
     {
       id: 'ws-1',
       name: 'api-refactor',
+      project: 'backend',
       paths: {
         source: '/home/user/projects/backend',
         configuration: '/home/user/.config/kortex/workspaces/api-refactor.yaml',
@@ -56,6 +57,7 @@ test('Expect workspace cards displayed with total count', () => {
     {
       id: 'ws-2',
       name: 'frontend-redesign',
+      project: 'frontend',
       paths: {
         source: '/home/user/projects/frontend',
         configuration: '/home/user/.config/kortex/workspaces/frontend-redesign.yaml',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: 'workspace:'
         version: link:packages/extension-api
       '@kortex-hub/kortex-cli-api':
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.1.6
+        version: 0.1.6
       '@kortex-hub/kortex-workspace-configuration':
         specifier: ^0.1.4
         version: 0.1.4
@@ -1671,8 +1671,8 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@kortex-hub/kortex-cli-api@0.1.4':
-    resolution: {integrity: sha512-UqwJsq11TDI90FQPihautoEFGARGIkCvezEJArPR6ZynM6N8a+tgHHBGembuA3VYdJvTeSFAcYjnyEdgJBloUw==}
+  '@kortex-hub/kortex-cli-api@0.1.6':
+    resolution: {integrity: sha512-e0ekovbwR8EzPJww2f0QMc09Sn/8F7xTjMYl5woxZDrIL7oLI6hGJRSWb1r1D3mzpZQIWXlMaSvLJfp0Tz82ug==}
 
   '@kortex-hub/kortex-workspace-configuration@0.1.4':
     resolution: {integrity: sha512-TuSjsPrnu2PkhNbtPFRehoyvEFKE4E/XrGWLd+lwW0ywqKM42mCBfWibCCeo5wBCy+nbKcfPvEWo6Alvy+Cp3Q==}
@@ -8076,8 +8076,8 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.7.3
-      tar: 7.5.10
+      semver: 7.7.4
+      tar: 7.5.13
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -8586,7 +8586,7 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kortex-hub/kortex-cli-api@0.1.4': {}
+  '@kortex-hub/kortex-cli-api@0.1.6': {}
 
   '@kortex-hub/kortex-workspace-configuration@0.1.4': {}
 
@@ -8707,7 +8707,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@npmcli/fs@4.0.0':
     dependencies:
@@ -10465,7 +10465,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 9.0.1
-      tar: 7.5.10
+      tar: 7.5.13
       unique-filename: 2.0.1
     transitivePeerDependencies:
       - bluebird


### PR DESCRIPTION
The upstream kortex-cli-api v0.1.6 added a required project field to the Workspace schema. Bump the dependency and surface the field in the card list and details page so users can see which project a workspace belongs to.

Closes #1180