### PR TITLE
feat: add setting to show/hide chat window

### DIFF
--- a/packages/api/src/chat/chat-settings.ts
+++ b/packages/api/src/chat/chat-settings.ts
@@ -19,4 +19,5 @@
 export enum ChatSettings {
   SectionName = 'chat',
   MaxDndFileSizeMB = 'maxAttachmentFileSize',
+  ShowChatWindow = 'showChatWindow',
 }

--- a/packages/main/src/plugin/chat-init.ts
+++ b/packages/main/src/plugin/chat-init.ts
@@ -31,6 +31,11 @@ export class ChatInit {
       title: 'Chat',
       type: 'object',
       properties: {
+        [ChatSettings.SectionName + '.' + ChatSettings.ShowChatWindow]: {
+          description: 'Show or hide the chat window.',
+          type: 'boolean',
+          default: false,
+        },
         [ChatSettings.SectionName + '.' + ChatSettings.MaxDndFileSizeMB]: {
           description: 'Maximum file size (in MB) for attachments. Files exceeding this limit are rejected.',
           type: 'number',

--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -21,8 +21,9 @@ import { render, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { get, writable } from 'svelte/store';
 import { router } from 'tinro';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { showChatWindow } from '/@/stores/chat-window';
 import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
 
 import App from './App.svelte';
@@ -87,6 +88,7 @@ const messages = new Map<string, (args: unknown) => void>();
 
 beforeEach(() => {
   vi.resetAllMocks();
+  showChatWindow.set(true);
   router.goto('/');
   (window.events as unknown) = {
     receive: vi.fn().mockImplementation((channel, func) => {
@@ -97,6 +99,10 @@ beforeEach(() => {
   (window.getConfigurationValue as unknown) = vi.fn();
   vi.mocked(window.inferenceGetChats).mockResolvedValue([]);
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
+});
+
+afterEach(() => {
+  showChatWindow.set(false);
 });
 
 test('test /image/run/* route', async () => {

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -3,6 +3,7 @@ import './app.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import { tablePersistence } from '@podman-desktop/ui-svelte';
+import { onDestroy } from 'svelte';
 import { router } from 'tinro';
 
 import AgentWorkspaceCreate from '/@/lib/agent-workspaces/AgentWorkspaceCreate.svelte';
@@ -18,6 +19,7 @@ import RAGEnvironmentDetails from '/@/lib/rag/RAGEnvironmentDetails.svelte';
 import RAGEnvironmentList from '/@/lib/rag/RAGEnvironmentList.svelte';
 import PinActions from '/@/lib/statusbar/PinActions.svelte';
 import { handleNavigation } from '/@/navigation';
+import { showChatWindow } from '/@/stores/chat-window';
 import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
 import type { NavigationRequest } from '/@api/navigation-request';
@@ -108,9 +110,38 @@ router.mode.memory();
 
 //remember from where we come to preference pages
 let nonSettingsPage = '/';
+
+function isChatRoute(url: string): boolean {
+  return url === '/' || url.startsWith('/chat');
+}
+
+// When chat setting loads, redirect as needed.
+// undefined = still loading (no redirect), false = disabled, true = enabled.
+let chatConfigLoaded = false;
+let currentUrl: string | undefined;
+const unsubscribeShowChatWindow = showChatWindow.subscribe(value => {
+  if (value === undefined) return;
+  if (value === false && currentUrl !== undefined && isChatRoute(currentUrl)) {
+    router.goto('/agent-workspaces');
+  } else if (value === true && !chatConfigLoaded && currentUrl === '/') {
+    // Force tinro to re-match after chat routes mount on initial load
+    router.goto('/');
+  }
+  chatConfigLoaded = true;
+});
+
+onDestroy(unsubscribeShowChatWindow);
+
 router.subscribe(function (navigation) {
-  if (navigation.url !== undefined && !navigation.url.startsWith('/preferences')) {
-    nonSettingsPage = navigation.url;
+  if (navigation.url !== undefined) {
+    currentUrl = navigation.url;
+    if (!navigation.url.startsWith('/preferences')) {
+      nonSettingsPage = navigation.url;
+    }
+  }
+  // Guard: redirect away from chat routes when chat is disabled
+  if (navigation.url !== undefined && $showChatWindow === false && isChatRoute(navigation.url)) {
+    router.goto('/agent-workspaces');
   }
 });
 
@@ -170,6 +201,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <SendFeedback />
         <ToastHandler />
         <ToastTaskNotifications />
+        {#if $showChatWindow}
         <Route path="/" breadcrumb="Chat" navigationHint="root">
           <CustomChat />
         </Route>
@@ -179,6 +211,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/chat/:chatId/*" let:meta breadcrumb="Chat">
           <CustomChat chatId={meta.params.chatId} />
         </Route>
+        {/if}
 
         <Route path="/agent-workspaces/*" breadcrumb="Agent Workspaces" navigationHint="root" firstmatch>
           <Route path="/" breadcrumb="Agent Workspaces" navigationHint="root">

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -23,8 +23,9 @@ import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { readable } from 'svelte/store';
 import type { TinroRouteMeta } from 'tinro';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import { showChatWindow } from '/@/stores/chat-window';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import type { ContributionInfo } from '/@api/contribution-info';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
@@ -44,22 +45,7 @@ vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   return {};
 });
 
-// fake the window object
-beforeAll(() => {
-  Object.defineProperty(window, 'events', { value: eventsMock });
-  Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn() });
-  Object.defineProperty(window, 'sendNavigationItems', { value: vi.fn() });
-  onDidChangeConfiguration.addEventListener = vi.fn().mockImplementation((message: string, callback: () => void) => {
-    callbacks.set(message, callback);
-  });
-});
-
-test('Test rendering of the navigation bar with empty items', async (_arg: unknown) => {
-  const meta = {
-    url: '/',
-  } as unknown as TinroRouteMeta;
-
-  // mock no kubernetes resources
+function mockEmptyKubernetesContextStores(): void {
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
@@ -73,6 +59,38 @@ test('Test rendering of the navigation bar with empty items', async (_arg: unkno
   vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
   vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextJobs = readable<KubernetesObject[]>([]);
+}
+
+// fake the window object
+beforeAll(() => {
+  Object.defineProperty(window, 'events', { value: eventsMock });
+  Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn() });
+  Object.defineProperty(window, 'sendNavigationItems', { value: vi.fn() });
+  onDidChangeConfiguration.addEventListener = vi.fn().mockImplementation((message: string, callback: () => void) => {
+    callbacks.set(message, callback);
+  });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  callbacks.clear();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  onDidChangeConfiguration.addEventListener = vi.fn().mockImplementation((message: string, callback: () => void) => {
+    callbacks.set(message, callback);
+  });
+  showChatWindow.set(true);
+  mockEmptyKubernetesContextStores();
+});
+
+afterEach(() => {
+  showChatWindow.set(false);
+  vi.useRealTimers();
+});
+
+test('Test rendering of the navigation bar with empty items', async (_arg: unknown) => {
+  const meta = {
+    url: '/',
+  } as unknown as TinroRouteMeta;
 
   // init navigation registry
   await fetchNavigationRegistries();
@@ -113,6 +131,29 @@ test('Test contributions', () => {
     meta,
     exitSettingsCallback: () => {},
   });
+});
+
+test('Chat nav item hidden when showChatWindow is false', async () => {
+  const meta = {
+    url: '/',
+  } as unknown as TinroRouteMeta;
+
+  await fetchNavigationRegistries();
+
+  showChatWindow.set(true);
+  render(AppNavigation, {
+    meta,
+    exitSettingsCallback: () => {},
+  });
+
+  await vi.waitFor(() => expect(screen.getByRole('link', { name: 'Chat' })).toBeInTheDocument());
+
+  showChatWindow.set(false);
+
+  await vi.waitFor(() => expect(screen.queryByRole('link', { name: 'Chat' })).not.toBeInTheDocument());
+
+  // Settings still visible
+  expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
 });
 
 test('NAV_BAR_LAYOUT updates on configuration change', async () => {

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -4,6 +4,7 @@
 import { onDestroy, onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 
+import { showChatWindow } from '/@/stores/chat-window';
 import { NavigationPage } from '/@api/navigation-page';
 
 import { AppearanceSettings } from '../../main/src/plugin/appearance-settings';
@@ -64,6 +65,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 <nav
   class="group w-leftnavbar {minNavbarWidth} flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
+  {#if $showChatWindow}
   <NavItem href="/" tooltip="Chat" bind:meta={meta}>
     <div class="relative w-full">
       <div class="flex flex-col items-center w-full h-full">
@@ -79,6 +81,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
       </div>
     </div>
   </NavItem>
+  {/if}
   {#each $navigationRegistry as navigationRegistryItem, index (index)}
     {#if navigationRegistryItem.items && navigationRegistryItem.type === 'group'}
       <!-- This is a group, list all items from the entry -->

--- a/packages/renderer/src/stores/chat-window.spec.ts
+++ b/packages/renderer/src/stores/chat-window.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { showChatWindow } from './chat-window';
+import { configurationProperties } from './configurationProperties';
+
+const getConfigurationValueMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
+  showChatWindow.set(true);
+});
+
+afterEach(() => {
+  showChatWindow.set(false);
+});
+
+test('showChatWindow is undefined before config loads', () => {
+  showChatWindow.set(undefined);
+  expect(get(showChatWindow)).toBeUndefined();
+});
+
+test('showChatWindow set to true when config value is true', async () => {
+  showChatWindow.set(undefined);
+  getConfigurationValueMock.mockResolvedValue(true);
+
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(showChatWindow)).toBe(true));
+});
+
+test('showChatWindow set to false when config value is false', async () => {
+  getConfigurationValueMock.mockResolvedValue(false);
+
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(showChatWindow)).toBe(false));
+});
+
+test('showChatWindow ignores stale configuration reads', async () => {
+  showChatWindow.set(undefined);
+
+  let resolveFirst: (value: boolean) => void = () => {};
+  const firstRead = new Promise<boolean>(resolve => {
+    resolveFirst = resolve;
+  });
+
+  getConfigurationValueMock.mockReturnValueOnce(firstRead).mockResolvedValueOnce(true);
+
+  // Trigger two reads — second resolves immediately, first is still pending
+  configurationProperties.set([]);
+  configurationProperties.set([]);
+
+  // Second (newer) read should win
+  await vi.waitFor(() => expect(get(showChatWindow)).toBe(true));
+
+  // First (stale) read resolves with false — should be ignored
+  resolveFirst(false);
+  await Promise.resolve();
+
+  expect(get(showChatWindow)).toBe(true);
+});

--- a/packages/renderer/src/stores/chat-window.ts
+++ b/packages/renderer/src/stores/chat-window.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import { ChatSettings } from '/@api/chat/chat-settings';
+
+import { configurationProperties } from './configurationProperties';
+
+const SHOW_CHAT_WINDOW = `${ChatSettings.SectionName}.${ChatSettings.ShowChatWindow}`;
+let requestId = 0;
+
+// undefined = config not yet loaded, true/false = loaded value
+export const showChatWindow: Writable<boolean | undefined> = writable();
+
+// Re-read on configuration updates (fires on system-ready, extensions-started, configuration-changed, etc.)
+configurationProperties.subscribe(() => {
+  if (!window?.getConfigurationValue) {
+    return;
+  }
+
+  const currentRequestId = ++requestId;
+  window
+    .getConfigurationValue<boolean>(SHOW_CHAT_WINDOW)
+    ?.then(value => {
+      if (currentRequestId === requestId) {
+        showChatWindow.set(value === true);
+      }
+    })
+    ?.catch((err: unknown) => console.error(`Error getting configuration value ${SHOW_CHAT_WINDOW}`, err));
+});

--- a/tests/playwright/src/model/navigation/navigation.ts
+++ b/tests/playwright/src/model/navigation/navigation.ts
@@ -97,6 +97,15 @@ export class NavigationBar {
     return this.navigateTo(this.extensionsLink, ExtensionsPage);
   }
 
+  async ensureChatWindowEnabled(): Promise<void> {
+    if (await this.chatLink.isVisible()) {
+      return;
+    }
+    const settingsPage = await this.navigateToSettingsPage();
+    const preferencesPage = await settingsPage.openPreferences();
+    await preferencesPage.enableChatWindow();
+  }
+
   async navigateToSettingsPage(): Promise<SettingsPage> {
     const settingsPage = new SettingsPage(this.page);
     // Settings nav link is a toggle: clicking while on Settings exits it

--- a/tests/playwright/src/model/pages/settings-preferences-tab-page.ts
+++ b/tests/playwright/src/model/pages/settings-preferences-tab-page.ts
@@ -60,4 +60,14 @@ export class SettingsPreferencesPage extends BasePage {
     await preferenceLink.click();
     await expect(this.getPreferenceContent(option)).toBeVisible();
   }
+
+  async enableChatWindow(): Promise<void> {
+    await this.selectPreference('Chat');
+    const toggle = this.page.getByRole('checkbox', { name: 'Show or hide the chat window.' });
+    await toggle.check({ force: true });
+    // Wait for the Chat nav link to appear after the async config update propagates
+    await expect(
+      this.page.getByRole('navigation', { name: 'AppNavigation' }).getByRole('link', { name: 'Chat' }),
+    ).toBeVisible();
+  }
 }

--- a/tests/playwright/src/specs/dashboard.spec.ts
+++ b/tests/playwright/src/specs/dashboard.spec.ts
@@ -22,8 +22,9 @@ import { expect, workerTest as test } from '../fixtures/electron-app';
 
 test.describe
   .serial('App start', { tag: '@smoke' }, () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, navigationBar }) => {
       await waitForNavigationReady(page);
+      await navigationBar.ensureChatWindowEnabled();
     });
 
     test('[APP-01] Navigation bar is visible and contains all expected navigation links', async ({ navigationBar }) => {

--- a/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/chat-smoke.spec.ts
@@ -28,6 +28,7 @@ test.use({
 
 test.beforeEach(async ({ page, navigationBar, chatPage }) => {
   await waitForNavigationReady(page);
+  await navigationBar.ensureChatWindowEnabled();
   await navigationBar.navigateToChatPage();
   await chatPage.ensureChatSidebarVisible();
   const existingCount = await chatPage.getChatHistoryCount();


### PR DESCRIPTION
Add a `chat.showChatWindow` boolean setting (default: true) that
controls visibility of the chat window and its navigation item.
When disabled, the home route falls back to Agent Workspaces.

https://github.com/user-attachments/assets/bd76867d-25de-4146-a77f-dc8bcd1135b4

Fixes #1329