### PR TITLE
fix: handle multi files skill when importing

### DIFF
--- a/packages/api/src/skill/skill-info.ts
+++ b/packages/api/src/skill/skill-info.ts
@@ -36,6 +36,7 @@ export interface SkillFolderInfo {
 
 export interface SkillFileContent extends SkillMetadata {
   content?: string;
+  sourcePath?: string;
 }
 
 export const SKILL_SECTION = 'skills';

--- a/packages/main/src/plugin/skill/skill-manager.spec.ts
+++ b/packages/main/src/plugin/skill/skill-manager.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
-import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { cp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
@@ -633,6 +633,57 @@ test('createSkill with extension-registered target should write to that target d
     expect.stringContaining('name: new-skill'),
     'utf-8',
   );
+});
+
+test('createSkill with sourcePath should copy supporting files from source directory', async () => {
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(mkdir).mockResolvedValue(undefined);
+  vi.mocked(writeFile).mockResolvedValue(undefined);
+  vi.mocked(readdir).mockResolvedValue(['SKILL.md', 'examples.md', 'references'] as unknown as Awaited<
+    ReturnType<typeof readdir>
+  >);
+  vi.mocked(cp).mockResolvedValue(undefined);
+
+  const skillManager = createSkillManager();
+  await skillManager.init();
+
+  const sourceDir = resolve('/source/skills/my-skill');
+  const sourcePath = join(sourceDir, 'SKILL.md');
+
+  await skillManager.createSkill(
+    {
+      name: 'imported-skill',
+      description: 'An imported skill',
+      content: '# Imported',
+      sourcePath,
+    },
+    SKILLS_DIR,
+  );
+
+  const expectedDir = join(SKILLS_DIR, 'imported-skill');
+  expect(cp).toHaveBeenCalledWith(join(sourceDir, 'examples.md'), join(expectedDir, 'examples.md'), {
+    recursive: true,
+  });
+  expect(cp).toHaveBeenCalledWith(join(sourceDir, 'references'), join(expectedDir, 'references'), {
+    recursive: true,
+  });
+  expect(cp).not.toHaveBeenCalledWith(join(sourceDir, 'SKILL.md'), join(expectedDir, 'SKILL.md'), expect.anything());
+});
+
+test('createSkill without sourcePath should not copy any files', async () => {
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(mkdir).mockResolvedValue(undefined);
+  vi.mocked(writeFile).mockResolvedValue(undefined);
+
+  const skillManager = createSkillManager();
+  await skillManager.init();
+
+  await skillManager.createSkill(
+    { name: 'manual-skill', description: 'A manual skill', content: '# Manual' },
+    SKILLS_DIR,
+  );
+
+  expect(cp).not.toHaveBeenCalled();
 });
 
 test('createSkill should throw when target is not registered', async () => {

--- a/packages/main/src/plugin/skill/skill-manager.ts
+++ b/packages/main/src/plugin/skill/skill-manager.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
-import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { join, resolve, sep } from 'node:path';
+import { cp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
 
 import type { Configuration } from '@openkaiden/api';
 import { inject, injectable, preDestroy } from 'inversify';
@@ -267,6 +267,15 @@ export class SkillManager {
     const frontmatter = dump({ name: metadata.name, description: metadata.description }).trimEnd();
     const fileContent = `---\n${frontmatter}\n---\n\n${body}`;
     await writeFile(join(skillDir, SKILL_FILE_NAME), fileContent, 'utf-8');
+
+    if (options.sourcePath) {
+      const sourceDir = dirname(options.sourcePath);
+      const entries = await readdir(sourceDir);
+      for (const entry of entries) {
+        if (entry === SKILL_FILE_NAME) continue;
+        await cp(join(sourceDir, entry), join(skillDir, entry), { recursive: true });
+      }
+    }
 
     const skill: SkillInfo = {
       ...metadata,

--- a/packages/renderer/src/lib/skills/SkillCreate.spec.ts
+++ b/packages/renderer/src/lib/skills/SkillCreate.spec.ts
@@ -242,7 +242,12 @@ test('should prefill fields from parsed file when browsing', async () => {
   await fireEvent.click(createButton);
 
   expect(window.createSkill).toHaveBeenCalledWith(
-    { name: 'parsed-skill', description: 'Parsed description', content: '# Body content' },
+    {
+      name: 'parsed-skill',
+      description: 'Parsed description',
+      content: '# Body content',
+      sourcePath: '/home/user/skills/SKILL.md',
+    },
     '/test/skills',
   );
 });

--- a/packages/renderer/src/lib/skills/SkillCreate.svelte
+++ b/packages/renderer/src/lib/skills/SkillCreate.svelte
@@ -37,7 +37,12 @@ async function create(): Promise<void> {
 
   try {
     await window.createSkill(
-      { name: name.trim(), description: description.trim(), content: skillContent.trim() || undefined },
+      {
+        name: name.trim(),
+        description: description.trim(),
+        content: skillContent.trim() || undefined,
+        sourcePath: selectedFile || undefined,
+      },
       target,
     );
     onclose();


### PR DESCRIPTION
To test:

- import the skill from Kaiden repository
- Check that all files have been copied into $HOME/.local/share/kaiden/skills
- Delete the skill
- Check that the folder $HOME/.local/share/kaiden/skills under has been removed

- Fixes #1346