### PR TITLE
fix(markdown): preserve XML tags in code blocks (#1186)

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -65,6 +65,7 @@
     "bits-ui": "^2.9.2",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.3.3",
     "electron-context-menu": "4.1.1",
     "highlight.js": "^11.11.1",
     "js-yaml": "^4.1.1",

--- a/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
@@ -111,7 +111,7 @@ const tools: Array<DynamicToolUIPart> = message.parts.filter(part => part?.type 
                 'animate-fade-in': message.role === 'assistant',
               })}
             >
-              <Markdown markdown={part.text} />
+              <Markdown markdown={part.text} allowDangerousHtml={message.role !== 'user'} />
             </div>
           </div>
 

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -125,7 +125,10 @@ describe('Custom link', () => {
   });
 
   test('expect a tags to be renderer as working links', async () => {
-    await waitRender({ markdown: '- **important info**: some more info. <a href="/some/link">click here to test</a>' });
+    await waitRender({
+      markdown: '- **important info**: some more info. <a href="/some/link">click here to test</a>',
+      allowDangerousHtml: true,
+    });
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML('<a href="/some/link">click here to test</a>');
@@ -261,6 +264,39 @@ test('Expect to render a markdown table as an HTML table', async () => {
   expect(table).toBeInTheDocument();
   expect(table).toContainHTML('<th>Header 1</th>');
   expect(table).toContainHTML('<td>Cell 1</td>');
+});
+
+test('Expect XML tags to be preserved in code blocks', async () => {
+  const markdown = '```xml\n<dependency>\n  <groupId>io.quarkus</groupId>\n</dependency>\n```';
+  await waitRender({ markdown });
+  const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+  expect(markdownContent).toBeInTheDocument();
+  const codeBlock = markdownContent.querySelector('pre code');
+  expect(codeBlock).toBeInTheDocument();
+  expect(codeBlock!.textContent).toContain('<dependency>');
+  expect(codeBlock!.textContent).toContain('<groupId>io.quarkus</groupId>');
+  expect(codeBlock!.textContent).toContain('</dependency>');
+});
+
+describe('XSS sanitization', () => {
+  test('Expect script tags to be stripped', async () => {
+    await waitRender({ markdown: '<script>alert(1)</script>', allowDangerousHtml: true });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent.innerHTML).not.toContain('<script>');
+  });
+
+  test('Expect event handlers to be stripped from img tags', async () => {
+    await waitRender({ markdown: '<img src=x onerror="alert(1)">', allowDangerousHtml: true });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent.innerHTML).not.toContain('onerror');
+  });
+
+  test('Expect safe HTML tags to be preserved', async () => {
+    await waitRender({ markdown: '<b>bold</b> and <em>italic</em>', allowDangerousHtml: true });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toContainHTML('<b>bold</b>');
+    expect(markdownContent).toContainHTML('<em>italic</em>');
+  });
 });
 
 describe('Unrecognized directives', () => {

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -70,6 +70,7 @@ UI guidelines -->
 <script lang="ts">
 import './syntax-highlighting.css';
 
+import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
 import { micromark } from 'micromark';
 import { directive, directiveHtml } from 'micromark-extension-directive';
@@ -91,6 +92,10 @@ let html: string;
 // the user can use: <Markdown>**bold</Markdown> or <Markdown markdown="**bold**" /> syntax
 export let markdown = '';
 
+// Whether to allow raw HTML tags in markdown prose.
+// Safe for model responses; should be disabled for user-authored content.
+export let allowDangerousHtml = false;
+
 // Button micromark related:
 //
 // In progress execution callbacks for all markdown buttons.
@@ -104,17 +109,12 @@ export let inProgressMarkdownCommandExecutionCallback: (
 const eventListeners: EventListener[] = [];
 
 // Render the markdown or the html+micromark markdown reactively
-$: html = markdown ? renderMarkdown(markdown) : '';
+$: html = markdown ? renderMarkdown(markdown, allowDangerousHtml) : '';
 
-function decode(htmlString: string): string {
-  let textArea = document.createElement('textarea');
-  textArea.innerHTML = htmlString;
-  return textArea.value;
-}
-
-function renderMarkdown(source: string): string {
+function renderMarkdown(source: string, dangerousHtml: boolean): string {
   // Provide micromark + extensions
   const rendered = micromark(source, {
+    allowDangerousHtml: dangerousHtml,
     extensions: [gfmAutolinkLiteral(), gfmTable(), directive()],
     htmlExtensions: [
       gfmAutolinkLiteralHtml(),
@@ -126,7 +126,7 @@ function renderMarkdown(source: string): string {
   // remove href values in each anchor using # for links
   // and set the attribute data-pd-jump-in-page
   const parser = new DOMParser();
-  const doc = parser.parseFromString(decode(rendered), 'text/html');
+  const doc = parser.parseFromString(rendered, 'text/html');
   const links = doc.querySelectorAll('a');
   links.forEach(link => {
     const currentHref = link.getAttribute('href');
@@ -165,7 +165,10 @@ function renderMarkdown(source: string): string {
     hljs.highlightElement(block as HTMLElement);
   });
 
-  return doc.body.innerHTML;
+  // Sanitize the output to prevent XSS from raw HTML (e.g. <img onerror="...">)
+  return DOMPurify.sanitize(doc.body.innerHTML, {
+    ADD_ATTR: ['data-pd-jump-in-page', 'data-command', 'data-args', 'data-expandable'],
+  });
 }
 
 onMount(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,6 +713,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
       electron-context-menu:
         specifier: 4.1.1
         version: 4.1.1
@@ -3796,8 +3799,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -11008,7 +11011,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.3.1:
+  dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -13428,7 +13431,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.3.1
+      dompurify: 3.3.3
       marked: 14.0.0
 
   moo-color@1.0.3:


### PR DESCRIPTION
The `decode()` function in `Markdown.svelte` was converting all HTML
entities in micromark's final output back to raw characters before
passing the result to DOMParser. This caused XML/HTML tags inside code
blocks (e.g. `<dependency>`, `<groupId>`) to be interpreted as real
HTML elements by DOMParser, silently stripping them from the rendered
output.

**What `decode()` did:**
It used a textarea element to convert HTML entities (`&lt;` → `<`,
`&gt;` → `>`, etc.) across the entire rendered HTML string — including
content inside `<pre><code>` blocks that micromark had intentionally
escaped.

**Why removing it is safe:**
- Micromark already produces valid HTML with properly escaped entities
  in code blocks. DOMParser handles this correctly without decoding.
- All custom directives (button, link, image, warnings, fallback) emit
  HTML via `this.tag()` and `this.encode()`, which are unaffected by
  this change. The warnings directive has its own local `decode()` for
  JSON parsing of labels, which is also unaffected.

**Raw HTML in prose:**
Instead of the blanket `decode()` approach, raw HTML in markdown prose
is now controlled via an `allowDangerousHtml` prop on the Markdown
component (defaults to `false`). In the chat, this is enabled only for
non-user messages (`message.role !== 'user'`), so model responses can
include raw HTML while user input remains safely escaped. Micromark
escapes code blocks at parse time before the HTML serialization step,
so `allowDangerousHtml` does not affect code block content.

**XSS protection:**
Added DOMPurify sanitization as a final step before returning the
rendered HTML. This strips dangerous elements (`<script>`, `<iframe>`)
and event handler attributes (`onerror`, `onclick`, etc.) while
preserving safe HTML tags and the custom data attributes used by
the directive system (`data-command`, `data-args`, `data-expandable`,
`data-pd-jump-in-page`).

**Test changes:**
- Added a test verifying XML tags are preserved in code blocks.
- Updated the raw HTML link test to pass `allowDangerousHtml: true`.
- Added XSS sanitization tests (script tags, event handlers, safe tags).


<img width="1122" height="1086" alt="Screenshot 2026-03-26 at 13 46 07" src="https://github.com/user-attachments/assets/eb931afb-88ac-43e5-a2fd-5abac88846ed" />
<img width="1122" height="1086" alt="Screenshot 2026-03-26 at 13 46 30" src="https://github.com/user-attachments/assets/6d8859fb-f5c4-414a-bc22-55ee0e470f7a" />


Fixes #1186

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
