### PR TITLE
fix(skills): add missing type property to SkillInfo in tests

### DIFF
--- a/packages/renderer/src/lib/skills/SkillCreate.spec.ts
+++ b/packages/renderer/src/lib/skills/SkillCreate.spec.ts
@@ -37,6 +37,7 @@ beforeEach(() => {
     description: 'A test skill',
     path: '/skills/test-skill',
     enabled: true,
+    type: 'custom',
   });
 });
 

--- a/packages/renderer/src/lib/skills/columns/SkillEnabledColumn.spec.ts
+++ b/packages/renderer/src/lib/skills/columns/SkillEnabledColumn.spec.ts
@@ -36,6 +36,7 @@ const enabledSkill: SkillInfo = {
   description: 'A test skill',
   path: '/skills/my-skill',
   enabled: true,
+  type: 'custom',
 };
 
 const disabledSkill: SkillInfo = {
@@ -43,6 +44,7 @@ const disabledSkill: SkillInfo = {
   description: 'A test skill',
   path: '/skills/my-skill',
   enabled: false,
+  type: 'custom',
 };
 
 test('should show "Disable skill" title when skill is enabled', () => {


### PR DESCRIPTION
## Summary
- Adds the required `type: 'custom'` property to `SkillInfo` test objects in `SkillCreate.spec.ts` and `SkillEnabledColumn.spec.ts`
- Fixes typecheck failures caused by the `SkillInfo` interface gaining a required `type` field without corresponding test updates

## Test plan
- [x] `pnpm run typecheck` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)