### PR TITLE
feat: improve attachment handling in chat 

### DIFF
--- a/packages/renderer/src/lib/chat/components/PreviewAttachmentTestWrapper.svelte
+++ b/packages/renderer/src/lib/chat/components/PreviewAttachmentTestWrapper.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { Attachment } from '@ai-sdk/ui-utils';
+import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+import PreviewAttachment from './preview-attachment.svelte';
+
+let {
+  attachment,
+  uploading = false,
+  onremove,
+}: {
+  attachment: Attachment;
+  uploading?: boolean;
+  onremove?: () => void;
+} = $props();
+</script>
+
+<TooltipPrimitive.Provider>
+	<PreviewAttachment {attachment} {uploading} {onremove} />
+</TooltipPrimitive.Provider>

--- a/packages/renderer/src/lib/chat/components/messages/message-actions.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/message-actions.svelte
@@ -15,10 +15,12 @@ let {
   message,
   readonly,
   alwaysVisible = false,
+  hasCopyableText = true,
 }: {
   message: UIMessage;
   readonly: boolean;
   alwaysVisible?: boolean;
+  hasCopyableText?: boolean;
 } = $props();
 
 const editState = EditState.fromContext();
@@ -83,6 +85,7 @@ onDestroy(() => {
     </Tooltip>
   {/if}
 
+  {#if hasCopyableText}
   {#key copied}
     <Tooltip>
       <TooltipTrigger>
@@ -105,4 +108,5 @@ onDestroy(() => {
       <TooltipContent>{copied ? 'Copied!' : 'Copy'}</TooltipContent>
     </Tooltip>
   {/key}
+  {/if}
 </div>

--- a/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
+++ b/packages/renderer/src/lib/chat/components/messages/preview-message.svelte
@@ -40,6 +40,7 @@ const tools: Array<DynamicToolUIPart> = $derived(message.parts.filter(part => pa
 const reasoningParts = $derived(message.parts.filter(part => part.type === 'reasoning'));
 const textParts = $derived(message.parts.filter(part => part.type === 'text'));
 const hasText = $derived(textParts.some(part => part.text.trim().length > 0));
+const hasFiles = $derived(message.parts.some(part => part.type === 'file'));
 
 // Show spinner only for the last assistant message while loading (during reasoning or text generation)
 const isLastMessage = $derived(messages.length > 0 && messages[messages.length - 1].id === message.id);
@@ -56,10 +57,7 @@ const isGeneratingResponse = $derived(loading && isLastAssistantMessage);
 >
 
   <div
-    class={cn(
-      'flex w-full gap-4 group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-2xl',
-      'group-data-[role=user]/message:w-fit',
-    )}
+    class="flex w-full gap-4 group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-2xl"
   >
     {#if message.role === 'assistant'}
       <div
@@ -71,7 +69,7 @@ const isGeneratingResponse = $derived(loading && isLastAssistantMessage);
       </div>
     {/if}
 
-    <div class="flex w-full flex-col gap-4" use:codeCopyButtons>
+    <div class="flex w-full min-w-0 flex-col gap-4" use:codeCopyButtons>
       {#if message.role === 'assistant'}
         <!-- do we have tooling in parts ?-->
         {#if tools.length > 0}
@@ -80,10 +78,12 @@ const isGeneratingResponse = $derived(loading && isLastAssistantMessage);
       {/if}
 
       {#if message.parts.filter(part => part.type === 'file').length > 0}
-        <div class="flex flex-row justify-end gap-2">
-          {#each message.parts.filter(part => part.type === 'file') as attachment (attachment.url)}
-            <PreviewAttachment attachment={fileUIPart2Attachment(attachment)} />
-          {/each}
+        <div class="w-full overflow-x-auto overflow-y-visible">
+          <div class="ml-auto flex w-max flex-row gap-2">
+            {#each message.parts.filter(part => part.type === 'file') as attachment, i (`${attachment.url}:${i}`)}
+              <PreviewAttachment attachment={fileUIPart2Attachment(attachment)} />
+            {/each}
+          </div>
         </div>
       {/if}
 
@@ -96,7 +96,7 @@ const isGeneratingResponse = $derived(loading && isLastAssistantMessage);
       {#each textParts as part, i (`${message.id}-text-${i}`)}
         <div
           class={cn('flex flex-col gap-4 overflow-hidden [&_p:last-child]:mb-0 [&_p:last-child]:pb-0', {
-            'bg-primary text-primary-foreground rounded-xl px-3 pt-4': message.role === 'user',
+            'bg-primary text-primary-foreground ml-auto w-fit rounded-xl px-3 pt-4': message.role === 'user',
             'animate-fade-in': message.role === 'assistant',
           })}
         >
@@ -113,8 +113,8 @@ const isGeneratingResponse = $derived(loading && isLastAssistantMessage);
         </div>
       {/if}
 
-      {#if hasText && (message.role === 'user' || !isGeneratingResponse)}
-        <MessageActions {message} {readonly} alwaysVisible={isLastAssistantMessage && !isGeneratingResponse} />
+      {#if (hasText || hasFiles) && (message.role === 'user' || !isGeneratingResponse)}
+        <MessageActions {message} {readonly} alwaysVisible={isLastAssistantMessage && !isGeneratingResponse} hasCopyableText={hasText} />
       {/if}
     </div>
   </div>

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -9,6 +9,7 @@ import { router } from 'tinro';
 
 import { EditState } from '/@/lib/chat/hooks/edit-state.svelte';
 import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
+import { fileUIPart2Attachment } from '/@/lib/chat/utils/chat';
 import { cn } from '/@/lib/chat/utils/shadcn';
 import { ChatSettings } from '/@api/chat/chat-settings';
 
@@ -44,6 +45,7 @@ const editState = EditState.fromContext();
 
 let input = $state('');
 let savedInput = $state('');
+let savedAttachments = $state<Attachment[]>([]);
 let mounted = $state(false);
 let textareaRef = $state<HTMLTextAreaElement | null>(null);
 const storedInput = new LocalStorage('input', '');
@@ -53,13 +55,17 @@ const loading = $derived(
 
 $effect(() => {
   if (editState.editingMessage) {
-    const text = editState.editingMessage.parts
-      .filter(part => part.type === 'text')
-      .map(part => (part as { type: 'text'; text: string }).text)
-      .join('');
+    const parts = editState.editingMessage.parts;
     untrack(() => {
+      const text = parts
+        .filter(part => part.type === 'text')
+        .map(part => (part as { type: 'text'; text: string }).text)
+        .join('');
+      const fileAttachments = parts.filter(part => part.type === 'file').map(part => fileUIPart2Attachment(part));
       savedInput = input;
+      savedAttachments = [...attachments];
       input = text;
+      attachments = fileAttachments;
       // Wait for DOM to update before adjusting height
       requestAnimationFrame(() => {
         adjustHeight();
@@ -77,6 +83,8 @@ async function cancelEditing(): Promise<void> {
   editState.cancelEditing();
   input = savedInput;
   savedInput = '';
+  attachments = savedAttachments;
+  savedAttachments = [];
 
   // Wait for DOM to update before resetting height
   await new Promise(resolve => requestAnimationFrame(resolve));
@@ -103,12 +111,11 @@ function setInput(value: string): void {
   adjustHeight();
 }
 
+function removeAttachment(index: number): void {
+  attachments = attachments.filter((_, i) => i !== index);
+}
+
 function canSubmit(): boolean {
-  // When editing, only allow non-empty text (attachments are discarded in edit mode)
-  if (editState.isEditing) {
-    return input.trim().length > 0;
-  }
-  // When not editing, allow either text or attachments
   return input.trim().length > 0 || attachments.length > 0;
 }
 
@@ -120,9 +127,12 @@ async function submitForm(): Promise<void> {
 
   if (editState.editingMessage) {
     const editingMessage = editState.editingMessage;
+    const editedAttachments = attachments;
     // Clear input directly instead of using setInput('') to avoid calling adjustHeight() before DOM updates
     input = '';
     savedInput = '';
+    attachments = [];
+    savedAttachments = [];
     editState.cancelEditing();
 
     // Wait for DOM to update before resetting height
@@ -133,9 +143,15 @@ async function submitForm(): Promise<void> {
 
     const index = chatClient.messages.findIndex(m => m.id === editingMessage.id);
     if (index !== -1) {
+      const fileParts = editedAttachments.map(attachment => ({
+        type: 'file' as const,
+        url: attachment.url,
+        filename: attachment.name,
+        mediaType: attachment.contentType ?? 'application/octet-stream',
+      }));
       const updatedMessage = {
         ...editingMessage,
-        parts: [{ type: 'text' as const, text }],
+        parts: [...(text.trim().length > 0 ? [{ type: 'text' as const, text }] : []), ...fileParts],
       };
       chatClient.messages = [...chatClient.messages.slice(0, index), updatedMessage];
     }
@@ -210,19 +226,23 @@ function rejectOversizedFile(fileName: string, maxSizeMB: number): void {
 }
 
 async function handleFile(): Promise<void> {
-  const filepath = await window.openDialog({
-    title: 'Select a file',
+  const filepaths = await window.openDialog({
+    title: 'Select files',
+    selectors: ['openFile', 'multiSelections'],
   });
-  if (filepath?.[0]) {
-    const maxSizeBytes = await getMaxFileSizeBytes();
-    const fileSize = await window.pathFileSize(filepath[0]);
+  if (!filepaths?.length) return;
+
+  const maxSizeBytes = await getMaxFileSizeBytes();
+
+  for (const filepath of filepaths) {
+    const fileSize = await window.pathFileSize(filepath);
     if (fileSize > maxSizeBytes) {
-      const fileName = filepath[0].split(/[/\\]/).pop() ?? filepath[0];
+      const fileName = filepath.split(/[/\\]/).pop() ?? filepath;
       rejectOversizedFile(fileName, maxSizeBytes / (1024 * 1024));
-      return;
+      continue;
     }
-    const mimeType = await window.pathMimeType(filepath[0]);
-    const url = fileUrl(filepath[0]);
+    const mimeType = await window.pathMimeType(filepath);
+    const url = fileUrl(filepath);
     attachments.push({
       url,
       name: url.substring(url.lastIndexOf('/') + 1),
@@ -328,14 +348,6 @@ $effect((): (() => void) | void => {
     <SuggestedActions {chatClient} {selectedMCPTools} />
   {/if}
 
-  {#if attachments.length > 0}
-    <div class="flex flex-row items-end gap-2 overflow-x-scroll">
-      {#each attachments as attachment (attachment.url)}
-        <PreviewAttachment {attachment} />
-      {/each}
-    </div>
-  {/if}
-
   {#if editState.isEditing}
     <div class="text-muted-foreground px-3 pt-2 text-sm">Press ESC to cancel editing</div>
   {/if}
@@ -353,6 +365,18 @@ $effect((): (() => void) | void => {
     ondragleave={handleDragLeave}
     ondrop={(e): void => { handleDrop(e).catch(console.error); }}
   >
+    {#if attachments.length > 0}
+      <div
+        class="flex flex-row items-end gap-2 overflow-x-auto overflow-y-visible px-2 pt-1 pb-0"
+        onwheel={(e): void => { if (e.deltaX !== 0) e.stopPropagation(); }}
+        ontouchmove={(e): void => { e.stopPropagation(); }}
+      >
+        {#each attachments as attachment, index (`${attachment.url}:${index}`)}
+          <PreviewAttachment {attachment} onremove={(): void => removeAttachment(index)} />
+        {/each}
+      </div>
+    {/if}
+
     <Textarea
       bind:ref={textareaRef}
       placeholder="Send a message..."

--- a/packages/renderer/src/lib/chat/components/preview-attachment.spec.ts
+++ b/packages/renderer/src/lib/chat/components/preview-attachment.spec.ts
@@ -1,0 +1,124 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import type { Attachment } from '@ai-sdk/ui-utils';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PreviewAttachmentWrapper from './PreviewAttachmentTestWrapper.svelte';
+
+function getAttachmentContainer(): HTMLElement {
+  const container = document.querySelector('[data-slot="tooltip-trigger"]');
+  if (!container) throw new Error('Attachment container with [data-slot="tooltip-trigger"] not found');
+  return container as HTMLElement;
+}
+
+describe('preview-attachment.svelte', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function renderAttachment(props: { attachment: Attachment; uploading?: boolean; onremove?: () => void }): void {
+    render(PreviewAttachmentWrapper, props);
+  }
+
+  test('renders image attachment with alt text', () => {
+    const attachment: Attachment = {
+      url: 'file:///path/to/image.png',
+      name: 'image.png',
+      contentType: 'image/png',
+    };
+
+    renderAttachment({ attachment });
+
+    const img = screen.getByRole('img');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('alt', 'image.png');
+    expect(img).toHaveAttribute('src', 'file:///path/to/image.png');
+  });
+
+  test('renders non-image attachment without img element', () => {
+    const attachment: Attachment = {
+      url: 'file:///path/to/document.pdf',
+      name: 'document.pdf',
+      contentType: 'application/pdf',
+    };
+
+    renderAttachment({ attachment });
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByText('document.pdf')).toBeInTheDocument();
+  });
+
+  test('decodes URL-encoded file name in label', () => {
+    const attachment: Attachment = {
+      url: 'file:///path/to/my%20file%20(1).pdf',
+      name: 'my%20file%20(1).pdf',
+      contentType: 'application/pdf',
+    };
+
+    renderAttachment({ attachment });
+
+    expect(screen.getByText('my file (1).pdf')).toBeInTheDocument();
+  });
+
+  test('does not show remove button when onremove is not provided', async () => {
+    const attachment: Attachment = {
+      url: 'file:///path/to/file.txt',
+      name: 'file.txt',
+      contentType: 'text/plain',
+    };
+
+    renderAttachment({ attachment });
+
+    const container = getAttachmentContainer();
+    await fireEvent.mouseEnter(container);
+
+    expect(screen.queryByLabelText('Remove attachment')).not.toBeInTheDocument();
+  });
+
+  test('renders remove button when onremove is provided', () => {
+    const attachment: Attachment = {
+      url: 'file:///path/to/file.txt',
+      name: 'file.txt',
+      contentType: 'text/plain',
+    };
+    const onremove = vi.fn();
+
+    renderAttachment({ attachment, onremove });
+
+    expect(screen.getByLabelText('Remove attachment')).toBeInTheDocument();
+  });
+
+  test('calls onremove when remove button is clicked', async () => {
+    const attachment: Attachment = {
+      url: 'file:///path/to/file.txt',
+      name: 'file.txt',
+      contentType: 'text/plain',
+    };
+    const onremove = vi.fn();
+
+    renderAttachment({ attachment, onremove });
+
+    const removeButton = screen.getByLabelText('Remove attachment');
+    await fireEvent.click(removeButton);
+
+    expect(onremove).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/renderer/src/lib/chat/components/preview-attachment.svelte
+++ b/packages/renderer/src/lib/chat/components/preview-attachment.svelte
@@ -12,20 +12,35 @@ import {
   faFileVideo,
   faFileWord,
   faFileZipper,
+  faXmark,
 } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import LoaderIcon from './icons/loader.svelte';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
 let {
   attachment,
   uploading = false,
+  onremove,
 }: {
   attachment: Attachment;
   uploading?: boolean;
+  onremove?: () => void;
 } = $props();
 
-const { name, url, contentType } = $derived(attachment);
+const { url, contentType } = $derived(attachment);
+
+function decodeAttachmentName(raw?: string): string | undefined {
+  if (!raw) return undefined;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+const name = $derived(decodeAttachmentName(attachment.name));
 
 function getFileIcon(mimeType?: string): IconDefinition {
   if (!mimeType) return faFile;
@@ -54,25 +69,47 @@ function getFileIcon(mimeType?: string): IconDefinition {
 }
 </script>
 
-<div class="flex flex-col gap-2">
-	<div
-		class="bg-muted relative flex aspect-video h-16 w-20 flex-col items-center justify-center rounded-md"
-	>
-		{#if contentType?.startsWith('image')}
-			<img
-				src={url}
-				alt={name ?? 'An image attachment'}
-				class="size-full rounded-md object-cover"
-			/>
-		{:else}
-			<Icon icon={getFileIcon(contentType)} class="text-muted-foreground fa-2x" />
-		{/if}
+<Tooltip>
+	<TooltipTrigger>
+		{#snippet child({ props })}
+			<div
+				class="group/attachment flex flex-col gap-2 pt-2 pr-2"
+				{...props}
+			>
+				<div
+					class="bg-muted relative flex aspect-video h-16 w-20 flex-col items-center justify-center overflow-visible rounded-md"
+				>
+					{#if contentType?.startsWith('image')}
+						<img
+							src={url}
+							alt={name ?? 'An image attachment'}
+							class="size-full rounded-md object-cover"
+						/>
+					{:else}
+						<Icon icon={getFileIcon(contentType)} class="text-muted-foreground fa-2x" />
+					{/if}
 
-		{#if uploading}
-			<div class="absolute animate-spin text-zinc-500">
-				<LoaderIcon />
+					{#if uploading}
+						<div class="absolute animate-spin text-zinc-500">
+							<LoaderIcon />
+						</div>
+					{/if}
+
+					{#if onremove}
+						<button
+							class="absolute -top-1.5 -right-1.5 z-10 hidden h-4 w-4 items-center justify-center rounded-full bg-zinc-700 text-white group-hover/attachment:flex group-focus-within/attachment:flex"
+							onclick={onremove}
+							aria-label="Remove attachment"
+						>
+							<Icon icon={faXmark} class="text-[10px]" />
+						</button>
+					{/if}
+				</div>
+				<div class="max-w-16 truncate text-xs text-zinc-500">{name ?? 'Untitled'}</div>
 			</div>
-		{/if}
-	</div>
-	<div class="max-w-16 truncate text-xs text-zinc-500">{name}</div>
-</div>
+		{/snippet}
+	</TooltipTrigger>
+	{#if name}
+		<TooltipContent>{name}</TooltipContent>
+	{/if}
+</Tooltip>


### PR DESCRIPTION
- Add Svelte tooltip and remove button on attachment previews
- Decode file names for display in tooltips
- Support editing message attachments (save/restore on cancel)
- Allow multi-file selection in attach dialog
- Make attachment previews horizontally scrollable in messages
- Decouple message text bubble width from attachment count
- Prevent horizontal scroll gestures from triggering page navigation
- Add unit tests for preview-attachment component

https://github.com/user-attachments/assets/46f4a6d3-9535-4010-8af9-bf5fc59e1064

Fixes #526 
