### PR TITLE
feat: added inference connection type

### DIFF
--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -196,6 +196,7 @@ describe('factory', () => {
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
       name: 'dum*****',
+      type: 'cloud',
       status: expect.any(Function),
       lifecycle: {
         delete: expect.any(Function),

--- a/extensions/gemini/src/gemini.ts
+++ b/extensions/gemini/src/gemini.ts
@@ -154,6 +154,7 @@ export class Gemini implements Disposable {
 
     const connectionDisposable = this.provider.registerInferenceProviderConnection({
       name: this.maskKey(token),
+      type: 'cloud',
       sdk: google,
       status(): ProviderConnectionStatus {
         return status;

--- a/extensions/ollama/src/ollama-extension.ts
+++ b/extensions/ollama/src/ollama-extension.ts
@@ -100,6 +100,7 @@ export class OllamaExtension {
         const sdk = createOllama();
         const disposable = ollamaProvider.registerInferenceProviderConnection({
           name: 'ollama',
+          type: 'local',
           sdk,
           status() {
             return 'started';

--- a/extensions/openai-compatible/src/openAI.spec.ts
+++ b/extensions/openai-compatible/src/openAI.spec.ts
@@ -177,6 +177,7 @@ describe('factory', () => {
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     const call = vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mock.calls[0][0];
     expect(call.name).toBe('http://localhost:11434/v1');
+    expect(call.type).toBe('cloud');
     expect(call.sdk).toBe(OPENAI_PROVIDER_MOCK);
     expect(call.status).toEqual(expect.any(Function));
     expect(call.lifecycle).toEqual({ delete: expect.any(Function) });

--- a/extensions/openai-compatible/src/openAI.ts
+++ b/extensions/openai-compatible/src/openAI.ts
@@ -186,6 +186,7 @@ export class OpenAI implements Disposable {
 
     const connectionDisposable = this.provider.registerInferenceProviderConnection({
       name: baseURL,
+      type: 'cloud',
       sdk: openai,
       status(): ProviderConnectionStatus {
         return status;

--- a/extensions/openshift-ai/src/openshiftai.ts
+++ b/extensions/openshift-ai/src/openshiftai.ts
@@ -257,6 +257,7 @@ export class OpenShiftAI implements Disposable {
 
       const connectionDisposable = this.provider.registerInferenceProviderConnection({
         name: baseURL,
+        type: 'self-hosted',
         sdk: openai,
         status(): ProviderConnectionStatus {
           return 'unknown'; // if status is not unknown we cannot delete the connection

--- a/extensions/ramalama/src/manager/inference-model-manager.spec.ts
+++ b/extensions/ramalama/src/manager/inference-model-manager.spec.ts
@@ -69,6 +69,7 @@ describe('InferenceModelManager', () => {
     expect(vi.mocked(ramaLamaProviderMock.registerInferenceProviderConnection)).toHaveBeenCalledWith(
       expect.objectContaining({
         name: `port/${modelPort}`,
+        type: 'local',
         sdk: sdkInstance,
         models: [{ label: modelName }],
       }),

--- a/extensions/ramalama/src/manager/inference-model-manager.ts
+++ b/extensions/ramalama/src/manager/inference-model-manager.ts
@@ -57,6 +57,7 @@ export class InferenceModelManager {
       });
       const disposable = this.ramaLamaProvider.registerInferenceProviderConnection({
         name: `port/${modelinfo.port}`,
+        type: 'local',
         sdk,
         status() {
           return 'started';

--- a/packages/api/src/chat/message-config.ts
+++ b/packages/api/src/chat/message-config.ts
@@ -5,6 +5,7 @@ export const MessageConfigSchema = z.object({
   modelId: z.string(),
   connectionName: z.string(),
   providerId: z.string(),
+  type: z.enum(['cloud', 'local', 'self-hosted']).optional(),
 });
 
 export type MessageConfig = z.output<typeof MessageConfigSchema>;

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type {
+  InferenceProviderConnectionType,
   Link,
   ProviderCleanupAction,
   ProviderConnectionStatus,
@@ -72,6 +73,7 @@ export interface ProviderFlowConnectionInfo {
 export interface ProviderInferenceConnectionInfo {
   connectionType: 'inference';
   name: string;
+  type: InferenceProviderConnectionType;
   status: ProviderConnectionStatus;
   lifecycleMethods?: LifecycleMethod[];
   models: Array<{

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -648,8 +648,11 @@ declare module '@openkaiden/api' {
     label: string;
   }
 
+  export type InferenceProviderConnectionType = 'cloud' | 'local' | 'self-hosted';
+
   export type InferenceProviderConnection = {
     name: string;
+    type: InferenceProviderConnectionType;
     sdk: AISDKInferenceProvider;
     credentials(): Record<string, string>;
     lifecycle?: ProviderConnectionLifecycle;

--- a/packages/main/src/chat/chat-manager.ts
+++ b/packages/main/src/chat/chat-manager.ts
@@ -376,6 +376,7 @@ export class ChatManager {
         modelId: params.modelId,
         connectionName: params.connectionName,
         providerId: params.providerId,
+        type: this.providerRegistry.getInferenceConnectionType(params.providerId, params.connectionName),
       };
       await this.chatQueries.saveMessages({
         messages: [

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -791,6 +791,7 @@ export class ProviderRegistry {
       providerConnection = {
         connectionType: 'inference',
         name: connection.name,
+        type: connection.type,
         models: connection.models,
         status: connection.status(),
       };
@@ -2030,6 +2031,16 @@ export class ProviderRegistry {
     const connection = provider.inferenceConnections.find(({ name }) => name === connectionName);
     if (!connection) throw new Error('Connection not found');
     return connection.sdk;
+  }
+
+  getInferenceConnectionType(providerId: string, connectionName: string): InferenceProviderConnection['type'] {
+    const internalId = this.getMatchingProviderInternalId(providerId);
+    const provider = this.providers.get(internalId);
+    if (!provider) throw new Error('Provider not found');
+
+    const connection = provider.inferenceConnections.find(({ name }) => name === connectionName);
+    if (!connection) throw new Error('Connection not found');
+    return connection.type;
   }
 
   getFirstInferenceSDK(providerName: string): ProviderV2 {

--- a/packages/renderer/src/lib/chat/components/chat.spec.ts
+++ b/packages/renderer/src/lib/chat/components/chat.spec.ts
@@ -30,13 +30,13 @@ beforeEach(() => {
 
 describe('findModel', () => {
   const models: ModelInfo[] = [
-    { providerId: 'ollama', connectionName: 'local', label: 'llama3' },
-    { providerId: 'ollama', connectionName: 'local', label: 'mistral' },
-    { providerId: 'gemini', connectionName: 'cloud', label: 'gemini-pro' },
+    { providerId: 'ollama', connectionName: 'local', label: 'llama3', type: 'local' },
+    { providerId: 'ollama', connectionName: 'local', label: 'mistral', type: 'local' },
+    { providerId: 'gemini', connectionName: 'cloud', label: 'gemini-pro', type: 'cloud' },
   ];
 
   test('should return matching model when all fields match', () => {
-    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'mistral' };
+    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'mistral', type: 'local' };
     const result = findModel(models, target);
     expect(result).toEqual(target);
   });
@@ -47,31 +47,36 @@ describe('findModel', () => {
   });
 
   test('should return undefined when no model matches', () => {
-    const target: ModelInfo = { providerId: 'openai', connectionName: 'remote', label: 'gpt-4' };
+    const target: ModelInfo = { providerId: 'openai', connectionName: 'remote', label: 'gpt-4', type: 'cloud' };
     const result = findModel(models, target);
     expect(result).toBeUndefined();
   });
 
   test('should return undefined when label does not match', () => {
-    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'nonexistent' };
+    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'nonexistent', type: 'local' };
     const result = findModel(models, target);
     expect(result).toBeUndefined();
   });
 
   test('should return undefined when providerId does not match', () => {
-    const target: ModelInfo = { providerId: 'wrong-provider', connectionName: 'local', label: 'llama3' };
+    const target: ModelInfo = { providerId: 'wrong-provider', connectionName: 'local', label: 'llama3', type: 'local' };
     const result = findModel(models, target);
     expect(result).toBeUndefined();
   });
 
   test('should return undefined when connectionName does not match', () => {
-    const target: ModelInfo = { providerId: 'ollama', connectionName: 'wrong-connection', label: 'llama3' };
+    const target: ModelInfo = {
+      providerId: 'ollama',
+      connectionName: 'wrong-connection',
+      label: 'llama3',
+      type: 'local',
+    };
     const result = findModel(models, target);
     expect(result).toBeUndefined();
   });
 
   test('should return undefined when models list is empty', () => {
-    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'llama3' };
+    const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'llama3', type: 'local' };
     const result = findModel([], target);
     expect(result).toBeUndefined();
   });

--- a/packages/renderer/src/lib/chat/components/chat.spec.ts
+++ b/packages/renderer/src/lib/chat/components/chat.spec.ts
@@ -75,6 +75,17 @@ describe('findModel', () => {
     expect(result).toBeUndefined();
   });
 
+  test('should return undefined when type does not match', () => {
+    const target: ModelInfo = {
+      providerId: 'ollama',
+      connectionName: 'local',
+      label: 'llama3',
+      type: 'cloud',
+    };
+    const result = findModel(models, target);
+    expect(result).toBeUndefined();
+  });
+
   test('should return undefined when models list is empty', () => {
     const target: ModelInfo = { providerId: 'ollama', connectionName: 'local', label: 'llama3', type: 'local' };
     const result = findModel([], target);

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -57,6 +57,7 @@ let selectedModel = $derived<ModelInfo | undefined>(
         connectionName: config.connectionName,
         label: config.modelId,
         providerId: config.providerId,
+        type: config.type ?? 'cloud',
       }
     : findModel(models, lastUsedModel.value) ?? models[0],
 );

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -4,7 +4,11 @@ import type { ModelInfo } from '/@/lib/chat/components/model-info';
 export function findModel(models: ModelInfo[], model: ModelInfo | undefined): ModelInfo | undefined {
   if (!model) return undefined;
   return models.find(
-    m => m.label === model.label && m.providerId === model.providerId && m.connectionName === model.connectionName,
+    m =>
+      m.label === model.label &&
+      m.providerId === model.providerId &&
+      m.connectionName === model.connectionName &&
+      m.type === model.type,
   );
 }
 </script>

--- a/packages/renderer/src/lib/chat/components/model-info.ts
+++ b/packages/renderer/src/lib/chat/components/model-info.ts
@@ -16,8 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { InferenceProviderConnectionType } from '@openkaiden/api';
+
 export interface ModelInfo {
   providerId: string;
   connectionName: string;
+  type: InferenceProviderConnectionType;
   label: string;
 }

--- a/packages/renderer/src/lib/chat/components/model-selector.spec.ts
+++ b/packages/renderer/src/lib/chat/components/model-selector.spec.ts
@@ -31,9 +31,9 @@ beforeEach(() => {
 describe('ModelSelector', () => {
   test('should sort models alphabetically within a single group', () => {
     const models: ModelInfo[] = [
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Zebra Model' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Alpha Model' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Model Beta' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Zebra Model', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Alpha Model', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Model Beta', type: 'cloud' },
     ];
 
     const groups = groupAndSortModels(models);
@@ -47,10 +47,10 @@ describe('ModelSelector', () => {
 
   test('should sort models alphabetically across multiple groups', () => {
     const models: ModelInfo[] = [
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Zebra' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Alpha' },
-      { providerId: 'provider2', connectionName: 'connection2', label: 'Zulu' },
-      { providerId: 'provider2', connectionName: 'connection2', label: 'Bravo' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Zebra', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Alpha', type: 'cloud' },
+      { providerId: 'provider2', connectionName: 'connection2', label: 'Zulu', type: 'cloud' },
+      { providerId: 'provider2', connectionName: 'connection2', label: 'Bravo', type: 'cloud' },
     ];
 
     const groups = groupAndSortModels(models);
@@ -68,9 +68,9 @@ describe('ModelSelector', () => {
 
   test('should handle case-insensitive sorting', () => {
     const models: ModelInfo[] = [
-      { providerId: 'provider1', connectionName: 'connection1', label: 'model-c' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Model-B' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'MODEL-A' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'model-c', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Model-B', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'MODEL-A', type: 'cloud' },
     ];
 
     const groups = groupAndSortModels(models);
@@ -84,10 +84,10 @@ describe('ModelSelector', () => {
 
   test('should handle special characters and numbers in model names', () => {
     const models: ModelInfo[] = [
-      { providerId: 'provider1', connectionName: 'connection1', label: 'model-3.5-turbo' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'model-4' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'model-4-turbo' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'model-3' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'model-3.5-turbo', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'model-4', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'model-4-turbo', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'model-3', type: 'cloud' },
     ];
 
     const groups = groupAndSortModels(models);
@@ -102,10 +102,10 @@ describe('ModelSelector', () => {
 
   test('should maintain separate sorted groups for different providers', () => {
     const models: ModelInfo[] = [
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Model Z' },
-      { providerId: 'provider1', connectionName: 'connection1', label: 'Model A' },
-      { providerId: 'provider2', connectionName: 'connection2', label: 'Model C' },
-      { providerId: 'provider2', connectionName: 'connection2', label: 'Model B' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Model Z', type: 'cloud' },
+      { providerId: 'provider1', connectionName: 'connection1', label: 'Model A', type: 'cloud' },
+      { providerId: 'provider2', connectionName: 'connection2', label: 'Model C', type: 'cloud' },
+      { providerId: 'provider2', connectionName: 'connection2', label: 'Model B', type: 'cloud' },
     ];
 
     const groups = groupAndSortModels(models);

--- a/packages/renderer/src/lib/models/models-utils.ts
+++ b/packages/renderer/src/lib/models/models-utils.ts
@@ -5,11 +5,12 @@ export function getModels(providerInfos: ProviderInfo[]): ModelInfo[] {
   return providerInfos.reduce(
     (accumulator, current) => {
       if (current.inferenceConnections.length > 0) {
-        for (const { name, models } of current.inferenceConnections) {
+        for (const { name, type, models } of current.inferenceConnections) {
           accumulator.push(
             ...models.map((model: { label: string }) => ({
               providerId: current.id,
               connectionName: name,
+              type,
               label: model.label,
             })),
           );


### PR DESCRIPTION
Adds type field for inderence connections

- LLMs provided: online (Anthropic, Gemini, OpenAPI, Mistral)...
-  Local (ramalama, ollama)
-  In house: everything else (OpenShift AI)

Closes https://github.com/openkaiden/kaiden/issues/1294