### PR TITLE
feat: move model and MCP selection to the prompt input area

### DIFF
--- a/packages/renderer/src/lib/chat/components/ExportButton.svelte
+++ b/packages/renderer/src/lib/chat/components/ExportButton.svelte
@@ -76,7 +76,7 @@ const exportAsFlow = async (): Promise<void> => {
 </script>
 
 <Button
-	class="h-fit rounded-2xl p-[5px] mr-1 border"
+	class="h-8 px-2"
 	onclick={async(event): Promise<void> => {
 		event.preventDefault();
 		await exportAsFlow();

--- a/packages/renderer/src/lib/chat/components/chat-header.svelte
+++ b/packages/renderer/src/lib/chat/components/chat-header.svelte
@@ -4,11 +4,7 @@ import { innerWidth } from 'svelte/reactivity/window';
 /* eslint-enable import/no-duplicates */
 import { router } from 'tinro';
 
-import type { ModelInfo } from '/@/lib/chat/components/model-info';
-import ModelSelector from '/@/lib/chat/components/model-selector.svelte';
 import { currentChatId } from '/@/lib/chat/state/current-chat-id.svelte';
-import { cn } from '/@/lib/chat/utils/shadcn';
-import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 
 import Plus from './icons/plus.svelte';
 import SidebarToggle from './sidebar-toggle.svelte';
@@ -16,30 +12,7 @@ import { Button } from './ui/button';
 import { useSidebar } from './ui/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
-let {
-  readonly,
-  models,
-  selectedModel = $bindable<ModelInfo | undefined>(),
-  selectedMCPToolsCount,
-  mcpSelectorOpen = $bindable(),
-}: {
-  readonly: boolean;
-  selectedModel: ModelInfo | undefined;
-  models: Array<ModelInfo>;
-  /**
-   * Represent the number of tools selected
-   */
-  selectedMCPToolsCount: number;
-  mcpSelectorOpen: boolean;
-} = $props();
-
 const sidebar = useSidebar();
-
-const noMcps = $derived($mcpRemoteServerInfos.length === 0);
-
-function onToolSelection(): void {
-  mcpSelectorOpen = true;
-}
 </script>
 
 <header class="bg-background sticky top-0 flex items-start gap-2 p-2">
@@ -70,38 +43,4 @@ function onToolSelection(): void {
 			<TooltipContent side="bottom" >New Chat</TooltipContent>
 		</Tooltip>
 	{/if}
-
-	{#if !readonly}
-        <ModelSelector
-            class="order-1 md:order-2"
-            models={models}
-            bind:value={selectedModel}
-        />
-        <div class="flex flex-col gap-1">
-            {#if noMcps}
-                <div class="flex items-center gap-1 px-1 text-xs text-muted-foreground">
-                    <Button
-                        variant="link"
-                        class="h-auto p-0 text-xs hover:underline"
-                        onclick={():void => router.goto('/mcps')}
-                    >
-                        Configure MCP servers
-                    </Button>
-                </div>
-            {:else}
-              <Button
-                aria-label="Tools Selection"
-                variant="outline"
-                onclick={onToolSelection}
-                class={cn(
-					'data-[state=open]:bg-accent data-[state=open]:text-accent-foreground w-fit md:h-[34px] md:px-2',
-				)}>Tools Selection ({selectedMCPToolsCount})</Button>
-            {/if}
-        </div>
-    {/if}
-
-    <!-- {#if !readonly && chat}
-		<VisibilitySelector {chat} class="order-1 md:order-3" />
-	{/if} -->
-
 </header>

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -296,15 +296,7 @@ $effect(() => {
 </script>
 
 <div class="bg-background flex h-full min-w-0 flex-col">
-  {#if hasModels}
-	  <ChatHeader
-      bind:mcpSelectorOpen={mcpSelectorOpen}
-      {readonly}
-      models={models}
-      selectedMCPToolsCount={selectedMCPToolsCount}
-      bind:selectedModel={selectedModel}
-    />
-  {/if}
+  <ChatHeader />
   <div class="flex min-h-0 flex-1">
         {#if hasModels}
             <div class="flex flex-col flex-3/4">
@@ -315,7 +307,18 @@ $effect(() => {
                 />
                 <form class="bg-background mx-auto flex w-full gap-2 px-4 pb-4 md:max-w-3xl md:pb-6">
                     {#if !readonly}
-                        <MultimodalInput {attachments} {chatClient} {selectedModel} {selectedMCPTools} {hasActiveStream} {activeStreamOnDataId} class="flex-1" />
+                        <MultimodalInput
+                          {attachments}
+                          {chatClient}
+                          bind:selectedModel={selectedModel}
+                          {selectedMCPTools}
+                          {hasActiveStream}
+                          {activeStreamOnDataId}
+                          {models}
+                          bind:mcpSelectorOpen={mcpSelectorOpen}
+                          selectedMCPToolsCount={selectedMCPToolsCount}
+                          class="flex-1"
+                        />
                     {/if}
                 </form>
             </div>

--- a/packages/renderer/src/lib/chat/components/mcp-selector.svelte
+++ b/packages/renderer/src/lib/chat/components/mcp-selector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faToolbox } from '@fortawesome/free-solid-svg-icons/faToolbox';
-import Fa from 'svelte-fa';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { cn } from '/@/lib/chat/utils/shadcn';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
@@ -48,7 +48,7 @@ function onSelect(mcp: MCPRemoteServerInfo, event: Event): void {
         disabled={disabled}
         class={cn('data-[state=open]:bg-accent data-[state=open]:text-accent-foreground w-fit md:h-[34px] md:px-2', className)}
       >
-        <Fa icon={faToolbox} />
+        <Icon icon={faToolbox} />
         {selected.length} selected
         <ChevronDownIcon />
       </Button>

--- a/packages/renderer/src/lib/chat/components/model-selector.svelte
+++ b/packages/renderer/src/lib/chat/components/model-selector.svelte
@@ -31,11 +31,13 @@ import {
 let {
   class: c,
   models,
+  menuSide = 'bottom',
   value = $bindable<ModelInfo | undefined>(),
 }: {
-  class: ClassValue;
+  class?: ClassValue;
   value: ModelInfo | undefined;
   models: Array<ModelInfo>;
+  menuSide?: 'top' | 'bottom';
 } = $props();
 
 let groups: Map<string, Array<ModelInfo>> = $derived(groupAndSortModels(models));
@@ -87,7 +89,7 @@ $effect(() => {
 				aria-label="Select model"
 				variant="outline"
 				class={cn(
-					'data-[state=open]:bg-accent data-[state=open]:text-accent-foreground w-fit md:h-[34px] md:px-2',
+					'data-[state=open]:bg-accent data-[state=open]:text-accent-foreground w-fit h-8 px-2',
 					c
 				)}
 			>
@@ -96,7 +98,7 @@ $effect(() => {
 			</Button>
 		{/snippet}
 	</DropdownMenuTrigger>
-	<DropdownMenuContent bind:ref={contentContainer} align="start" class="min-w-[300px] max-h-[400px] overflow-y-auto">
+	<DropdownMenuContent bind:ref={contentContainer} align="start" side={menuSide} class="min-w-[300px] max-h-[400px] overflow-y-auto">
     {#each groups.entries() as [key, mModels] (key)}
 
       <DropdownMenuGroup>

--- a/packages/renderer/src/lib/chat/components/multimodal-input.spec.ts
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.spec.ts
@@ -129,6 +129,9 @@ describe('multimodal-input drag and drop', () => {
       attachments,
       chatClient: chatClient as never,
       selectedMCPTools: new Map() as never,
+      models: [],
+      selectedMCPToolsCount: 0,
+      mcpSelectorOpen: false,
     });
     // The drop target is the outer div with the border classes
     const dropZone = container.querySelector('.rounded-2xl')!;
@@ -336,6 +339,9 @@ describe('multimodal-input paste handling', () => {
       attachments,
       chatClient: createChatClient() as never,
       selectedMCPTools: new Map() as never,
+      models: [],
+      selectedMCPToolsCount: 0,
+      mcpSelectorOpen: false,
     });
     return screen.getByPlaceholderText('Send a message...');
   }

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import type { Chat } from '@ai-sdk/svelte';
 import type { Attachment } from '@ai-sdk/ui-utils';
+import { faToolbox } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount, untrack } from 'svelte';
 import type { SvelteMap } from 'svelte/reactivity';
 import { innerWidth } from 'svelte/reactivity/window';
@@ -11,6 +13,7 @@ import { EditState } from '/@/lib/chat/hooks/edit-state.svelte';
 import { LocalStorage } from '/@/lib/chat/hooks/local-storage.svelte';
 import { fileUIPart2Attachment } from '/@/lib/chat/utils/chat';
 import { cn } from '/@/lib/chat/utils/shadcn';
+import { mcpRemoteServerInfos, mcpRemoteServerInfosStatus } from '/@/stores/mcp-remote-servers';
 import { ChatSettings } from '/@api/chat/chat-settings';
 
 import ExportButton from './ExportButton.svelte';
@@ -18,6 +21,7 @@ import ArrowUpIcon from './icons/arrow-up.svelte';
 import PaperclipIcon from './icons/paperclip.svelte';
 import StopIcon from './icons/stop.svelte';
 import type { ModelInfo } from './model-info';
+import ModelSelector from './model-selector.svelte';
 import PreviewAttachment from './preview-attachment.svelte';
 import SuggestedActions from './suggested-actions.svelte';
 import { Button } from './ui/button';
@@ -27,16 +31,22 @@ let {
   attachments = $bindable(),
   chatClient,
   class: c,
+  models = [],
   selectedMCPTools,
-  selectedModel,
+  selectedModel = $bindable(),
+  selectedMCPToolsCount = 0,
+  mcpSelectorOpen = $bindable(false),
   hasActiveStream,
   activeStreamOnDataId,
 }: {
   attachments: Attachment[];
   chatClient: Chat;
   class?: string;
+  models?: Array<ModelInfo>;
   selectedMCPTools: SvelteMap<string, Set<string>>;
   selectedModel?: ModelInfo;
+  selectedMCPToolsCount?: number;
+  mcpSelectorOpen?: boolean;
   hasActiveStream?: boolean;
   activeStreamOnDataId?: number;
 } = $props();
@@ -52,6 +62,7 @@ const storedInput = new LocalStorage('input', '');
 const loading = $derived(
   chatClient.status === 'streaming' || chatClient.status === 'submitted' || hasActiveStream === true,
 );
+const noMcps = $derived($mcpRemoteServerInfosStatus === 'loaded' && $mcpRemoteServerInfos.length === 0);
 
 $effect(() => {
   if (editState.editingMessage) {
@@ -483,13 +494,37 @@ $effect((): (() => void) | void => {
         </Button>
       </div>
 
-      <div class="flex flex-row items-center justify-end gap-2">
+      <div class="flex flex-row items-center justify-end gap-1">
         <ExportButton {chatClient} {selectedModel} {loading} {selectedMCPTools} />
+        {#if noMcps}
+          <Button
+            variant="link"
+            class="h-auto p-0 text-xs hover:underline text-muted-foreground"
+            onclick={(): void => router.goto('/mcps')}
+          >
+            Configure MCP servers
+          </Button>
+        {:else}
+          <Button
+            aria-label="Tools Selection"
+            variant="outline"
+            onclick={(): void => { mcpSelectorOpen = true; }}
+            class="w-fit h-8 px-2"
+          >
+            <Icon icon={faToolbox} />
+            Tools ({selectedMCPToolsCount})
+          </Button>
+        {/if}
+        <ModelSelector
+          models={models}
+          menuSide="top"
+          bind:value={selectedModel}
+        />
         {#if loading}
           <Button
             aria-label="Stop generation"
             title="Stop generation"
-            class="h-fit rounded-full border border-[var(--pd-input-field-stroke)] p-1.5"
+            class="h-8 w-8 rounded-full border border-[var(--pd-input-field-stroke)] p-1.5"
             onclick={async (event): Promise<void> => {
               event.preventDefault();
               try {
@@ -507,7 +542,7 @@ $effect((): (() => void) | void => {
           <Button
               aria-label="Send message"
               title="Send message"
-              class="h-fit rounded-full border border-[var(--pd-input-field-stroke)] p-1.5"
+              class="h-8 w-8 rounded-full border border-[var(--pd-input-field-stroke)] p-1.5"
               onclick={async (event): Promise<void> => {
                 event.preventDefault();
                 await submitForm();

--- a/packages/renderer/src/stores/mcp-remote-servers.ts
+++ b/packages/renderer/src/stores/mcp-remote-servers.ts
@@ -23,6 +23,7 @@ import { findMatchInLeaves } from '/@/stores/search-util';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
 export const mcpRemoteServerInfos: Writable<readonly MCPRemoteServerInfo[]> = writable([]);
+export const mcpRemoteServerInfosStatus = writable<'idle' | 'loading' | 'loaded' | 'error'>('idle');
 
 export const mcpRemoteServerInfoSearchPattern = writable('');
 
@@ -36,8 +37,15 @@ export const filteredMcpRemoteServerInfos = derived(
 );
 
 export async function fetchMcpRemoteServers(): Promise<void> {
-  const data = await window.fetchMcpRemoteServers();
-  mcpRemoteServerInfos.set(data);
+  mcpRemoteServerInfosStatus.set('loading');
+  try {
+    const data = await window.fetchMcpRemoteServers();
+    mcpRemoteServerInfos.set(data);
+    mcpRemoteServerInfosStatus.set('loaded');
+  } catch (error) {
+    mcpRemoteServerInfosStatus.set('error');
+    throw error;
+  }
 }
 
 // need to refresh when new registry are updated/deleted

--- a/tests/playwright/src/model/pages/chat-page.ts
+++ b/tests/playwright/src/model/pages/chat-page.ts
@@ -109,12 +109,13 @@ export class ChatPage extends BasePage {
     // newChatButton is in the header only when the sidebar is collapsed; when open it moves into the sidebar
     const isSidebarOpen = await this.sidebarNewChatButton.isVisible();
     await expect(isSidebarOpen ? this.sidebarNewChatButton : this.newChatButton).toBeVisible();
-    await expect(this.modelDropdownSelector).toBeVisible();
   }
 
   async verifyInputAreaVisible(): Promise<void> {
     await expect(this.messageField).toBeVisible();
     await expect(this.sendButton).toBeVisible();
+    await expect(this.modelDropdownSelector).toBeVisible();
+    await expect(this.toolsSelectionButton.or(this.configureMcpServersButton)).toBeVisible();
   }
 
   async verifySuggestedMessagesVisible(minCount = 4): Promise<void> {


### PR DESCRIPTION
Move the model selector dropdown and MCP tools selection button from the
chat header into the bottom toolbar of the multimodal input card, closer
to the send button for a more cohesive UX.

<img width="1153" height="1010" alt="Screenshot 2026-04-09 at 09 15 49" src="https://github.com/user-attachments/assets/2064af5a-fd93-4531-bb5a-c722f41cd9b1" />
<img width="1153" height="1010" alt="Screenshot 2026-04-09 at 09 16 28" src="https://github.com/user-attachments/assets/9fe14e66-1631-4f05-9f01-8aceb324127f" />

Fixes #1139

