### PR TITLE
fix: treat application/octet-stream as unknown instead of binary

### DIFF
--- a/packages/main/src/chat/file-content-detector.spec.ts
+++ b/packages/main/src/chat/file-content-detector.spec.ts
@@ -38,7 +38,6 @@ test.each([
   'audio/mpeg',
   'video/mp4',
   'application/pdf',
-  'application/octet-stream',
 ])('should detect MIME type %s as binary', mimeType => {
   expect(detector.isTextContent(mimeType, undefined, textBuffer)).toBe(false);
 });
@@ -69,5 +68,10 @@ test('should detect binary content with null bytes', () => {
 
 test('should not apply buffer fallback for known binary MIME types', () => {
   expect(detector.isTextContent('application/pdf', 'doc.pdf', textBuffer)).toBe(false);
-  expect(detector.isTextContent('application/octet-stream', undefined, textBuffer)).toBe(false);
+});
+
+test('should fall through to buffer detection for application/octet-stream', () => {
+  expect(detector.isTextContent('application/octet-stream', undefined, textBuffer)).toBe(true);
+  const binaryBuffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  expect(detector.isTextContent('application/octet-stream', undefined, binaryBuffer)).toBe(false);
 });

--- a/packages/main/src/chat/file-content-detector.ts
+++ b/packages/main/src/chat/file-content-detector.ts
@@ -27,7 +27,7 @@ import { isText } from 'istextorbinary';
  */
 export class FileContentDetector {
   private static readonly BINARY_MIME_PREFIXES = ['image/', 'audio/', 'video/'];
-  private static readonly BINARY_MIME_TYPES = new Set(['application/pdf', 'application/octet-stream']);
+  private static readonly BINARY_MIME_TYPES = new Set(['application/pdf']);
 
   /**
    * Determines whether a file should be sent as text content rather than a

--- a/packages/renderer/src/lib/chat/components/multimodal-input.spec.ts
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.spec.ts
@@ -137,7 +137,8 @@ describe('multimodal-input drag and drop', () => {
     expect(attachments[0].url).toContain('data:image/png;base64,');
   });
 
-  test('dropping a file with empty MIME type defaults to application/octet-stream', async () => {
+  test('dropping a file with empty MIME type resolves type from filename', async () => {
+    vi.mocked(window.pathMimeType).mockResolvedValue('application/octet-stream');
     const { dropZone } = renderComponent();
     const file = fakeFile('data.xyz', '', 'some-data');
 
@@ -146,6 +147,7 @@ describe('multimodal-input drag and drop', () => {
     await waitFor(() => {
       expect(attachments).toHaveLength(1);
     });
+    expect(window.pathMimeType).toHaveBeenCalledWith('data.xyz');
     expect(attachments[0].contentType).toBe('application/octet-stream');
   });
 

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -290,7 +290,7 @@ async function handleDrop(event: DragEvent): Promise<void> {
     attachments.push({
       url,
       name: file.name,
-      contentType: file.type || 'application/octet-stream',
+      contentType: file.type || (await window.pathMimeType(file.name)),
     });
   }
 }


### PR DESCRIPTION
When files are drag-and-dropped, the browser often returns an empty
MIME type for unrecognized extensions (e.g. .java, .ts, .py). The
fallback was application/octet-stream, which FileContentDetector
treated as binary, causing text files to be sent as binary file
parts that providers like Ollama reject.

Two fixes:
- Resolve MIME type from filename via pathMimeType() when the
  browser's file.type is empty
- Remove application/octet-stream from the known binary list in
  FileContentDetector so it falls through to buffer-based text
  detection as a safety net

Try drag/dropping a text based file and send it