### PR TITLE
fix(chat): support background streaming when navigating away and back (#1160)

### DIFF
--- a/packages/main/src/chat/chat-manager.ts
+++ b/packages/main/src/chat/chat-manager.ts
@@ -397,20 +397,29 @@ export class ChatManager {
         abortSignal: abortController.signal,
       });
 
+      let onFinishSavePromise: Promise<void> | undefined;
+
       const reader = streaming
         .toUIMessageStream({
-          onFinish: async ({ messages }): Promise<void> => {
-            await this.chatQueries.saveMessages({
-              messages: messages.map(message => ({
-                id: randomUUID().toString(),
-                role: message.role,
-                parts: message.parts,
-                createdAt: new Date(),
-                chatId,
-                attachments: [],
-                config,
-              })),
-            });
+          onFinish: ({ messages }): void => {
+            onFinishSavePromise = this.chatQueries
+              .saveMessages({
+                messages: messages.map(message => ({
+                  id: randomUUID().toString(),
+                  role: message.role,
+                  parts: message.parts,
+                  createdAt: new Date(),
+                  chatId,
+                  attachments: [],
+                  config,
+                })),
+              })
+              .match(
+                () => {},
+                error => {
+                  throw error;
+                },
+              );
           },
         })
         .getReader();
@@ -422,6 +431,11 @@ export class ChatManager {
           break;
         }
         this.webContents.send('inference:streamText-onChunk', params.onDataId, value);
+      }
+
+      // Wait for onFinish message save to complete before signaling stream end
+      if (onFinishSavePromise) {
+        await onFinishSavePromise;
       }
     } finally {
       this.activeStreams.delete(params.onDataId);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1398,6 +1398,20 @@ export function initExposure(): void {
     number,
     { onChunk: (chunk: UIMessageChunk) => void; onError: (error: string) => void; onEnd: () => void }
   >();
+
+  // Grace period to keep buffered chunks after stream completion, allowing late reconnection
+  const STREAM_BUFFER_TTL_MS = 30_000;
+
+  // Track active streams by chatId and buffer chunks for background streams
+  const activeStreamsByChatId = new Map<
+    string,
+    {
+      onDataId: number;
+      bufferedChunks: UIMessageChunk[];
+      isComplete: boolean;
+      error?: string;
+    }
+  >();
   contextBridge.exposeInMainWorld(
     'inferenceStreamText',
     (
@@ -1409,6 +1423,14 @@ export function initExposure(): void {
       onDataCallbacksStreamTextId++;
       const id = onDataCallbacksStreamTextId;
       onDataCallbacksStreamText.set(id, { onChunk, onError, onEnd });
+
+      // Track this stream by chatId
+      activeStreamsByChatId.set(params.chatId, {
+        onDataId: id,
+        bufferedChunks: [],
+        isComplete: false,
+      });
+
       ipcInvoke('inference:streamText', { ...params, onDataId: id }).catch((err: unknown) => {
         const callback = onDataCallbacksStreamText.get(id);
         if (callback) {
@@ -1419,6 +1441,12 @@ export function initExposure(): void {
             callback.onEnd();
           }
         }
+        // Track error in stream state
+        const streamState = activeStreamsByChatId.get(params.chatId);
+        if (streamState) {
+          streamState.error = String(err);
+          streamState.isComplete = true;
+        }
       });
       return id;
     },
@@ -1428,8 +1456,68 @@ export function initExposure(): void {
     return ipcInvoke('inference:stopStream', onDataId);
   });
 
+  contextBridge.exposeInMainWorld(
+    'inferenceGetActiveStream',
+    (chatId: string): { onDataId: number; bufferedChunks: UIMessageChunk[]; isComplete: boolean } | null => {
+      const streamState = activeStreamsByChatId.get(chatId);
+      return streamState ? { ...streamState } : null;
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'inferenceReconnectToStream',
+    (
+      chatId: string,
+      onChunk: (data: UIMessageChunk) => void,
+      onError: (error: string) => void,
+      onEnd: () => void,
+    ): { bufferedChunks: UIMessageChunk[]; onDataId: number } | null => {
+      const streamState = activeStreamsByChatId.get(chatId);
+      if (!streamState) {
+        return null;
+      }
+
+      // Register callbacks for this stream
+      onDataCallbacksStreamText.set(streamState.onDataId, { onChunk, onError, onEnd });
+
+      // Return buffered chunks to be replayed (keep them for potential re-reconnection)
+      const bufferedChunks = [...streamState.bufferedChunks];
+
+      // If stream completed while disconnected, trigger onEnd
+      if (streamState.isComplete) {
+        // Trigger after buffered chunks are processed
+        setTimeout(() => {
+          if (streamState.error) {
+            onError(streamState.error);
+          } else {
+            onEnd();
+          }
+          onDataCallbacksStreamText.delete(streamState.onDataId);
+        }, 0);
+      }
+
+      return {
+        bufferedChunks,
+        onDataId: streamState.onDataId,
+      };
+    },
+  );
+
+  contextBridge.exposeInMainWorld('inferenceDisconnectFromStream', (onDataId: number): void => {
+    // Remove the active callback, but keep stream state for buffering
+    onDataCallbacksStreamText.delete(onDataId);
+  });
+
   ipcRenderer.on('inference:streamText-onChunk', (_, callbackId: number, chunk: UIMessageChunk) => {
-    // grab callback from the map
+    // Always buffer chunks for potential reconnection
+    for (const [, streamState] of activeStreamsByChatId.entries()) {
+      if (streamState.onDataId === callbackId) {
+        streamState.bufferedChunks.push(chunk);
+        break;
+      }
+    }
+
+    // Deliver to active callback if present
     const callback = onDataCallbacksStreamText.get(callbackId);
     if (callback) {
       callback.onChunk(chunk);
@@ -1441,6 +1529,15 @@ export function initExposure(): void {
     if (callback) {
       callback.onError(error);
     }
+
+    // Mark stream as complete with error
+    for (const [, streamState] of activeStreamsByChatId.entries()) {
+      if (streamState.onDataId === callbackId) {
+        streamState.error = error;
+        streamState.isComplete = true;
+        break;
+      }
+    }
   });
 
   ipcRenderer.on('inference:streamText-onEnd', (_, callbackId: number) => {
@@ -1450,6 +1547,22 @@ export function initExposure(): void {
       callback.onEnd();
       // remove callback from the map
       onDataCallbacksStreamText.delete(callbackId);
+    }
+
+    // Mark stream as complete and keep buffered chunks for potential reconnection
+    for (const [chatId, streamState] of activeStreamsByChatId.entries()) {
+      if (streamState.onDataId === callbackId) {
+        streamState.isComplete = true;
+        // Clean up after a delay to allow reconnection, but only if the
+        // entry hasn't been replaced by a newer stream for the same chat.
+        const completedOnDataId = callbackId;
+        setTimeout(() => {
+          if (activeStreamsByChatId.get(chatId)?.onDataId === completedOnDataId) {
+            activeStreamsByChatId.delete(chatId);
+          }
+        }, STREAM_BUFFER_TTL_MS);
+        break;
+      }
     }
   });
 

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -12,6 +12,7 @@ export function findModel(models: ModelInfo[], model: ModelInfo | undefined): Mo
 <script lang="ts">
 import { Chat } from '@ai-sdk/svelte';
 import type { Attachment } from '@ai-sdk/ui-utils';
+import type { ReasoningUIPart, TextUIPart, UIMessage, UIMessageChunk } from 'ai';
 import { untrack } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { toast } from 'svelte-sonner';
@@ -143,8 +144,11 @@ EditState.toContext();
 
 let attachments = $state<Attachment[]>([]);
 let mcpSelectorOpen = $state(false);
+let activeStreamOnDataId = $state<number | undefined>(undefined);
+let reconnectedStreamingMessage = $state<UIMessage | undefined>(undefined);
 
 const hasModels = $derived(models && models.length > 0);
+const hasActiveStream = $derived(activeStreamOnDataId !== undefined);
 
 function onCheckMCPTool(mcpId: string, toolId: string, checked: boolean): void {
   const tools = selectedMCPTools.get(mcpId) ?? new SvelteSet();
@@ -155,6 +159,140 @@ function onCheckMCPTool(mcpId: string, toolId: string, checked: boolean): void {
   }
   selectedMCPTools.set(mcpId, tools);
 }
+
+// Reconnect to active stream when returning to a chat
+let reconnectedMessageId = '';
+let reconnectedText = '';
+let reconnectedReasoning = '';
+
+$effect(() => {
+  const currentChatId = chat?.id;
+  if (!currentChatId) {
+    activeStreamOnDataId = undefined;
+    reconnectedStreamingMessage = undefined;
+    return;
+  }
+
+  untrack(() => {
+    const activeStream = window.inferenceGetActiveStream(currentChatId);
+    if (!activeStream || activeStream.isComplete) {
+      return;
+    }
+
+    // Reset state for fresh reconnection
+    reconnectedMessageId = '';
+    reconnectedText = '';
+    reconnectedReasoning = '';
+    reconnectedStreamingMessage = undefined;
+
+    function buildParts(
+      state: 'streaming' | 'done',
+    ): Array<TextUIPart | ReasoningUIPart> {
+      const parts: Array<TextUIPart | ReasoningUIPart> = [];
+      if (reconnectedReasoning) {
+        parts.push({ type: 'reasoning' as const, text: reconnectedReasoning, state });
+      }
+      if (reconnectedText || state === 'streaming') {
+        parts.push({ type: 'text' as const, text: reconnectedText, state });
+      }
+      return parts;
+    }
+
+    function appendChunkToLastMessage(chunk: UIMessageChunk): void {
+      if (chunk.type === 'text-start') {
+        reconnectedMessageId = chunk.id;
+        reconnectedText = '';
+        reconnectedReasoning = '';
+        reconnectedStreamingMessage = {
+          id: chunk.id,
+          role: 'assistant',
+          parts: [],
+        };
+      } else if (chunk.type === 'text-delta' && chunk.id === reconnectedMessageId) {
+        reconnectedText += chunk.delta;
+        reconnectedStreamingMessage = {
+          id: reconnectedMessageId,
+          role: 'assistant',
+          parts: buildParts('streaming'),
+        };
+      } else if (chunk.type === 'reasoning-delta' && chunk.id === reconnectedMessageId) {
+        reconnectedReasoning += chunk.delta;
+        reconnectedStreamingMessage = {
+          id: reconnectedMessageId,
+          role: 'assistant',
+          parts: buildParts('streaming'),
+        };
+      } else if (chunk.type === 'text-end' && chunk.id === reconnectedMessageId) {
+        reconnectedStreamingMessage = {
+          id: reconnectedMessageId,
+          role: 'assistant',
+          parts: buildParts('done'),
+        };
+      }
+    }
+
+    const result = window.inferenceReconnectToStream(
+      currentChatId,
+      (chunk: UIMessageChunk): void => {
+        appendChunkToLastMessage(chunk);
+      },
+      (error: unknown): void => {
+        console.error('Error during reconnected stream:', error);
+        activeStreamOnDataId = undefined;
+        reconnectedStreamingMessage = undefined;
+      },
+      (): void => {
+        console.log('Reconnected stream completed');
+        activeStreamOnDataId = undefined;
+        if (!reconnectedStreamingMessage) {
+          // No text chunks were received (the stream may have been aborted before
+          // producing text, e.g. due to model queuing). Load the persisted assistant
+          // message from the database since onFinish saved it before onEnd was sent.
+          window.inferenceGetChatMessagesById(currentChatId).then(({ messages: dbMessages }) => {
+            if (chat?.id !== currentChatId) {
+              return;
+            }
+            const assistantMsg = dbMessages.filter(m => m.role === 'assistant').pop();
+            if (assistantMsg) {
+              reconnectedStreamingMessage = {
+                id: assistantMsg.id,
+                role: 'assistant',
+                parts: assistantMsg.parts as UIMessage['parts'],
+              };
+            }
+          }).catch(console.error);
+        }
+      },
+    );
+
+    if (result) {
+      activeStreamOnDataId = result.onDataId;
+
+      // Process buffered chunks
+      for (const chunk of result.bufferedChunks) {
+        appendChunkToLastMessage(chunk);
+      }
+    }
+  });
+
+  return (): void => {
+    untrack(() => {
+      if (activeStreamOnDataId !== undefined) {
+        window.inferenceDisconnectFromStream(activeStreamOnDataId);
+      }
+      activeStreamOnDataId = undefined;
+      // Only clear the reconnected message when navigating to a different chat.
+      // If the effect re-runs for the same chat (e.g. after chatHistory.refetch()),
+      // keep the message visible since the completed stream can't be reconnected.
+      if (currentChatId !== chat?.id) {
+        reconnectedStreamingMessage = undefined;
+      }
+      reconnectedMessageId = '';
+      reconnectedText = '';
+      reconnectedReasoning = '';
+    });
+  };
+});
 </script>
 
 <div class="bg-background flex h-full min-w-0 flex-col">
@@ -172,12 +310,12 @@ function onCheckMCPTool(mcpId: string, toolId: string, checked: boolean): void {
             <div class="flex flex-col flex-3/4">
                 <Messages
                     {readonly}
-                    loading={chatClient.status === 'streaming' || chatClient.status === 'submitted'}
-                    messages={chatClient.messages}
+                    loading={chatClient.status === 'streaming' || chatClient.status === 'submitted' || hasActiveStream}
+                    messages={reconnectedStreamingMessage ? [...chatClient.messages, reconnectedStreamingMessage] : chatClient.messages}
                 />
                 <form class="bg-background mx-auto flex w-full gap-2 px-4 pb-4 md:max-w-3xl md:pb-6">
                     {#if !readonly}
-                        <MultimodalInput {attachments} {chatClient} {selectedModel} {selectedMCPTools} class="flex-1" />
+                        <MultimodalInput {attachments} {chatClient} {selectedModel} {selectedMCPTools} {hasActiveStream} {activeStreamOnDataId} class="flex-1" />
                     {/if}
                 </form>
             </div>

--- a/packages/renderer/src/lib/chat/components/ipc-chat-transport.ts
+++ b/packages/renderer/src/lib/chat/components/ipc-chat-transport.ts
@@ -70,9 +70,46 @@ export class IPCChatTransport<T extends UIMessage> implements ChatTransport<T> {
     });
   }
 
-  reconnectToStream(options: { chatId: string } & ChatRequestOptions): Promise<ReadableStream<UIMessageChunk> | null> {
-    //FIX ME: not implemented
-    console.log('reconnecting to stream with options', options);
-    return Promise.resolve(null);
+  async reconnectToStream(
+    options: { chatId: string } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk> | null> {
+    // Check if there's an active stream for this chat
+    const activeStream = window.inferenceGetActiveStream(options.chatId);
+    if (!activeStream) {
+      return null;
+    }
+
+    return new ReadableStream<UIMessageChunk>({
+      start(controller): void {
+        // Reconnect to the existing stream
+        const result = window.inferenceReconnectToStream(
+          options.chatId,
+          (chunk: UIMessageChunk) => {
+            console.log('IPCChatTransport->reconnect->chunk:', chunk);
+            controller.enqueue(chunk);
+          },
+          (error: unknown) => {
+            console.error('Error during reconnected stream:', error);
+            controller.error(error);
+          },
+          () => {
+            console.log('IPCChatTransport: Reconnected stream completed');
+            controller.close();
+          },
+        );
+
+        if (!result) {
+          console.log('IPCChatTransport: Stream no longer active');
+          controller.close();
+          return;
+        }
+
+        // First, replay all buffered chunks
+        for (const chunk of result.bufferedChunks) {
+          console.log('IPCChatTransport->reconnect->buffered chunk:', chunk);
+          controller.enqueue(chunk);
+        }
+      },
+    });
   }
 }

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -26,12 +26,16 @@ let {
   class: c,
   selectedMCPTools,
   selectedModel,
+  hasActiveStream,
+  activeStreamOnDataId,
 }: {
   attachments: Attachment[];
   chatClient: Chat;
   class?: string;
   selectedMCPTools: SvelteMap<string, Set<string>>;
   selectedModel?: ModelInfo;
+  hasActiveStream?: boolean;
+  activeStreamOnDataId?: number;
 } = $props();
 
 const editState = EditState.fromContext();
@@ -41,7 +45,9 @@ let savedInput = $state('');
 let mounted = $state(false);
 let textareaRef = $state<HTMLTextAreaElement | null>(null);
 const storedInput = new LocalStorage('input', '');
-const loading = $derived(chatClient.status === 'streaming' || chatClient.status === 'submitted');
+const loading = $derived(
+  chatClient.status === 'streaming' || chatClient.status === 'submitted' || hasActiveStream === true,
+);
 
 $effect(() => {
   if (editState.editingMessage) {
@@ -255,7 +261,7 @@ $effect((): (() => void) | void => {
       class="max-h-[calc(25dvh)] min-h-[24px] resize-none overflow-y-auto border-0 bg-transparent text-base! shadow-none focus-visible:ring-0"
       rows={2}
       autofocus
-      onkeydown={async(event): Promise<void> => {
+      onkeydown={async (event): Promise<void> => {
         if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
           event.preventDefault();
 
@@ -286,7 +292,7 @@ $effect((): (() => void) | void => {
       </div>
 
       <div class="flex flex-row items-center justify-end gap-2">
-        <ExportButton {chatClient} {selectedModel} {loading} {selectedMCPTools}/>
+        <ExportButton {chatClient} {selectedModel} {loading} {selectedMCPTools} />
         {#if loading}
           <Button
             aria-label="Stop generation"
@@ -294,7 +300,13 @@ $effect((): (() => void) | void => {
             class="h-fit rounded-full border border-[var(--pd-input-field-stroke)] p-1.5"
             onclick={async (event): Promise<void> => {
               event.preventDefault();
-              await chatClient.stop();
+              try {
+                await chatClient.stop();
+              } finally {
+                if (activeStreamOnDataId !== undefined) {
+                  await window.inferenceStopStream(activeStreamOnDataId);
+                }
+              }
             }}
           >
             <StopIcon size={14} />
@@ -304,7 +316,7 @@ $effect((): (() => void) | void => {
               aria-label="Send message"
               title="Send message"
               class="h-fit rounded-full border border-[var(--pd-input-field-stroke)] p-1.5"
-              onclick={async(event): Promise<void> => {
+              onclick={async (event): Promise<void> => {
                 event.preventDefault();
                 await submitForm();
               }}

--- a/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
@@ -410,6 +410,58 @@ test.describe
   });
 
 test.describe
+  .serial('Chat background streaming', { tag: '@smoke' }, () => {
+    test('[CHAT-STREAM-01] Background streaming continues when returning to chat', async ({
+      chatPage,
+      navigationBar,
+      flowsPage,
+    }) => {
+      await chatPage.clickNewChat();
+
+      // Send a message that should generate a long response
+      const message = 'Write a comprehensive and detailed explanation of Kubernetes networking';
+      await chatPage.sendMessage(message, { waitForMessage: true });
+
+      // Verify streaming has started
+      await chatPage.verifyStopButtonVisible();
+      await chatPage.verifySendButtonHidden();
+
+      // Navigate away from the chat page while streaming is active
+      await navigationBar.navigateToFlowsPage();
+      await flowsPage.waitForLoad();
+
+      // Return to the chat page and select the conversation from history
+      await navigationBar.navigateToChatPage();
+      await chatPage.waitForLoad();
+      await chatPage.ensureChatSidebarVisible();
+      await chatPage.clickChatHistoryItemByIndex(0);
+
+      // Verify the user message is visible
+      await chatPage.verifyConversationMessage(message);
+
+      // Verify model response is visible (from buffered chunks or completed stream)
+      await expect(chatPage.modelConversationMessages.first()).toBeVisible({ timeout: TIMEOUTS.SHORT });
+
+      // The stream may still be active or may have completed while navigated away.
+      // Either way, we should see the stop button OR the send button.
+      const isStillStreaming = await chatPage.stopButton.isVisible();
+
+      if (isStillStreaming) {
+        // Stop the background stream
+        await chatPage.clickStopButton();
+      }
+
+      // Verify the UI is in ready state (stream finished or was stopped)
+      await chatPage.verifyStopButtonHidden(TIMEOUTS.SHORT);
+      await chatPage.verifySendButtonVisible(TIMEOUTS.SHORT);
+
+      // Verify the conversation still contains both messages
+      await chatPage.verifyConversationMessage(message);
+      await expect(chatPage.modelConversationMessages.first()).toBeVisible();
+    });
+  });
+
+test.describe
   .serial('Chat integrations', { tag: '@smoke' }, () => {
     test('[CHAT-INTG-01] Verify MCP tool list visibility and sidebar interaction', async ({
       mcpSetup: _mcpSetup,


### PR DESCRIPTION
Buffer streaming chunks in the preload layer so that when the user navigates
away from a chat mid-stream and returns, the response continues rendering.
Implements reconnectToStream in IPCChatTransport and adds an E2E test.

https://github.com/user-attachments/assets/985fde4d-a57b-492a-a287-427cc77cb7d9

Fixes https://github.com/kortex-hub/kortex/issues/1160