### PR TITLE
fix: ensure Milvus MCP servers are unique

### DIFF
--- a/extensions/milvus/src/api/milvus-connection.ts
+++ b/extensions/milvus/src/api/milvus-connection.ts
@@ -36,7 +36,7 @@ export class MilvusConnection implements api.RagProviderConnection {
   ) {
     this.connectionStatus = running ? 'started' : 'stopped';
     const server: MCPServerDetail = {
-      name: 'mcp-server-milvus',
+      name: `kaiden.milvus.mcp-server-milvus-${name}`,
       version: '0.1.1.dev8',
       description: 'Milvus MCP Server for RAG',
       packages: [


### PR DESCRIPTION
To test

- create 2 Milvus resources
- check that the registered MCP servers have different ids

<img width="1033" height="554" alt="image" src="https://github.com/user-attachments/assets/e91e3468-a242-40a9-b5a0-64fcf6915871" />


Fixes #1349