### PR TITLE
fix(mcp): normalize registry URLs, relax schema validation, improve loading UX

### DIFF
--- a/packages/main/src/plugin/mcp/mcp-registry.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.spec.ts
@@ -70,7 +70,7 @@ beforeEach(() => {
 
   mcpRegistry = new MCPRegistry(
     apiSender,
-    {} as Telemetry,
+    { track: vi.fn() } as unknown as Telemetry,
     {} as Certificates,
     proxy,
     {} as MCPManager,
@@ -130,6 +130,39 @@ test('listMCPServersFromRegistries strips trailing slashes from registry base UR
   expect(globalFetch).toHaveBeenCalledWith(
     'https://registry.example.com/base/v0/servers?version=latest',
     expect.anything(),
+  );
+});
+
+test('updateMCPRegistry sends normalized URL in API event and fire', async () => {
+  // Register with a normalized URL so the registry exists internally
+  mcpRegistry.registerMCPRegistry({ serverUrl: 'https://registry.example.com' }, false);
+
+  // Update using a non-normalized URL (trailing slash)
+  await mcpRegistry.updateMCPRegistry({ serverUrl: 'https://registry.example.com/' });
+
+  expect(apiSender.send).toHaveBeenCalledWith(
+    'mcp-registry-update',
+    expect.objectContaining({ serverUrl: 'https://registry.example.com' }),
+  );
+});
+
+test('updateMCPRegistry throws when registry not found after normalization', async () => {
+  await expect(mcpRegistry.updateMCPRegistry({ serverUrl: 'https://unknown.example.com/' })).rejects.toThrow(
+    'MCP Registry https://unknown.example.com was not found',
+  );
+});
+
+test('unsuggestMCPRegistry sends normalized URL in API event', () => {
+  // Suggest with a host-only URL (gets normalized to https://)
+  mcpRegistry.suggestMCPRegistry({ name: 'Test', url: 'registry.example.com' });
+  vi.mocked(apiSender.send).mockClear();
+
+  // Unsuggest using the non-normalized form
+  mcpRegistry.unsuggestMCPRegistry({ name: 'Test', url: 'registry.example.com/' });
+
+  expect(apiSender.send).toHaveBeenCalledWith(
+    'mcp-registry-update',
+    expect.objectContaining({ url: 'https://registry.example.com', name: 'Test' }),
   );
 });
 

--- a/packages/main/src/plugin/mcp/mcp-registry.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.spec.ts
@@ -27,7 +27,7 @@ import type { Proxy } from '../proxy.js';
 import type { SafeStorageRegistry } from '../safe-storage/safe-storage-registry.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
 import type { MCPManager } from './mcp-manager.js';
-import { MCPRegistry } from './mcp-registry.js';
+import { MCPRegistry, normalizeMcpRegistryServerUrl } from './mcp-registry.js';
 import type { MCPSchemaValidator } from './mcp-schema-validator.js';
 
 const proxy: Proxy = {
@@ -83,6 +83,54 @@ beforeEach(() => {
 
 afterEach(() => {
   console.error = originalConsoleError;
+});
+
+test('normalizeMcpRegistryServerUrl adds https for host-only input', () => {
+  expect(normalizeMcpRegistryServerUrl('registry.modelcontextprotocol.io')).toBe(
+    'https://registry.modelcontextprotocol.io',
+  );
+  expect(normalizeMcpRegistryServerUrl('  https://example.com/path  ')).toBe('https://example.com/path');
+  expect(normalizeMcpRegistryServerUrl('http://localhost:8080')).toBe('http://localhost:8080');
+});
+
+test('normalizeMcpRegistryServerUrl strips trailing slashes', () => {
+  expect(normalizeMcpRegistryServerUrl('https://registry.example.com/base///')).toBe(
+    'https://registry.example.com/base',
+  );
+  expect(normalizeMcpRegistryServerUrl('registry.example.com/')).toBe('https://registry.example.com');
+});
+
+test('listMCPServersFromRegistries uses https for host-only suggested registry URLs', async () => {
+  mcpRegistry.suggestMCPRegistry({
+    name: 'Host only',
+    url: 'registry.example.com',
+  });
+  globalFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ servers: [] }),
+  } as unknown as Response);
+
+  await mcpRegistry.listMCPServersFromRegistries();
+
+  expect(globalFetch).toHaveBeenCalledWith('https://registry.example.com/v0/servers?version=latest', expect.anything());
+});
+
+test('listMCPServersFromRegistries strips trailing slashes from registry base URL', async () => {
+  mcpRegistry.suggestMCPRegistry({
+    name: 'Trailing slashes',
+    url: 'https://registry.example.com/base///',
+  });
+  globalFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ servers: [] }),
+  } as unknown as Response);
+
+  await mcpRegistry.listMCPServersFromRegistries();
+
+  expect(globalFetch).toHaveBeenCalledWith(
+    'https://registry.example.com/base/v0/servers?version=latest',
+    expect.anything(),
+  );
 });
 
 test('listMCPServersFromRegistries', async () => {

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -357,15 +357,18 @@ export class MCPRegistry {
   }
 
   unsuggestMCPRegistry(registry: kaidenAPI.MCPRegistrySuggestedProvider): void {
-    const url = normalizeMcpRegistryServerUrl(registry.url);
+    const normalized: kaidenAPI.MCPRegistrySuggestedProvider = {
+      ...registry,
+      url: normalizeMcpRegistryServerUrl(registry.url),
+    };
     // Find the registry within this.suggestedRegistries[] and remove it
-    const index = this.suggestedRegistries.findIndex(reg => reg.url === url && reg.name === registry.name);
+    const index = this.suggestedRegistries.findIndex(reg => reg.url === normalized.url && reg.name === normalized.name);
     if (index > -1) {
       this.suggestedRegistries.splice(index, 1);
     }
 
     // Fire an update to the UI to remove the suggested registry
-    this.apiSender.send('mcp-registry-update', registry);
+    this.apiSender.send('mcp-registry-update', normalized);
   }
 
   unregisterMCPRegistry(registry: kaidenAPI.MCPRegistry, save: boolean): void {
@@ -734,17 +737,22 @@ export class MCPRegistry {
   }
 
   async updateMCPRegistry(registry: kaidenAPI.MCPRegistry): Promise<void> {
-    const serverUrl = normalizeMcpRegistryServerUrl(registry.serverUrl);
-    const matchingRegistry = this.registries.find(existingRegistry => serverUrl === existingRegistry.serverUrl);
+    const normalized: kaidenAPI.MCPRegistry = {
+      ...registry,
+      serverUrl: normalizeMcpRegistryServerUrl(registry.serverUrl),
+    };
+    const matchingRegistry = this.registries.find(
+      existingRegistry => normalized.serverUrl === existingRegistry.serverUrl,
+    );
     if (!matchingRegistry) {
-      throw new Error(`MCP Registry ${serverUrl} was not found`);
+      throw new Error(`MCP Registry ${normalized.serverUrl} was not found`);
     }
     this.telemetryService.track('updateMCPRegistry', {
       serverUrl: this.getRegistryHash(matchingRegistry),
       total: this.registries.length,
     });
-    this.apiSender.send('mcp-registry-update', registry);
-    this._onDidUpdateRegistry.fire(Object.freeze(registry));
+    this.apiSender.send('mcp-registry-update', normalized);
+    this._onDidUpdateRegistry.fire(Object.freeze(normalized));
   }
 
   getOptions(insecure?: boolean): OptionsOfTextResponseBody {

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -46,6 +46,28 @@ import { Disposable } from '../types/disposable.js';
 import { MCPManager } from './mcp-manager.js';
 import { MCPSchemaValidator } from './mcp-schema-validator.js';
 
+/**
+ * Returns an absolute registry base URL for HTTP requests. Host-only input (e.g.
+ * `registry.modelcontextprotocol.io`) is prefixed with `https://` so `new URL()` and `fetch` work.
+ */
+export function normalizeMcpRegistryServerUrl(serverUrl: string): string {
+  const trimmed = serverUrl.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  let result = trimmed;
+  if (!/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(result)) {
+    result = `https://${result}`;
+  }
+  // Strip trailing slashes so `/v0/servers` is appended cleanly.
+  // Uses a loop instead of regex to avoid sonarjs/slow-regex on `/\/+$/`.
+  let end = result.length;
+  while (end > 0 && result.charCodeAt(end - 1) === 47 /* / */) {
+    end--;
+  }
+  return end < result.length ? result.slice(0, end) : result;
+}
+
 interface RemoteStorageConfigFormat {
   serverId: string;
   remoteId: number;
@@ -271,6 +293,18 @@ export class MCPRegistry {
   }
 
   registerMCPRegistry(registry: kaidenAPI.MCPRegistry, save: boolean): Disposable {
+    const normalized: kaidenAPI.MCPRegistry = {
+      ...registry,
+      serverUrl: normalizeMcpRegistryServerUrl(registry.serverUrl),
+    };
+    return this.registerMCPRegistryNormalized(normalized, save);
+  }
+
+  /**
+   * Registers using an already-normalized `serverUrl` (e.g. after {@link createRegistry} normalized once).
+   * Public {@link registerMCPRegistry} normalizes then delegates here.
+   */
+  private registerMCPRegistryNormalized(registry: kaidenAPI.MCPRegistry, save: boolean): Disposable {
     console.log(`[MCPRegistry] registerMCPRegistry ${registry.serverUrl}`);
     const found = this.registries.find(reg => reg.serverUrl === registry.serverUrl);
     if (found) {
@@ -294,33 +328,38 @@ export class MCPRegistry {
   }
 
   suggestMCPRegistry(registry: kaidenAPI.MCPRegistrySuggestedProvider): Disposable {
+    const normalized: kaidenAPI.MCPRegistrySuggestedProvider = {
+      ...registry,
+      url: normalizeMcpRegistryServerUrl(registry.url),
+    };
     // Do not add it to the list if it's already been suggested by name & URL
     // this may have been done by another extension.
-    if (this.suggestedRegistries.find(reg => reg.url === registry.url && reg.name === registry.name)) {
+    if (this.suggestedRegistries.find(reg => reg.url === normalized.url && reg.name === normalized.name)) {
       // Ignore and don't register
-      console.log(`Registry already registered: ${registry.url}`);
+      console.log(`Registry already registered: ${normalized.url}`);
       return Disposable.noop();
     }
 
-    this.suggestedRegistries.push(registry);
-    this.apiSender.send('mcp-registry-update', registry);
+    this.suggestedRegistries.push(normalized);
+    this.apiSender.send('mcp-registry-update', normalized);
 
     this._onDidRegisterRegistry.fire({
-      name: registry.name,
-      serverUrl: registry.url,
-      icon: registry.icon,
+      name: normalized.name,
+      serverUrl: normalized.url,
+      icon: normalized.icon,
       alias: undefined,
     });
 
     // Create a disposable to remove the registry from the list
     return Disposable.create(() => {
-      this.unsuggestMCPRegistry(registry);
+      this.unsuggestMCPRegistry(normalized);
     });
   }
 
   unsuggestMCPRegistry(registry: kaidenAPI.MCPRegistrySuggestedProvider): void {
+    const url = normalizeMcpRegistryServerUrl(registry.url);
     // Find the registry within this.suggestedRegistries[] and remove it
-    const index = this.suggestedRegistries.findIndex(reg => reg.url === registry.url && reg.name === registry.name);
+    const index = this.suggestedRegistries.findIndex(reg => reg.url === url && reg.name === registry.name);
     if (index > -1) {
       this.suggestedRegistries.splice(index, 1);
     }
@@ -330,17 +369,21 @@ export class MCPRegistry {
   }
 
   unregisterMCPRegistry(registry: kaidenAPI.MCPRegistry, save: boolean): void {
-    const filtered = this.registries.filter(registryItem => registryItem.serverUrl !== registry.serverUrl);
+    const normalized: kaidenAPI.MCPRegistry = {
+      ...registry,
+      serverUrl: normalizeMcpRegistryServerUrl(registry.serverUrl),
+    };
+    const filtered = this.registries.filter(registryItem => registryItem.serverUrl !== normalized.serverUrl);
     if (filtered.length !== this.registries.length) {
-      this._onDidUnregisterRegistry.fire(Object.freeze({ ...registry }));
+      this._onDidUnregisterRegistry.fire(Object.freeze({ ...normalized }));
       this.registries = filtered;
       if (save) {
         this.saveRegistriesToConfig();
       }
-      this.apiSender.send('mcp-registry-unregister', registry);
+      this.apiSender.send('mcp-registry-unregister', normalized);
     }
     this.telemetryService.track('unregisterMCPRegistry', {
-      serverUrl: this.getRegistryHash(registry),
+      serverUrl: this.getRegistryHash(normalized),
       total: this.registries.length,
     });
   }
@@ -366,19 +409,25 @@ export class MCPRegistry {
 
   async createRegistry(registryCreateOptions: kaidenAPI.MCPRegistryCreateOptions): Promise<Disposable> {
     let telemetryOptions = {};
+    const normalized: kaidenAPI.MCPRegistryCreateOptions = {
+      ...registryCreateOptions,
+      serverUrl: normalizeMcpRegistryServerUrl(registryCreateOptions.serverUrl),
+    };
     try {
-      const exists = this.registries.find(registry => registry.serverUrl === registryCreateOptions.serverUrl);
+      const exists = this.registries.find(registry => registry.serverUrl === normalized.serverUrl);
       if (exists) {
-        throw new Error(`Registry ${registryCreateOptions.serverUrl} already exists`);
+        throw new Error(`Registry ${normalized.serverUrl} already exists`);
       }
 
-      return this.registerMCPRegistry(registryCreateOptions, true);
+      // `MCPRegistry` extends `MCPRegistryCreateOptions` with only optional fields (`name`, `icon`);
+      // create flow only supplies create-options, which is structurally valid for registration.
+      return this.registerMCPRegistryNormalized(normalized, true);
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;
     } finally {
       this.telemetryService.track('createMCPRegistry', {
-        serverUrlHash: this.getRegistryHash(registryCreateOptions),
+        serverUrlHash: this.getRegistryHash(normalized),
         total: this.registries.length,
         ...telemetryOptions,
       });
@@ -589,7 +638,8 @@ export class MCPRegistry {
     registryEntry?: MCPRegistryEntry,
     cursor?: string, // optional param for recursion
   ): Promise<ValidatedServerList> {
-    const url = new URL(`${registryURL}/v0/servers`);
+    const baseUrl = normalizeMcpRegistryServerUrl(registryURL);
+    const url = new URL(`${baseUrl}/v0/servers`);
     if (cursor) {
       url.searchParams.set('cursor', cursor);
     }
@@ -607,7 +657,7 @@ export class MCPRegistry {
     });
 
     if (!content.ok) {
-      throw new Error(`Failed to fetch MCP servers from ${registryURL}: ${content.statusText}`);
+      throw new Error(`Failed to fetch MCP servers from ${baseUrl}: ${content.statusText}`);
     }
 
     const data: components['schemas']['ServerList'] = await content.json();
@@ -617,7 +667,7 @@ export class MCPRegistry {
       const validationResult = this.schemaValidator.validateSchemaData(
         serverResponse,
         'ServerResponse',
-        registryURL,
+        baseUrl,
         false,
       );
       return {
@@ -631,7 +681,7 @@ export class MCPRegistry {
 
     // If pagination info exists, fetch the next page recursively
     if (data.metadata?.nextCursor) {
-      const nextPage = await this.fetchMCPServersFromRegistry(registryURL, registryEntry, data.metadata.nextCursor);
+      const nextPage = await this.fetchMCPServersFromRegistry(baseUrl, registryEntry, data.metadata.nextCursor);
       return {
         ...data,
         servers: [...validatedServers, ...nextPage.servers],
@@ -684,11 +734,10 @@ export class MCPRegistry {
   }
 
   async updateMCPRegistry(registry: kaidenAPI.MCPRegistry): Promise<void> {
-    const matchingRegistry = this.registries.find(
-      existingRegistry => registry.serverUrl === existingRegistry.serverUrl,
-    );
+    const serverUrl = normalizeMcpRegistryServerUrl(registry.serverUrl);
+    const matchingRegistry = this.registries.find(existingRegistry => serverUrl === existingRegistry.serverUrl);
     if (!matchingRegistry) {
-      throw new Error(`MCP Registry ${registry.serverUrl} was not found`);
+      throw new Error(`MCP Registry ${serverUrl} was not found`);
     }
     this.telemetryService.track('updateMCPRegistry', {
       serverUrl: this.getRegistryHash(matchingRegistry),
@@ -754,6 +803,7 @@ export class MCPRegistry {
   private loadRegistriesFromConfig(): void {
     this.registries = (this.configuration.get<kaidenAPI.MCPRegistry[]>(MCP_REGISTRIES) ?? []).map(registry => ({
       ...registry,
+      serverUrl: normalizeMcpRegistryServerUrl(registry.serverUrl),
       save: true,
     }));
   }

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
@@ -100,56 +100,44 @@ describe('validateSchemaData', () => {
     );
   });
 
-  test('should warn when server name does not match required pattern', () => {
-    const invalidServerResponse = {
+  test('should accept ServerResponse when only server name fails bundled reverse-DNS pattern', () => {
+    const serverResponse = {
       server: {
-        name: 'invalid-name-without-slash', // Should be in format "namespace/name"
+        name: 'com.github.mcp',
         description: 'Test',
         version: '1.0.0',
       },
       _meta: {},
     };
 
-    const result = validator.validateSchemaData(invalidServerResponse, 'ServerResponse', 'test-registry');
+    const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry');
 
-    expect(result).toBe(false);
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
-      invalidServerResponse,
-      'errors:',
-      expect.arrayContaining([
-        expect.objectContaining({
-          message: expect.stringContaining('pattern'),
-        }),
-      ]),
-    );
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
-  test('should warn when remote type is not a valid enum value', () => {
-    const invalidServerResponse = {
+  test('should still validate core server fields when packages/remotes are omitted from validation copy', () => {
+    const serverResponse = {
       server: {
-        name: 'io.github.example/test-server',
+        name: 'invalid-name-without-slash',
         description: 'Test',
         version: '1.0.0',
-        remotes: [
+        remotes: [{ type: 'invalid-type', url: 'https://example.com' }],
+        packages: [
           {
-            type: 'invalid-type', // Should be 'sse' or 'streamable-http'
-            url: 'https://example.com',
+            registryType: 'npm',
+            identifier: '@scope/pkg',
+            transport: { type: 'stdio' },
           },
         ],
       },
       _meta: {},
     };
 
-    const result = validator.validateSchemaData(invalidServerResponse, 'ServerResponse', 'test-registry');
+    const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry');
 
-    expect(result).toBe(false);
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
-      invalidServerResponse,
-      'errors:',
-      expect.anything(),
-    );
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   test('should validate valid ServerResponse with remotes', () => {
@@ -172,6 +160,92 @@ describe('validateSchemaData', () => {
 
     expect(result).toBe(true);
     expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  test('should validate ServerResponse when official registry _meta includes API-only fields (e.g. statusChangedAt)', () => {
+    const serverResponse = {
+      server: {
+        name: 'zone.example/registry-test',
+        description: 'Test',
+        version: '1.0.0',
+      },
+      _meta: {
+        'io.modelcontextprotocol.registry/official': {
+          status: 'active',
+          statusChangedAt: '2026-03-13T03:50:03.628037Z',
+          publishedAt: '2026-03-13T03:50:03.628037Z',
+          updatedAt: '2026-03-13T03:50:03.628037Z',
+          isLatest: true,
+        },
+      },
+    };
+
+    const result = validator.validateSchemaData(
+      serverResponse,
+      'ServerResponse',
+      'https://registry.modelcontextprotocol.io',
+    );
+
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(
+      (serverResponse._meta['io.modelcontextprotocol.registry/official'] as { statusChangedAt?: string })
+        .statusChangedAt,
+    ).toBe('2026-03-13T03:50:03.628037Z');
+  });
+
+  test('should validate ServerResponse when server.json packages/runtimeArguments are ahead of bundled schema', () => {
+    const serverResponse = {
+      server: {
+        name: 'io.github.example/memphora',
+        description: 'Memory',
+        version: '0.1.3',
+        packages: [
+          {
+            registryType: 'npm',
+            identifier: '@scope/pkg',
+            transport: { type: 'stdio' },
+            runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
+          },
+        ],
+      },
+      _meta: {},
+    };
+
+    const result = validator.validateSchemaData(
+      serverResponse,
+      'ServerResponse',
+      'https://registry.modelcontextprotocol.io',
+    );
+
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(serverResponse.server.packages?.[0]).toMatchObject({
+      runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
+    });
+  });
+
+  test('should validate ServerResponse when repository is an empty object (registry placeholder)', () => {
+    const serverResponse = {
+      server: {
+        name: 'io.github.example/scrimba-teaching',
+        description: 'Teaching',
+        version: '2.0.0',
+        repository: {},
+        packages: [{ registryType: 'npm', identifier: 'x', transport: { type: 'stdio' } }],
+      },
+      _meta: {},
+    };
+
+    const result = validator.validateSchemaData(
+      serverResponse,
+      'ServerResponse',
+      'https://registry.modelcontextprotocol.io',
+    );
+
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(serverResponse.server.repository).toEqual({});
   });
 
   test('should validate valid ServerDetail', () => {
@@ -337,10 +411,10 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
     expect(invalidServerNames.has('io.github.example/valid-server')).toBe(false);
   });
 
-  test('should identify invalid server with bad name pattern', () => {
+  test('should treat pattern-only server name as valid for registry compatibility', () => {
     const serverResponse = {
       server: {
-        name: 'invalid-name-no-slash', // Invalid pattern
+        name: 'invalid-name-no-slash',
         description: 'Invalid server',
         version: '1.0.0',
       },
@@ -349,7 +423,7 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
 
     const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry', true);
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   test('should return valid for all valid servers', () => {

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -37,7 +37,9 @@ function isCompleteRepositoryForBundledSchema(repository: unknown): boolean {
     return false;
   }
   const r = repository as Record<string, unknown>;
-  return typeof r.url === 'string' && r.url.length > 0 && typeof r.source === 'string' && r.source.length > 0;
+  return (
+    typeof r['url'] === 'string' && r['url'].length > 0 && typeof r['source'] === 'string' && r['source'].length > 0
+  );
 }
 
 /**
@@ -57,13 +59,13 @@ function normalizeServerResponseForSchemaValidation(jsonData: unknown): unknown 
   }
   const response = jsonData as Record<string, unknown>;
 
-  const server = response.server;
+  const server = response['server'];
   const serverIsObject = server !== null && typeof server === 'object' && !Array.isArray(server);
   const serverObj = serverIsObject ? (server as Record<string, unknown>) : null;
 
   const needsNestedOmit = serverObj && SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION.some(key => key in serverObj);
   const needsRepositoryOmit =
-    serverObj && 'repository' in serverObj && !isCompleteRepositoryForBundledSchema(serverObj.repository);
+    serverObj && 'repository' in serverObj && !isCompleteRepositoryForBundledSchema(serverObj['repository']);
 
   let nextServer = server;
   if (serverObj && (needsNestedOmit || needsRepositoryOmit)) {
@@ -74,12 +76,12 @@ function normalizeServerResponseForSchemaValidation(jsonData: unknown): unknown 
       }
     }
     if (needsRepositoryOmit) {
-      delete stripped.repository;
+      delete stripped['repository'];
     }
     nextServer = stripped;
   }
 
-  const meta = response._meta;
+  const meta = response['_meta'];
   const metaIsObject = meta !== null && typeof meta === 'object' && !Array.isArray(meta);
   const metaObj = metaIsObject ? (meta as Record<string, unknown>) : null;
 

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -20,6 +20,121 @@ import { type components, createValidator } from '@kortex-hub/mcp-registry-types
 import { injectable } from 'inversify';
 
 /**
+ * Keys allowed on `_meta['io.modelcontextprotocol.registry/official']` for validation normalization.
+ * When the official registry adds new properties, sync this set with the bundled OpenAPI in
+ * `@kortex-hub/mcp-registry-types` (e.g. `components.schemas` / ServerResponse `_meta`).
+ */
+const OFFICIAL_REGISTRY_META_KEYS = new Set(['status', 'publishedAt', 'updatedAt', 'isLatest']);
+
+const OFFICIAL_REGISTRY_META_KEY = 'io.modelcontextprotocol.registry/official';
+
+/** Nested `server` fields that track the upstream MCP server.json spec and often drift ahead of our bundled OpenAPI. */
+const SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION = ['packages', 'remotes', 'icons'] as const;
+
+/** `repository` is optional on ServerDetail; registries sometimes send `{}` which is invalid for bundled `Repository` (requires url + source). */
+function isCompleteRepositoryForBundledSchema(repository: unknown): boolean {
+  if (repository === null || typeof repository !== 'object' || Array.isArray(repository)) {
+    return false;
+  }
+  const r = repository as Record<string, unknown>;
+  return typeof r.url === 'string' && r.url.length > 0 && typeof r.source === 'string' && r.source.length > 0;
+}
+
+/**
+ * Build a shallow copy of a registry `ServerResponse` suitable for AJV validation against the
+ * bundled `@kortex-hub/mcp-registry-types` schema:
+ * - Official registry `_meta` may include keys not yet in the OpenAPI (e.g. `statusChangedAt`).
+ * - `server.packages` / `remotes` / `icons` follow the live MCP server.json schema and may use
+ *   shapes our package has not picked up yet.
+ * - `server.repository` may be `{}` or otherwise incomplete; we omit it for validation only when it
+ *   does not satisfy the bundled `Repository` schema.
+ *
+ * The original payload is never mutated; install/runtime code still sees the full server object.
+ */
+function normalizeServerResponseForSchemaValidation(jsonData: unknown): unknown {
+  if (jsonData === null || typeof jsonData !== 'object' || Array.isArray(jsonData)) {
+    return jsonData;
+  }
+  const response = jsonData as Record<string, unknown>;
+
+  const server = response.server;
+  const serverIsObject = server !== null && typeof server === 'object' && !Array.isArray(server);
+  const serverObj = serverIsObject ? (server as Record<string, unknown>) : null;
+
+  const needsNestedOmit = serverObj && SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION.some(key => key in serverObj);
+  const needsRepositoryOmit =
+    serverObj && 'repository' in serverObj && !isCompleteRepositoryForBundledSchema(serverObj.repository);
+
+  let nextServer = server;
+  if (serverObj && (needsNestedOmit || needsRepositoryOmit)) {
+    const stripped: Record<string, unknown> = { ...serverObj };
+    if (needsNestedOmit) {
+      for (const key of SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION) {
+        delete stripped[key];
+      }
+    }
+    if (needsRepositoryOmit) {
+      delete stripped.repository;
+    }
+    nextServer = stripped;
+  }
+
+  const meta = response._meta;
+  const metaIsObject = meta !== null && typeof meta === 'object' && !Array.isArray(meta);
+  const metaObj = metaIsObject ? (meta as Record<string, unknown>) : null;
+
+  let nextMeta = meta;
+  if (metaObj) {
+    const official = metaObj[OFFICIAL_REGISTRY_META_KEY];
+    const officialIsObject = official !== null && typeof official === 'object' && !Array.isArray(official);
+    const officialObj = officialIsObject ? (official as Record<string, unknown>) : null;
+
+    if (officialObj) {
+      const hasUnknownOfficialKey = Object.keys(officialObj).some(key => !OFFICIAL_REGISTRY_META_KEYS.has(key));
+      if (hasUnknownOfficialKey) {
+        const normalizedOfficial: Record<string, unknown> = {};
+        for (const key of OFFICIAL_REGISTRY_META_KEYS) {
+          if (key in officialObj) {
+            normalizedOfficial[key] = officialObj[key];
+          }
+        }
+        nextMeta = {
+          ...metaObj,
+          [OFFICIAL_REGISTRY_META_KEY]: normalizedOfficial,
+        };
+      }
+    }
+  }
+
+  const changedServer = Boolean(needsNestedOmit) || Boolean(needsRepositoryOmit);
+  const changedMeta = nextMeta !== meta;
+
+  if (!changedServer && !changedMeta) {
+    return jsonData;
+  }
+
+  return {
+    ...response,
+    server: nextServer,
+    _meta: nextMeta,
+  };
+}
+
+/**
+ * Third-party registries sometimes publish `server.name` values that do not match the bundled
+ * reverse-DNS pattern (e.g. `com.github.mcp` with no `/`). Treat pattern-only failures on
+ * `server.name` as acceptable so listing works without console noise; the real name is unchanged.
+ */
+function isOnlyServerNamePatternFailure(errors: unknown): boolean {
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return false;
+  }
+  return errors.every((e: { instancePath?: string; keyword?: string }) => {
+    return e.instancePath === '/server/name' && e.keyword === 'pattern';
+  });
+}
+
+/**
  * Service for validating MCP registry data against OpenAPI schemas.
  * Uses AJV validators created from the mcp-registry-types schemas.
  */
@@ -40,8 +155,15 @@ export class MCPSchemaValidator {
     contextName?: string,
     suppressWarnings: boolean = false,
   ): boolean {
+    const payloadForValidation =
+      schemaName === 'ServerResponse' ? normalizeServerResponseForSchemaValidation(jsonData) : jsonData;
+
     const validator = createValidator(schemaName);
-    const isValid = validator(jsonData);
+    let isValid = validator(payloadForValidation);
+
+    if (!isValid && schemaName === 'ServerResponse' && isOnlyServerNamePatternFailure(validator.errors)) {
+      isValid = true;
+    }
 
     if (!isValid && !suppressWarnings) {
       const context = contextName ? ` from '${contextName}'` : '';

--- a/packages/renderer/src/lib/mcp/MCPRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/mcp/MCPRegistriesEditing.svelte
@@ -57,113 +57,93 @@ async function removeExistingRegistry(registry: containerDesktopAPI.MCPRegistry)
   await window.unregisterMCPRegistry(registry);
 }
 </script>
-<div class="flex flex-col min-w-full h-full" role="region">
-  <div class="min-w-full px-5 py-4" role="region" aria-label="Header">
+<div class="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col" role="region">
+  <div class="min-w-0 w-full shrink-0 px-5 py-4" role="region" aria-label="Header">
     <div class="flex flex-row">
       <Button onclick={(): void => setNewRegistryFormVisible(true)} icon={faPlusCircle} disabled={showNewRegistryForm}>
         Add MCP registry
       </Button>
     </div>
   </div>
-  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
-    <div class="flex flex-col grow max-w-[905px] mx-auto">
-
-      <div class="container bg-[var(--pd-invert-content-card-bg)] rounded-md p-3">
-      <!-- Registries table start -->
-      <div class="w-full border-t border-b border-[var(--pd-content-text)]" role="table" aria-label="Registries">
-        <div
-          class="flex w-full space-x-2 text-sm font-semibold text-[var(--pd-table-header-text)]"
-          role="rowgroup"
-          aria-label="header">
-          <div class="text-left py-4 uppercase w-2/5 pl-5" role="columnheader">Registry Location</div>
-          <div class="text-left py-4 uppercase w-1/5" role="columnheader"></div>
-        </div>
-
+  <div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-5 py-4" role="region" aria-label="Content">
+    <div class="flex w-full min-w-0 flex-1 flex-col">
+      <div class="w-full min-w-0 rounded-md bg-[var(--pd-invert-content-card-bg)] p-3">
+      <table
+        class="registries-table w-full table-fixed border-collapse border-y border-[var(--pd-content-text)] text-[var(--pd-invert-content-card-text)] text-sm"
+        aria-label="Registries">
+        <colgroup>
+          <col class="w-[32%]" />
+          <col />
+          <col class="w-28" />
+        </colgroup>
+        <thead>
+          <tr class="border-b border-[var(--pd-content-text)] text-xs font-semibold uppercase tracking-wide text-[var(--pd-table-header-text)]">
+            <th class="py-3 pl-5 text-left font-semibold" scope="col">Registry</th>
+            <th class="py-3 pr-3 text-left font-semibold" scope="col">URL</th>
+            <th class="py-3 pr-5 text-right font-semibold" scope="col"><span class="sr-only">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
         {#each $mcpRegistriesInfos as registry, index (index)}
-          <!-- containerDesktopAPI.MCPRegistry row start -->
-          <div
-            class="flex flex-col w-full border-t border-[var(--pd-content-text)] text-[var(--pd-invert-content-card-text)]"
-            role="row"
-            aria-label={registry.name ?? registry.serverUrl}>
-            <div class="flex flex-row items-center pt-4 pb-3 space-x-2">
-              <div class="pl-5 w-2/5" role="cell">
-                <div class="flex w-full h-full">
-                  <div class="flex items-center">
-                    <!-- Only show if a "suggested" registry icon has been added -->
-                    {#if registry.icon}
-                      <IconImage image={registry.icon} class="w-6 h-6" alt={registry.name}></IconImage>
-                    {/if}
-                    {#if registry.name}
-                      <span class="ml-2">
-                        {registry.name}
-                      </span>
-                    {:else}
-                      <span class="ml-2">
-                        {registry.serverUrl.replace('https://', '')}
-                      </span>
-                    {/if}
-                  </div>
-                </div>
+          <tr class="border-t border-[var(--pd-content-text)] align-top" aria-label={registry.name ?? registry.serverUrl}>
+            <td class="py-3 pl-5 pr-2">
+              <div class="flex items-start gap-2">
+                <span class="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center" aria-hidden="true">
+                  {#if registry.icon}
+                    <IconImage image={registry.icon} class="h-6 w-6" alt={registry.name ?? ''}></IconImage>
+                  {/if}
+                </span>
+                <span class="min-w-0 break-words font-medium leading-snug">
+                  {#if registry.name}
+                    {registry.name}
+                  {:else}
+                    {registry.serverUrl.replace(/^https:\/\//, '')}
+                  {/if}
+                </span>
               </div>
-                <div class="w-1/5 flex space-x-2" role="cell">
-                {registry.serverUrl}
-              </div>
-              <div class="w-1/5 flex space-x-2 justify-end" role="cell">
-                <!-- Add remove button-->
-                <Button
-                  icon={faTrash}
-                  title="Remove MCP registry"
-                  onclick={(): Promise<void> => removeExistingRegistry(registry)}
-                  disabled={adding || originRegistries.some(r => r.serverUrl === registry.serverUrl)}>Remove</Button>
-              </div>
-            </div>
-          </div>
-          <div class="flex flex-row-reverse w-full pb-3 -mt-2">
-            <span class="w-2/3 pl-4 font-bold">
-              {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
+            </td>
+            <td class="py-3 pr-3 align-top break-words">
+              <Link
+                class="leading-snug"
+                on:click={(): Promise<void> => window.openExternal(registry.serverUrl)}>{registry.serverUrl}</Link>
+            </td>
+            <td class="py-3 pr-5 text-right align-top">
+              <Button
+                icon={faTrash}
+                title="Remove MCP registry"
+                onclick={(): Promise<void> => removeExistingRegistry(registry)}
+                disabled={adding || originRegistries.some(r => r.serverUrl === registry.serverUrl)}>Remove</Button>
+            </td>
+          </tr>
+          {#if originRegistries.some(r => r.serverUrl === registry.serverUrl) && errorResponses.find(o => o.serverUrl === registry.serverUrl)?.error}
+            <tr>
+              <td class="pb-3 pl-[calc(1.25rem+1.5rem)] pr-2 text-sm font-semibold text-[var(--pd-state-error)]" colspan="3">
                 {errorResponses.find(o => o.serverUrl === registry.serverUrl)?.error ?? ''}
-              {/if}
-            </span>
-          </div>
-          <!-- containerDesktopAPI.MCPRegistry row end -->
+              </td>
+            </tr>
+          {/if}
         {/each}
 
         {#each $mcpRegistriesSuggestedInfos as registry, i (i)}
-          <!-- Add new registry form start -->
-          <div
-            class="flex flex-col w-full border-t border-[var(--pd-content-text)] text-[var(--pd-invert-content-card-text)]"
-            role="row"
-            aria-label={registry.name ? registry.name : registry.url}>
-            <div class="flex flex-row items-center pt-4 pb-3 space-x-2">
-              <div class="pl-5 w-2/5" role="cell">
-                <div class="flex w-full h-full">
-                  <div class="flex items-center">
-                    {#if registry.icon}
-                      <IconImage image={registry.icon} class="w-6 h-6" alt={registry.name}></IconImage>
-                    {/if}
-                    <!-- By default, just show the name, but if we go to add it, show the full URL including https -->
-                    <span class="ml-2">
-                        {registry.name}
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div class="w-3/5" role="cell">
-                    <Link on:click={(): Promise<void> => window.openExternal(registry.url)}>{registry.url}</Link>
-              </div>
-              <div class="w-1/5 flex space-x-2 justify-end" role="cell">
-              </div>
-            </div>
-            <div class="flex flex-row w-full pb-3 -mt-2 pl-10">
-                <span class="font-bold whitespace-pre-line">
-                  {errorResponses.find(o => o.serverUrl === newRegistryRequest.serverUrl)?.error ?? ''}
+          <tr class="border-t border-[var(--pd-content-text)] align-top" aria-label={registry.name ? registry.name : registry.url}>
+            <td class="py-3 pl-5 pr-2">
+              <div class="flex items-start gap-2">
+                <span class="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center" aria-hidden="true">
+                  {#if registry.icon}
+                    <IconImage image={registry.icon} class="h-6 w-6" alt={registry.name ?? ''}></IconImage>
+                  {/if}
                 </span>
-            </div>
-          </div>
-          <!-- Add new registry form end -->
+                <span class="min-w-0 break-words font-medium leading-snug">{registry.name}</span>
+              </div>
+            </td>
+            <td class="py-3 pr-3 align-top break-words">
+              <Link class="leading-snug" on:click={(): Promise<void> => window.openExternal(registry.url)}>{registry.url}</Link>
+            </td>
+            <td class="py-3 pr-5 align-top"></td>
+          </tr>
         {/each}
-      </div>
-      <!-- Registries table end -->
+        </tbody>
+      </table>
       </div>
     </div>
   </div>

--- a/packages/renderer/src/lib/mcp/MCPServerList.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerList.svelte
@@ -31,7 +31,7 @@ let searchTerm = $state('');
   {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col">
       {#if selectedTab === 'READY'}
         <McpServerListRemoteReady bind:filter={searchTerm}/>
       {:else if selectedTab === 'INSTALLABLE'}

--- a/packages/renderer/src/lib/mcp/MCPServerListRegistryInstall.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerListRegistryInstall.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-import { FilteredEmptyScreen, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import { FilteredEmptyScreen, Spinner, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import SimpleColumn from '@podman-desktop/ui-svelte/TableSimpleColumn';
 
 import MCPValidServerIndicatorIcon from '/@/lib/images/MCPValidServerIndicatorIcon.svelte';
 import PreviousNext from '/@/lib/ui/PreviousNext.svelte';
 import {
   filteredMcpRegistriesServerInfos,
+  mcpRegistriesServerInfos,
   mcpRegistriesServerInfosSearchPattern,
+  mcpRegistryServersLoading,
 } from '/@/stores/mcp-registry-servers';
 import type { MCPServerDetail } from '/@api/mcp/mcp-server-info';
 
@@ -96,31 +98,55 @@ const columns = [
 const row = new TableRow<MCPServerDetail>({});
 </script>
 
-{#if servers.length === 0}
+{#if servers.length === 0 && !$mcpRegistryServersLoading}
   {#if filter}
     <FilteredEmptyScreen icon={McpIcon} kind="MCP Servers" bind:searchTerm={filter}/>
   {:else}
     <McpEmptyScreen />
   {/if}
 {:else}
-  <div class="flex flex-col h-full w-full">
-    {#if totalPages > 1}
-      <PreviousNext onPrevious={previousPage} onNext={nextPage} currentPage={currentPage} totalPages={totalPages}></PreviousNext>
+  <div class="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col">
+    {#if $mcpRegistryServersLoading}
+      <div
+        class="flex shrink-0 items-center gap-2 border-b border-[var(--pd-card-border)] px-3 py-2 text-sm text-[var(--pd-details-empty-sub-header)]"
+        aria-busy="true"
+        aria-live="polite">
+        <Spinner size="12" />
+        <span
+          >{$mcpRegistriesServerInfos.length === 0
+            ? 'Loading catalog…'
+            : 'Refreshing catalog…'}</span>
+      </div>
     {/if}
+    {#if servers.length === 0}
+      {#if filter}
+        <FilteredEmptyScreen icon={McpIcon} kind="MCP Servers" bind:searchTerm={filter}/>
+      {:else}
+        <div class="flex min-h-0 flex-1 flex-col px-3 pt-3" aria-live="polite">
+          <p class="text-pretty text-sm text-[var(--pd-details-empty-sub-header)]">
+            Fetching entries from your registries. Large catalogs may take a few minutes.
+          </p>
+        </div>
+      {/if}
+    {:else}
+      {#if totalPages > 1}
+        <PreviousNext onPrevious={previousPage} onNext={nextPage} currentPage={currentPage} totalPages={totalPages}></PreviousNext>
+      {/if}
 
-    <div class="flex">
-      <Table
-        kind="mcpServer"
-        bind:this={table}
-        data={paginatedServers}
-        columns={columns}
-        row={row}
-        defaultSortColumn="Name">
-      </Table>
-     </div>
+      <div class="flex min-h-0 min-w-0 w-full flex-1 overflow-x-auto">
+        <Table
+          kind="mcpServer"
+          bind:this={table}
+          data={paginatedServers}
+          columns={columns}
+          row={row}
+          defaultSortColumn="Name">
+        </Table>
+      </div>
 
-    {#if totalPages > 1}
-      <PreviousNext onPrevious={previousPage} onNext={nextPage} currentPage={currentPage} totalPages={totalPages}></PreviousNext>
+      {#if totalPages > 1}
+        <PreviousNext onPrevious={previousPage} onNext={nextPage} currentPage={currentPage} totalPages={totalPages}></PreviousNext>
+      {/if}
     {/if}
   </div>
 {/if}

--- a/packages/renderer/src/lib/mcp/MCPServerListRemoteReady.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerListRemoteReady.svelte
@@ -60,12 +60,13 @@ const row = new TableRow<MCPRemoteServerInfo>({});
     <MCPServerEmptyScreen />
   {/if}
 {:else}
-
-  <Table
-    kind="mcp"
-    data={servers}
-    columns={columns}
-    row={row}
-    defaultSortColumn="Name">
-  </Table>
+  <div class="flex min-h-0 min-w-0 w-full flex-1 overflow-x-auto">
+    <Table
+      kind="mcp"
+      data={servers}
+      columns={columns}
+      row={row}
+      defaultSortColumn="Name">
+    </Table>
+  </div>
 {/if}

--- a/packages/renderer/src/stores/mcp-registry-servers.ts
+++ b/packages/renderer/src/stores/mcp-registry-servers.ts
@@ -24,6 +24,15 @@ import type { MCPServerDetail } from '/@api/mcp/mcp-server-info';
 
 export const mcpRegistriesServerInfos: Writable<readonly MCPServerDetail[]> = writable([]);
 
+/**
+ * True while the main process is fetching the full MCP catalog.
+ * Starts as `true` so the Install tab shows loading until the first `fetchMcpRegistryServers()`
+ * run completes—avoids a flash of the wrong empty state.
+ * Fetch is always scheduled from this module (`system-ready` listener and `extensions-started` IPC);
+ * `fetchMcpRegistryServers` uses `finally` so the flag clears even when the request fails.
+ */
+export const mcpRegistryServersLoading: Writable<boolean> = writable(true);
+
 export const mcpRegistriesServerInfosSearchPattern = writable('');
 
 export const filteredMcpRegistriesServerInfos = derived(
@@ -38,8 +47,13 @@ export const filteredMcpRegistriesServerInfos = derived(
 );
 
 export async function fetchMcpRegistryServers(): Promise<void> {
-  const registries = await window.getMcpRegistryServers();
-  mcpRegistriesServerInfos.set(registries);
+  mcpRegistryServersLoading.set(true);
+  try {
+    const registries = await window.getMcpRegistryServers();
+    mcpRegistriesServerInfos.set(registries);
+  } finally {
+    mcpRegistryServersLoading.set(false);
+  }
 }
 
 // need to refresh when new registry are updated/deleted


### PR DESCRIPTION
Fixes https://github.com/openkaiden/kaiden/issues/1284

1. Normalize registry URLs (auto-add https://, strip trailing slashes)
2. Relax schema validation to stop rejecting valid servers from live registries
3. Add loading spinner to Install tab

Live registries return payloads with fields our bundled schema doesn't know about yet (statusChangedAt, new packages shapes, empty repository, etc). This caused [MCPSchemaValidator] Failed to validate data against schema 'ServerResponse' warnings flooding the console and valid servers being silently dropped from the catalog.

<img width="1510" height="831" alt="Screenshot 2026-04-08 at 5 54 06 PM" src="https://github.com/user-attachments/assets/f5c6a822-aa7d-4433-bb4f-cdae16eacf86" />
<img width="1800" height="841" alt="Screenshot 2026-04-08 at 5 54 38 PM" src="https://github.com/user-attachments/assets/bc46e2a7-19ae-48fa-8322-d7984f267965" />
<img width="639" height="597" alt="Screenshot 2026-04-08 at 5 54 51 PM" src="https://github.com/user-attachments/assets/fb1e1257-a9d1-493c-811b-423e67ef60b8" />



### How to test:
1. Open DevTools console, navigate to MCP registries                                                                                                                                                                      
2. Verify no [MCPSchemaValidator] Failed to validate data warnings appear
3. Add a registry using just a hostname (e.g. registry.modelcontextprotocol.io) — should resolve without error                                                                                                            
4. Open the Install tab — spinner should show while the catalog loads, no flash of empty state