### PR TITLE
fix(mcp): lenient AJV validation for live registry payloads

### DIFF
--- a/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
@@ -100,56 +100,44 @@ describe('validateSchemaData', () => {
     );
   });
 
-  test('should warn when server name does not match required pattern', () => {
-    const invalidServerResponse = {
+  test('should accept ServerResponse when only server name fails bundled reverse-DNS pattern', () => {
+    const serverResponse = {
       server: {
-        name: 'invalid-name-without-slash', // Should be in format "namespace/name"
+        name: 'com.github.mcp',
         description: 'Test',
         version: '1.0.0',
       },
       _meta: {},
     };
 
-    const result = validator.validateSchemaData(invalidServerResponse, 'ServerResponse', 'test-registry');
+    const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry');
 
-    expect(result).toBe(false);
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
-      invalidServerResponse,
-      'errors:',
-      expect.arrayContaining([
-        expect.objectContaining({
-          message: expect.stringContaining('pattern'),
-        }),
-      ]),
-    );
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
-  test('should warn when remote type is not a valid enum value', () => {
-    const invalidServerResponse = {
+  test('should still validate core server fields when packages/remotes are omitted from validation copy', () => {
+    const serverResponse = {
       server: {
-        name: 'io.github.example/test-server',
+        name: 'invalid-name-without-slash',
         description: 'Test',
         version: '1.0.0',
-        remotes: [
+        remotes: [{ type: 'invalid-type', url: 'https://example.com' }],
+        packages: [
           {
-            type: 'invalid-type', // Should be 'sse' or 'streamable-http'
-            url: 'https://example.com',
+            registryType: 'npm',
+            identifier: '@scope/pkg',
+            transport: { type: 'stdio' },
           },
         ],
       },
       _meta: {},
     };
 
-    const result = validator.validateSchemaData(invalidServerResponse, 'ServerResponse', 'test-registry');
+    const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry');
 
-    expect(result).toBe(false);
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[MCPSchemaValidator] Failed to validate data against schema'),
-      invalidServerResponse,
-      'errors:',
-      expect.anything(),
-    );
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   test('should validate valid ServerResponse with remotes', () => {
@@ -172,6 +160,92 @@ describe('validateSchemaData', () => {
 
     expect(result).toBe(true);
     expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  test('should validate ServerResponse when official registry _meta includes API-only fields (e.g. statusChangedAt)', () => {
+    const serverResponse = {
+      server: {
+        name: 'zone.example/registry-test',
+        description: 'Test',
+        version: '1.0.0',
+      },
+      _meta: {
+        'io.modelcontextprotocol.registry/official': {
+          status: 'active',
+          statusChangedAt: '2026-03-13T03:50:03.628037Z',
+          publishedAt: '2026-03-13T03:50:03.628037Z',
+          updatedAt: '2026-03-13T03:50:03.628037Z',
+          isLatest: true,
+        },
+      },
+    };
+
+    const result = validator.validateSchemaData(
+      serverResponse,
+      'ServerResponse',
+      'https://registry.modelcontextprotocol.io',
+    );
+
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(
+      (serverResponse._meta['io.modelcontextprotocol.registry/official'] as { statusChangedAt?: string })
+        .statusChangedAt,
+    ).toBe('2026-03-13T03:50:03.628037Z');
+  });
+
+  test('should validate ServerResponse when server.json packages/runtimeArguments are ahead of bundled schema', () => {
+    const serverResponse = {
+      server: {
+        name: 'io.github.example/memphora',
+        description: 'Memory',
+        version: '0.1.3',
+        packages: [
+          {
+            registryType: 'npm',
+            identifier: '@scope/pkg',
+            transport: { type: 'stdio' },
+            runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
+          },
+        ],
+      },
+      _meta: {},
+    };
+
+    const result = validator.validateSchemaData(
+      serverResponse,
+      'ServerResponse',
+      'https://registry.modelcontextprotocol.io',
+    );
+
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(serverResponse.server.packages?.[0]).toMatchObject({
+      runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
+    });
+  });
+
+  test('should validate ServerResponse when repository is an empty object (registry placeholder)', () => {
+    const serverResponse = {
+      server: {
+        name: 'io.github.example/scrimba-teaching',
+        description: 'Teaching',
+        version: '2.0.0',
+        repository: {},
+        packages: [{ registryType: 'npm', identifier: 'x', transport: { type: 'stdio' } }],
+      },
+      _meta: {},
+    };
+
+    const result = validator.validateSchemaData(
+      serverResponse,
+      'ServerResponse',
+      'https://registry.modelcontextprotocol.io',
+    );
+
+    expect(result).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(serverResponse.server.repository).toEqual({});
   });
 
   test('should validate valid ServerDetail', () => {
@@ -337,10 +411,10 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
     expect(invalidServerNames.has('io.github.example/valid-server')).toBe(false);
   });
 
-  test('should identify invalid server with bad name pattern', () => {
+  test('should treat pattern-only server name as valid for registry compatibility', () => {
     const serverResponse = {
       server: {
-        name: 'invalid-name-no-slash', // Invalid pattern
+        name: 'invalid-name-no-slash',
         description: 'Invalid server',
         version: '1.0.0',
       },
@@ -349,7 +423,7 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
 
     const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry', true);
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   test('should return valid for all valid servers', () => {

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { MCPSchemaValidator } from './mcp-schema-validator.js';
 
 const originalConsoleWarn = console.warn;
+const originalConsoleDebug = console.debug;
 
 let validator: MCPSchemaValidator;
 
@@ -28,10 +29,12 @@ beforeEach(() => {
   vi.resetAllMocks();
   validator = new MCPSchemaValidator();
   console.warn = vi.fn();
+  console.debug = vi.fn();
 });
 
 afterEach(() => {
   console.warn = originalConsoleWarn;
+  console.debug = originalConsoleDebug;
 });
 
 describe('validateSchemaData', () => {
@@ -222,7 +225,7 @@ describe('validateSchemaData', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  test('should tolerate repository as an empty object (registry placeholder)', () => {
+  test('should tolerate repository as an empty object (registry placeholder) and emit debug log', () => {
     const serverResponse = {
       server: {
         name: 'io.github.example/scrimba-teaching',
@@ -241,6 +244,10 @@ describe('validateSchemaData', () => {
 
     expect(result).toBe(true);
     expect(console.warn).not.toHaveBeenCalled();
+    expect(console.debug).toHaveBeenCalledWith(
+      expect.stringContaining('[MCPSchemaValidator] Tolerated schema drift'),
+      expect.any(String),
+    );
   });
 
   test('should validate valid ServerDetail', () => {

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
@@ -115,7 +115,7 @@ describe('validateSchemaData', () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
-  test('should accept ServerResponse when only server name fails bundled reverse-DNS pattern', () => {
+  test('should reject ServerResponse when server name fails bundled reverse-DNS pattern', () => {
     const serverResponse = {
       server: {
         name: 'com.github.mcp',
@@ -127,23 +127,39 @@ describe('validateSchemaData', () => {
 
     const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry');
 
-    expect(result).toBe(true);
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+    expect(console.warn).toHaveBeenCalled();
   });
 
-  test('should tolerate volatile server fields (packages, remotes, icons) with non-conforming shapes', () => {
+  test('should reject ServerResponse with non-conforming remotes type', () => {
     const serverResponse = {
       server: {
         name: 'io.github.example/test-server',
         description: 'Test',
         version: '1.0.0',
         remotes: [{ type: 'invalid-type', url: 'https://example.com' }],
+      },
+      _meta: {},
+    };
+
+    const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry');
+
+    expect(result).toBe(false);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test('should tolerate errors under /server/packages path (schema drift)', () => {
+    const serverResponse = {
+      server: {
+        name: 'io.github.example/test-server',
+        description: 'Test',
+        version: '1.0.0',
         packages: [
           {
             registryType: 'npm',
             identifier: '@scope/pkg',
             transport: { type: 'stdio' },
-            runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
+            packageArguments: [{ type: 'future-type', name: 'arg1' }],
           },
         ],
       },
@@ -381,7 +397,7 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
     expect(invalidServerNames.has('io.github.example/valid-server')).toBe(false);
   });
 
-  test('should treat pattern-only server name as valid for registry compatibility', () => {
+  test('should reject ServerResponse when server name does not match pattern', () => {
     const serverResponse = {
       server: {
         name: 'invalid-name-no-slash',
@@ -393,7 +409,7 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
 
     const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry', true);
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   test('should return valid for all valid servers', () => {

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
@@ -21,7 +21,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { MCPSchemaValidator } from './mcp-schema-validator.js';
 
 const originalConsoleWarn = console.warn;
-const originalConsoleDebug = console.debug;
 
 let validator: MCPSchemaValidator;
 
@@ -29,12 +28,10 @@ beforeEach(() => {
   vi.resetAllMocks();
   validator = new MCPSchemaValidator();
   console.warn = vi.fn();
-  console.debug = vi.fn();
 });
 
 afterEach(() => {
   console.warn = originalConsoleWarn;
-  console.debug = originalConsoleDebug;
 });
 
 describe('validateSchemaData', () => {
@@ -225,7 +222,7 @@ describe('validateSchemaData', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  test('should tolerate repository as an empty object (registry placeholder) and emit debug log', () => {
+  test('should tolerate repository as an empty object (registry placeholder)', () => {
     const serverResponse = {
       server: {
         name: 'io.github.example/scrimba-teaching',
@@ -244,10 +241,6 @@ describe('validateSchemaData', () => {
 
     expect(result).toBe(true);
     expect(console.warn).not.toHaveBeenCalled();
-    expect(console.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[MCPSchemaValidator] Tolerated schema drift'),
-      expect.any(String),
-    );
   });
 
   test('should validate valid ServerDetail', () => {

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.spec.ts
@@ -25,6 +25,7 @@ const originalConsoleWarn = console.warn;
 let validator: MCPSchemaValidator;
 
 beforeEach(() => {
+  vi.resetAllMocks();
   validator = new MCPSchemaValidator();
   console.warn = vi.fn();
 });
@@ -63,7 +64,6 @@ describe('validateSchemaData', () => {
             description: 'Test',
             version: '1.0.0',
           },
-          // Missing _meta field
         },
       ],
     };
@@ -86,7 +86,6 @@ describe('validateSchemaData', () => {
         description: 'Test',
         version: '1.0.0',
       },
-      // Missing _meta field
     };
 
     const result = validator.validateSchemaData(invalidServerResponse, 'ServerResponse', 'test-registry');
@@ -98,6 +97,22 @@ describe('validateSchemaData', () => {
       'errors:',
       expect.anything(),
     );
+  });
+
+  test('should fail when server.description is missing even with tolerable errors present', () => {
+    const serverResponse = {
+      server: {
+        name: 'com.github.mcp',
+        version: '1.0.0',
+        packages: [{ registryType: 'npm', identifier: 'x', transport: { type: 'stdio' } }],
+      },
+      _meta: {},
+    };
+
+    const result = validator.validateSchemaData(serverResponse, 'ServerResponse', 'test-registry');
+
+    expect(result).toBe(false);
+    expect(console.warn).toHaveBeenCalled();
   });
 
   test('should accept ServerResponse when only server name fails bundled reverse-DNS pattern', () => {
@@ -116,10 +131,10 @@ describe('validateSchemaData', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  test('should still validate core server fields when packages/remotes are omitted from validation copy', () => {
+  test('should tolerate volatile server fields (packages, remotes, icons) with non-conforming shapes', () => {
     const serverResponse = {
       server: {
-        name: 'invalid-name-without-slash',
+        name: 'io.github.example/test-server',
         description: 'Test',
         version: '1.0.0',
         remotes: [{ type: 'invalid-type', url: 'https://example.com' }],
@@ -128,6 +143,7 @@ describe('validateSchemaData', () => {
             registryType: 'npm',
             identifier: '@scope/pkg',
             transport: { type: 'stdio' },
+            runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
           },
         ],
       },
@@ -162,7 +178,7 @@ describe('validateSchemaData', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  test('should validate ServerResponse when official registry _meta includes API-only fields (e.g. statusChangedAt)', () => {
+  test('should tolerate unknown _meta fields from official registry (e.g. statusChangedAt)', () => {
     const serverResponse = {
       server: {
         name: 'zone.example/registry-test',
@@ -188,51 +204,15 @@ describe('validateSchemaData', () => {
 
     expect(result).toBe(true);
     expect(console.warn).not.toHaveBeenCalled();
-    expect(
-      (serverResponse._meta['io.modelcontextprotocol.registry/official'] as { statusChangedAt?: string })
-        .statusChangedAt,
-    ).toBe('2026-03-13T03:50:03.628037Z');
   });
 
-  test('should validate ServerResponse when server.json packages/runtimeArguments are ahead of bundled schema', () => {
-    const serverResponse = {
-      server: {
-        name: 'io.github.example/memphora',
-        description: 'Memory',
-        version: '0.1.3',
-        packages: [
-          {
-            registryType: 'npm',
-            identifier: '@scope/pkg',
-            transport: { type: 'stdio' },
-            runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
-          },
-        ],
-      },
-      _meta: {},
-    };
-
-    const result = validator.validateSchemaData(
-      serverResponse,
-      'ServerResponse',
-      'https://registry.modelcontextprotocol.io',
-    );
-
-    expect(result).toBe(true);
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(serverResponse.server.packages?.[0]).toMatchObject({
-      runtimeArguments: [{ type: 'future-argument-kind', value: 'x' }],
-    });
-  });
-
-  test('should validate ServerResponse when repository is an empty object (registry placeholder)', () => {
+  test('should tolerate repository as an empty object (registry placeholder)', () => {
     const serverResponse = {
       server: {
         name: 'io.github.example/scrimba-teaching',
         description: 'Teaching',
         version: '2.0.0',
         repository: {},
-        packages: [{ registryType: 'npm', identifier: 'x', transport: { type: 'stdio' } }],
       },
       _meta: {},
     };
@@ -245,7 +225,6 @@ describe('validateSchemaData', () => {
 
     expect(result).toBe(true);
     expect(console.warn).not.toHaveBeenCalled();
-    expect(serverResponse.server.repository).toEqual({});
   });
 
   test('should validate valid ServerDetail', () => {
@@ -264,7 +243,6 @@ describe('validateSchemaData', () => {
   test('should warn when ServerDetail is missing required fields', () => {
     const invalidServerDetail = {
       name: 'io.github.example/test-server',
-      // Missing description and version
     };
 
     const result = validator.validateSchemaData(invalidServerDetail, 'ServerDetail');
@@ -287,7 +265,6 @@ describe('validateSchemaData', () => {
             description: 'test',
             version: '1.0.0',
           },
-          // Missing required '_meta' field
         },
       ],
     };
@@ -335,13 +312,11 @@ describe('validateSchemaData', () => {
     const result = validator.validateSchemaData(validRepository, 'Repository');
 
     expect(result).toBe(true);
-    // Note: AJV may warn about unknown formats like "uri", but validation still passes
   });
 
   test('should warn on invalid Repository missing required fields', () => {
     const invalidRepository = {
       url: 'https://github.com/example/repo',
-      // Missing 'source' field
     };
 
     const result = validator.validateSchemaData(invalidRepository, 'Repository');
@@ -353,7 +328,6 @@ describe('validateSchemaData', () => {
   test('should not warn when suppressWarnings is true', () => {
     const invalidRepository = {
       url: 'https://github.com/example/repo',
-      // Missing 'source' field
     };
 
     const result = validator.validateSchemaData(invalidRepository, 'Repository', undefined, true);
@@ -368,8 +342,6 @@ describe('validateSchemaData', () => {
 
 describe('validateSchemaData with individual ServerResponse validation', () => {
   test('should identify all invalid servers when validating each ServerResponse individually', () => {
-    // This test validates each server individually (as done in mcp-registry.ts)
-    // to properly detect all invalid servers
     const servers = [
       {
         server: {
@@ -377,7 +349,6 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
           description: 'Invalid server 1',
           version: '1.0.0',
         },
-        // Missing _meta
       },
       {
         server: {
@@ -393,7 +364,6 @@ describe('validateSchemaData with individual ServerResponse validation', () => {
           description: 'Invalid server 2',
           version: '1.0.0',
         },
-        // Missing _meta
       },
     ];
 

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -25,7 +25,7 @@ import { injectable } from 'inversify';
  *
  * Tolerated errors:
  * - `statusChangedAt` additionalProperty: official registry includes this field not yet in bundled schema
- * - `repository` missing `url`: registry sometimes returns empty repository objects as placeholders
+ * - `repository` missing `url` or `source`: registry sometimes returns empty repository objects as placeholders
  * - Errors under `/server/packages`: packageArguments and other nested structures evolve independently
  */
 function isTolerableValidationError(error: {
@@ -39,7 +39,7 @@ function isTolerableValidationError(error: {
   if (
     error.keyword === 'required' &&
     error.instancePath === '/server/repository' &&
-    error.params?.missingProperty === 'url'
+    (error.params?.missingProperty === 'url' || error.params?.missingProperty === 'source')
   ) {
     return true;
   }
@@ -75,6 +75,13 @@ export class MCPSchemaValidator {
     let isValid = validator(jsonData);
 
     if (!isValid && schemaName === 'ServerResponse' && validator.errors?.every(isTolerableValidationError)) {
+      if (!suppressWarnings) {
+        const context = contextName ? ` from '${contextName}'` : '';
+        console.debug(
+          `[MCPSchemaValidator] Tolerated schema drift for '${schemaName}'${context}:`,
+          validator.errors?.map(e => e.message).join(', '),
+        );
+      }
       isValid = true;
     }
 

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -20,30 +20,33 @@ import { type components, createValidator } from '@openkaiden/mcp-registry-types
 import { injectable } from 'inversify';
 
 /**
- * Sub-paths under `server` that track the upstream MCP server.json spec and frequently
- * drift ahead of the bundled OpenAPI schema. Errors rooted at these paths are tolerated
- * so that live registry data doesn't produce noisy validation warnings.
- */
-const VOLATILE_SERVER_SUBPATHS = ['/server/packages', '/server/remotes', '/server/icons', '/server/repository'];
-
-/**
  * Determines whether a single AJV validation error can be tolerated for `ServerResponse`
- * payloads from live MCP registries. This replaces per-field payload stripping with a
- * generic, maintenance-free error filter.
+ * payloads from live MCP registries.
  *
  * Tolerated errors:
- * - `additionalProperties` at any path — live schemas add fields faster than the bundled
- *   OpenAPI tracks them (e.g. `_meta` gains `statusChangedAt`, `server` gains new keys).
- * - `pattern` on `/server/name` — third-party registries use names that don't match the
- *   bundled reverse-DNS pattern (e.g. `com.github.mcp` without a `/`).
- * - Any error under volatile sub-paths — `packages`, `remotes`, `icons`, and `repository`
- *   evolve independently and may use shapes the bundled schema hasn't adopted yet.
+ * - `statusChangedAt` additionalProperty: official registry includes this field not yet in bundled schema
+ * - `repository` missing `url`: registry sometimes returns empty repository objects as placeholders
+ * - Errors under `/server/packages`: packageArguments and other nested structures evolve independently
  */
-function isTolerableValidationError(error: { keyword?: string; instancePath?: string }): boolean {
-  if (error.keyword === 'additionalProperties') return true;
-  if (error.keyword === 'pattern' && error.instancePath === '/server/name') return true;
+function isTolerableValidationError(error: {
+  keyword?: string;
+  instancePath?: string;
+  params?: { additionalProperty?: string; missingProperty?: string };
+}): boolean {
+  if (error.keyword === 'additionalProperties' && error.params?.additionalProperty === 'statusChangedAt') {
+    return true;
+  }
+  if (
+    error.keyword === 'required' &&
+    error.instancePath === '/server/repository' &&
+    error.params?.missingProperty === 'url'
+  ) {
+    return true;
+  }
   const path = error.instancePath;
-  if (path && VOLATILE_SERVER_SUBPATHS.some(prefix => path === prefix || path.startsWith(`${prefix}/`))) return true;
+  if (path && (path === '/server/packages' || path.startsWith('/server/packages/'))) {
+    return true;
+  }
   return false;
 }
 

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { type components, createValidator } from '@kortex-hub/mcp-registry-types';
+import { type components, createValidator } from '@openkaiden/mcp-registry-types';
 import { injectable } from 'inversify';
 
 /**
  * Keys allowed on `_meta['io.modelcontextprotocol.registry/official']` for validation normalization.
  * When the official registry adds new properties, sync this set with the bundled OpenAPI in
- * `@kortex-hub/mcp-registry-types` (e.g. `components.schemas` / ServerResponse `_meta`).
+ * `@openkaiden/mcp-registry-types` (e.g. `components.schemas` / ServerResponse `_meta`).
  */
 const OFFICIAL_REGISTRY_META_KEYS = new Set(['status', 'publishedAt', 'updatedAt', 'isLatest']);
 
@@ -44,7 +44,7 @@ function isCompleteRepositoryForBundledSchema(repository: unknown): boolean {
 
 /**
  * Build a shallow copy of a registry `ServerResponse` suitable for AJV validation against the
- * bundled `@kortex-hub/mcp-registry-types` schema:
+ * bundled `@openkaiden/mcp-registry-types` schema:
  * - Official registry `_meta` may include keys not yet in the OpenAPI (e.g. `statusChangedAt`).
  * - `server.packages` / `remotes` / `icons` follow the live MCP server.json schema and may use
  *   shapes our package has not picked up yet.

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -75,13 +75,6 @@ export class MCPSchemaValidator {
     let isValid = validator(jsonData);
 
     if (!isValid && schemaName === 'ServerResponse' && validator.errors?.every(isTolerableValidationError)) {
-      if (!suppressWarnings) {
-        const context = contextName ? ` from '${contextName}'` : '';
-        console.debug(
-          `[MCPSchemaValidator] Tolerated schema drift for '${schemaName}'${context}:`,
-          validator.errors?.map(e => e.message).join(', '),
-        );
-      }
       isValid = true;
     }
 

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -42,7 +42,8 @@ const VOLATILE_SERVER_SUBPATHS = ['/server/packages', '/server/remotes', '/serve
 function isTolerableValidationError(error: { keyword?: string; instancePath?: string }): boolean {
   if (error.keyword === 'additionalProperties') return true;
   if (error.keyword === 'pattern' && error.instancePath === '/server/name') return true;
-  if (VOLATILE_SERVER_SUBPATHS.some(prefix => error.instancePath?.startsWith(prefix))) return true;
+  const path = error.instancePath;
+  if (path && VOLATILE_SERVER_SUBPATHS.some(prefix => path === prefix || path.startsWith(`${prefix}/`))) return true;
   return false;
 }
 

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -16,8 +16,125 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { type components, createValidator } from '@openkaiden/mcp-registry-types';
+import { type components, createValidator } from '@kortex-hub/mcp-registry-types';
 import { injectable } from 'inversify';
+
+/**
+ * Keys allowed on `_meta['io.modelcontextprotocol.registry/official']` for validation normalization.
+ * When the official registry adds new properties, sync this set with the bundled OpenAPI in
+ * `@kortex-hub/mcp-registry-types` (e.g. `components.schemas` / ServerResponse `_meta`).
+ */
+const OFFICIAL_REGISTRY_META_KEYS = new Set(['status', 'publishedAt', 'updatedAt', 'isLatest']);
+
+const OFFICIAL_REGISTRY_META_KEY = 'io.modelcontextprotocol.registry/official';
+
+/** Nested `server` fields that track the upstream MCP server.json spec and often drift ahead of our bundled OpenAPI. */
+const SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION = ['packages', 'remotes', 'icons'] as const;
+
+/** `repository` is optional on ServerDetail; registries sometimes send `{}` which is invalid for bundled `Repository` (requires url + source). */
+function isCompleteRepositoryForBundledSchema(repository: unknown): boolean {
+  if (repository === null || typeof repository !== 'object' || Array.isArray(repository)) {
+    return false;
+  }
+  const r = repository as Record<string, unknown>;
+  return (
+    typeof r['url'] === 'string' && r['url'].length > 0 && typeof r['source'] === 'string' && r['source'].length > 0
+  );
+}
+
+/**
+ * Build a shallow copy of a registry `ServerResponse` suitable for AJV validation against the
+ * bundled `@kortex-hub/mcp-registry-types` schema:
+ * - Official registry `_meta` may include keys not yet in the OpenAPI (e.g. `statusChangedAt`).
+ * - `server.packages` / `remotes` / `icons` follow the live MCP server.json schema and may use
+ *   shapes our package has not picked up yet.
+ * - `server.repository` may be `{}` or otherwise incomplete; we omit it for validation only when it
+ *   does not satisfy the bundled `Repository` schema.
+ *
+ * The original payload is never mutated; install/runtime code still sees the full server object.
+ */
+function normalizeServerResponseForSchemaValidation(jsonData: unknown): unknown {
+  if (jsonData === null || typeof jsonData !== 'object' || Array.isArray(jsonData)) {
+    return jsonData;
+  }
+  const response = jsonData as Record<string, unknown>;
+
+  const server = response['server'];
+  const serverIsObject = server !== null && typeof server === 'object' && !Array.isArray(server);
+  const serverObj = serverIsObject ? (server as Record<string, unknown>) : null;
+
+  const needsNestedOmit = serverObj && SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION.some(key => key in serverObj);
+  const needsRepositoryOmit =
+    serverObj && 'repository' in serverObj && !isCompleteRepositoryForBundledSchema(serverObj['repository']);
+
+  let nextServer = server;
+  if (serverObj && (needsNestedOmit || needsRepositoryOmit)) {
+    const stripped: Record<string, unknown> = { ...serverObj };
+    if (needsNestedOmit) {
+      for (const key of SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION) {
+        delete stripped[key];
+      }
+    }
+    if (needsRepositoryOmit) {
+      delete stripped['repository'];
+    }
+    nextServer = stripped;
+  }
+
+  const meta = response['_meta'];
+  const metaIsObject = meta !== null && typeof meta === 'object' && !Array.isArray(meta);
+  const metaObj = metaIsObject ? (meta as Record<string, unknown>) : null;
+
+  let nextMeta = meta;
+  if (metaObj) {
+    const official = metaObj[OFFICIAL_REGISTRY_META_KEY];
+    const officialIsObject = official !== null && typeof official === 'object' && !Array.isArray(official);
+    const officialObj = officialIsObject ? (official as Record<string, unknown>) : null;
+
+    if (officialObj) {
+      const hasUnknownOfficialKey = Object.keys(officialObj).some(key => !OFFICIAL_REGISTRY_META_KEYS.has(key));
+      if (hasUnknownOfficialKey) {
+        const normalizedOfficial: Record<string, unknown> = {};
+        for (const key of OFFICIAL_REGISTRY_META_KEYS) {
+          if (key in officialObj) {
+            normalizedOfficial[key] = officialObj[key];
+          }
+        }
+        nextMeta = {
+          ...metaObj,
+          [OFFICIAL_REGISTRY_META_KEY]: normalizedOfficial,
+        };
+      }
+    }
+  }
+
+  const changedServer = Boolean(needsNestedOmit) || Boolean(needsRepositoryOmit);
+  const changedMeta = nextMeta !== meta;
+
+  if (!changedServer && !changedMeta) {
+    return jsonData;
+  }
+
+  return {
+    ...response,
+    server: nextServer,
+    _meta: nextMeta,
+  };
+}
+
+/**
+ * Third-party registries sometimes publish `server.name` values that do not match the bundled
+ * reverse-DNS pattern (e.g. `com.github.mcp` with no `/`). Treat pattern-only failures on
+ * `server.name` as acceptable so listing works without console noise; the real name is unchanged.
+ */
+function isOnlyServerNamePatternFailure(errors: unknown): boolean {
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return false;
+  }
+  return errors.every((e: { instancePath?: string; keyword?: string }) => {
+    return e.instancePath === '/server/name' && e.keyword === 'pattern';
+  });
+}
 
 /**
  * Service for validating MCP registry data against OpenAPI schemas.
@@ -40,8 +157,15 @@ export class MCPSchemaValidator {
     contextName?: string,
     suppressWarnings: boolean = false,
   ): boolean {
+    const payloadForValidation =
+      schemaName === 'ServerResponse' ? normalizeServerResponseForSchemaValidation(jsonData) : jsonData;
+
     const validator = createValidator(schemaName);
-    const isValid = validator(jsonData);
+    let isValid = validator(payloadForValidation);
+
+    if (!isValid && schemaName === 'ServerResponse' && isOnlyServerNamePatternFailure(validator.errors)) {
+      isValid = true;
+    }
 
     if (!isValid && !suppressWarnings) {
       const context = contextName ? ` from '${contextName}'` : '';

--- a/packages/main/src/plugin/mcp/mcp-schema-validator.ts
+++ b/packages/main/src/plugin/mcp/mcp-schema-validator.ts
@@ -20,120 +20,30 @@ import { type components, createValidator } from '@openkaiden/mcp-registry-types
 import { injectable } from 'inversify';
 
 /**
- * Keys allowed on `_meta['io.modelcontextprotocol.registry/official']` for validation normalization.
- * When the official registry adds new properties, sync this set with the bundled OpenAPI in
- * `@openkaiden/mcp-registry-types` (e.g. `components.schemas` / ServerResponse `_meta`).
+ * Sub-paths under `server` that track the upstream MCP server.json spec and frequently
+ * drift ahead of the bundled OpenAPI schema. Errors rooted at these paths are tolerated
+ * so that live registry data doesn't produce noisy validation warnings.
  */
-const OFFICIAL_REGISTRY_META_KEYS = new Set(['status', 'publishedAt', 'updatedAt', 'isLatest']);
-
-const OFFICIAL_REGISTRY_META_KEY = 'io.modelcontextprotocol.registry/official';
-
-/** Nested `server` fields that track the upstream MCP server.json spec and often drift ahead of our bundled OpenAPI. */
-const SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION = ['packages', 'remotes', 'icons'] as const;
-
-/** `repository` is optional on ServerDetail; registries sometimes send `{}` which is invalid for bundled `Repository` (requires url + source). */
-function isCompleteRepositoryForBundledSchema(repository: unknown): boolean {
-  if (repository === null || typeof repository !== 'object' || Array.isArray(repository)) {
-    return false;
-  }
-  const r = repository as Record<string, unknown>;
-  return (
-    typeof r['url'] === 'string' && r['url'].length > 0 && typeof r['source'] === 'string' && r['source'].length > 0
-  );
-}
+const VOLATILE_SERVER_SUBPATHS = ['/server/packages', '/server/remotes', '/server/icons', '/server/repository'];
 
 /**
- * Build a shallow copy of a registry `ServerResponse` suitable for AJV validation against the
- * bundled `@openkaiden/mcp-registry-types` schema:
- * - Official registry `_meta` may include keys not yet in the OpenAPI (e.g. `statusChangedAt`).
- * - `server.packages` / `remotes` / `icons` follow the live MCP server.json schema and may use
- *   shapes our package has not picked up yet.
- * - `server.repository` may be `{}` or otherwise incomplete; we omit it for validation only when it
- *   does not satisfy the bundled `Repository` schema.
+ * Determines whether a single AJV validation error can be tolerated for `ServerResponse`
+ * payloads from live MCP registries. This replaces per-field payload stripping with a
+ * generic, maintenance-free error filter.
  *
- * The original payload is never mutated; install/runtime code still sees the full server object.
+ * Tolerated errors:
+ * - `additionalProperties` at any path — live schemas add fields faster than the bundled
+ *   OpenAPI tracks them (e.g. `_meta` gains `statusChangedAt`, `server` gains new keys).
+ * - `pattern` on `/server/name` — third-party registries use names that don't match the
+ *   bundled reverse-DNS pattern (e.g. `com.github.mcp` without a `/`).
+ * - Any error under volatile sub-paths — `packages`, `remotes`, `icons`, and `repository`
+ *   evolve independently and may use shapes the bundled schema hasn't adopted yet.
  */
-function normalizeServerResponseForSchemaValidation(jsonData: unknown): unknown {
-  if (jsonData === null || typeof jsonData !== 'object' || Array.isArray(jsonData)) {
-    return jsonData;
-  }
-  const response = jsonData as Record<string, unknown>;
-
-  const server = response['server'];
-  const serverIsObject = server !== null && typeof server === 'object' && !Array.isArray(server);
-  const serverObj = serverIsObject ? (server as Record<string, unknown>) : null;
-
-  const needsNestedOmit = serverObj && SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION.some(key => key in serverObj);
-  const needsRepositoryOmit =
-    serverObj && 'repository' in serverObj && !isCompleteRepositoryForBundledSchema(serverObj['repository']);
-
-  let nextServer = server;
-  if (serverObj && (needsNestedOmit || needsRepositoryOmit)) {
-    const stripped: Record<string, unknown> = { ...serverObj };
-    if (needsNestedOmit) {
-      for (const key of SERVER_NESTED_KEYS_TO_OMIT_FOR_VALIDATION) {
-        delete stripped[key];
-      }
-    }
-    if (needsRepositoryOmit) {
-      delete stripped['repository'];
-    }
-    nextServer = stripped;
-  }
-
-  const meta = response['_meta'];
-  const metaIsObject = meta !== null && typeof meta === 'object' && !Array.isArray(meta);
-  const metaObj = metaIsObject ? (meta as Record<string, unknown>) : null;
-
-  let nextMeta = meta;
-  if (metaObj) {
-    const official = metaObj[OFFICIAL_REGISTRY_META_KEY];
-    const officialIsObject = official !== null && typeof official === 'object' && !Array.isArray(official);
-    const officialObj = officialIsObject ? (official as Record<string, unknown>) : null;
-
-    if (officialObj) {
-      const hasUnknownOfficialKey = Object.keys(officialObj).some(key => !OFFICIAL_REGISTRY_META_KEYS.has(key));
-      if (hasUnknownOfficialKey) {
-        const normalizedOfficial: Record<string, unknown> = {};
-        for (const key of OFFICIAL_REGISTRY_META_KEYS) {
-          if (key in officialObj) {
-            normalizedOfficial[key] = officialObj[key];
-          }
-        }
-        nextMeta = {
-          ...metaObj,
-          [OFFICIAL_REGISTRY_META_KEY]: normalizedOfficial,
-        };
-      }
-    }
-  }
-
-  const changedServer = Boolean(needsNestedOmit) || Boolean(needsRepositoryOmit);
-  const changedMeta = nextMeta !== meta;
-
-  if (!changedServer && !changedMeta) {
-    return jsonData;
-  }
-
-  return {
-    ...response,
-    server: nextServer,
-    _meta: nextMeta,
-  };
-}
-
-/**
- * Third-party registries sometimes publish `server.name` values that do not match the bundled
- * reverse-DNS pattern (e.g. `com.github.mcp` with no `/`). Treat pattern-only failures on
- * `server.name` as acceptable so listing works without console noise; the real name is unchanged.
- */
-function isOnlyServerNamePatternFailure(errors: unknown): boolean {
-  if (!Array.isArray(errors) || errors.length === 0) {
-    return false;
-  }
-  return errors.every((e: { instancePath?: string; keyword?: string }) => {
-    return e.instancePath === '/server/name' && e.keyword === 'pattern';
-  });
+function isTolerableValidationError(error: { keyword?: string; instancePath?: string }): boolean {
+  if (error.keyword === 'additionalProperties') return true;
+  if (error.keyword === 'pattern' && error.instancePath === '/server/name') return true;
+  if (VOLATILE_SERVER_SUBPATHS.some(prefix => error.instancePath?.startsWith(prefix))) return true;
+  return false;
 }
 
 /**
@@ -157,13 +67,10 @@ export class MCPSchemaValidator {
     contextName?: string,
     suppressWarnings: boolean = false,
   ): boolean {
-    const payloadForValidation =
-      schemaName === 'ServerResponse' ? normalizeServerResponseForSchemaValidation(jsonData) : jsonData;
-
     const validator = createValidator(schemaName);
-    let isValid = validator(payloadForValidation);
+    let isValid = validator(jsonData);
 
-    if (!isValid && schemaName === 'ServerResponse' && isOnlyServerNamePatternFailure(validator.errors)) {
+    if (!isValid && schemaName === 'ServerResponse' && validator.errors?.every(isTolerableValidationError)) {
       isValid = true;
     }
 


### PR DESCRIPTION
Part of the split of #1278. This PR is **PR 2/3**: lenient MCP registry **ServerResponse** validation (bundled OpenAPI vs live registries).

Related: **#1338** (PR 1/3 — registry URL normalization).

### Changes
- Replace payload-stripping normalization with post-validation error filtering — the original `ServerResponse` is validated directly by AJV, and tolerable errors (unknown `additionalProperties`, server name pattern mismatches, errors under volatile sub-paths like `packages`/`remotes`/`icons`/`repository`) are accepted generically.
- No per-field allowlists to maintain — schema drift from live registries is handled without coupling to specific field names.
- Core validation preserved — missing `_meta`, missing `server`, wrong types on `name`/`description`/`version` still fail.
- Tests updated in `mcp-schema-validator.spec.ts`.

Made with [Cursor](https://cursor.com)