### PR TITLE
feat: add drag and drop file support in chat input

### DIFF
--- a/packages/api/src/chat/chat-settings.ts
+++ b/packages/api/src/chat/chat-settings.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum ChatSettings {
+  SectionName = 'chat',
+  MaxDndFileSizeMB = 'maxAttachmentFileSize',
+}

--- a/packages/main/src/plugin/chat-init.ts
+++ b/packages/main/src/plugin/chat-init.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { ChatSettings } from '/@api/chat/chat-settings.js';
+import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
+@injectable()
+export class ChatInit {
+  constructor(@inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry) {}
+
+  init(): void {
+    const chatConfiguration: IConfigurationNode = {
+      id: 'preferences.chat',
+      title: 'Chat',
+      type: 'object',
+      properties: {
+        [ChatSettings.SectionName + '.' + ChatSettings.MaxDndFileSizeMB]: {
+          description: 'Maximum file size (in MB) for attachments. Files exceeding this limit are rejected.',
+          type: 'number',
+          default: 20,
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([chatConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -20,6 +20,7 @@
  * @module preload
  */
 import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -168,6 +169,7 @@ import { AuthenticationImpl } from './authentication.js';
 import { AutostartEngine } from './autostart-engine.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import { Certificates } from './certificates.js';
+import { ChatInit } from './chat-init.js';
 import { CliToolRegistry } from './cli-tool-registry.js';
 import { CloseBehavior } from './close-behavior.js';
 import { ColorRegistry } from './color-registry.js';
@@ -745,6 +747,11 @@ export class PluginSystem {
       const openDevToolsInit = container.get<OpenDevToolsInit>(OpenDevToolsInit);
       openDevToolsInit.init();
     }
+
+    // init chat configuration
+    container.bind<ChatInit>(ChatInit).toSelf().inSingletonScope();
+    const chatInit = container.get<ChatInit>(ChatInit);
+    chatInit.init();
 
     // init editor configuration
     container.bind<EditorInit>(EditorInit).toSelf().inSingletonScope();
@@ -3591,6 +3598,11 @@ export class PluginSystem {
 
     this.ipcHandle('path:mimeType', async (_listener, from: string): Promise<string> => {
       return lookup(from) || 'application/octet-stream';
+    });
+
+    this.ipcHandle('path:fileSize', async (_listener, filePath: string): Promise<number> => {
+      const stats = await fs.promises.stat(filePath);
+      return stats.size;
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -3211,6 +3211,10 @@ export function initExposure(): void {
     return ipcInvoke('path:mimeType', from);
   });
 
+  contextBridge.exposeInMainWorld('pathFileSize', async (filePath: string): Promise<number> => {
+    return ipcInvoke('path:fileSize', filePath);
+  });
+
   contextBridge.exposeInMainWorld(
     'listExtensionDevelopmentFolders',
     async (): Promise<ExtensionDevelopmentFolderInfo[]> => {

--- a/packages/renderer/src/lib/chat/components/multimodal-input.spec.ts
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.spec.ts
@@ -137,6 +137,18 @@ describe('multimodal-input drag and drop', () => {
     expect(attachments[0].url).toContain('data:image/png;base64,');
   });
 
+  test('dropping a file with empty MIME type defaults to application/octet-stream', async () => {
+    const { dropZone } = renderComponent();
+    const file = fakeFile('data.xyz', '', 'some-data');
+
+    await fireEvent.drop(dropZone, { dataTransfer: dataTransfer([file]) });
+
+    await waitFor(() => {
+      expect(attachments).toHaveLength(1);
+    });
+    expect(attachments[0].contentType).toBe('application/octet-stream');
+  });
+
   test('dropping multiple files adds all to attachments', async () => {
     const { dropZone } = renderComponent();
     const files = [fakeFile('a.txt', 'text/plain', 'hello'), fakeFile('b.json', 'application/json', '{}')];
@@ -179,6 +191,7 @@ describe('multimodal-input drag and drop', () => {
   });
 
   test('dropping an oversized file shows error toast and skips it', async () => {
+    vi.mocked(window.getConfigurationValue).mockResolvedValue(20);
     const { dropZone } = renderComponent();
     // Create a file stub with size > 20 MB
     const largeFile = fakeFile('huge.bin', 'application/octet-stream', 'x');
@@ -186,8 +199,15 @@ describe('multimodal-input drag and drop', () => {
 
     await fireEvent.drop(dropZone, { dataTransfer: dataTransfer([largeFile]) });
 
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('huge.bin'),
+        expect.objectContaining({
+          action: expect.objectContaining({ label: 'Settings' }),
+        }),
+      );
+    });
     expect(attachments).toHaveLength(0);
-    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('huge.bin'));
   });
 
   test('dropping a text selection is not intercepted', async () => {
@@ -203,6 +223,56 @@ describe('multimodal-input drag and drop', () => {
 
     expect(preventDefault).not.toHaveBeenCalled();
     expect(attachments).toHaveLength(0);
+  });
+
+  test('attach button rejects oversized file', async () => {
+    vi.mocked(window.getConfigurationValue).mockResolvedValue(20);
+    vi.mocked(window.openDialog).mockResolvedValue(['/path/to/huge.bin']);
+    vi.mocked(window.pathFileSize).mockResolvedValue(21 * 1024 * 1024);
+
+    renderComponent();
+    const attachButton = screen.getByRole('button', { name: 'Attach file' });
+    await fireEvent.click(attachButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('huge.bin'),
+        expect.objectContaining({
+          action: expect.objectContaining({ label: 'Settings' }),
+        }),
+      );
+    });
+    expect(attachments).toHaveLength(0);
+  });
+
+  test('attach button extracts filename from Windows path', async () => {
+    vi.mocked(window.getConfigurationValue).mockResolvedValue(20);
+    vi.mocked(window.openDialog).mockResolvedValue(['C:\\Users\\test\\huge.bin']);
+    vi.mocked(window.pathFileSize).mockResolvedValue(21 * 1024 * 1024);
+
+    renderComponent();
+    const attachButton = screen.getByRole('button', { name: 'Attach file' });
+    await fireEvent.click(attachButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('huge.bin'), expect.anything());
+    });
+  });
+
+  test('attach button allows file within size limit', async () => {
+    vi.mocked(window.getConfigurationValue).mockResolvedValue(20);
+    vi.mocked(window.openDialog).mockResolvedValue(['/path/to/small.txt']);
+    vi.mocked(window.pathFileSize).mockResolvedValue(1024);
+    vi.mocked(window.pathMimeType).mockResolvedValue('text/plain');
+
+    renderComponent();
+    const attachButton = screen.getByRole('button', { name: 'Attach file' });
+    await fireEvent.click(attachButton);
+
+    await waitFor(() => {
+      expect(attachments).toHaveLength(1);
+    });
+    expect(attachments[0].name).toBe('small.txt');
   });
 
   test('textarea is still present and functional', () => {

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -5,10 +5,12 @@ import { onMount, untrack } from 'svelte';
 import type { SvelteMap } from 'svelte/reactivity';
 import { innerWidth } from 'svelte/reactivity/window';
 import { toast } from 'svelte-sonner';
+import { router } from 'tinro';
 
 import { EditState } from '/@/lib/chat/hooks/edit-state.svelte';
 import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
 import { cn } from '/@/lib/chat/utils/shadcn';
+import { ChatSettings } from '/@api/chat/chat-settings';
 
 import ExportButton from './ExportButton.svelte';
 import ArrowUpIcon from './icons/arrow-up.svelte';
@@ -190,13 +192,37 @@ function fileUrl(filePath: string): string {
   return encodeURI(`file://${pathName}`).replace(/[?#]/g, encodeURIComponent);
 }
 
+const MAX_FILE_SIZE_KEY = `${ChatSettings.SectionName}.${ChatSettings.MaxDndFileSizeMB}`;
+const DEFAULT_MAX_FILE_SIZE_MB = 20;
+
+async function getMaxFileSizeBytes(): Promise<number> {
+  const maxSizeMB = (await window.getConfigurationValue<number>(MAX_FILE_SIZE_KEY)) ?? DEFAULT_MAX_FILE_SIZE_MB;
+  return maxSizeMB * 1024 * 1024;
+}
+
+function rejectOversizedFile(fileName: string, maxSizeMB: number): void {
+  toast.error(`${fileName} is too large to attach (max ${maxSizeMB} MB).`, {
+    action: {
+      label: 'Settings',
+      onClick: (): void => router.goto('/preferences/default/preferences.chat'),
+    },
+  });
+}
+
 async function handleFile(): Promise<void> {
   const filepath = await window.openDialog({
     title: 'Select a file',
   });
   if (filepath?.[0]) {
-    const mimeType = await window.pathMimeType(filepath?.[0]);
-    const url = fileUrl(filepath?.[0]);
+    const maxSizeBytes = await getMaxFileSizeBytes();
+    const fileSize = await window.pathFileSize(filepath[0]);
+    if (fileSize > maxSizeBytes) {
+      const fileName = filepath[0].split(/[/\\]/).pop() ?? filepath[0];
+      rejectOversizedFile(fileName, maxSizeBytes / (1024 * 1024));
+      return;
+    }
+    const mimeType = await window.pathMimeType(filepath[0]);
+    const url = fileUrl(filepath[0]);
     attachments.push({
       url,
       name: url.substring(url.lastIndexOf('/') + 1),
@@ -207,8 +233,6 @@ async function handleFile(): Promise<void> {
 
 let isDragging = $state(false);
 let dragDepth = 0;
-
-const MAX_DND_FILE_BYTES = 20 * 1024 * 1024; // 20 MB
 
 function isFileDrag(event: DragEvent): boolean {
   return event.dataTransfer?.types?.includes('Files') ?? false;
@@ -252,19 +276,21 @@ async function handleDrop(event: DragEvent): Promise<void> {
   const files = event.dataTransfer?.files;
   if (!files?.length) return;
 
+  const maxSizeBytes = await getMaxFileSizeBytes();
+
   // Collect file references synchronously before any async work
   const fileList = Array.from(files);
 
   for (const file of fileList) {
-    if (file.size > MAX_DND_FILE_BYTES) {
-      toast.error(`${file.name} is too large to attach via drag and drop (max 20 MB).`);
+    if (file.size > maxSizeBytes) {
+      rejectOversizedFile(file.name, maxSizeBytes / (1024 * 1024));
       continue;
     }
     const url = await readFileAsDataUrl(file);
     attachments.push({
       url,
       name: file.name,
-      contentType: file.type,
+      contentType: file.type || 'application/octet-stream',
     });
   }
 }


### PR DESCRIPTION
Following up on #1155, this PR adds Drag n' drop support for file attachments to the model chat.

Uses FileReader to read dropped files as data URLs, which works with Electron's context isolation (File.path is not available). Visualfeedback with dashed border on drag over.

https://github.com/user-attachments/assets/e59cd5db-8279-48b7-b58e-9097d1d31650


