### PR TITLE
fix: update Claude extension to manage InferenceConnections

### DIFF
--- a/extensions/claude/package.json
+++ b/extensions/claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude",
-  "displayName": "Claude Skills",
-  "description": "Registers skills from the Claude skills directory ($HOME/.claude/skills)",
+  "displayName": "Claude",
+  "description": "Integration for Claude",
   "version": "0.0.1-next",
   "icon": "icon.png",
   "publisher": "kaiden",
@@ -11,6 +11,24 @@
   },
   "main": "./dist/extension.js",
   "source": "./src/extension.ts",
+  "contributes": {
+    "configuration": {
+      "title": "Claude",
+      "properties": {
+        "claude.factory._description": {
+          "type": "markdown",
+          "scope": "InferenceProviderConnectionFactory",
+          "markdownDescription": "Provide a Claude API key\n\n:button[Grab a key]{href=\"https://console.anthropic.com/settings/keys\"}"
+        },
+        "claude.factory.apiKey": {
+          "type": "string",
+          "scope": "InferenceProviderConnectionFactory",
+          "description": "Enter your Claude API key (ANTHROPIC_API_KEY)",
+          "format": "password"
+        }
+      }
+    }
+  },
   "scripts": {
     "build": "vite build && node ./scripts/build.js",
     "test": "vitest run --coverage",
@@ -18,6 +36,8 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.69",
+    "@anthropic-ai/sdk": "^0.88.0",
     "inversify": "^7.7.1"
   },
   "devDependencies": {

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -21,10 +21,12 @@ import type { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ClaudeExtension } from '/@/claude-extension';
+import { ClaudeInferenceManager } from '/@/manager/claude-inference-manager';
 import { ClaudeSkillsManager } from '/@/manager/claude-skills-manager';
 
 vi.mock(import('@openkaiden/api'));
 vi.mock(import('/@/manager/claude-skills-manager'));
+vi.mock(import('/@/manager/claude-inference-manager'));
 
 class TestClaudeExtension extends ClaudeExtension {
   getContainer(): Container | undefined {
@@ -45,6 +47,7 @@ describe('ClaudeExtension', () => {
   test('activate', async () => {
     await claudeExtension.activate();
     expect(ClaudeSkillsManager.prototype.init).toHaveBeenCalled();
+    expect(ClaudeInferenceManager.prototype.init).toHaveBeenCalled();
   });
 
   test('activate handles error during container creation', async () => {
@@ -59,5 +62,6 @@ describe('ClaudeExtension', () => {
     await claudeExtension.activate();
     await claudeExtension.deactivate();
     expect(ClaudeSkillsManager.prototype.dispose).toHaveBeenCalled();
+    expect(ClaudeInferenceManager.prototype.dispose).toHaveBeenCalled();
   });
 });

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -21,6 +21,7 @@ import { provider } from '@openkaiden/api';
 import type { Container } from 'inversify';
 
 import { InversifyBinding } from '/@/inject/inversify-binding';
+import { ClaudeInferenceManager } from '/@/manager/claude-inference-manager';
 import { ClaudeSkillsManager } from '/@/manager/claude-skills-manager';
 
 export class ClaudeExtension {
@@ -29,6 +30,7 @@ export class ClaudeExtension {
   #inversifyBinding: InversifyBinding | undefined;
   #container: Container | undefined;
   #claudeSkillsManager: ClaudeSkillsManager | undefined;
+  #claudeInferenceManager: ClaudeInferenceManager | undefined;
 
   constructor(extensionContext: ExtensionContext) {
     this.#extensionContext = extensionContext;
@@ -58,7 +60,15 @@ export class ClaudeExtension {
       throw e;
     }
 
+    try {
+      this.#claudeInferenceManager = await this.getContainer()?.getAsync(ClaudeInferenceManager);
+    } catch (e) {
+      console.error('Error while creating the Claude inference manager', e);
+      throw e;
+    }
+
     await this.#claudeSkillsManager?.init();
+    await this.#claudeInferenceManager?.init();
   }
 
   protected getContainer(): Container | undefined {
@@ -69,5 +79,7 @@ export class ClaudeExtension {
     await this.#inversifyBinding?.dispose();
     this.#claudeSkillsManager?.dispose();
     this.#claudeSkillsManager = undefined;
+    this.#claudeInferenceManager?.dispose();
+    this.#claudeInferenceManager = undefined;
   }
 }

--- a/extensions/claude/src/inject/inversify-binding.spec.ts
+++ b/extensions/claude/src/inject/inversify-binding.spec.ts
@@ -16,20 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext, Provider } from '@openkaiden/api';
+import type { ExtensionContext, Provider, SecretStorage } from '@openkaiden/api';
 import { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { managersModule } from '/@/manager/_manager-module';
+import { ClaudeInferenceManager } from '/@/manager/claude-inference-manager';
 import { ClaudeSkillsManager } from '/@/manager/claude-skills-manager';
 
 import { InversifyBinding } from './inversify-binding';
-import { ClaudeProviderSymbol, ExtensionContextSymbol } from './symbol';
+import { ClaudeProviderSymbol, ExtensionContextSymbol, SecretStorageSymbol } from './symbol';
 
 let inversifyBinding: InversifyBinding;
 
 const providerMock = {} as Provider;
-const extensionContextMock = {} as ExtensionContext;
+const secretStorageMock = {} as SecretStorage;
+const extensionContextMock = { secrets: secretStorageMock } as ExtensionContext;
 
 vi.mock(import('inversify'));
 
@@ -46,9 +48,11 @@ describe('InversifyBinding', () => {
     const container = await inversifyBinding.initBindings();
 
     await container.getAsync(ClaudeSkillsManager);
+    await container.getAsync(ClaudeInferenceManager);
 
     expect(vi.mocked(Container.prototype.bind)).toHaveBeenCalledWith(ExtensionContextSymbol);
     expect(vi.mocked(Container.prototype.bind)).toHaveBeenCalledWith(ClaudeProviderSymbol);
+    expect(vi.mocked(Container.prototype.bind)).toHaveBeenCalledWith(SecretStorageSymbol);
 
     expect(vi.mocked(Container.prototype.load)).toHaveBeenCalledWith(managersModule);
   });

--- a/extensions/claude/src/inject/inversify-binding.ts
+++ b/extensions/claude/src/inject/inversify-binding.ts
@@ -19,8 +19,9 @@
 import type { ExtensionContext, Provider } from '@openkaiden/api';
 import { Container } from 'inversify';
 
-import { ClaudeProviderSymbol, ExtensionContextSymbol } from '/@/inject/symbol';
+import { ClaudeProviderSymbol, ExtensionContextSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 import { managersModule } from '/@/manager/_manager-module';
+import { ClaudeInferenceManager } from '/@/manager/claude-inference-manager';
 import { ClaudeSkillsManager } from '/@/manager/claude-skills-manager';
 
 export class InversifyBinding {
@@ -39,10 +40,12 @@ export class InversifyBinding {
 
     this.#container.bind(ExtensionContextSymbol).toConstantValue(this.#extensionContext);
     this.#container.bind(ClaudeProviderSymbol).toConstantValue(this.#provider);
+    this.#container.bind(SecretStorageSymbol).toConstantValue(this.#extensionContext.secrets);
 
     await this.#container.load(managersModule);
 
     await this.#container.getAsync(ClaudeSkillsManager);
+    await this.#container.getAsync(ClaudeInferenceManager);
     return this.#container;
   }
 

--- a/extensions/claude/src/inject/symbol.ts
+++ b/extensions/claude/src/inject/symbol.ts
@@ -18,3 +18,4 @@
 
 export const ExtensionContextSymbol = Symbol.for('ExtensionContext');
 export const ClaudeProviderSymbol = Symbol.for('ClaudeProvider');
+export const SecretStorageSymbol = Symbol.for('SecretStorage');

--- a/extensions/claude/src/manager/_manager-module.ts
+++ b/extensions/claude/src/manager/_manager-module.ts
@@ -18,10 +18,12 @@
 
 import { ContainerModule } from 'inversify';
 
+import { ClaudeInferenceManager } from './claude-inference-manager';
 import { ClaudeSkillsManager } from './claude-skills-manager';
 
 const managersModule = new ContainerModule(options => {
   options.bind<ClaudeSkillsManager>(ClaudeSkillsManager).toSelf().inSingletonScope();
+  options.bind<ClaudeInferenceManager>(ClaudeInferenceManager).toSelf().inSingletonScope();
 });
 
 export { managersModule };

--- a/extensions/claude/src/manager/claude-inference-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.spec.ts
@@ -27,9 +27,7 @@ import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
 import { ClaudeInferenceManager, TOKENS_KEY } from './claude-inference-manager';
 
-vi.mock(import('@ai-sdk/anthropic'), () => ({
-  createAnthropic: vi.fn(),
-}));
+vi.mock(import('@ai-sdk/anthropic'));
 
 vi.mock(import('@anthropic-ai/sdk'));
 

--- a/extensions/claude/src/manager/claude-inference-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.spec.ts
@@ -1,0 +1,251 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type AnthropicProvider, createAnthropic } from '@ai-sdk/anthropic';
+import AnthropicClient from '@anthropic-ai/sdk';
+import type { ModelInfo } from '@anthropic-ai/sdk/resources';
+import type { CancellationToken, Disposable, Logger, Provider, SecretStorage } from '@openkaiden/api';
+import { Container } from 'inversify';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
+
+import { ClaudeInferenceManager, TOKENS_KEY } from './claude-inference-manager';
+
+vi.mock(import('@ai-sdk/anthropic'), () => ({
+  createAnthropic: vi.fn(),
+}));
+
+vi.mock(import('@anthropic-ai/sdk'));
+
+const ANTHROPIC_PROVIDER_MOCK: AnthropicProvider = {} as unknown as AnthropicProvider;
+
+const PROVIDER_MOCK: Provider = {
+  setInferenceProviderConnectionFactory: vi.fn(),
+  registerInferenceProviderConnection: vi.fn(),
+} as unknown as Provider;
+
+const SECRET_STORAGE_MOCK: SecretStorage = {
+  get: vi.fn(),
+  store: vi.fn(),
+  delete: vi.fn(),
+  onDidChange: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(createAnthropic).mockReturnValue(ANTHROPIC_PROVIDER_MOCK);
+
+  const mockModels: ModelInfo[] = [
+    {
+      id: 'claude-sonnet-4-20250514',
+      display_name: 'Claude Sonnet 4',
+      created_at: '2025-05-14T00:00:00Z',
+      type: 'model',
+      capabilities: null,
+      max_tokens: null,
+      max_input_tokens: null,
+    },
+    {
+      id: 'claude-haiku-3.5-20241022',
+      display_name: 'Claude 3.5 Haiku',
+      created_at: '2024-10-22T00:00:00Z',
+      type: 'model',
+      capabilities: null,
+      max_tokens: null,
+      max_input_tokens: null,
+    },
+  ];
+
+  const mockPage = {
+    async *[Symbol.asyncIterator](): AsyncGenerator<ModelInfo> {
+      for (const model of mockModels) {
+        yield model;
+      }
+    },
+  };
+
+  const mockList = vi.fn().mockReturnValue(mockPage);
+  (vi.mocked(AnthropicClient.prototype) as unknown as { models: { list: typeof mockList } }).models = {
+    list: mockList,
+  };
+});
+
+async function createManager(): Promise<ClaudeInferenceManager> {
+  const container = new Container();
+  container.bind(ClaudeInferenceManager).toSelf();
+  container.bind(ClaudeProviderSymbol).toConstantValue(PROVIDER_MOCK);
+  container.bind(SecretStorageSymbol).toConstantValue(SECRET_STORAGE_MOCK);
+  return container.getAsync<ClaudeInferenceManager>(ClaudeInferenceManager);
+}
+
+describe('init', () => {
+  test('should register inference factory', async () => {
+    const manager = await createManager();
+    await manager.init();
+
+    expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      create: expect.any(Function),
+    });
+  });
+
+  test('should restore connections from secret storage', async () => {
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('existingKey');
+
+    const manager = await createManager();
+    await manager.init();
+
+    expect(SECRET_STORAGE_MOCK.get).toHaveBeenCalledWith(TOKENS_KEY);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+  });
+
+  test('should handle empty secret storage', async () => {
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(undefined);
+
+    const manager = await createManager();
+    await manager.init();
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('factory', () => {
+  let create: (params: { [key: string]: unknown }, logger?: Logger, token?: CancellationToken) => Promise<void>;
+
+  beforeEach(async () => {
+    const manager = await createManager();
+    await manager.init();
+
+    const mock = vi.mocked(PROVIDER_MOCK.setInferenceProviderConnectionFactory);
+    assert(mock, 'setInferenceProviderConnectionFactory must be defined');
+    create = mock.mock.calls[0][0].create;
+  });
+
+  test('calling create without params should throw', async () => {
+    await expect(() => {
+      return create({});
+    }).rejects.toThrowError('invalid apiKey');
+  });
+
+  test('calling create with proper params should save token', async () => {
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+    });
+
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey');
+  });
+
+  test('calling create with proper params should register inference connection', async () => {
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+    });
+
+    expect(createAnthropic).toHaveBeenCalledOnce();
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
+    });
+
+    expect(AnthropicClient).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
+    });
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
+      name: 'dum*****',
+      status: expect.any(Function),
+      lifecycle: {
+        delete: expect.any(Function),
+      },
+      sdk: ANTHROPIC_PROVIDER_MOCK,
+      models: [{ label: 'claude-sonnet-4-20250514' }, { label: 'claude-haiku-3.5-20241022' }],
+      credentials: expect.any(Function),
+    });
+  });
+});
+
+describe('connection delete lifecycle', () => {
+  let manager: ClaudeInferenceManager;
+  let mDelete: (logger?: Logger) => Promise<void>;
+  const disposeMock = vi.fn();
+
+  beforeEach(async () => {
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockReturnValue({
+      dispose: disposeMock,
+    } as unknown as Disposable);
+
+    manager = await createManager();
+    await manager.init();
+
+    const mock = vi.mocked(PROVIDER_MOCK.setInferenceProviderConnectionFactory);
+    const create = mock.mock.calls[0][0].create;
+
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+    });
+
+    const registerMock = vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection);
+    const lifecycle = registerMock.mock.calls[0][0].lifecycle;
+    assert(lifecycle?.delete, 'delete method of lifecycle must be defined');
+
+    mDelete = lifecycle.delete;
+  });
+
+  test('calling delete should delete the token', async () => {
+    await mDelete();
+
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
+
+    // first time when registering the connection
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, 'dummyKey');
+
+    // second time when unregistering the connection
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, '');
+  });
+
+  test('calling delete should dispose provider inference connection', async () => {
+    await mDelete();
+
+    expect(disposeMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('dispose', () => {
+  test('should dispose all connections', async () => {
+    const disposeMock = vi.fn();
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockReturnValue({
+      dispose: disposeMock,
+    } as unknown as Disposable);
+
+    const manager = await createManager();
+    await manager.init();
+
+    const mock = vi.mocked(PROVIDER_MOCK.setInferenceProviderConnectionFactory);
+    const create = mock.mock.calls[0][0].create;
+
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+    });
+
+    manager.dispose();
+
+    expect(disposeMock).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/claude/src/manager/claude-inference-manager.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.ts
@@ -1,0 +1,155 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { createHash } from 'node:crypto';
+
+import { createAnthropic } from '@ai-sdk/anthropic';
+import AnthropicClient from '@anthropic-ai/sdk';
+import type { Disposable, InferenceModel, Provider, ProviderConnectionStatus, SecretStorage } from '@openkaiden/api';
+import { inject, injectable } from 'inversify';
+
+import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
+
+export const TOKENS_KEY = 'claude:tokens';
+export const TOKEN_SEPARATOR = ',';
+
+@injectable()
+export class ClaudeInferenceManager {
+  @inject(ClaudeProviderSymbol)
+  private claudeProvider: Provider;
+
+  @inject(SecretStorageSymbol)
+  private secrets: SecretStorage;
+
+  private connections: Map<string, Disposable> = new Map();
+
+  async init(): Promise<void> {
+    this.claudeProvider.setInferenceProviderConnectionFactory({ create: this.factory.bind(this) });
+    await this.restoreConnections();
+  }
+
+  private async restoreConnections(): Promise<void> {
+    const tokens = await this.getTokens();
+    for (const token of tokens) {
+      await this.registerInferenceProviderConnection({ token });
+    }
+  }
+
+  private async getTokens(): Promise<string[]> {
+    let raw: string | undefined;
+    try {
+      raw = await this.secrets.get(TOKENS_KEY);
+    } catch (err: unknown) {
+      console.error('Claude: something went wrong while trying to get tokens from secret storage', err);
+    }
+    if (!raw) return [];
+    return raw.split(TOKEN_SEPARATOR);
+  }
+
+  private async saveToken(token: string): Promise<void> {
+    const tokens: Array<string> = await this.getTokens();
+    const raw = [...tokens, token].join(TOKEN_SEPARATOR);
+    await this.secrets.store(TOKENS_KEY, raw);
+  }
+
+  private getTokenHash(token: string): string {
+    const sha256 = createHash('sha256');
+    return sha256.update(token).digest('hex');
+  }
+
+  private async removeToken(token: string): Promise<void> {
+    const tokens: Array<string> = await this.getTokens();
+    const raw = tokens.filter(t => t !== token).join(TOKEN_SEPARATOR);
+    await this.secrets.store(TOKENS_KEY, raw);
+  }
+
+  private async registerInferenceProviderConnection({ token }: { token: string }): Promise<void> {
+    const key = this.maskKey(token);
+    const tokenHash = this.getTokenHash(token);
+
+    if (this.connections.has(tokenHash)) {
+      throw new Error(`connection already exists for token ${key}`);
+    }
+
+    const anthropic = createAnthropic({
+      apiKey: token,
+    });
+
+    const clean = async (): Promise<void> => {
+      this.connections.get(tokenHash)?.dispose();
+      this.connections.delete(tokenHash);
+      await this.removeToken(token);
+    };
+
+    let status: ProviderConnectionStatus = 'unknown';
+    let models: InferenceModel[] = [];
+
+    try {
+      models = await this.getAnthropicModels(token);
+    } catch (err: unknown) {
+      status = 'stopped';
+    }
+
+    const connectionDisposable = this.claudeProvider.registerInferenceProviderConnection({
+      name: this.maskKey(token),
+      sdk: anthropic,
+      status(): ProviderConnectionStatus {
+        return status;
+      },
+      lifecycle: {
+        delete: clean.bind(this),
+      },
+      models,
+      credentials(): Record<string, string> {
+        return {
+          [TOKENS_KEY]: token,
+        };
+      },
+    });
+    this.connections.set(tokenHash, connectionDisposable);
+  }
+
+  private async getAnthropicModels(token: string): Promise<Array<{ label: string }>> {
+    const client = new AnthropicClient({ apiKey: token });
+    const models: InferenceModel[] = [];
+    for await (const model of client.models.list()) {
+      if (model.id) {
+        models.push({ label: model.id });
+      }
+    }
+    return models;
+  }
+
+  private maskKey(name: string): string {
+    if (!name || name.length <= 3) return name;
+    return name.slice(0, 3) + '*'.repeat(name.length - 3);
+  }
+
+  private async factory(params: { [p: string]: unknown }): Promise<void> {
+    const apiKey = params['claude.factory.apiKey'];
+    if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
+
+    await this.saveToken(apiKey);
+    await this.registerInferenceProviderConnection({ token: apiKey });
+  }
+
+  dispose(): void {
+    this.connections.forEach(disposable => disposable.dispose());
+    this.connections.clear();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,12 @@ importers:
 
   extensions/claude:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.69
+        version: 3.0.69(zod@4.3.6)
+      '@anthropic-ai/sdk':
+        specifier: ^0.88.0
+        version: 0.88.0(zod@4.3.6)
       inversify:
         specifier: ^7.7.1
         version: 7.11.0(reflect-metadata@0.2.2)
@@ -933,6 +939,12 @@ packages:
   '@adobe/css-tools@4.4.3':
     resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
 
+  '@ai-sdk/anthropic@3.0.69':
+    resolution: {integrity: sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.95':
     resolution: {integrity: sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==}
     engines: {node: '>=18'}
@@ -997,6 +1009,15 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
+
+  '@anthropic-ai/sdk@0.88.0':
+    resolution: {integrity: sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
@@ -5258,6 +5279,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -7270,6 +7295,9 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -7827,6 +7855,12 @@ snapshots:
 
   '@adobe/css-tools@4.4.3': {}
 
+  '@ai-sdk/anthropic@3.0.69(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/gateway@3.0.95(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -7900,6 +7934,12 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
       zod: 4.3.6
       zod-to-json-schema: 3.25.1(zod@4.3.6)
+
+  '@anthropic-ai/sdk@0.88.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -12767,6 +12807,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -15125,6 +15170,8 @@ snapshots:
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
To test:

- create an account on https://platform.claude.com
- wait a little bit and create an API key https://platform.claude.com/settings/workspaces/default/keys
- launch Kaiden and create a new Anthropic resource using the just created API key
- go to the chat window and you should see the Anthropic models being listed

![anthropic](https://github.com/user-attachments/assets/16d5f464-00d8-4694-9614-8dad5c17695c)

Fixes #1273