### PR TITLE
chore(claude): update stale kortex references to kaiden

### DIFF
--- a/extensions/claude/package.json
+++ b/extensions/claude/package.json
@@ -4,10 +4,10 @@
   "description": "Registers skills from the Claude skills directory ($HOME/.claude/skills)",
   "version": "0.0.1-next",
   "icon": "icon.png",
-  "publisher": "kortex",
+  "publisher": "kaiden",
   "license": "Apache-2.0",
   "engines": {
-    "kortex": "^0.0.1"
+    "kaiden": "^0.0.1"
   },
   "main": "./dist/extension.js",
   "source": "./src/extension.ts",
@@ -21,7 +21,7 @@
     "inversify": "^7.7.1"
   },
   "devDependencies": {
-    "@kortex-app/api": "workspace:*",
+    "@openkaiden/api": "workspace:*",
     "adm-zip": "^0.5.16",
     "mkdirp": "^3.0.1",
     "vite": "^7.1.2",

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -16,14 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@kortex-app/api';
+import type { ExtensionContext } from '@openkaiden/api';
 import type { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ClaudeExtension } from '/@/claude-extension';
 import { ClaudeSkillsManager } from '/@/manager/claude-skills-manager';
 
-vi.mock(import('@kortex-app/api'));
+vi.mock(import('@openkaiden/api'));
 vi.mock(import('/@/manager/claude-skills-manager'));
 
 class TestClaudeExtension extends ClaudeExtension {

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@kortex-app/api';
-import { provider } from '@kortex-app/api';
+import type { ExtensionContext } from '@openkaiden/api';
+import { provider } from '@openkaiden/api';
 import type { Container } from 'inversify';
 
 import { InversifyBinding } from '/@/inject/inversify-binding';

--- a/extensions/claude/src/extension.spec.ts
+++ b/extensions/claude/src/extension.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@kortex-app/api';
+import type { ExtensionContext } from '@openkaiden/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ClaudeExtension } from './claude-extension';

--- a/extensions/claude/src/extension.ts
+++ b/extensions/claude/src/extension.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@kortex-app/api';
+import type { ExtensionContext } from '@openkaiden/api';
 
 import { ClaudeExtension } from './claude-extension';
 

--- a/extensions/claude/src/inject/inversify-binding.spec.ts
+++ b/extensions/claude/src/inject/inversify-binding.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext, Provider } from '@kortex-app/api';
+import type { ExtensionContext, Provider } from '@openkaiden/api';
 import { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/extensions/claude/src/inject/inversify-binding.ts
+++ b/extensions/claude/src/inject/inversify-binding.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext, Provider } from '@kortex-app/api';
+import type { ExtensionContext, Provider } from '@openkaiden/api';
 import { Container } from 'inversify';
 
 import { ClaudeProviderSymbol, ExtensionContextSymbol } from '/@/inject/symbol';

--- a/extensions/claude/src/manager/claude-skills-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-skills-manager.spec.ts
@@ -19,7 +19,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import type { Disposable, Provider } from '@kortex-app/api';
+import type { Disposable, Provider } from '@openkaiden/api';
 import { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/extensions/claude/src/manager/claude-skills-manager.ts
+++ b/extensions/claude/src/manager/claude-skills-manager.ts
@@ -19,7 +19,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import type { Disposable, Provider } from '@kortex-app/api';
+import type { Disposable, Provider } from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 
 import { ClaudeProviderSymbol } from '/@/inject/symbol';

--- a/extensions/claude/vite.config.js
+++ b/extensions/claude/vite.config.js
@@ -46,7 +46,7 @@ const config = {
       formats: ['cjs'],
     },
     rollupOptions: {
-      external: ['@kortex-app/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
+      external: ['@openkaiden/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
       output: {
         entryFileNames: '[name].js',
       },
@@ -60,7 +60,7 @@ const config = {
     include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
     alias: {
-      '@kortex-app/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@kortex-app/api.js'),
+      '@openkaiden/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@openkaiden/api.js'),
     },
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,7 +393,7 @@ importers:
         specifier: ^7.7.1
         version: 7.11.0(reflect-metadata@0.2.2)
     devDependencies:
-      '@kortex-app/api':
+      '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
       adm-zip:
@@ -404,10 +404,10 @@ importers:
         version: 3.0.1
       vite:
         specifier: ^7.1.2
-        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.10
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.2)
 
   extensions/container/packages/api:
     dependencies:


### PR DESCRIPTION
## Summary
- Updated `extensions/claude/package.json` to replace leftover `kortex` references with the current `kaiden` naming
- Fixes `pnpm install` failure caused by `@kortex-app/api` not existing in the workspace (now `@openkaiden/api`)
- Also updated `engines.kortex` → `engines.kaiden` and `publisher` field

## Test plan
- [ ] Run `pnpm install` and verify it completes without errors
- [ ] Run `pnpm build:extensions` and verify the Claude extension builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)