### PR TITLE
fix: align chat view background with the rest of the app

### DIFF
--- a/packages/renderer/src/app.css
+++ b/packages/renderer/src/app.css
@@ -60,7 +60,7 @@ a {
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
+  --background: var(--pd-content-bg, #222222);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);
   --card-foreground: oklch(0.985 0 0);

--- a/packages/renderer/src/lib/chat/components/multimodal-input.svelte
+++ b/packages/renderer/src/lib/chat/components/multimodal-input.svelte
@@ -460,7 +460,7 @@ $effect((): (() => void) | void => {
       bind:ref={textareaRef}
       placeholder="Send a message..."
       bind:value={():string => input, setInput}
-      class="max-h-[calc(25dvh)] min-h-[24px] resize-none overflow-y-auto border-0 bg-transparent text-base! shadow-none focus-visible:ring-0"
+      class="max-h-[calc(25dvh)] min-h-[24px] resize-none overflow-y-auto border-0 bg-transparent dark:bg-transparent text-base! shadow-none focus-visible:ring-0"
       rows={2}
       autofocus
       onpaste={handlePaste}


### PR DESCRIPTION
The chat dark mode background was near-black instead of dark gray like
all other views. Update --background to use --pd-content-bg, and fix
the input box toolbar having a different shade than the textarea.

Before:
<img width="1420" height="1102" alt="Screenshot 2026-04-13 at 10 34 30" src="https://github.com/user-attachments/assets/5e50275d-c5d8-4d75-a688-f1b57158cfeb" />

After:
<img width="1420" height="1102" alt="Screenshot 2026-04-13 at 10 32 42" src="https://github.com/user-attachments/assets/01eeb700-ba76-435b-958a-87a607adcb19" />
