### PR TITLE
feat(Workspace): show message dialog when error occupied

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
@@ -164,3 +164,63 @@ test('Expect clicking stop button calls stopAgentWorkspace', async () => {
     expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
   });
 });
+
+test('Expect error dialog shown when start fails', async () => {
+  vi.mocked(window.startAgentWorkspace).mockRejectedValue(new Error('container not found'));
+
+  render(AgentWorkspaceCard, { workspace });
+
+  const startButton = screen.getByRole('button', { name: 'Start workspace api-refactor' });
+  await fireEvent.click(startButton);
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: expect.stringContaining('container not found'),
+      }),
+    );
+  });
+
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+});
+
+test('Expect error dialog uses workspace name when start fails', async () => {
+  vi.mocked(window.startAgentWorkspace).mockRejectedValue(new Error('start failed'));
+
+  render(AgentWorkspaceCard, { workspace });
+
+  const startButton = screen.getByRole('button', { name: 'Start workspace api-refactor' });
+  await fireEvent.click(startButton);
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('api-refactor'),
+      }),
+    );
+  });
+});
+
+test('Expect error dialog shown when stop fails', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+  vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));
+
+  render(AgentWorkspaceCard, { workspace });
+
+  const stopButton = screen.getByRole('button', { name: 'Stop workspace api-refactor' });
+  await fireEvent.click(stopButton);
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: expect.stringContaining('stop timeout'),
+      }),
+    );
+  });
+
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
@@ -38,15 +38,25 @@ function handleActionKeydown(e: KeyboardEvent): void {
 
 function handleStartStopClick(e: MouseEvent): void {
   e.stopPropagation();
-  handleStartStop();
+  handleStartStop().catch(console.error);
 }
 
-function handleStartStop(): void {
+async function handleStartStop(): Promise<void> {
   if (inProgress) return;
-  if (isRunning) {
-    stopAgentWorkspace(workspace.id).catch(console.error);
-  } else {
-    startAgentWorkspace(workspace.id).catch(console.error);
+  try {
+    if (isRunning) {
+      await stopAgentWorkspace(workspace.id);
+    } else {
+      await startAgentWorkspace(workspace.id);
+    }
+  } catch (error: unknown) {
+    const action = isRunning ? 'stopping' : 'starting';
+    await window.showMessageBox({
+      title: 'Agent Workspace',
+      type: 'error',
+      message: `Error while ${action} workspace "${workspace.name}": ${error}`,
+      buttons: ['OK'],
+    });
   }
 }
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -213,6 +213,78 @@ test('Expect workspace not removed when user cancels', async () => {
   expect(router.goto).not.toHaveBeenCalled();
 });
 
+test('Expect error dialog shown when start fails', async () => {
+  vi.mocked(window.startAgentWorkspace).mockRejectedValue(new Error('container not found'));
+
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Start Workspace' })).toBeInTheDocument();
+  });
+
+  const startButton = screen.getByRole('button', { name: 'Start Workspace' });
+  await fireEvent.click(startButton);
+
+  await waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: expect.stringContaining('container not found'),
+      }),
+    );
+  });
+
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+});
+
+test('Expect error dialog uses workspace name when start fails', async () => {
+  vi.mocked(window.startAgentWorkspace).mockRejectedValue(new Error('start failed'));
+
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Start Workspace' })).toBeInTheDocument();
+  });
+
+  const startButton = screen.getByRole('button', { name: 'Start Workspace' });
+  await fireEvent.click(startButton);
+
+  await waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('api-refactor'),
+      }),
+    );
+  });
+});
+
+test('Expect error dialog shown when stop fails', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+  vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));
+
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Stop Workspace' })).toBeInTheDocument();
+  });
+
+  const stopButton = screen.getByRole('button', { name: 'Stop Workspace' });
+  await fireEvent.click(stopButton);
+
+  await waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: expect.stringContaining('stop timeout'),
+      }),
+    );
+  });
+
+  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+});
+
 test('Expect no navigation when removal fails', async () => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   vi.mocked(window.removeAgentWorkspace).mockRejectedValue(new Error('removal failed'));

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -32,12 +32,23 @@ const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspa
 const isRunning = $derived(status === 'running' || status === 'stopping');
 const inProgress = $derived(status === 'starting' || status === 'stopping');
 
-function handleStartStop(): void {
+async function handleStartStop(): Promise<void> {
   if (inProgress) return;
-  if (isRunning) {
-    stopAgentWorkspace(workspaceId).catch(console.error);
-  } else {
-    startAgentWorkspace(workspaceId).catch(console.error);
+  const name = workspaceSummary?.name ?? workspaceId;
+  try {
+    if (isRunning) {
+      await stopAgentWorkspace(workspaceId);
+    } else {
+      await startAgentWorkspace(workspaceId);
+    }
+  } catch (error: unknown) {
+    const action = isRunning ? 'stopping' : 'starting';
+    await window.showMessageBox({
+      title: 'Agent Workspace',
+      type: 'error',
+      message: `Error while ${action} workspace "${name}": ${error}`,
+      buttons: ['OK'],
+    });
   }
 }
 

--- a/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
@@ -52,10 +52,10 @@ test('startAgentWorkspace should set starting status during the call', async () 
   expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
 });
 
-test('startAgentWorkspace should revert to stopped on failure', async () => {
+test('startAgentWorkspace should revert to stopped on failure and re-throw', async () => {
   vi.mocked(window.startAgentWorkspace).mockRejectedValue(new Error('start failed'));
 
-  await startAgentWorkspace('ws-1');
+  await expect(startAgentWorkspace('ws-1')).rejects.toThrow('start failed');
 
   expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
 });
@@ -90,11 +90,11 @@ test('stopAgentWorkspace should set stopping status during the call', async () =
   expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
 });
 
-test('stopAgentWorkspace should revert to running on failure', async () => {
+test('stopAgentWorkspace should revert to running on failure and re-throw', async () => {
   agentWorkspaceStatuses.set('ws-1', 'running');
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop failed'));
 
-  await stopAgentWorkspace('ws-1');
+  await expect(stopAgentWorkspace('ws-1')).rejects.toThrow('stop failed');
 
   expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
 });

--- a/packages/renderer/src/stores/agent-workspaces.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.ts
@@ -57,6 +57,7 @@ export async function startAgentWorkspace(id: string): Promise<void> {
   } catch (error: unknown) {
     agentWorkspaceStatuses.set(id, 'stopped');
     console.error('Failed to start agent workspace', error);
+    throw error;
   }
 }
 
@@ -68,5 +69,6 @@ export async function stopAgentWorkspace(id: string): Promise<void> {
   } catch (error: unknown) {
     agentWorkspaceStatuses.set(id, 'running');
     console.error('Failed to stop agent workspace', error);
+    throw error;
   }
 }


### PR DESCRIPTION
Adds message dialog when error occupies when starting/stopping a workspace

Closes https://github.com/kortex-hub/kortex/issues/1215