### PR TITLE
Workspace details page no config file error

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -186,11 +186,22 @@ describe('getConfiguration', () => {
     );
   });
 
-  test('rejects when reading the configuration file fails', async () => {
+  test('returns empty configuration when file does not exist', async () => {
     vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT: no such file'));
+    const enoent = Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
+    vi.mocked(readFile).mockRejectedValue(enoent);
 
-    await expect(manager.getConfiguration('ws-1')).rejects.toThrow('ENOENT: no such file');
+    const result = await manager.getConfiguration('ws-1');
+
+    expect(result).toEqual({});
+  });
+
+  test('rejects when reading the configuration file fails with a non-ENOENT error', async () => {
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SUMMARIES })));
+    const eacces = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+    vi.mocked(readFile).mockRejectedValue(eacces);
+
+    await expect(manager.getConfiguration('ws-1')).rejects.toThrow('EACCES: permission denied');
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -67,8 +67,15 @@ export class AgentWorkspaceManager implements Disposable {
     if (!workspace) {
       throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
     }
-    const content = await readFile(workspace.paths.configuration, 'utf-8');
-    return parseYAML(content) as AgentWorkspaceConfiguration;
+    try {
+      const content = await readFile(workspace.paths.configuration, 'utf-8');
+      return parseYAML(content) as AgentWorkspaceConfiguration;
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {} as AgentWorkspaceConfiguration;
+      }
+      throw error;
+    }
   }
 
   async start(id: string): Promise<AgentWorkspaceId> {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -100,13 +100,15 @@ test('Expect workspace summary with project is resolved from the store', () => {
   expect(resolved.find(ws => ws.id === 'ws-1')?.project).toBe('backend');
 });
 
-test('Expect error message displayed when configuration fetch fails', async () => {
-  vi.mocked(window.getAgentWorkspaceConfiguration).mockRejectedValue(new Error('workspace not found'));
+test('Expect page shell renders when configuration fetch fails', async () => {
+  vi.mocked(window.getAgentWorkspaceConfiguration).mockRejectedValue(new Error('ENOENT'));
 
-  render(AgentWorkspaceDetails, { workspaceId: 'ws-unknown' });
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 
   await waitFor(() => {
-    expect(screen.getByText('Error: workspace not found')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Start Workspace' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove Workspace' })).toBeInTheDocument();
+    expect(screen.getByText('Summary')).toBeInTheDocument();
   });
 });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -101,7 +101,7 @@ test('Expect workspace summary with project is resolved from the store', () => {
 });
 
 test('Expect page shell renders when configuration fetch fails', async () => {
-  vi.mocked(window.getAgentWorkspaceConfiguration).mockRejectedValue(new Error('ENOENT'));
+  vi.mocked(window.getAgentWorkspaceConfiguration).mockRejectedValue(new Error('EACCES: permission denied'));
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -34,14 +34,18 @@ const inProgress = $derived(status === 'starting' || status === 'stopping');
 
 $effect(() => {
   configurationError = undefined;
+  let current = true;
   window
     .getAgentWorkspaceConfiguration(workspaceId)
     .then(config => {
-      configuration = config;
+      if (current) configuration = config;
     })
     .catch((err: unknown) => {
-      configurationError = String(err);
+      if (current) configurationError = String(err);
     });
+  return (): void => {
+    current = false;
+  };
 });
 
 async function handleStartStop(): Promise<void> {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { Tab } from '@podman-desktop/ui-svelte';
+import { ErrorMessage, Tab } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import AgentWorkspaceDetailsSummary from '/@/lib/agent-workspaces/AgentWorkspaceDetailsSummary.svelte';
@@ -24,6 +24,7 @@ interface Props {
 let { workspaceId }: Props = $props();
 
 let configuration: Awaited<ReturnType<typeof window.getAgentWorkspaceConfiguration>> = $state({});
+let configurationError: string | undefined = $state(undefined);
 
 const workspaceSummary = $derived($agentWorkspaces.find(ws => ws.id === workspaceId));
 
@@ -36,8 +37,11 @@ $effect(() => {
     .getAgentWorkspaceConfiguration(workspaceId)
     .then(config => {
       configuration = config;
+      configurationError = undefined;
     })
-    .catch(console.error);
+    .catch((err: unknown) => {
+      configurationError = String(err);
+    });
 });
 
 async function handleStartStop(): Promise<void> {
@@ -92,6 +96,9 @@ function handleRemove(): void {
   {/snippet}
   {#snippet contentSnippet()}
     <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+      {#if configurationError}
+        <ErrorMessage error={configurationError} />
+      {/if}
       <AgentWorkspaceDetailsSummary {workspaceSummary} {configuration} />
     </Route>
   {/snippet}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { ErrorMessage, Spinner, Tab } from '@podman-desktop/ui-svelte';
+import { Tab } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import AgentWorkspaceDetailsSummary from '/@/lib/agent-workspaces/AgentWorkspaceDetailsSummary.svelte';
@@ -23,12 +23,22 @@ interface Props {
 
 let { workspaceId }: Props = $props();
 
-const configurationPromise = $derived(window.getAgentWorkspaceConfiguration(workspaceId));
+let configuration: Awaited<ReturnType<typeof window.getAgentWorkspaceConfiguration>> = $state({});
+
 const workspaceSummary = $derived($agentWorkspaces.find(ws => ws.id === workspaceId));
 
 const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
 const isRunning = $derived(status === 'running' || status === 'stopping');
 const inProgress = $derived(status === 'starting' || status === 'stopping');
+
+$effect(() => {
+  window
+    .getAgentWorkspaceConfiguration(workspaceId)
+    .then(config => {
+      configuration = config;
+    })
+    .catch(console.error);
+});
 
 async function handleStartStop(): Promise<void> {
   if (inProgress) return;
@@ -50,44 +60,39 @@ async function handleStartStop(): Promise<void> {
   }
 }
 
-function handleRemove(name: string): void {
-  withConfirmation(async () => {
-    try {
-      await window.removeAgentWorkspace(workspaceId);
-      router.goto('/agent-workspaces');
-    } catch (error: unknown) {
-      console.error('Failed to remove agent workspace', error);
-    }
-  }, `remove workspace ${name}`);
+function handleRemove(): void {
+  withConfirmation(
+    async () => {
+      try {
+        await window.removeAgentWorkspace(workspaceId);
+        router.goto('/agent-workspaces');
+      } catch (error: unknown) {
+        console.error('Failed to remove agent workspace', error);
+      }
+    },
+    `remove workspace ${workspaceSummary?.name ?? workspaceId}`,
+  );
 }
 </script>
 
-{#await configurationPromise}
-  <div class="flex items-center justify-center h-full">
-    <Spinner />
-  </div>
-{:then configuration}
-  <DetailsPage title={workspaceSummary?.name ?? ''}>
-    {#snippet actionsSnippet()}
-      <ListItemButtonIcon
-        title={isRunning ? 'Stop Workspace' : 'Start Workspace'}
-        onClick={handleStartStop}
-        icon={isRunning ? faStop : faPlay}
-        inProgress={inProgress} />
-      <ListItemButtonIcon
-        title="Remove Workspace"
-        onClick={handleRemove.bind(undefined, workspaceSummary?.name ?? '')}
-        icon={faTrash} />
-    {/snippet}
-    {#snippet tabsSnippet()}
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-    {/snippet}
-    {#snippet contentSnippet()}
-      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
-        <AgentWorkspaceDetailsSummary {workspaceSummary} {configuration} />
-      </Route>
-    {/snippet}
-  </DetailsPage>
-{:catch error}
-  <ErrorMessage error={String(error)} />
-{/await}
+<DetailsPage title={workspaceSummary?.name ?? ''}>
+  {#snippet actionsSnippet()}
+    <ListItemButtonIcon
+      title={isRunning ? 'Stop Workspace' : 'Start Workspace'}
+      onClick={handleStartStop}
+      icon={isRunning ? faStop : faPlay}
+      inProgress={inProgress} />
+    <ListItemButtonIcon
+      title="Remove Workspace"
+      onClick={handleRemove}
+      icon={faTrash} />
+  {/snippet}
+  {#snippet tabsSnippet()}
+    <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
+  {/snippet}
+  {#snippet contentSnippet()}
+    <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+      <AgentWorkspaceDetailsSummary {workspaceSummary} {configuration} />
+    </Route>
+  {/snippet}
+</DetailsPage>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -33,11 +33,11 @@ const isRunning = $derived(status === 'running' || status === 'stopping');
 const inProgress = $derived(status === 'starting' || status === 'stopping');
 
 $effect(() => {
+  configurationError = undefined;
   window
     .getAgentWorkspaceConfiguration(workspaceId)
     .then(config => {
       configuration = config;
-      configurationError = undefined;
     })
     .catch((err: unknown) => {
       configurationError = String(err);


### PR DESCRIPTION
- **Backend**: `getConfiguration` now catches `ENOENT` errors and returns an empty configuration instead of letting the error propagate — the config file is optional.
- **Frontend**: The details page no longer wraps the entire UI in `{#await}`. The page shell (title, action buttons, tabs) always renders using workspace summary data from the store. Configuration is loaded as a non-blocking `$effect` side effect, and unexpected errors (e.g. permission denied) are surfaced inline via `ErrorMessage` within the summary tab.
- **Tests**: Updated backend tests to verify ENOENT returns `{}` and non-ENOENT errors still throw. Updated frontend tests to verify the page renders normally when configuration is missing or fetch fails.