### PR TITLE
feat(guided-setup): add wizard shell with step navigation framework

### DIFF
--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -1,0 +1,191 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { faBrain, faCheckCircle, faRobot } from '@fortawesome/free-solid-svg-icons';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { GuidedSetupStep } from './guided-setup-steps';
+import GuidedSetup from './GuidedSetup.svelte';
+
+vi.mock(import('./guided-setup-steps'), async importOriginal => {
+  const orig = await importOriginal();
+  return {
+    ...orig,
+    guidedSetupSteps: [
+      {
+        id: 'step-a',
+        title: 'Step A',
+        description: 'First test step.',
+        icon: faBrain,
+        component: (await import('./StubStep.svelte')).default,
+        isComplete: (): boolean => false,
+        isSkippable: true,
+      },
+      {
+        id: 'step-b',
+        title: 'Step B',
+        description: 'Second test step.',
+        icon: faRobot,
+        component: (await import('./StubStep.svelte')).default,
+        isComplete: (): boolean => false,
+        isSkippable: true,
+      },
+      {
+        id: 'step-c',
+        title: 'Step C',
+        description: 'Last test step.',
+        icon: faCheckCircle,
+        component: (await import('./StubStep.svelte')).default,
+        isComplete: (): boolean => false,
+        isSkippable: false,
+      },
+    ] satisfies GuidedSetupStep[],
+  };
+});
+
+const closeMock = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+});
+
+test('renders stepper with all step labels', () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  expect(screen.getByRole('button', { name: 'Step A step' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Step B step' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Step C step' })).toBeInTheDocument();
+});
+
+test('renders the dialog with Guided Setup label', () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  expect(screen.getByRole('dialog', { name: 'Guided Setup' })).toBeInTheDocument();
+});
+
+test('first step is active on mount', () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
+  expect(firstStepButton).toHaveAttribute('aria-current', 'step');
+});
+
+test('"Continue" advances to next step', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  const continueButton = screen.getByRole('button', { name: 'Continue' });
+  await fireEvent.click(continueButton);
+
+  const secondStepButton = screen.getByRole('button', { name: 'Step B step' });
+  expect(secondStepButton).toHaveAttribute('aria-current', 'step');
+});
+
+test('"Skip" advances to next step', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  const skipButton = screen.getByRole('button', { name: 'Skip' });
+  await fireEvent.click(skipButton);
+
+  const secondStepButton = screen.getByRole('button', { name: 'Step B step' });
+  expect(secondStepButton).toHaveAttribute('aria-current', 'step');
+});
+
+test('completed steps are tracked after Continue', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  const continueButton = screen.getByRole('button', { name: 'Continue' });
+  await fireEvent.click(continueButton);
+
+  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
+  expect(firstStepButton).not.toHaveAttribute('aria-current', 'step');
+  expect(firstStepButton).toBeEnabled();
+});
+
+test('skipped steps are not marked completed', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  const skipButton = screen.getByRole('button', { name: 'Skip' });
+  await fireEvent.click(skipButton);
+
+  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
+  expect(firstStepButton).toBeDisabled();
+});
+
+test('last step shows "Go to Dashboard" instead of "Continue"', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+  expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Go to Dashboard' })).toBeInTheDocument();
+});
+
+test('dispatches close event when finishing on last step', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+  const dashboardButton = screen.getByRole('button', { name: 'Go to Dashboard' });
+  await fireEvent.click(dashboardButton);
+
+  expect(closeMock).toHaveBeenCalled();
+});
+
+test('clicking on completed step navigates back to it', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
+  await fireEvent.click(firstStepButton);
+
+  expect(firstStepButton).toHaveAttribute('aria-current', 'step');
+});
+
+test('clicking on upcoming (not yet reached) step does nothing', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  const thirdStepButton = screen.getByRole('button', { name: 'Step C step' });
+  await fireEvent.click(thirdStepButton);
+
+  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
+  expect(firstStepButton).toHaveAttribute('aria-current', 'step');
+});
+
+test('stepper progress bar has correct number of connector lines', () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  const nav = screen.getByRole('navigation', { name: 'Setup progress' });
+  const connectors = nav.querySelectorAll('[aria-hidden="true"]');
+  expect(connectors.length).toBe(2);
+});
+
+test('Skip button is not shown for non-skippable steps', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+  expect(screen.queryByRole('button', { name: 'Skip' })).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { SvelteSet } from 'svelte/reactivity';
+
+import { guidedSetupSteps } from './guided-setup-steps';
+
+interface Props {
+  onclose: () => void;
+}
+
+let { onclose }: Props = $props();
+
+let currentStepIndex = $state(0);
+let completedSteps = new SvelteSet<string>();
+
+let hasSteps = $derived(guidedSetupSteps.length > 0);
+let currentStep = $derived(guidedSetupSteps[currentStepIndex]);
+let isLastStep = $derived(currentStepIndex === guidedSetupSteps.length - 1);
+let continueLabel = $derived(isLastStep ? 'Go to Dashboard' : 'Continue');
+
+function getStepState(index: number): 'completed' | 'active' | 'upcoming' {
+  const step = guidedSetupSteps[index];
+  if (completedSteps.has(step.id)) return 'completed';
+  if (index === currentStepIndex) return 'active';
+  return 'upcoming';
+}
+
+function advance(): void {
+  if (!hasSteps || isLastStep) {
+    onclose();
+  } else {
+    currentStepIndex++;
+  }
+}
+
+function handleContinue(): void {
+  completedSteps.add(currentStep.id);
+  advance();
+}
+
+function handleSkip(): void {
+  advance();
+}
+
+function handleStepClick(index: number): void {
+  const state = getStepState(index);
+  if (state === 'completed' || index === currentStepIndex) {
+    currentStepIndex = index;
+  }
+}
+</script>
+
+<div
+  class="fixed inset-0 z-50 flex flex-col bg-[var(--pd-content-card-bg)]"
+  role="dialog"
+  aria-label="Guided Setup">
+
+  <!-- Stepper bar -->
+  <nav class="flex items-center justify-center gap-0 px-8 pt-10 pb-6" aria-label="Setup progress">
+    {#each guidedSetupSteps as step, index (step.id)}
+      {@const state = getStepState(index)}
+      {#if index > 0}
+        <div
+          class="h-0.5 w-12 mx-1 transition-colors {state === 'upcoming'
+            ? 'bg-[var(--pd-content-divider)]'
+            : 'bg-[var(--pd-button-primary-bg)]'}"
+          aria-hidden="true">
+        </div>
+      {/if}
+      <button
+        class="flex flex-col items-center gap-1.5 min-w-[80px] cursor-pointer transition-opacity
+          {state === 'upcoming' ? 'opacity-50' : 'opacity-100'}
+          {state === 'completed' || index === currentStepIndex ? '' : 'cursor-default'}"
+        aria-label="{step.title} step"
+        aria-current={index === currentStepIndex ? 'step' : undefined}
+        disabled={state === 'upcoming'}
+        onclick={handleStepClick.bind(undefined, index)}>
+        <div
+          class="flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold transition-colors
+            {state === 'completed'
+              ? 'bg-green-600 text-white'
+              : state === 'active'
+                ? 'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-text)]'
+                : 'bg-[var(--pd-content-card-inset-bg)] text-[var(--pd-content-card-text)]'}">
+          {#if state === 'completed'}
+            <Icon icon={faCheck} size="0.8x" />
+          {:else}
+            {index + 1}
+          {/if}
+        </div>
+        <span class="text-xs text-[var(--pd-content-card-text)] whitespace-nowrap">{step.title}</span>
+      </button>
+    {/each}
+  </nav>
+
+  <!-- Step content area -->
+  <div class="flex-1 overflow-y-auto px-8" aria-label="Step content">
+    {#each guidedSetupSteps as step, index (step.id)}
+      {#if index === currentStepIndex}
+        <step.component stepId={step.id} title={step.title} description={step.description} />
+      {/if}
+    {/each}
+  </div>
+
+  <!-- Footer -->
+  <footer class="flex justify-end gap-3 px-8 py-6 bg-[var(--pd-content-bg)]">
+    {#if currentStep?.isSkippable}
+      <Button type="secondary" aria-label="Skip" onclick={handleSkip}>Skip</Button>
+    {/if}
+    <Button type="primary" aria-label={continueLabel} onclick={handleContinue}>{continueLabel}</Button>
+  </footer>
+</div>

--- a/packages/renderer/src/lib/guided-setup/StubStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/StubStep.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import type { GuidedSetupStepProps } from './guided-setup-steps';
+
+let { stepId, title, description }: GuidedSetupStepProps = $props();
+</script>
+
+<div data-testid="stub-step-{stepId}">{title} - {description}</div>

--- a/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
+++ b/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
+import type { Component } from 'svelte';
+
+export interface GuidedSetupStepProps {
+  stepId: string;
+  title: string;
+  description: string;
+}
+
+export interface GuidedSetupStep {
+  id: string;
+  title: string;
+  description: string;
+  icon: IconDefinition;
+  component: Component<GuidedSetupStepProps>;
+  isComplete: () => boolean;
+  isSkippable: boolean;
+}
+
+export const guidedSetupSteps: GuidedSetupStep[] = [];

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -332,3 +332,9 @@ test('Expect that releaseNotesBanner.show configuration value is not set to curr
   await waitRender({});
   expect(vi.mocked(window.updateConfigurationValue)).not.toBeCalledWith(`releaseNotesBanner.show`, '1.0.0');
 });
+
+test('Expect "Start guided setup" button is hidden when no steps are registered', async () => {
+  await waitRender({ showWelcome: true });
+
+  expect(screen.queryByRole('button', { name: 'Start guided setup' })).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -4,6 +4,8 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
+import { guidedSetupSteps } from '/@/lib/guided-setup/guided-setup-steps';
+import GuidedSetup from '/@/lib/guided-setup/GuidedSetup.svelte';
 import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
@@ -16,6 +18,7 @@ import { WelcomeUtils } from './welcome-utils';
 
 export let showWelcome = false;
 export let showTelemetry = false;
+let showGuidedSetup = false;
 
 let telemetry = true;
 let telemetryMessages: TelemetryMessages;
@@ -92,11 +95,13 @@ function toggleOnboardingSelection(providerName: string): void {
   });
 }
 
-function startOnboardingQueue(): void {
-  const selectedProviders = onboardingProviders.filter(provider => provider.selected);
-  const extensionIds = selectedProviders.map(provider => provider.extension);
-  const queryParams = new URLSearchParams({ ids: extensionIds.join(',') }).toString();
-  router.goto(`/global-onboarding?${queryParams}`);
+function openGuidedSetup(): void {
+  showGuidedSetup = true;
+}
+
+async function handleGuidedSetupClose(): Promise<void> {
+  showGuidedSetup = false;
+  await closeWelcome();
 }
 </script>
 
@@ -189,25 +194,19 @@ function startOnboardingQueue(): void {
     <!-- Footer - button bar -->
     <div class="flex justify-end flex-none bg-[var(--pd-content-bg)] p-8">
       <div class="flex flex-row">
-        <!-- If Providers have any onboarding elements selected, create a button that says "Start onboarding" rather than Skip -->
-        {#if onboardingProviders && onboardingProviders.filter(o => o.selected).length > 0}
-          <!-- We will "always" show the "Skip" button
-          in-case anything were to happen with the Start onboarding button / sequence not working correctly.
-          we do not want the user to not be able to continue. -->
-          <Button
-            type="secondary"
-            on:click={closeWelcome}>Skip</Button>
+        <Button
+          type="secondary"
+          on:click={closeWelcome}>Skip</Button>
+        {#if guidedSetupSteps.length > 0}
           <Button
             class="ml-2"
-            on:click={async (): Promise<void> => {
-              await closeWelcome();
-              startOnboardingQueue();
-            }}>Start onboarding</Button>
-        {:else}
-          <Button
-            on:click={closeWelcome}>Skip</Button>
+            on:click={openGuidedSetup}>Start guided setup</Button>
         {/if}
       </div>
     </div>
   </div>
+{/if}
+
+{#if showGuidedSetup}
+  <GuidedSetup onclose={handleGuidedSetupClose} />
 {/if}

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -95,6 +95,13 @@ function toggleOnboardingSelection(providerName: string): void {
   });
 }
 
+function startOnboardingQueue(): void {
+  const selectedProviders = onboardingProviders.filter(provider => provider.selected);
+  const extensionIds = selectedProviders.map(provider => provider.extension);
+  const queryParams = new URLSearchParams({ ids: extensionIds.join(',') }).toString();
+  router.goto(`/global-onboarding?${queryParams}`);
+}
+
 function openGuidedSetup(): void {
   showGuidedSetup = true;
 }
@@ -194,9 +201,24 @@ async function handleGuidedSetupClose(): Promise<void> {
     <!-- Footer - button bar -->
     <div class="flex justify-end flex-none bg-[var(--pd-content-bg)] p-8">
       <div class="flex flex-row">
-        <Button
-          type="secondary"
-          on:click={closeWelcome}>Skip</Button>
+        <!-- If Providers have any onboarding elements selected, create a button that says "Start onboarding" rather than Skip -->
+        {#if onboardingProviders && onboardingProviders.filter(o => o.selected).length > 0}
+          <!-- We will "always" show the "Skip" button
+          in-case anything were to happen with the Start onboarding button / sequence not working correctly.
+          we do not want the user to not be able to continue. -->
+          <Button
+            type="secondary"
+            on:click={closeWelcome}>Skip</Button>
+          <Button
+            class="ml-2"
+            on:click={async (): Promise<void> => {
+              await closeWelcome();
+              startOnboardingQueue();
+            }}>Start onboarding</Button>
+        {:else}
+          <Button
+            on:click={closeWelcome}>Skip</Button>
+        {/if}
         {#if guidedSetupSteps.length > 0}
           <Button
             class="ml-2"


### PR DESCRIPTION
Introduce the foundational guided setup overlay that will host the onboarding flow. The wizard shell provides a stepper progress bar, dynamic step content area, and skip/continue footer. The step registry is empty by design — each sub-issue will register its own step.

Since there is no step still registered this is how the wizard looks with some example of steps and content (not included in the PR):

https://github.com/user-attachments/assets/0ef63af8-4d5e-4723-b9b7-2b9972b9a15a

To test it you can add a step in ```guidedSetupSteps```array of ```guided-setup-teps.ts``` file

Closes #1333