### PR TITLE
feat(Workspaces): added connecting to workspace using kdn terminal

### DIFF
--- a/extensions/kdn/src/kdn-extension.ts
+++ b/extensions/kdn/src/kdn-extension.ts
@@ -48,7 +48,7 @@ export class KdnExtension {
     if (!binaryPath) {
       const systemResult = await this.findOnPath();
       if (systemResult) {
-        binaryPath = 'kdn';
+        binaryPath = binaryName;
         version = systemResult.version;
         installationSource = 'external';
         console.log('kdn binary found in system PATH');

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "moment": "^2.30.1",
     "ms": "^2.1.3",
     "neverthrow": "^8.2.0",
+    "node-pty": "^1.0.0",
     "os-locale": "^6.0.2",
     "semver": "^7.7.3",
     "stream-json": "^1.9.1",

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -35,8 +35,12 @@ import type { CliToolInfo } from '/@api/cli-tool-info.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
 import { AgentWorkspaceManager } from './agent-workspace-manager.js';
+import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { WebContents } from 'electron';
 
 vi.mock(import('node:fs/promises'));
+vi.mock(import('yaml'));
+vi.mock(import('node:child_process'));
 
 const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
   {
@@ -100,6 +104,10 @@ const filesystemMonitoring = {
 
 const KAIDEN_CLI_PATH = '/usr/local/bin/kdn';
 
+const webContents = {
+  send: vi.fn(),
+  receive: vi.fn(),
+} as unknown as WebContents;
 function mockExecResult(stdout: string): RunResult {
   return { command: KAIDEN_CLI_PATH, stdout, stderr: '' };
 }
@@ -125,7 +133,7 @@ beforeEach(() => {
   mockTask.status = '' as TaskStatus;
   mockTask.error = '';
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
-  manager = new AgentWorkspaceManager(apiSender, ipcHandle, exec, cliToolRegistry, taskManager, filesystemMonitoring);
+  manager = new AgentWorkspaceManager(apiSender, ipcHandle, exec, cliToolRegistry, taskManager, filesystemMonitoring, webContents);
   manager.init();
 });
 
@@ -502,5 +510,137 @@ describe('stop', () => {
     vi.spyOn(exec, 'exec').mockRejectedValue(new Error('workspace not found: unknown-id'));
 
     await expect(manager.stop('unknown-id')).rejects.toThrow('workspace not found: unknown-id');
+  });
+});
+
+describe('shellInAgentWorkspace', () => {
+  function createMockProcess(overrides?: {
+    stdoutOn?: ReturnType<typeof vi.fn>;
+    stderrOn?: ReturnType<typeof vi.fn>;
+    processOn?: ReturnType<typeof vi.fn>;
+  }): ChildProcessWithoutNullStreams {
+    return {
+      stdout: { on: overrides?.stdoutOn ?? vi.fn() },
+      stderr: { on: overrides?.stderrOn ?? vi.fn() },
+      stdin: { write: vi.fn() },
+      on: overrides?.processOn ?? vi.fn(),
+      killed: false,
+      kill: vi.fn(),
+    } as unknown as ChildProcessWithoutNullStreams;
+  }
+
+  test('returns write and resize functions', () => {
+    vi.mocked(spawn).mockReturnValue(createMockProcess());
+
+    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+
+    expect(result).toHaveProperty('write');
+    expect(result).toHaveProperty('resize');
+    expect(result).toHaveProperty('process');
+  });
+
+  test('spawns kdn-cli terminal with correct arguments', () => {
+    vi.mocked(spawn).mockReturnValue(createMockProcess());
+
+    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+
+    expect(spawn).toHaveBeenCalledWith('kdn-cli', [
+      'terminal',
+      'ws-1',
+      '--',
+      '/bin/sh',
+      '-c',
+      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
+    ]);
+  });
+
+  test('write function forwards data to stdin', () => {
+    const mockProcess = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    result.write('hello');
+
+    expect(mockProcess.stdin.write).toHaveBeenCalledWith('hello');
+  });
+
+  test('calls onData when stdout emits data', () => {
+    const stdoutListeners = new Map<string, (data: Buffer) => void>();
+    const mockProcess = createMockProcess({
+      stdoutOn: vi.fn((event: string, cb: (data: Buffer) => void) => stdoutListeners.set(event, cb)),
+    });
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const onData = vi.fn();
+    manager.shellInAgentWorkspace('ws-1', onData, vi.fn(), vi.fn());
+
+    const dataCallback = stdoutListeners.get('data');
+    expect(dataCallback).toBeDefined();
+    dataCallback!(Buffer.from('output'));
+
+    expect(onData).toHaveBeenCalledWith('output');
+  });
+
+  test('calls onEnd when process closes', () => {
+    const processListeners = new Map<string, () => void>();
+    const mockProcess = createMockProcess({
+      processOn: vi.fn((event: string, cb: () => void) => processListeners.set(event, cb)),
+    });
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const onEnd = vi.fn();
+    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), onEnd);
+
+    const closeCallback = processListeners.get('close');
+    expect(closeCallback).toBeDefined();
+    closeCallback!();
+
+    expect(onEnd).toHaveBeenCalled();
+  });
+
+  test('calls onError when process emits error', () => {
+    const processListeners = new Map<string, (err: Error) => void>();
+    const mockProcess = createMockProcess({
+      processOn: vi.fn((event: string, cb: (err: Error) => void) => processListeners.set(event, cb)),
+    });
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const onError = vi.fn();
+    manager.shellInAgentWorkspace('ws-1', vi.fn(), onError, vi.fn());
+
+    const errorCallback = processListeners.get('error');
+    expect(errorCallback).toBeDefined();
+    errorCallback!(new Error('spawn failed'));
+
+    expect(onError).toHaveBeenCalledWith('spawn failed');
+  });
+});
+
+describe('dispose', () => {
+  test('kills active terminal processes', async () => {
+    const mockProcess = {
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      stdin: { write: vi.fn() },
+      on: vi.fn(),
+      killed: false,
+      kill: vi.fn(),
+    } as unknown as ChildProcessWithoutNullStreams;
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const terminalHandler = vi
+      .mocked(ipcHandle)
+      .mock.calls.find(call => call[0] === 'agent-workspace:terminal')?.[1] as (
+      _listener: unknown,
+      id: string,
+      onDataId: number,
+    ) => Promise<number>;
+    expect(terminalHandler).toBeDefined();
+
+    await terminalHandler({}, 'ws-1', 1);
+
+    manager.dispose();
+
+    expect(mockProcess.kill).toHaveBeenCalled();
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ChildProcessWithoutNullStreams } from 'node:child_process';
-import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
+import type { IPty } from 'node-pty';
+import { spawn } from 'node-pty';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
@@ -40,7 +40,7 @@ import { AgentWorkspaceManager } from './agent-workspace-manager.js';
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('yaml'));
-vi.mock(import('node:child_process'));
+vi.mock(import('node-pty'));
 
 vi.mock(import('/@/plugin/kdn-cli/kdn-cli.js'));
 
@@ -391,114 +391,111 @@ describe('stop', () => {
 });
 
 describe('shellInAgentWorkspace', () => {
-  function createMockProcess(overrides?: {
-    stdoutOn?: ReturnType<typeof vi.fn>;
-    stderrOn?: ReturnType<typeof vi.fn>;
-    processOn?: ReturnType<typeof vi.fn>;
-  }): ChildProcessWithoutNullStreams {
+  let onDataCallback: ((data: string) => void) | undefined;
+  let onExitCallback: (() => void) | undefined;
+
+  function createMockPty(): IPty {
+    onDataCallback = undefined;
+    onExitCallback = undefined;
     return {
-      stdout: { on: overrides?.stdoutOn ?? vi.fn() },
-      stderr: { on: overrides?.stderrOn ?? vi.fn() },
-      stdin: { write: vi.fn() },
-      on: overrides?.processOn ?? vi.fn(),
-      killed: false,
+      onData: vi.fn((cb: (data: string) => void) => {
+        onDataCallback = cb;
+        return { dispose: vi.fn() };
+      }),
+      onExit: vi.fn((cb: () => void) => {
+        onExitCallback = cb;
+        return { dispose: vi.fn() };
+      }),
+      write: vi.fn(),
+      resize: vi.fn(),
       kill: vi.fn(),
-    } as unknown as ChildProcessWithoutNullStreams;
+      pid: 123,
+      cols: 80,
+      rows: 24,
+      process: 'kdn',
+      handleFlowControl: false,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      clear: vi.fn(),
+    } as unknown as IPty;
   }
 
-  test('returns write and resize functions', () => {
-    vi.mocked(spawn).mockReturnValue(createMockProcess());
+  test('returns write, resize, and ptyProcess', () => {
+    vi.mocked(spawn).mockReturnValue(createMockPty());
 
     const result = manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
 
     expect(result).toHaveProperty('write');
     expect(result).toHaveProperty('resize');
-    expect(result).toHaveProperty('process');
+    expect(result).toHaveProperty('ptyProcess');
   });
 
   test('spawns kdn terminal with workspace name', () => {
-    vi.mocked(spawn).mockReturnValue(createMockProcess());
+    vi.mocked(spawn).mockReturnValue(createMockPty());
 
     manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
 
-    expect(spawn).toHaveBeenCalledWith('kdn', ['terminal', 'test-workspace-1']);
+    expect(spawn).toHaveBeenCalledWith('kdn', ['terminal', 'test-workspace-1'], expect.any(Object));
   });
 
-  test('write function forwards data to stdin', () => {
-    const mockProcess = createMockProcess();
-    vi.mocked(spawn).mockReturnValue(mockProcess);
+  test('write function forwards data to pty', () => {
+    const mockPty = createMockPty();
+    vi.mocked(spawn).mockReturnValue(mockPty);
 
     const result = manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
     result.write('hello');
 
-    expect(mockProcess.stdin.write).toHaveBeenCalledWith('hello');
+    expect(mockPty.write).toHaveBeenCalledWith('hello');
   });
 
-  test('calls onData when stdout emits data', () => {
-    const stdoutListeners = new Map<string, (data: Buffer) => void>();
-    const mockProcess = createMockProcess({
-      stdoutOn: vi.fn((event: string, cb: (data: Buffer) => void) => stdoutListeners.set(event, cb)),
-    });
-    vi.mocked(spawn).mockReturnValue(mockProcess);
+  test('resize function forwards dimensions to pty', () => {
+    const mockPty = createMockPty();
+    vi.mocked(spawn).mockReturnValue(mockPty);
+
+    const result = manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
+    result.resize(120, 40);
+
+    expect(mockPty.resize).toHaveBeenCalledWith(120, 40);
+  });
+
+  test('calls onData when pty emits data', () => {
+    vi.mocked(spawn).mockReturnValue(createMockPty());
 
     const onData = vi.fn();
     manager.shellInAgentWorkspace('test-workspace-1', onData, vi.fn(), vi.fn());
 
-    const dataCallback = stdoutListeners.get('data');
-    expect(dataCallback).toBeDefined();
-    dataCallback!(Buffer.from('output'));
+    expect(onDataCallback).toBeDefined();
+    onDataCallback!('output');
 
     expect(onData).toHaveBeenCalledWith('output');
   });
 
-  test('calls onEnd when process closes', () => {
-    const processListeners = new Map<string, () => void>();
-    const mockProcess = createMockProcess({
-      processOn: vi.fn((event: string, cb: () => void) => processListeners.set(event, cb)),
-    });
-    vi.mocked(spawn).mockReturnValue(mockProcess);
+  test('calls onEnd when pty exits', () => {
+    vi.mocked(spawn).mockReturnValue(createMockPty());
 
     const onEnd = vi.fn();
     manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), onEnd);
 
-    const closeCallback = processListeners.get('close');
-    expect(closeCallback).toBeDefined();
-    closeCallback!();
+    expect(onExitCallback).toBeDefined();
+    onExitCallback!();
 
     expect(onEnd).toHaveBeenCalled();
-  });
-
-  test('calls onError when process emits error', () => {
-    const processListeners = new Map<string, (err: Error) => void>();
-    const mockProcess = createMockProcess({
-      processOn: vi.fn((event: string, cb: (err: Error) => void) => processListeners.set(event, cb)),
-    });
-    vi.mocked(spawn).mockReturnValue(mockProcess);
-
-    const onError = vi.fn();
-    manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), onError, vi.fn());
-
-    const errorCallback = processListeners.get('error');
-    expect(errorCallback).toBeDefined();
-    errorCallback!(new Error('spawn failed'));
-
-    expect(onError).toHaveBeenCalledWith('spawn failed');
   });
 });
 
 describe('dispose', () => {
   test('kills active terminal processes', async () => {
-    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
 
-    const mockProcess = {
-      stdout: { on: vi.fn() },
-      stderr: { on: vi.fn() },
-      stdin: { write: vi.fn() },
-      on: vi.fn(),
-      killed: false,
+    const mockPty = {
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      onExit: vi.fn(() => ({ dispose: vi.fn() })),
+      write: vi.fn(),
+      resize: vi.fn(),
       kill: vi.fn(),
-    } as unknown as ChildProcessWithoutNullStreams;
-    vi.mocked(spawn).mockReturnValue(mockProcess);
+      pid: 123,
+    } as unknown as IPty;
+    vi.mocked(spawn).mockReturnValue(mockPty);
 
     const terminalHandler = vi
       .mocked(ipcHandle)
@@ -513,11 +510,11 @@ describe('dispose', () => {
 
     manager.dispose();
 
-    expect(mockProcess.kill).toHaveBeenCalled();
+    expect(mockPty.kill).toHaveBeenCalled();
   });
 
   test('terminal IPC handler rejects when workspace id is not found', async () => {
-    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
 
     const terminalHandler = vi
       .mocked(ipcHandle)

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -134,7 +134,15 @@ beforeEach(() => {
   mockTask.status = '' as TaskStatus;
   mockTask.error = '';
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
-  manager = new AgentWorkspaceManager(apiSender, ipcHandle, exec, cliToolRegistry, taskManager, filesystemMonitoring, webContents);
+  manager = new AgentWorkspaceManager(
+    apiSender,
+    ipcHandle,
+    exec,
+    cliToolRegistry,
+    taskManager,
+    filesystemMonitoring,
+    webContents,
+  );
   manager.init();
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -432,6 +432,7 @@ describe('shellInAgentWorkspace', () => {
 
   test('spawns kdn terminal with workspace name', () => {
     vi.mocked(spawn).mockReturnValue(createMockPty());
+    vi.mocked(kdnCli.getCliPath).mockReturnValue('kdn');
 
     manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -34,8 +34,12 @@ import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
 import { AgentWorkspaceManager } from './agent-workspace-manager.js';
+import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { WebContents } from 'electron';
 
 vi.mock(import('node:fs/promises'));
+vi.mock(import('yaml'));
+vi.mock(import('node:child_process'));
 
 vi.mock(import('/@/plugin/kdn-cli/kdn-cli.js'));
 
@@ -95,6 +99,11 @@ const filesystemMonitoring = {
   createFileSystemWatcher: vi.fn().mockReturnValue(mockWatcher),
 } as unknown as FilesystemMonitoring;
 
+const webContents = {
+  send: vi.fn(),
+  receive: vi.fn(),
+} as unknown as WebContents;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(taskManager.createTask).mockReturnValue(mockTask);
@@ -102,7 +111,7 @@ beforeEach(() => {
   mockTask.status = '' as TaskStatus;
   mockTask.error = '';
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
-  manager = new AgentWorkspaceManager(apiSender, ipcHandle, kdnCli, taskManager, filesystemMonitoring);
+  manager = new AgentWorkspaceManager(apiSender, ipcHandle, kdnCli, taskManager, filesystemMonitoring, webContents);
   manager.init();
 });
 
@@ -377,5 +386,137 @@ describe('stop', () => {
     vi.mocked(kdnCli.stopWorkspace).mockRejectedValue(new Error('workspace not found: unknown-id'));
 
     await expect(manager.stop('unknown-id')).rejects.toThrow('workspace not found: unknown-id');
+  });
+});
+
+describe('shellInAgentWorkspace', () => {
+  function createMockProcess(overrides?: {
+    stdoutOn?: ReturnType<typeof vi.fn>;
+    stderrOn?: ReturnType<typeof vi.fn>;
+    processOn?: ReturnType<typeof vi.fn>;
+  }): ChildProcessWithoutNullStreams {
+    return {
+      stdout: { on: overrides?.stdoutOn ?? vi.fn() },
+      stderr: { on: overrides?.stderrOn ?? vi.fn() },
+      stdin: { write: vi.fn() },
+      on: overrides?.processOn ?? vi.fn(),
+      killed: false,
+      kill: vi.fn(),
+    } as unknown as ChildProcessWithoutNullStreams;
+  }
+
+  test('returns write and resize functions', () => {
+    vi.mocked(spawn).mockReturnValue(createMockProcess());
+
+    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+
+    expect(result).toHaveProperty('write');
+    expect(result).toHaveProperty('resize');
+    expect(result).toHaveProperty('process');
+  });
+
+  test('spawns kdn-cli terminal with correct arguments', () => {
+    vi.mocked(spawn).mockReturnValue(createMockProcess());
+
+    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+
+    expect(spawn).toHaveBeenCalledWith('kdn-cli', [
+      'terminal',
+      'ws-1',
+      '--',
+      '/bin/sh',
+      '-c',
+      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
+    ]);
+  });
+
+  test('write function forwards data to stdin', () => {
+    const mockProcess = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    result.write('hello');
+
+    expect(mockProcess.stdin.write).toHaveBeenCalledWith('hello');
+  });
+
+  test('calls onData when stdout emits data', () => {
+    const stdoutListeners = new Map<string, (data: Buffer) => void>();
+    const mockProcess = createMockProcess({
+      stdoutOn: vi.fn((event: string, cb: (data: Buffer) => void) => stdoutListeners.set(event, cb)),
+    });
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const onData = vi.fn();
+    manager.shellInAgentWorkspace('ws-1', onData, vi.fn(), vi.fn());
+
+    const dataCallback = stdoutListeners.get('data');
+    expect(dataCallback).toBeDefined();
+    dataCallback!(Buffer.from('output'));
+
+    expect(onData).toHaveBeenCalledWith('output');
+  });
+
+  test('calls onEnd when process closes', () => {
+    const processListeners = new Map<string, () => void>();
+    const mockProcess = createMockProcess({
+      processOn: vi.fn((event: string, cb: () => void) => processListeners.set(event, cb)),
+    });
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const onEnd = vi.fn();
+    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), onEnd);
+
+    const closeCallback = processListeners.get('close');
+    expect(closeCallback).toBeDefined();
+    closeCallback!();
+
+    expect(onEnd).toHaveBeenCalled();
+  });
+
+  test('calls onError when process emits error', () => {
+    const processListeners = new Map<string, (err: Error) => void>();
+    const mockProcess = createMockProcess({
+      processOn: vi.fn((event: string, cb: (err: Error) => void) => processListeners.set(event, cb)),
+    });
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const onError = vi.fn();
+    manager.shellInAgentWorkspace('ws-1', vi.fn(), onError, vi.fn());
+
+    const errorCallback = processListeners.get('error');
+    expect(errorCallback).toBeDefined();
+    errorCallback!(new Error('spawn failed'));
+
+    expect(onError).toHaveBeenCalledWith('spawn failed');
+  });
+});
+
+describe('dispose', () => {
+  test('kills active terminal processes', async () => {
+    const mockProcess = {
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      stdin: { write: vi.fn() },
+      on: vi.fn(),
+      killed: false,
+      kill: vi.fn(),
+    } as unknown as ChildProcessWithoutNullStreams;
+    vi.mocked(spawn).mockReturnValue(mockProcess);
+
+    const terminalHandler = vi
+      .mocked(ipcHandle)
+      .mock.calls.find(call => call[0] === 'agent-workspace:terminal')?.[1] as (
+      _listener: unknown,
+      id: string,
+      onDataId: number,
+    ) => Promise<number>;
+    expect(terminalHandler).toBeDefined();
+
+    await terminalHandler({}, 'ws-1', 1);
+
+    manager.dispose();
+
+    expect(mockProcess.kill).toHaveBeenCalled();
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -16,10 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { FileSystemWatcher } from '@openkaiden/api';
+import type { WebContents } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
@@ -34,8 +37,6 @@ import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
 import { AgentWorkspaceManager } from './agent-workspace-manager.js';
-import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
-import { WebContents } from 'electron';
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('yaml'));
@@ -408,26 +409,26 @@ describe('shellInAgentWorkspace', () => {
   test('returns write and resize functions', () => {
     vi.mocked(spawn).mockReturnValue(createMockProcess());
 
-    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    const result = manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
 
     expect(result).toHaveProperty('write');
     expect(result).toHaveProperty('resize');
     expect(result).toHaveProperty('process');
   });
 
-  test('spawns kdn-cli terminal with correct arguments', () => {
+  test('spawns kdn terminal with workspace name', () => {
     vi.mocked(spawn).mockReturnValue(createMockProcess());
 
-    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
 
-    expect(spawn).toHaveBeenCalledWith('kortex-cli', ['terminal', 'ws-1']);
+    expect(spawn).toHaveBeenCalledWith('kdn', ['terminal', 'test-workspace-1']);
   });
 
   test('write function forwards data to stdin', () => {
     const mockProcess = createMockProcess();
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
-    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    const result = manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
     result.write('hello');
 
     expect(mockProcess.stdin.write).toHaveBeenCalledWith('hello');
@@ -441,7 +442,7 @@ describe('shellInAgentWorkspace', () => {
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
     const onData = vi.fn();
-    manager.shellInAgentWorkspace('ws-1', onData, vi.fn(), vi.fn());
+    manager.shellInAgentWorkspace('test-workspace-1', onData, vi.fn(), vi.fn());
 
     const dataCallback = stdoutListeners.get('data');
     expect(dataCallback).toBeDefined();
@@ -458,7 +459,7 @@ describe('shellInAgentWorkspace', () => {
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
     const onEnd = vi.fn();
-    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), onEnd);
+    manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), onEnd);
 
     const closeCallback = processListeners.get('close');
     expect(closeCallback).toBeDefined();
@@ -475,7 +476,7 @@ describe('shellInAgentWorkspace', () => {
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
     const onError = vi.fn();
-    manager.shellInAgentWorkspace('ws-1', vi.fn(), onError, vi.fn());
+    manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), onError, vi.fn());
 
     const errorCallback = processListeners.get('error');
     expect(errorCallback).toBeDefined();
@@ -487,6 +488,8 @@ describe('shellInAgentWorkspace', () => {
 
 describe('dispose', () => {
   test('kills active terminal processes', async () => {
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
+
     const mockProcess = {
       stdout: { on: vi.fn() },
       stderr: { on: vi.fn() },
@@ -511,5 +514,22 @@ describe('dispose', () => {
     manager.dispose();
 
     expect(mockProcess.kill).toHaveBeenCalled();
+  });
+
+  test('terminal IPC handler rejects when workspace id is not found', async () => {
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
+
+    const terminalHandler = vi
+      .mocked(ipcHandle)
+      .mock.calls.find(call => call[0] === 'agent-workspace:terminal')?.[1] as (
+      _listener: unknown,
+      id: string,
+      onDataId: number,
+    ) => Promise<number>;
+    expect(terminalHandler).toBeDefined();
+
+    await expect(terminalHandler({}, 'unknown-id', 1)).rejects.toThrow(
+      'workspace "unknown-id" not found. Use "workspace list" to see available workspaces.',
+    );
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -420,14 +420,7 @@ describe('shellInAgentWorkspace', () => {
 
     manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
 
-    expect(spawn).toHaveBeenCalledWith('kdn-cli', [
-      'terminal',
-      'ws-1',
-      '--',
-      '/bin/sh',
-      '-c',
-      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
-    ]);
+    expect(spawn).toHaveBeenCalledWith('kortex-cli', ['terminal', 'ws-1']);
   });
 
   test('write function forwards data to stdin', () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -16,10 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { FileSystemWatcher, RunError, RunResult } from '@openkaiden/api';
+import type { WebContents } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
@@ -35,8 +38,6 @@ import type { CliToolInfo } from '/@api/cli-tool-info.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
 import { AgentWorkspaceManager } from './agent-workspace-manager.js';
-import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
-import { WebContents } from 'electron';
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('yaml'));
@@ -532,26 +533,26 @@ describe('shellInAgentWorkspace', () => {
   test('returns write and resize functions', () => {
     vi.mocked(spawn).mockReturnValue(createMockProcess());
 
-    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    const result = manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
 
     expect(result).toHaveProperty('write');
     expect(result).toHaveProperty('resize');
     expect(result).toHaveProperty('process');
   });
 
-  test('spawns kdn-cli terminal with correct arguments', () => {
+  test('spawns kdn terminal with workspace name', () => {
     vi.mocked(spawn).mockReturnValue(createMockProcess());
 
-    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
 
-    expect(spawn).toHaveBeenCalledWith('kortex-cli', ['terminal', 'ws-1']);
+    expect(spawn).toHaveBeenCalledWith('kdn', ['terminal', 'test-workspace-1']);
   });
 
   test('write function forwards data to stdin', () => {
     const mockProcess = createMockProcess();
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
-    const result = manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
+    const result = manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), vi.fn());
     result.write('hello');
 
     expect(mockProcess.stdin.write).toHaveBeenCalledWith('hello');
@@ -565,7 +566,7 @@ describe('shellInAgentWorkspace', () => {
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
     const onData = vi.fn();
-    manager.shellInAgentWorkspace('ws-1', onData, vi.fn(), vi.fn());
+    manager.shellInAgentWorkspace('test-workspace-1', onData, vi.fn(), vi.fn());
 
     const dataCallback = stdoutListeners.get('data');
     expect(dataCallback).toBeDefined();
@@ -582,7 +583,7 @@ describe('shellInAgentWorkspace', () => {
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
     const onEnd = vi.fn();
-    manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), onEnd);
+    manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), vi.fn(), onEnd);
 
     const closeCallback = processListeners.get('close');
     expect(closeCallback).toBeDefined();
@@ -599,7 +600,7 @@ describe('shellInAgentWorkspace', () => {
     vi.mocked(spawn).mockReturnValue(mockProcess);
 
     const onError = vi.fn();
-    manager.shellInAgentWorkspace('ws-1', vi.fn(), onError, vi.fn());
+    manager.shellInAgentWorkspace('test-workspace-1', vi.fn(), onError, vi.fn());
 
     const errorCallback = processListeners.get('error');
     expect(errorCallback).toBeDefined();
@@ -611,6 +612,8 @@ describe('shellInAgentWorkspace', () => {
 
 describe('dispose', () => {
   test('kills active terminal processes', async () => {
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
+
     const mockProcess = {
       stdout: { on: vi.fn() },
       stderr: { on: vi.fn() },
@@ -635,5 +638,22 @@ describe('dispose', () => {
     manager.dispose();
 
     expect(mockProcess.kill).toHaveBeenCalled();
+  });
+
+  test('terminal IPC handler rejects when workspace id is not found', async () => {
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
+
+    const terminalHandler = vi
+      .mocked(ipcHandle)
+      .mock.calls.find(call => call[0] === 'agent-workspace:terminal')?.[1] as (
+      _listener: unknown,
+      id: string,
+      onDataId: number,
+    ) => Promise<number>;
+    expect(terminalHandler).toBeDefined();
+
+    await expect(terminalHandler({}, 'unknown-id', 1)).rejects.toThrow(
+      'workspace "unknown-id" not found. Use "workspace list" to see available workspaces.',
+    );
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -544,14 +544,7 @@ describe('shellInAgentWorkspace', () => {
 
     manager.shellInAgentWorkspace('ws-1', vi.fn(), vi.fn(), vi.fn());
 
-    expect(spawn).toHaveBeenCalledWith('kdn-cli', [
-      'terminal',
-      'ws-1',
-      '--',
-      '/bin/sh',
-      '-c',
-      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
-    ]);
+    expect(spawn).toHaveBeenCalledWith('kortex-cli', ['terminal', 'ws-1']);
   });
 
   test('write function forwards data to stdin', () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -24,6 +23,8 @@ import { join } from 'node:path';
 import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
+import type { IPty } from 'node-pty';
+import { spawn } from 'node-pty';
 
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
@@ -48,7 +49,7 @@ export class AgentWorkspaceManager implements Disposable {
     number,
     { write: (param: string) => void; resize: (w: number, h: number) => void }
   >();
-  private readonly terminalProcesses = new Map<number, ChildProcessWithoutNullStreams>();
+  private readonly terminalProcesses = new Map<number, IPty>();
 
   constructor(
     @inject(ApiSenderType)
@@ -131,40 +132,34 @@ export class AgentWorkspaceManager implements Disposable {
   shellInAgentWorkspace(
     name: string,
     onData: (data: string) => void,
-    onError: (error: string) => void,
+    _onError: (error: string) => void,
     onEnd: () => void,
   ): {
     write: (param: string) => void;
     resize: (w: number, h: number) => void;
-    process: ChildProcessWithoutNullStreams;
+    ptyProcess: IPty;
   } {
-    // eslint-disable-next-line sonarjs/no-os-command-from-path
-    const childProcess = spawn('kdn', ['terminal', name]);
-
-    childProcess.stdout.on('data', (chunk: Buffer) => {
-      onData(chunk.toString('utf-8'));
+    const ptyProcess = spawn('kdn', ['terminal', name], {
+      name: 'xterm-256color',
+      env: process.env as Record<string, string>,
     });
 
-    childProcess.stderr.on('data', (chunk: Buffer) => {
-      onData(chunk.toString('utf-8'));
+    ptyProcess.onData((data: string) => {
+      onData(data);
     });
 
-    childProcess.on('error', (error: Error) => {
-      onError(error.message);
-    });
-
-    childProcess.on('close', () => {
+    ptyProcess.onExit(() => {
       onEnd();
     });
 
     return {
       write: (param: string): void => {
-        childProcess.stdin.write(param);
+        ptyProcess.write(param);
       },
-      resize: (_w: number, _h: number): void => {
-        // no-op: resize requires a PTY (e.g. node-pty); can be added later
+      resize: (cols: number, rows: number): void => {
+        ptyProcess.resize(cols, rows);
       },
-      process: childProcess,
+      ptyProcess,
     };
   }
 
@@ -226,7 +221,7 @@ export class AgentWorkspaceManager implements Disposable {
           },
         );
         this.terminalCallbacks.set(onDataId, { write: invocation.write, resize: invocation.resize });
-        this.terminalProcesses.set(onDataId, invocation.process);
+        this.terminalProcesses.set(onDataId, invocation.ptyProcess);
         return onDataId;
       },
     );
@@ -251,6 +246,19 @@ export class AgentWorkspaceManager implements Disposable {
       },
     );
 
+    this.ipcHandle('agent-workspace:terminalClose', async (_listener: unknown, onDataId: number): Promise<void> => {
+      const proc = this.terminalProcesses.get(onDataId);
+      if (proc) {
+        try {
+          proc.kill();
+        } catch {
+          /* already exited */
+        }
+      }
+      this.terminalProcesses.delete(onDataId);
+      this.terminalCallbacks.delete(onDataId);
+    });
+
     this.watchInstancesFile();
   }
 
@@ -270,8 +278,10 @@ export class AgentWorkspaceManager implements Disposable {
   dispose(): void {
     this.instancesWatcher?.dispose();
     for (const proc of this.terminalProcesses.values()) {
-      if (!proc.killed) {
+      try {
         proc.kill();
+      } catch {
+        /* already exited */
       }
     }
     this.terminalProcesses.clear();

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -139,7 +139,7 @@ export class AgentWorkspaceManager implements Disposable {
     resize: (w: number, h: number) => void;
     ptyProcess: IPty;
   } {
-    const ptyProcess = spawn('kdn', ['terminal', name], {
+    const ptyProcess = spawn(this.kdnCli.getCliPath(), ['terminal', name], {
       name: 'xterm-256color',
       env: process.env as Record<string, string>,
     });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -139,14 +139,7 @@ export class AgentWorkspaceManager implements Disposable {
     process: ChildProcessWithoutNullStreams;
   } {
     // eslint-disable-next-line sonarjs/no-os-command-from-path
-    const childProcess = spawn('kdn-cli', [
-      'terminal',
-      id,
-      '--',
-      '/bin/sh',
-      '-c',
-      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
-    ]);
+    const childProcess = spawn('kortex-cli', ['terminal', id]);
 
     childProcess.stdout.on('data', (chunk: Buffer) => {
       onData(chunk.toString('utf-8'));

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -16,17 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import type { Disposable, FileSystemWatcher, RunError } from '@openkaiden/api';
+import type { WebContents } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
 
-import { IPCHandle } from '/@/plugin/api.js';
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
+import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { Exec } from '/@/plugin/util/exec.js';
 import type {
   AgentWorkspaceConfiguration,
@@ -42,6 +44,11 @@ import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 @injectable()
 export class AgentWorkspaceManager implements Disposable {
   private instancesWatcher: FileSystemWatcher | undefined;
+  private readonly terminalCallbacks = new Map<
+    number,
+    { write: (param: string) => void; resize: (w: number, h: number) => void }
+  >();
+  private readonly terminalProcesses = new Map<number, ChildProcessWithoutNullStreams>();
 
   constructor(
     @inject(ApiSenderType)
@@ -56,6 +63,8 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly taskManager: TaskManager,
     @inject(FilesystemMonitoring)
     private readonly filesystemMonitoring: FilesystemMonitoring,
+    @inject(WebContentsType)
+    private readonly webContents: WebContents,
   ) {}
 
   private getCliPath(): string {
@@ -176,6 +185,53 @@ export class AgentWorkspaceManager implements Disposable {
     return result;
   }
 
+  shellInAgentWorkspace(
+    id: string,
+    onData: (data: string) => void,
+    onError: (error: string) => void,
+    onEnd: () => void,
+  ): {
+    write: (param: string) => void;
+    resize: (w: number, h: number) => void;
+    process: ChildProcessWithoutNullStreams;
+  } {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
+    const childProcess = spawn('kdn-cli', [
+      'terminal',
+      id,
+      '--',
+      '/bin/sh',
+      '-c',
+      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
+    ]);
+
+    childProcess.stdout.on('data', (chunk: Buffer) => {
+      onData(chunk.toString('utf-8'));
+    });
+
+    childProcess.stderr.on('data', (chunk: Buffer) => {
+      onData(chunk.toString('utf-8'));
+    });
+
+    childProcess.on('error', (error: Error) => {
+      onError(error.message);
+    });
+
+    childProcess.on('close', () => {
+      onEnd();
+    });
+
+    return {
+      write: (param: string): void => {
+        childProcess.stdin.write(param);
+      },
+      resize: (_w: number, _h: number): void => {
+        // no-op: resize requires a PTY (e.g. node-pty); can be added later
+      },
+      process: childProcess,
+    };
+  }
+
   init(): void {
     this.ipcHandle(
       'agent-workspace:create',
@@ -207,6 +263,49 @@ export class AgentWorkspaceManager implements Disposable {
       return this.stop(id);
     });
 
+    this.ipcHandle(
+      'agent-workspace:terminal',
+      async (_listener: unknown, id: string, onDataId: number): Promise<number> => {
+        const invocation = this.shellInAgentWorkspace(
+          id,
+          (content: string) => {
+            this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
+          },
+          (error: string) => {
+            this.webContents.send('agent-workspace:terminal-onError', onDataId, error);
+          },
+          () => {
+            this.webContents.send('agent-workspace:terminal-onEnd', onDataId);
+            this.terminalCallbacks.delete(onDataId);
+            this.terminalProcesses.delete(onDataId);
+          },
+        );
+        this.terminalCallbacks.set(onDataId, { write: invocation.write, resize: invocation.resize });
+        this.terminalProcesses.set(onDataId, invocation.process);
+        return onDataId;
+      },
+    );
+
+    this.ipcHandle(
+      'agent-workspace:terminalSend',
+      async (_listener: unknown, onDataId: number, content: string): Promise<void> => {
+        const callback = this.terminalCallbacks.get(onDataId);
+        if (callback) {
+          callback.write(content);
+        }
+      },
+    );
+
+    this.ipcHandle(
+      'agent-workspace:terminalResize',
+      async (_listener: unknown, onDataId: number, width: number, height: number): Promise<void> => {
+        const callback = this.terminalCallbacks.get(onDataId);
+        if (callback) {
+          callback.resize(width, height);
+        }
+      },
+    );
+    
     this.watchInstancesFile();
   }
 
@@ -225,5 +324,12 @@ export class AgentWorkspaceManager implements Disposable {
   @preDestroy()
   dispose(): void {
     this.instancesWatcher?.dispose();
+    for (const proc of this.terminalProcesses.values()) {
+      if (!proc.killed) {
+        proc.kill();
+      }
+    }
+    this.terminalProcesses.clear();
+    this.terminalCallbacks.clear();
   }
 }

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -25,10 +25,10 @@ import type { Disposable, FileSystemWatcher, RunError } from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
 
+import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
-import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { Exec } from '/@/plugin/util/exec.js';
 import type {
   AgentWorkspaceConfiguration,

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -303,7 +303,7 @@ export class AgentWorkspaceManager implements Disposable {
         }
       },
     );
-    
+
     this.watchInstancesFile();
   }
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -196,14 +196,7 @@ export class AgentWorkspaceManager implements Disposable {
     process: ChildProcessWithoutNullStreams;
   } {
     // eslint-disable-next-line sonarjs/no-os-command-from-path
-    const childProcess = spawn('kdn-cli', [
-      'terminal',
-      id,
-      '--',
-      '/bin/sh',
-      '-c',
-      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
-    ]);
+    const childProcess = spawn('kortex-cli', ['terminal', id]);
 
     childProcess.stdout.on('data', (chunk: Buffer) => {
       onData(chunk.toString('utf-8'));

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -129,7 +129,7 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   shellInAgentWorkspace(
-    id: string,
+    name: string,
     onData: (data: string) => void,
     onError: (error: string) => void,
     onEnd: () => void,
@@ -139,7 +139,7 @@ export class AgentWorkspaceManager implements Disposable {
     process: ChildProcessWithoutNullStreams;
   } {
     // eslint-disable-next-line sonarjs/no-os-command-from-path
-    const childProcess = spawn('kortex-cli', ['terminal', id]);
+    const childProcess = spawn('kdn', ['terminal', name]);
 
     childProcess.stdout.on('data', (chunk: Buffer) => {
       onData(chunk.toString('utf-8'));
@@ -206,8 +206,13 @@ export class AgentWorkspaceManager implements Disposable {
     this.ipcHandle(
       'agent-workspace:terminal',
       async (_listener: unknown, id: string, onDataId: number): Promise<number> => {
+        const workspaces = await this.list();
+        const workspace = workspaces.find(ws => ws.id === id);
+        if (!workspace) {
+          throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
+        }
         const invocation = this.shellInAgentWorkspace(
-          id,
+          workspace.name,
           (content: string) => {
             this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
           },

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -16,17 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
+import type { WebContents } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
 
-import { IPCHandle } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
+import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import type {
   AgentWorkspaceConfiguration,
   AgentWorkspaceCreateOptions,
@@ -42,6 +44,11 @@ import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 @injectable()
 export class AgentWorkspaceManager implements Disposable {
   private instancesWatcher: FileSystemWatcher | undefined;
+  private readonly terminalCallbacks = new Map<
+    number,
+    { write: (param: string) => void; resize: (w: number, h: number) => void }
+  >();
+  private readonly terminalProcesses = new Map<number, ChildProcessWithoutNullStreams>();
 
   constructor(
     @inject(ApiSenderType)
@@ -54,6 +61,8 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly taskManager: TaskManager,
     @inject(FilesystemMonitoring)
     private readonly filesystemMonitoring: FilesystemMonitoring,
+    @inject(WebContentsType)
+    private readonly webContents: WebContents,
   ) {}
 
   async getCliInfo(): Promise<CliInfo> {
@@ -119,6 +128,53 @@ export class AgentWorkspaceManager implements Disposable {
     return result;
   }
 
+  shellInAgentWorkspace(
+    id: string,
+    onData: (data: string) => void,
+    onError: (error: string) => void,
+    onEnd: () => void,
+  ): {
+    write: (param: string) => void;
+    resize: (w: number, h: number) => void;
+    process: ChildProcessWithoutNullStreams;
+  } {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
+    const childProcess = spawn('kdn-cli', [
+      'terminal',
+      id,
+      '--',
+      '/bin/sh',
+      '-c',
+      'if command -v bash >/dev/null 2>&1; then bash; else sh; fi',
+    ]);
+
+    childProcess.stdout.on('data', (chunk: Buffer) => {
+      onData(chunk.toString('utf-8'));
+    });
+
+    childProcess.stderr.on('data', (chunk: Buffer) => {
+      onData(chunk.toString('utf-8'));
+    });
+
+    childProcess.on('error', (error: Error) => {
+      onError(error.message);
+    });
+
+    childProcess.on('close', () => {
+      onEnd();
+    });
+
+    return {
+      write: (param: string): void => {
+        childProcess.stdin.write(param);
+      },
+      resize: (_w: number, _h: number): void => {
+        // no-op: resize requires a PTY (e.g. node-pty); can be added later
+      },
+      process: childProcess,
+    };
+  }
+
   init(): void {
     this.ipcHandle('agent-workspace:getCliInfo', async (): Promise<CliInfo> => {
       return this.getCliInfo();
@@ -154,6 +210,49 @@ export class AgentWorkspaceManager implements Disposable {
       return this.stop(id);
     });
 
+    this.ipcHandle(
+      'agent-workspace:terminal',
+      async (_listener: unknown, id: string, onDataId: number): Promise<number> => {
+        const invocation = this.shellInAgentWorkspace(
+          id,
+          (content: string) => {
+            this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
+          },
+          (error: string) => {
+            this.webContents.send('agent-workspace:terminal-onError', onDataId, error);
+          },
+          () => {
+            this.webContents.send('agent-workspace:terminal-onEnd', onDataId);
+            this.terminalCallbacks.delete(onDataId);
+            this.terminalProcesses.delete(onDataId);
+          },
+        );
+        this.terminalCallbacks.set(onDataId, { write: invocation.write, resize: invocation.resize });
+        this.terminalProcesses.set(onDataId, invocation.process);
+        return onDataId;
+      },
+    );
+
+    this.ipcHandle(
+      'agent-workspace:terminalSend',
+      async (_listener: unknown, onDataId: number, content: string): Promise<void> => {
+        const callback = this.terminalCallbacks.get(onDataId);
+        if (callback) {
+          callback.write(content);
+        }
+      },
+    );
+
+    this.ipcHandle(
+      'agent-workspace:terminalResize',
+      async (_listener: unknown, onDataId: number, width: number, height: number): Promise<void> => {
+        const callback = this.terminalCallbacks.get(onDataId);
+        if (callback) {
+          callback.resize(width, height);
+        }
+      },
+    );
+    
     this.watchInstancesFile();
   }
 
@@ -172,5 +271,12 @@ export class AgentWorkspaceManager implements Disposable {
   @preDestroy()
   dispose(): void {
     this.instancesWatcher?.dispose();
+    for (const proc of this.terminalProcesses.values()) {
+      if (!proc.killed) {
+        proc.kill();
+      }
+    }
+    this.terminalProcesses.clear();
+    this.terminalCallbacks.clear();
   }
 }

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -250,7 +250,7 @@ export class AgentWorkspaceManager implements Disposable {
         }
       },
     );
-    
+
     this.watchInstancesFile();
   }
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -25,10 +25,10 @@ import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
 
+import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
-import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import type {
   AgentWorkspaceConfiguration,
   AgentWorkspaceCreateOptions,

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -186,7 +186,7 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   shellInAgentWorkspace(
-    id: string,
+    name: string,
     onData: (data: string) => void,
     onError: (error: string) => void,
     onEnd: () => void,
@@ -196,7 +196,7 @@ export class AgentWorkspaceManager implements Disposable {
     process: ChildProcessWithoutNullStreams;
   } {
     // eslint-disable-next-line sonarjs/no-os-command-from-path
-    const childProcess = spawn('kortex-cli', ['terminal', id]);
+    const childProcess = spawn('kdn', ['terminal', name]);
 
     childProcess.stdout.on('data', (chunk: Buffer) => {
       onData(chunk.toString('utf-8'));
@@ -259,8 +259,13 @@ export class AgentWorkspaceManager implements Disposable {
     this.ipcHandle(
       'agent-workspace:terminal',
       async (_listener: unknown, id: string, onDataId: number): Promise<number> => {
+        const workspaces = await this.list();
+        const workspace = workspaces.find(ws => ws.id === id);
+        if (!workspace) {
+          throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
+        }
         const invocation = this.shellInAgentWorkspace(
-          id,
+          workspace.name,
           (content: string) => {
             this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
           },

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -56,6 +56,7 @@ const config = {
         'express',
         'isomorphic-ws',
         'better-sqlite3',
+        'node-pty',
         ...builtinModules.flatMap(p => [p, `node:${p}`]),
       ],
       output: {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -376,6 +376,18 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('shellInAgentWorkspaceClose', async (callbackId: number): Promise<void> => {
+    onDataCallbacksShellInAgentWorkspace.delete(callbackId);
+    return ipcInvoke('agent-workspace:terminalClose', callbackId);
+  });
+
+  contextBridge.exposeInMainWorld(
+    'shellInAgentWorkspaceReattach',
+    (callbackId: number, onData: (data: string) => void, onError: (error: string) => void, onEnd: () => void): void => {
+      onDataCallbacksShellInAgentWorkspace.set(callbackId, { onData, onError, onEnd });
+    },
+  );
+
   contextBridge.exposeInMainWorld(
     'shellInAgentWorkspaceSend',
     async (dataId: number, content: string): Promise<void> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -349,6 +349,62 @@ export function initExposure(): void {
     return ipcInvoke('agent-workspace:stop', id);
   });
 
+  // Agent Workspace Terminal
+  let onDataCallbacksShellInAgentWorkspaceId = 0;
+  const onDataCallbacksShellInAgentWorkspace = new Map<
+    number,
+    { onData: (data: string) => void; onError: (error: string) => void; onEnd: () => void }
+  >();
+  contextBridge.exposeInMainWorld(
+    'shellInAgentWorkspace',
+    async (
+      id: string,
+      onData: (data: string) => void,
+      onError: (error: string) => void,
+      onEnd: () => void,
+    ): Promise<number> => {
+      onDataCallbacksShellInAgentWorkspaceId++;
+      onDataCallbacksShellInAgentWorkspace.set(onDataCallbacksShellInAgentWorkspaceId, { onData, onError, onEnd });
+      return ipcInvoke('agent-workspace:terminal', id, onDataCallbacksShellInAgentWorkspaceId);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'shellInAgentWorkspaceSend',
+    async (dataId: number, content: string): Promise<void> => {
+      return ipcInvoke('agent-workspace:terminalSend', dataId, content);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'shellInAgentWorkspaceResize',
+    async (dataId: number, width: number, height: number): Promise<void> => {
+      return ipcInvoke('agent-workspace:terminalResize', dataId, width, height);
+    },
+  );
+
+  ipcRenderer.on('agent-workspace:terminal-onData', (_, callbackId: number, data: string) => {
+    const callback = onDataCallbacksShellInAgentWorkspace.get(callbackId);
+    if (callback) {
+      callback.onData(data);
+    }
+  });
+
+  ipcRenderer.on('agent-workspace:terminal-onError', (_, callbackId: number, error: string) => {
+    const callback = onDataCallbacksShellInAgentWorkspace.get(callbackId);
+    if (callback) {
+      callback.onError(error);
+    }
+  });
+
+  ipcRenderer.on('agent-workspace:terminal-onEnd', (_, callbackId: number) => {
+    const callback = onDataCallbacksShellInAgentWorkspace.get(callbackId);
+    if (callback) {
+      callback.onEnd();
+      onDataCallbacksShellInAgentWorkspace.delete(callbackId);
+    }
+  });
+
   contextBridge.exposeInMainWorld('listFlows', async (): Promise<Array<FlowInfo>> => {
     return ipcInvoke('flows:list');
   });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -356,6 +356,62 @@ export function initExposure(): void {
     return ipcInvoke('agent-workspace:stop', id);
   });
 
+  // Agent Workspace Terminal
+  let onDataCallbacksShellInAgentWorkspaceId = 0;
+  const onDataCallbacksShellInAgentWorkspace = new Map<
+    number,
+    { onData: (data: string) => void; onError: (error: string) => void; onEnd: () => void }
+  >();
+  contextBridge.exposeInMainWorld(
+    'shellInAgentWorkspace',
+    async (
+      id: string,
+      onData: (data: string) => void,
+      onError: (error: string) => void,
+      onEnd: () => void,
+    ): Promise<number> => {
+      onDataCallbacksShellInAgentWorkspaceId++;
+      onDataCallbacksShellInAgentWorkspace.set(onDataCallbacksShellInAgentWorkspaceId, { onData, onError, onEnd });
+      return ipcInvoke('agent-workspace:terminal', id, onDataCallbacksShellInAgentWorkspaceId);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'shellInAgentWorkspaceSend',
+    async (dataId: number, content: string): Promise<void> => {
+      return ipcInvoke('agent-workspace:terminalSend', dataId, content);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'shellInAgentWorkspaceResize',
+    async (dataId: number, width: number, height: number): Promise<void> => {
+      return ipcInvoke('agent-workspace:terminalResize', dataId, width, height);
+    },
+  );
+
+  ipcRenderer.on('agent-workspace:terminal-onData', (_, callbackId: number, data: string) => {
+    const callback = onDataCallbacksShellInAgentWorkspace.get(callbackId);
+    if (callback) {
+      callback.onData(data);
+    }
+  });
+
+  ipcRenderer.on('agent-workspace:terminal-onError', (_, callbackId: number, error: string) => {
+    const callback = onDataCallbacksShellInAgentWorkspace.get(callbackId);
+    if (callback) {
+      callback.onError(error);
+    }
+  });
+
+  ipcRenderer.on('agent-workspace:terminal-onEnd', (_, callbackId: number) => {
+    const callback = onDataCallbacksShellInAgentWorkspace.get(callbackId);
+    if (callback) {
+      callback.onEnd();
+      onDataCallbacksShellInAgentWorkspace.delete(callbackId);
+    }
+  });
+
   contextBridge.exposeInMainWorld('createSecret', async (options: SecretCreateOptions): Promise<SecretName> => {
     return ipcInvoke('secret-manager:create', options);
   });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
@@ -160,6 +160,43 @@ test('Expect error dialog uses workspace name when start fails', async () => {
   });
 });
 
+test('Expect terminal button is rendered', () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  expect(screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' })).toBeInTheDocument();
+});
+
+test('Expect clicking terminal button navigates to terminal tab', async () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
+  await fireEvent.click(terminalButton);
+
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
+test('Expect clicking terminal button starts workspace when stopped', async () => {
+  render(AgentWorkspaceCard, { workspace });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
+  await fireEvent.click(terminalButton);
+
+  expect(window.startAgentWorkspace).toHaveBeenCalledWith('ws-1');
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
+test('Expect clicking terminal button does not start workspace when already running', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  render(AgentWorkspaceCard, { workspace });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
+  await fireEvent.click(terminalButton);
+
+  expect(window.startAgentWorkspace).not.toHaveBeenCalled();
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
 test('Expect error dialog shown when stop fails', async () => {
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
@@ -20,12 +20,15 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { get } from 'svelte/store';
+import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 import AgentWorkspaceActions from './AgentWorkspaceActions.svelte';
+
+vi.mock(import('tinro'));
 
 const workspace: AgentWorkspaceSummary = {
   id: 'ws-1',
@@ -161,13 +164,13 @@ test('Expect error dialog uses workspace name when start fails', async () => {
 });
 
 test('Expect terminal button is rendered', () => {
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: workspace });
 
   expect(screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' })).toBeInTheDocument();
 });
 
 test('Expect clicking terminal button navigates to terminal tab', async () => {
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: workspace });
 
   const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
   await fireEvent.click(terminalButton);
@@ -176,7 +179,7 @@ test('Expect clicking terminal button navigates to terminal tab', async () => {
 });
 
 test('Expect clicking terminal button starts workspace when stopped', async () => {
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: workspace });
 
   const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
   await fireEvent.click(terminalButton);
@@ -186,9 +189,9 @@ test('Expect clicking terminal button starts workspace when stopped', async () =
 });
 
 test('Expect clicking terminal button does not start workspace when already running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: { ...workspace, state: 'running' } });
 
   const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
   await fireEvent.click(terminalButton);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
@@ -20,11 +20,14 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { get } from 'svelte/store';
+import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import AgentWorkspaceActions from '/@/lib/agent-workspaces/columns/AgentWorkspaceActions.svelte';
 import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+
+vi.mock(import('tinro'));
 
 const workspace: AgentWorkspaceSummary = {
   id: 'ws-1',
@@ -161,13 +164,13 @@ test('Expect error dialog uses workspace name when start fails', async () => {
 });
 
 test('Expect terminal button is rendered', () => {
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: workspace });
 
   expect(screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' })).toBeInTheDocument();
 });
 
 test('Expect clicking terminal button navigates to terminal tab', async () => {
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: workspace });
 
   const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
   await fireEvent.click(terminalButton);
@@ -176,7 +179,7 @@ test('Expect clicking terminal button navigates to terminal tab', async () => {
 });
 
 test('Expect clicking terminal button starts workspace when stopped', async () => {
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: workspace });
 
   const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
   await fireEvent.click(terminalButton);
@@ -186,9 +189,9 @@ test('Expect clicking terminal button starts workspace when stopped', async () =
 });
 
 test('Expect clicking terminal button does not start workspace when already running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceActions, { object: { ...workspace, state: 'running' } });
 
   const terminalButton = screen.getByRole('button', { name: 'Open terminal for workspace api-refactor' });
   await fireEvent.click(terminalButton);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlay, faStop, faTerminal, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { router } from 'tinro';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
@@ -38,6 +39,13 @@ async function handleStartStop(): Promise<void> {
   }
 }
 
+function handleTerminal(): void {
+  if (!isRunning && !inProgress) {
+    startAgentWorkspace(object.id).catch(console.error);
+  }
+  router.goto(`/agent-workspaces/${encodeURIComponent(object.id)}/terminal`);
+}
+
 function handleRemove(): void {
   withConfirmation(
     () => window.removeAgentWorkspace(object.id).catch(console.error),
@@ -51,6 +59,10 @@ function handleRemove(): void {
   icon={isRunning ? faStop : faPlay}
   inProgress={inProgress}
   onClick={handleStartStop} />
+<ListItemButtonIcon
+  title="Open terminal for workspace {object.name}"
+  icon={faTerminal}
+  onClick={handleTerminal} />
 <ListItemButtonIcon
   title="Remove workspace"
   icon={faTrash}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -307,7 +307,7 @@ test('Expect clicking terminal button starts workspace when stopped', async () =
 });
 
 test('Expect clicking terminal button does not start workspace when already running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -89,6 +89,14 @@ test('Expect Summary tab is present', async () => {
   });
 });
 
+test('Expect Terminal tab is present', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByText('Terminal')).toBeInTheDocument();
+  });
+});
+
 test('Expect workspace summary with project is resolved from the store', () => {
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -90,7 +90,15 @@ test('Expect Overview tab is present', async () => {
   });
 });
 
-test('Expect workspace overview with project is resolved from the store', () => {
+test('Expect Terminal tab is present', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByText('Terminal')).toBeInTheDocument();
+  });
+});
+
+test('Expect workspace summary with project is resolved from the store', () => {
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 
   const storeValue = [workspaceSummary];

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -271,6 +271,57 @@ test('Expect error dialog uses workspace name when start fails', async () => {
   });
 });
 
+test('Expect terminal button is rendered', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+});
+
+test('Expect clicking terminal button navigates to terminal tab', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open Terminal' });
+  await fireEvent.click(terminalButton);
+
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
+test('Expect clicking terminal button starts workspace when stopped', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open Terminal' });
+  await fireEvent.click(terminalButton);
+
+  expect(window.startAgentWorkspace).toHaveBeenCalledWith('ws-1');
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
+test('Expect clicking terminal button does not start workspace when already running', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open Terminal' });
+  await fireEvent.click(terminalButton);
+
+  expect(window.startAgentWorkspace).not.toHaveBeenCalled();
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
 test('Expect error dialog shown when stop fails', async () => {
   agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -272,6 +272,57 @@ test('Expect error dialog uses workspace name when start fails', async () => {
   });
 });
 
+test('Expect terminal button is rendered', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+});
+
+test('Expect clicking terminal button navigates to terminal tab', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open Terminal' });
+  await fireEvent.click(terminalButton);
+
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
+test('Expect clicking terminal button starts workspace when stopped', async () => {
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open Terminal' });
+  await fireEvent.click(terminalButton);
+
+  expect(window.startAgentWorkspace).toHaveBeenCalledWith('ws-1');
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
+test('Expect clicking terminal button does not start workspace when already running', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open Terminal' });
+  await fireEvent.click(terminalButton);
+
+  expect(window.startAgentWorkspace).not.toHaveBeenCalled();
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
+});
+
 test('Expect error dialog shown when stop fails', async () => {
   agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -308,7 +308,7 @@ test('Expect clicking terminal button starts workspace when stopped', async () =
 });
 
 test('Expect clicking terminal button does not start workspace when already running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlay, faStop, faTerminal, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { ErrorMessage, Tab } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
@@ -63,6 +63,13 @@ async function handleStartStop(): Promise<void> {
   }
 }
 
+function handleTerminal(): void {
+  if (!isRunning && !inProgress) {
+    startAgentWorkspace(workspaceId).catch(console.error);
+  }
+  router.goto(`/agent-workspaces/${encodeURIComponent(workspaceId)}/terminal`);
+}
+
 function handleRemove(): void {
   withConfirmation(
     async () => {
@@ -85,6 +92,10 @@ function handleRemove(): void {
       onClick={handleStartStop}
       icon={isRunning ? faStop : faPlay}
       inProgress={inProgress} />
+    <ListItemButtonIcon
+      title="Open Terminal"
+      onClick={handleTerminal}
+      icon={faTerminal} />
     <ListItemButtonIcon
       title="Remove Workspace"
       onClick={handleRemove}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -12,7 +12,8 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
-import { agentWorkspaces, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
+import {agentWorkspaces, startAgentWorkspace, stopAgentWorkspace} from '/@/stores/agent-workspaces.svelte';
+import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 
 interface Props {
   workspaceId: string;
@@ -113,6 +114,9 @@ function handleRemove(): void {
     </Route>
     <Route path="/settings" breadcrumb="Settings" navigationHint="tab">
       <AgentWorkspaceDetailsSettings />
+    </Route>
+    <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
+      <AgentWorkspaceTerminal workspaceId={workspaceId} />
     </Route>
   {/snippet}
 </DetailsPage>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -13,7 +13,6 @@ import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import {agentWorkspaces, startAgentWorkspace, stopAgentWorkspace} from '/@/stores/agent-workspaces.svelte';
-import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 
 interface Props {
   workspaceId: string;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlay, faStop, faTerminal, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { ErrorMessage, Tab } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
@@ -65,6 +65,13 @@ async function handleStartStop(): Promise<void> {
   }
 }
 
+function handleTerminal(): void {
+  if (!isRunning && !inProgress) {
+    startAgentWorkspace(workspaceId).catch(console.error);
+  }
+  router.goto(`/agent-workspaces/${encodeURIComponent(workspaceId)}/terminal`);
+}
+
 function handleRemove(): void {
   withConfirmation(
     async () => {
@@ -87,6 +94,10 @@ function handleRemove(): void {
       onClick={handleStartStop}
       icon={isRunning ? faStop : faPlay}
       inProgress={inProgress} />
+    <ListItemButtonIcon
+      title="Open Terminal"
+      onClick={handleTerminal}
+      icon={faTerminal} />
     <ListItemButtonIcon
       title="Remove Workspace"
       onClick={handleRemove}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -7,6 +7,7 @@ import AgentWorkspaceDetailsFiles from '/@/lib/agent-workspaces/AgentWorkspaceDe
 import AgentWorkspaceDetailsOverview from '/@/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte';
 import AgentWorkspaceDetailsSettings from '/@/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte';
 import AgentWorkspaceDetailsTerminal from '/@/lib/agent-workspaces/AgentWorkspaceDetailsTerminal.svelte';
+import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -4,13 +4,13 @@ import { ErrorMessage, Tab } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import AgentWorkspaceDetailsSummary from '/@/lib/agent-workspaces/AgentWorkspaceDetailsSummary.svelte';
+import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import {agentWorkspaces, startAgentWorkspace, stopAgentWorkspace} from '/@/stores/agent-workspaces.svelte';
-import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 
 interface Props {
   workspaceId: string;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -12,7 +12,7 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
-import {agentWorkspaces, startAgentWorkspace, stopAgentWorkspace} from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaces, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
 
 interface Props {
   workspaceId: string;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -9,7 +9,8 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
-import { agentWorkspaces, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
+import {agentWorkspaces, startAgentWorkspace, stopAgentWorkspace} from '/@/stores/agent-workspaces.svelte';
+import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 
 interface Props {
   workspaceId: string;
@@ -91,6 +92,7 @@ function handleRemove(): void {
   {/snippet}
   {#snippet tabsSnippet()}
     <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
+    <Tab title="Terminal" selected={isTabSelected($router.path, 'terminal')} url={getTabUrl($router.path, 'terminal')} />
   {/snippet}
   {#snippet contentSnippet()}
     <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -98,6 +100,9 @@ function handleRemove(): void {
         <ErrorMessage error={configurationError} />
       {/if}
       <AgentWorkspaceDetailsSummary {workspaceSummary} {configuration} />
+    </Route>
+    <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
+      <AgentWorkspaceTerminal workspaceId={workspaceId} />
     </Route>
   {/snippet}
 </DetailsPage>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -10,7 +10,7 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
-import {agentWorkspaces, startAgentWorkspace, stopAgentWorkspace} from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaces, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
 
 interface Props {
   workspaceId: string;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
@@ -1,0 +1,131 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { get, writable } from 'svelte/store';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { agentWorkspaceTerminals } from '/@/stores/agent-workspace-terminal-store';
+import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
+
+import AgentWorkspaceTerminal from './AgentWorkspaceTerminal.svelte';
+
+vi.mock(import('tinro'));
+
+const routerStore = writable({
+  path: '/agent-workspaces/ws-1/terminal',
+  url: '/agent-workspaces/ws-1/terminal',
+  from: '/',
+  query: {} as Record<string, string>,
+  hash: '',
+});
+
+let shellInAgentWorkspaceMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(router).subscribe.mockImplementation(routerStore.subscribe);
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
+  });
+  shellInAgentWorkspaceMock = vi.mocked(window.shellInAgentWorkspace);
+  agentWorkspaceTerminals.set([]);
+  agentWorkspaceStatuses.clear();
+});
+
+test('shows empty screen when workspace is not running', async () => {
+  render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+
+  await waitFor(() => {
+    expect(screen.getByText('Workspace is not running')).toBeInTheDocument();
+  });
+});
+
+test('calls shellInAgentWorkspace when workspace is running', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockResolvedValue(sendCallbackId);
+
+  render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalled());
+  expect(shellInAgentWorkspaceMock).toHaveBeenCalledWith(
+    'ws-1',
+    expect.any(Function),
+    expect.any(Function),
+    expect.any(Function),
+  );
+});
+
+test('writes received data to xterm terminal', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onDataCallback: (data: string) => void = () => {};
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, onData: (data: string) => void, _onError: (error: string) => void, _onEnd: () => void) => {
+      onDataCallback = onData;
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalled());
+
+  onDataCallback('hello\nworld');
+
+  await waitFor(() => {
+    const liveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
+    expect(liveRegion).toHaveTextContent('hello world');
+  });
+});
+
+test('serializes terminal buffer to store on unmount', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onDataCallback: (data: string) => void = () => {};
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, onData: (data: string) => void, _onError: (error: string) => void, _onEnd: () => void) => {
+      onDataCallback = onData;
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalled());
+
+  onDataCallback('test output');
+
+  expect(get(agentWorkspaceTerminals)).toHaveLength(0);
+
+  renderObject.unmount();
+
+  const terminals = get(agentWorkspaceTerminals);
+  expect(terminals).toHaveLength(1);
+  expect(terminals[0]?.workspaceId).toBe('ws-1');
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { get, writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -128,4 +129,246 @@ test('serializes terminal buffer to store on unmount', async () => {
   const terminals = get(agentWorkspaceTerminals);
   expect(terminals).toHaveLength(1);
   expect(terminals[0]?.workspaceId).toBe('ws-1');
+});
+
+test('receiveEndCallback reconnects when shell ends while workspace is running', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onEndCallback: () => void = () => {};
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
+
+  onEndCallback();
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
+
+  expect(window.shellInAgentWorkspaceResize).toHaveBeenCalledTimes(2);
+});
+
+test('receiveEndCallback schedules reconnect when workspace is not running', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onEndCallback: () => void = () => {};
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
+
+  agentWorkspaceStatuses.set('ws-1', 'stopped');
+  await tick();
+  onEndCallback();
+
+  expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1);
+
+  agentWorkspaceStatuses.set('ws-1', 'running');
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
+});
+
+test('terminal reconnects via scheduleReconnect when immediate reconnect fails', async () => {
+  vi.useFakeTimers();
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onEndCallback: () => void = () => {};
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
+
+  shellInAgentWorkspaceMock.mockRejectedValueOnce(new Error('workspace is restarting'));
+
+  onEndCallback();
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  await vi.advanceTimersByTimeAsync(2000);
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(3));
+
+  renderObject.unmount();
+  vi.useRealTimers();
+});
+
+test('scheduleReconnect retries when restartTerminal fails inside the timer callback', async () => {
+  vi.useFakeTimers();
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onEndCallback: () => void = () => {};
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
+
+  shellInAgentWorkspaceMock.mockRejectedValueOnce(new Error('first failure'));
+  shellInAgentWorkspaceMock.mockRejectedValueOnce(new Error('second failure'));
+
+  onEndCallback();
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
+
+  await vi.advanceTimersByTimeAsync(2000);
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(3));
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  await vi.advanceTimersByTimeAsync(2000);
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(4));
+
+  renderObject.unmount();
+  vi.useRealTimers();
+});
+
+test('concurrent receiveEndCallback calls do not create duplicate connections', async () => {
+  vi.useFakeTimers();
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onEndCallback: () => void = () => {};
+  let resolveShell: ((id: number) => void) | undefined;
+  const sendCallbackId = 42;
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    () =>
+      new Promise<number>(resolve => {
+        resolveShell = resolve;
+      }),
+  );
+
+  onEndCallback();
+  onEndCallback();
+
+  resolveShell?.(sendCallbackId);
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
+
+  expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2);
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  await vi.advanceTimersByTimeAsync(2000);
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(3));
+
+  renderObject.unmount();
+  vi.useRealTimers();
+});
+
+test('receiveEndCallback during reconnect schedules safety-net retry to prevent freeze', async () => {
+  vi.useFakeTimers();
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  let onEndCallback: () => void = () => {};
+  let resolveShell: ((id: number) => void) | undefined;
+  const sendCallbackId = 42;
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    () =>
+      new Promise<number>(resolve => {
+        resolveShell = resolve;
+      }),
+  );
+
+  onEndCallback();
+  onEndCallback();
+
+  resolveShell?.(sendCallbackId);
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, onEnd: () => void) => {
+      onEndCallback = onEnd;
+      return sendCallbackId;
+    },
+  );
+
+  await vi.advanceTimersByTimeAsync(2000);
+  await vi.waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(3));
+
+  renderObject.unmount();
+  vi.useRealTimers();
+});
+
+test('$effect schedules reconnect when restartTerminal fails', async () => {
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  const sendCallbackId = 42;
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, _onEnd: () => void) => {
+      return sendCallbackId;
+    },
+  );
+
+  render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
+
+  agentWorkspaceStatuses.set('ws-1', 'stopped');
+  await tick();
+
+  shellInAgentWorkspaceMock.mockRejectedValueOnce(new Error('not ready yet'));
+  agentWorkspaceStatuses.set('ws-1', 'running');
+
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
+
+  shellInAgentWorkspaceMock.mockImplementation(
+    async (_id: string, _onData: (data: string) => void, _onError: (error: string) => void, _onEnd: () => void) => {
+      return sendCallbackId;
+    },
+  );
+
+  await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(3), { timeout: 5000 });
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
@@ -39,6 +39,9 @@ const workspace: AgentWorkspaceSummaryUI = {
     source: '/home/user/projects/test',
     configuration: '/home/user/.config/kaiden/workspaces/test.yaml',
   },
+  timestamps: {
+    created: Date.now(),
+  },
 };
 
 vi.mock(import('tinro'));

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
@@ -25,9 +25,21 @@ import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { agentWorkspaceTerminals } from '/@/stores/agent-workspace-terminal-store';
-import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaces, type AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
 
 import AgentWorkspaceTerminal from './AgentWorkspaceTerminal.svelte';
+
+const workspace: AgentWorkspaceSummaryUI = {
+  id: 'ws-1',
+  name: 'test-workspace',
+  project: 'test-project',
+  agent: 'test-agent',
+  state: 'stopped',
+  paths: {
+    source: '/home/user/projects/test',
+    configuration: '/home/user/.config/kaiden/workspaces/test.yaml',
+  },
+};
 
 vi.mock(import('tinro'));
 
@@ -52,7 +64,7 @@ beforeEach(() => {
   });
   shellInAgentWorkspaceMock = vi.mocked(window.shellInAgentWorkspace);
   agentWorkspaceTerminals.set([]);
-  agentWorkspaceStatuses.clear();
+  agentWorkspaces.set([]);
 });
 
 test('shows empty screen when workspace is not running', async () => {
@@ -64,7 +76,7 @@ test('shows empty screen when workspace is not running', async () => {
 });
 
 test('calls shellInAgentWorkspace when workspace is running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   const sendCallbackId = 42;
   shellInAgentWorkspaceMock.mockResolvedValue(sendCallbackId);
@@ -81,7 +93,7 @@ test('calls shellInAgentWorkspace when workspace is running', async () => {
 });
 
 test('writes received data to xterm terminal', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onDataCallback: (data: string) => void = () => {};
   const sendCallbackId = 42;
@@ -105,7 +117,7 @@ test('writes received data to xterm terminal', async () => {
 });
 
 test('serializes terminal buffer to store on unmount', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onDataCallback: (data: string) => void = () => {};
   const sendCallbackId = 42;
@@ -132,7 +144,7 @@ test('serializes terminal buffer to store on unmount', async () => {
 });
 
 test('receiveEndCallback reconnects when shell ends while workspace is running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onEndCallback: () => void = () => {};
   const sendCallbackId = 42;
@@ -153,7 +165,7 @@ test('receiveEndCallback reconnects when shell ends while workspace is running',
 });
 
 test('receiveEndCallback schedules reconnect when workspace is not running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onEndCallback: () => void = () => {};
   const sendCallbackId = 42;
@@ -167,19 +179,19 @@ test('receiveEndCallback schedules reconnect when workspace is not running', asy
   render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
   await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
 
-  agentWorkspaceStatuses.set('ws-1', 'stopped');
+  agentWorkspaces.set([{ ...workspace, state: 'stopped' }]);
   await tick();
   onEndCallback();
 
   expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1);
 
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
   await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
 });
 
 test('terminal reconnects via scheduleReconnect when immediate reconnect fails', async () => {
   vi.useFakeTimers();
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onEndCallback: () => void = () => {};
   const sendCallbackId = 42;
@@ -214,7 +226,7 @@ test('terminal reconnects via scheduleReconnect when immediate reconnect fails',
 
 test('scheduleReconnect retries when restartTerminal fails inside the timer callback', async () => {
   vi.useFakeTimers();
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onEndCallback: () => void = () => {};
   const sendCallbackId = 42;
@@ -253,7 +265,7 @@ test('scheduleReconnect retries when restartTerminal fails inside the timer call
 
 test('concurrent receiveEndCallback calls do not create duplicate connections', async () => {
   vi.useFakeTimers();
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onEndCallback: () => void = () => {};
   let resolveShell: ((id: number) => void) | undefined;
@@ -300,7 +312,7 @@ test('concurrent receiveEndCallback calls do not create duplicate connections', 
 
 test('receiveEndCallback during reconnect schedules safety-net retry to prevent freeze', async () => {
   vi.useFakeTimers();
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let onEndCallback: () => void = () => {};
   let resolveShell: ((id: number) => void) | undefined;
@@ -344,7 +356,7 @@ test('receiveEndCallback during reconnect schedules safety-net retry to prevent 
 });
 
 test('$effect schedules reconnect when restartTerminal fails', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   const sendCallbackId = 42;
   shellInAgentWorkspaceMock.mockImplementation(
@@ -356,11 +368,11 @@ test('$effect schedules reconnect when restartTerminal fails', async () => {
   render(AgentWorkspaceTerminal, { workspaceId: 'ws-1', screenReaderMode: true });
   await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(1));
 
-  agentWorkspaceStatuses.set('ws-1', 'stopped');
+  agentWorkspaces.set([{ ...workspace, state: 'stopped' }]);
   await tick();
 
   shellInAgentWorkspaceMock.mockRejectedValueOnce(new Error('not ready yet'));
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   await waitFor(() => expect(shellInAgentWorkspaceMock).toHaveBeenCalledTimes(2));
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+import '@xterm/xterm/css/xterm.css';
+
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { SerializeAddon } from '@xterm/addon-serialize';
+import { Terminal } from '@xterm/xterm';
+import { onDestroy, onMount } from 'svelte';
+import { router } from 'tinro';
+
+import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { getExistingTerminal, registerTerminal } from '/@/stores/agent-workspace-terminal-store';
+import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
+import { TerminalSettings } from '/@api/terminal/terminal-settings';
+
+interface Props {
+  workspaceId: string;
+  screenReaderMode?: boolean;
+}
+
+let { workspaceId, screenReaderMode = false }: Props = $props();
+let terminalXtermDiv: HTMLDivElement;
+let shellTerminal: Terminal;
+let currentRouterPath: string;
+let sendCallbackId: number | undefined;
+let serializeAddon: SerializeAddon;
+let inputDisposable: { dispose: () => void } | undefined;
+let handleResize: (() => void) | undefined;
+
+const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
+const isRunning = $derived(status === 'running');
+let lastStatus = $state<AgentWorkspaceStatus>('stopped');
+
+$effect(() => {
+  if (lastStatus === 'starting' && status === 'running') {
+    executeShellInWorkspace().catch((err: unknown) =>
+      console.error(`Error starting terminal for workspace ${workspaceId}`, err),
+    );
+  }
+  lastStatus = status;
+});
+
+router.subscribe(route => {
+  currentRouterPath = route.path;
+});
+
+function createDataCallback(): (data: string) => void {
+  return (data: string) => {
+    shellTerminal.write(data);
+  };
+}
+
+function receiveEndCallback(): void {
+  if (sendCallbackId && isRunning) {
+    window
+      .shellInAgentWorkspace(workspaceId, createDataCallback(), () => {}, receiveEndCallback)
+      .then(id => {
+        sendCallbackId = id;
+        inputDisposable?.dispose();
+        inputDisposable = shellTerminal?.onData(async data => {
+          await window.shellInAgentWorkspaceSend(id, data);
+        });
+      })
+      .catch((err: unknown) => console.error(`Error reopening terminal for workspace ${workspaceId}`, err));
+  }
+}
+
+async function executeShellInWorkspace(): Promise<void> {
+  if (!isRunning) {
+    return;
+  }
+  const callbackId = await window.shellInAgentWorkspace(
+    workspaceId,
+    createDataCallback(),
+    () => {},
+    receiveEndCallback,
+  );
+  await window.shellInAgentWorkspaceResize(callbackId, shellTerminal.cols, shellTerminal.rows);
+  inputDisposable?.dispose();
+  inputDisposable = shellTerminal?.onData(data => {
+    window.shellInAgentWorkspaceSend(callbackId, data).catch((error: unknown) => console.log(String(error)));
+  });
+  sendCallbackId = callbackId;
+}
+
+async function refreshTerminal(): Promise<void> {
+  if (!terminalXtermDiv) {
+    return;
+  }
+
+  const fontSize = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.FontSize,
+  );
+  const lineHeight = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
+  );
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
+
+  const existingTerminal = getExistingTerminal(workspaceId);
+
+  shellTerminal = new Terminal({
+    fontSize,
+    lineHeight,
+    screenReaderMode,
+    theme: getTerminalTheme(),
+    scrollback,
+  });
+
+  if (existingTerminal) {
+    shellTerminal.options = { fontSize, lineHeight };
+    shellTerminal.write(existingTerminal.terminal);
+  }
+
+  const fitAddon = new FitAddon();
+  serializeAddon = new SerializeAddon();
+  shellTerminal.loadAddon(fitAddon);
+  shellTerminal.loadAddon(serializeAddon);
+
+  shellTerminal.open(terminalXtermDiv);
+
+  handleResize = (): void => {
+    if (currentRouterPath.includes(`/agent-workspaces/${encodeURIComponent(workspaceId)}/terminal`)) {
+      fitAddon.fit();
+      if (sendCallbackId) {
+        window
+          .shellInAgentWorkspaceResize(sendCallbackId, shellTerminal.cols, shellTerminal.rows)
+          .catch((err: unknown) => console.error(`Error resizing terminal for workspace ${workspaceId}`, err));
+      }
+    }
+  };
+  window.addEventListener('resize', handleResize);
+  fitAddon.fit();
+}
+
+onMount(async () => {
+  await refreshTerminal();
+  await executeShellInWorkspace();
+});
+
+onDestroy(() => {
+  if (handleResize) {
+    window.removeEventListener('resize', handleResize);
+  }
+  inputDisposable?.dispose();
+  const terminalContent = serializeAddon?.serialize() ?? '';
+  registerTerminal({
+    workspaceId,
+    callbackId: sendCallbackId,
+    terminal: terminalContent,
+  });
+  serializeAddon?.dispose();
+  shellTerminal?.dispose();
+  sendCallbackId = undefined;
+});
+</script>
+
+<div
+  class="h-full p-[5px] pr-0 bg-[var(--pd-terminal-background)]"
+  bind:this={terminalXtermDiv}
+  class:hidden={!isRunning}>
+</div>
+
+<EmptyScreen
+  hidden={isRunning}
+  icon={NoLogIcon}
+  title="No Terminal"
+  message="Workspace is not running" />

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -4,6 +4,7 @@ import '@xterm/xterm/css/xterm.css';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
+import type { IDisposable } from '@xterm/xterm';
 import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -26,18 +27,59 @@ let shellTerminal: Terminal;
 let currentRouterPath: string;
 let sendCallbackId: number | undefined;
 let serializeAddon: SerializeAddon;
-let inputDisposable: { dispose: () => void } | undefined;
 let handleResize: (() => void) | undefined;
+let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+let onDataDisposable: IDisposable | undefined;
+let reconnecting = false;
 
 const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
 const isRunning = $derived(status === 'running');
-let lastStatus = $state<AgentWorkspaceStatus>('stopped');
+let lastStatus = $state('');
+
+function registerInputHandler(callbackId: number): void {
+  onDataDisposable?.dispose();
+  onDataDisposable = shellTerminal?.onData(data => {
+    window.shellInAgentWorkspaceSend(callbackId, data).catch((error: unknown) => console.log(String(error)));
+  });
+}
+
+function clearReconnectTimer(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+  }
+}
+
+function scheduleReconnect(): void {
+  if (reconnectTimer) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = undefined;
+    if (isRunning) {
+      restartTerminal().catch((err: unknown) => {
+        console.error(`Error reopening terminal for workspace ${workspaceId}`, err);
+        scheduleReconnect();
+      });
+    }
+  }, 2000);
+}
+
+async function restartTerminal(): Promise<void> {
+  if (reconnecting) return;
+  reconnecting = true;
+  try {
+    clearReconnectTimer();
+    await executeShellInWorkspace();
+  } finally {
+    reconnecting = false;
+  }
+}
 
 $effect(() => {
-  if (lastStatus === 'starting' && status === 'running') {
-    executeShellInWorkspace().catch((err: unknown) =>
-      console.error(`Error starting terminal for workspace ${workspaceId}`, err),
-    );
+  if (lastStatus !== '' && lastStatus !== 'running' && status === 'running') {
+    restartTerminal().catch((err: unknown) => {
+      console.error(`Error starting terminal for workspace ${workspaceId}`, err);
+      scheduleReconnect();
+    });
   }
   lastStatus = status;
 });
@@ -53,17 +95,20 @@ function createDataCallback(): (data: string) => void {
 }
 
 function receiveEndCallback(): void {
-  if (sendCallbackId && isRunning) {
-    window
-      .shellInAgentWorkspace(workspaceId, createDataCallback(), () => {}, receiveEndCallback)
-      .then(id => {
-        sendCallbackId = id;
-        inputDisposable?.dispose();
-        inputDisposable = shellTerminal?.onData(async data => {
-          await window.shellInAgentWorkspaceSend(id, data);
-        });
-      })
-      .catch((err: unknown) => console.error(`Error reopening terminal for workspace ${workspaceId}`, err));
+  if (!sendCallbackId) return;
+
+  if (reconnecting) {
+    scheduleReconnect();
+    return;
+  }
+
+  if (isRunning) {
+    restartTerminal().catch((err: unknown) => {
+      console.error(`Error reopening terminal for workspace ${workspaceId}`, err);
+      scheduleReconnect();
+    });
+  } else {
+    scheduleReconnect();
   }
 }
 
@@ -78,10 +123,7 @@ async function executeShellInWorkspace(): Promise<void> {
     receiveEndCallback,
   );
   await window.shellInAgentWorkspaceResize(callbackId, shellTerminal.cols, shellTerminal.rows);
-  inputDisposable?.dispose();
-  inputDisposable = shellTerminal?.onData(data => {
-    window.shellInAgentWorkspaceSend(callbackId, data).catch((error: unknown) => console.log(String(error)));
-  });
+  registerInputHandler(callbackId);
   sendCallbackId = callbackId;
 }
 
@@ -142,10 +184,11 @@ onMount(async () => {
 });
 
 onDestroy(() => {
+  clearReconnectTimer();
   if (handleResize) {
     window.removeEventListener('resize', handleResize);
   }
-  inputDisposable?.dispose();
+  onDataDisposable?.dispose();
   const terminalContent = serializeAddon?.serialize() ?? '';
   registerTerminal({
     workspaceId,

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -12,8 +12,7 @@ import { router } from 'tinro';
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 import { getExistingTerminal, registerTerminal } from '/@/stores/agent-workspace-terminal-store';
-import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces.svelte';
-import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 interface Props {
@@ -32,7 +31,8 @@ let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 let onDataDisposable: IDisposable | undefined;
 let reconnecting = false;
 
-const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
+const workspaceSummary = $derived($agentWorkspaces.find(ws => ws.id === workspaceId));
+const status = $derived(workspaceSummary?.state ?? 'stopped');
 const isRunning = $derived(status === 'running');
 let lastStatus = $state('');
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -97,6 +97,9 @@ function createDataCallback(): (data: string) => void {
 function receiveEndCallback(): void {
   if (!sendCallbackId) return;
 
+  sendCallbackId = undefined;
+  registerTerminal({ workspaceId, callbackId: undefined, terminal: serializeAddon?.serialize() ?? '' });
+
   if (reconnecting) {
     scheduleReconnect();
     return;
@@ -116,10 +119,22 @@ async function executeShellInWorkspace(): Promise<void> {
   if (!isRunning) {
     return;
   }
-  const existingTerminal = getExistingTerminal(workspaceId);
-  const callbackId =
-    existingTerminal?.callbackId ??
-    (await window.shellInAgentWorkspace(workspaceId, createDataCallback(), () => {}, receiveEndCallback));
+
+  const existing = getExistingTerminal(workspaceId);
+  if (existing?.callbackId !== undefined) {
+    sendCallbackId = existing.callbackId;
+    window.shellInAgentWorkspaceReattach(existing.callbackId, createDataCallback(), () => {}, receiveEndCallback);
+    registerInputHandler(existing.callbackId);
+    await window.shellInAgentWorkspaceResize(existing.callbackId, shellTerminal.cols, shellTerminal.rows);
+    return;
+  }
+
+  const callbackId = await window.shellInAgentWorkspace(
+    workspaceId,
+    createDataCallback(),
+    () => {},
+    receiveEndCallback,
+  );
   await window.shellInAgentWorkspaceResize(callbackId, shellTerminal.cols, shellTerminal.rows);
   registerInputHandler(callbackId);
   sendCallbackId = callbackId;
@@ -188,11 +203,7 @@ onDestroy(() => {
   }
   onDataDisposable?.dispose();
   const terminalContent = serializeAddon?.serialize() ?? '';
-  registerTerminal({
-    workspaceId,
-    callbackId: sendCallbackId,
-    terminal: terminalContent,
-  });
+  registerTerminal({ workspaceId, callbackId: sendCallbackId, terminal: terminalContent });
   serializeAddon?.dispose();
   shellTerminal?.dispose();
   sendCallbackId = undefined;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -116,12 +116,10 @@ async function executeShellInWorkspace(): Promise<void> {
   if (!isRunning) {
     return;
   }
-  const callbackId = await window.shellInAgentWorkspace(
-    workspaceId,
-    createDataCallback(),
-    () => {},
-    receiveEndCallback,
-  );
+  const existingTerminal = getExistingTerminal(workspaceId);
+  const callbackId =
+    existingTerminal?.callbackId ??
+    (await window.shellInAgentWorkspace(workspaceId, createDataCallback(), () => {}, receiveEndCallback));
   await window.shellInAgentWorkspaceResize(callbackId, shellTerminal.cols, shellTerminal.rows);
   registerInputHandler(callbackId);
   sendCallbackId = callbackId;

--- a/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceActions.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlay, faStop, faTerminal, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { router } from 'tinro';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
@@ -38,6 +39,13 @@ async function handleStartStop(): Promise<void> {
   }
 }
 
+function handleTerminal(): void {
+  if (!isRunning && !inProgress) {
+    startAgentWorkspace(object.id).catch(console.error);
+  }
+  router.goto(`/agent-workspaces/${encodeURIComponent(object.id)}/terminal`);
+}
+
 function handleRemove(): void {
   withConfirmation(
     () => window.removeAgentWorkspace(object.id).catch(console.error),
@@ -51,6 +59,10 @@ function handleRemove(): void {
   icon={isRunning ? faStop : faPlay}
   inProgress={inProgress}
   onClick={handleStartStop} />
+<ListItemButtonIcon
+  title="Open terminal for workspace {object.name}"
+  icon={faTerminal}
+  onClick={handleTerminal} />
 <ListItemButtonIcon
   title="Remove workspace"
   icon={faTrash}

--- a/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
@@ -50,7 +50,16 @@ test('replaces existing terminal for the same workspace', () => {
 });
 
 test('removes terminal entries when workspace disappears from agentWorkspaces', () => {
-  agentWorkspaces.set([{ id: 'ws-1', name: 'test', project: 'proj', paths: { source: '/s', configuration: '/c' } }]);
+  agentWorkspaces.set([
+    {
+      id: 'ws-1',
+      name: 'test',
+      project: 'proj',
+      agent: 'agent',
+      state: 'stopped',
+      paths: { source: '/s', configuration: '/c' },
+    },
+  ]);
 
   registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer' });
   expect(get(agentWorkspaceTerminals)).toHaveLength(1);
@@ -60,10 +69,28 @@ test('removes terminal entries when workspace disappears from agentWorkspaces', 
 });
 
 test('keeps terminal entries when workspace still exists', () => {
-  agentWorkspaces.set([{ id: 'ws-1', name: 'test', project: 'proj', paths: { source: '/s', configuration: '/c' } }]);
+  agentWorkspaces.set([
+    {
+      id: 'ws-1',
+      name: 'test',
+      project: 'proj',
+      agent: 'agent',
+      state: 'stopped',
+      paths: { source: '/s', configuration: '/c' },
+    },
+  ]);
 
   registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer' });
 
-  agentWorkspaces.set([{ id: 'ws-1', name: 'test', project: 'proj', paths: { source: '/s', configuration: '/c' } }]);
+  agentWorkspaces.set([
+    {
+      id: 'ws-1',
+      name: 'test',
+      project: 'proj',
+      agent: 'agent',
+      state: 'stopped',
+      paths: { source: '/s', configuration: '/c' },
+    },
+  ]);
   expect(get(agentWorkspaceTerminals)).toHaveLength(1);
 });

--- a/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { agentWorkspaceTerminals, getExistingTerminal, registerTerminal } from './agent-workspace-terminal-store';
+import { agentWorkspaces } from './agent-workspaces.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  agentWorkspaceTerminals.set([]);
+});
+
+test('registers and retrieves a terminal by workspace id', () => {
+  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer-content' });
+
+  const terminal = getExistingTerminal('ws-1');
+  expect(terminal).toBeDefined();
+  expect(terminal?.terminal).toBe('buffer-content');
+});
+
+test('returns undefined for non-existent workspace terminal', () => {
+  const terminal = getExistingTerminal('ws-unknown');
+  expect(terminal).toBeUndefined();
+});
+
+test('replaces existing terminal for the same workspace', () => {
+  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'old-buffer' });
+  registerTerminal({ workspaceId: 'ws-1', callbackId: 2, terminal: 'new-buffer' });
+
+  const terminals = get(agentWorkspaceTerminals);
+  expect(terminals).toHaveLength(1);
+  expect(terminals[0]?.terminal).toBe('new-buffer');
+});
+
+test('removes terminal entries when workspace disappears from agentWorkspaces', () => {
+  agentWorkspaces.set([{ id: 'ws-1', name: 'test', project: 'proj', paths: { source: '/s', configuration: '/c' } }]);
+
+  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer' });
+  expect(get(agentWorkspaceTerminals)).toHaveLength(1);
+
+  agentWorkspaces.set([]);
+  expect(get(agentWorkspaceTerminals)).toHaveLength(0);
+});
+
+test('keeps terminal entries when workspace still exists', () => {
+  agentWorkspaces.set([{ id: 'ws-1', name: 'test', project: 'proj', paths: { source: '/s', configuration: '/c' } }]);
+
+  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer' });
+
+  agentWorkspaces.set([{ id: 'ws-1', name: 'test', project: 'proj', paths: { source: '/s', configuration: '/c' } }]);
+  expect(get(agentWorkspaceTerminals)).toHaveLength(1);
+});

--- a/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
@@ -58,6 +58,9 @@ test('removes terminal entries when workspace disappears from agentWorkspaces', 
       agent: 'agent',
       state: 'stopped',
       paths: { source: '/s', configuration: '/c' },
+      timestamps: {
+        created: Date.now(),
+      },
     },
   ]);
 
@@ -77,6 +80,9 @@ test('keeps terminal entries when workspace still exists', () => {
       agent: 'agent',
       state: 'stopped',
       paths: { source: '/s', configuration: '/c' },
+      timestamps: {
+        created: Date.now(),
+      },
     },
   ]);
 
@@ -90,6 +96,9 @@ test('keeps terminal entries when workspace still exists', () => {
       agent: 'agent',
       state: 'stopped',
       paths: { source: '/s', configuration: '/c' },
+      timestamps: {
+        created: Date.now(),
+      },
     },
   ]);
   expect(get(agentWorkspaceTerminals)).toHaveLength(1);

--- a/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 });
 
 test('registers and retrieves a terminal by workspace id', () => {
-  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer-content' });
+  registerTerminal({ workspaceId: 'ws-1', terminal: 'buffer-content' });
 
   const terminal = getExistingTerminal('ws-1');
   expect(terminal).toBeDefined();
@@ -41,8 +41,8 @@ test('returns undefined for non-existent workspace terminal', () => {
 });
 
 test('replaces existing terminal for the same workspace', () => {
-  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'old-buffer' });
-  registerTerminal({ workspaceId: 'ws-1', callbackId: 2, terminal: 'new-buffer' });
+  registerTerminal({ workspaceId: 'ws-1', terminal: 'old-buffer' });
+  registerTerminal({ workspaceId: 'ws-1', terminal: 'new-buffer' });
 
   const terminals = get(agentWorkspaceTerminals);
   expect(terminals).toHaveLength(1);
@@ -61,7 +61,7 @@ test('removes terminal entries when workspace disappears from agentWorkspaces', 
     },
   ]);
 
-  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer' });
+  registerTerminal({ workspaceId: 'ws-1', terminal: 'buffer' });
   expect(get(agentWorkspaceTerminals)).toHaveLength(1);
 
   agentWorkspaces.set([]);
@@ -80,7 +80,7 @@ test('keeps terminal entries when workspace still exists', () => {
     },
   ]);
 
-  registerTerminal({ workspaceId: 'ws-1', callbackId: 1, terminal: 'buffer' });
+  registerTerminal({ workspaceId: 'ws-1', terminal: 'buffer' });
 
   agentWorkspaces.set([
     {

--- a/packages/renderer/src/stores/agent-workspace-terminal-store.ts
+++ b/packages/renderer/src/stores/agent-workspace-terminal-store.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
+
+import { agentWorkspaces } from './agent-workspaces.svelte';
+
+export interface TerminalOfAgentWorkspace {
+  workspaceId: string;
+  callbackId?: number;
+  terminal: string;
+}
+
+export const agentWorkspaceTerminals: Writable<TerminalOfAgentWorkspace[]> = writable([]);
+
+agentWorkspaces.subscribe(workspaces => {
+  const terminals = get(agentWorkspaceTerminals);
+  const toRemove: TerminalOfAgentWorkspace[] = [];
+  for (const terminal of terminals) {
+    const found = workspaces.find(ws => ws.id === terminal.workspaceId);
+    if (!found) {
+      toRemove.push(terminal);
+    }
+  }
+
+  for (const terminal of toRemove) {
+    agentWorkspaceTerminals.update(list => {
+      const index = list.indexOf(terminal);
+      if (index > -1) {
+        list.splice(index, 1);
+      }
+      return list;
+    });
+  }
+});
+
+export function registerTerminal(terminal: TerminalOfAgentWorkspace): void {
+  agentWorkspaceTerminals.update(list => {
+    return [...list.filter(t => t.workspaceId !== terminal.workspaceId), terminal];
+  });
+}
+
+export function getExistingTerminal(workspaceId: string): TerminalOfAgentWorkspace | undefined {
+  const terminals = get(agentWorkspaceTerminals);
+  return terminals.find(terminal => terminal.workspaceId === workspaceId);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
+      node-pty:
+        specifier: ^1.0.0
+        version: 1.1.0
       os-locale:
         specifier: ^6.0.2
         version: 6.0.2
@@ -5966,6 +5969,9 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -6000,6 +6006,9 @@ packages:
     resolution: {integrity: sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==}
     engines: {node: ^12.13 || ^14.13 || >=16}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -13671,6 +13680,8 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
+  node-addon-api@7.1.1: {}
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.4
@@ -13722,6 +13733,10 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
       - supports-color
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.27: {}
 


### PR DESCRIPTION
This PR adds support for opening the running workspace terminal in Kortex

To test this, create a workspace using cli 
`kdn init --runtime podman --agent claude`
Run kortex open the workspace terminal, start the workspace (you have to do it manually even if the workspace is actually running from CLI) - kortex is not detecting if the workspace is running or not... 

Closes https://github.com/kortex-hub/kortex/issues/1125

https://github.com/user-attachments/assets/f7c9c9a2-920d-4eeb-9d39-5ec33d2a7640

