### PR TITLE
feat: add Secret Vault list page

### DIFF
--- a/packages/api/src/secret-vault/secret-vault-info.ts
+++ b/packages/api/src/secret-vault/secret-vault-info.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export type SecretCategory = 'api' | 'infra';
+export type SecretStatus = 'active' | 'expired' | 'warning';
+
+export interface SecretVaultInfo {
+  id: string;
+  name: string;
+  category: SecretCategory;
+  type?: string;
+  description?: string;
+  expiration?: Date;
+  status: SecretStatus;
+}

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -81,6 +81,7 @@ import PodsList from './lib/pod/PodsList.svelte';
 import PreferencesPage from './lib/preferences/PreferencesPage.svelte';
 import PVCDetails from './lib/pvc/PVCDetails.svelte';
 import PVCList from './lib/pvc/PVCList.svelte';
+import SecretVaultList from './lib/secret-vault/SecretVaultList.svelte';
 import ServiceDetails from './lib/service/ServiceDetails.svelte';
 import ServicesList from './lib/service/ServicesList.svelte';
 import SkillDetails from './lib/skills/SkillDetails.svelte';
@@ -237,6 +238,11 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
           <Route path="/:name/*" let:meta breadcrumb="Knowledge Database Details" navigationHint="details">
             <RAGEnvironmentDetails name={decodeURIComponent(meta.params.name)} />
           </Route>
+        </Route>
+
+        <!-- Secret Vault -->
+        <Route path="/secret-vault" breadcrumb="Secret Vault" navigationHint="root">
+          <SecretVaultList />
         </Route>
 
         <Route path="/containers" breadcrumb="Containers" navigationHint="root">

--- a/packages/renderer/src/lib/secret-vault/SecretVaultEmptyScreen.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultEmptyScreen.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
+
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+
+interface Props {
+  onclick(): void;
+}
+
+let { onclick }: Props = $props();
+</script>
+
+<EmptyScreen title="No secrets" icon={NoLogIcon}>
+  <Button icon={faPlus} onclick={onclick}>
+    Add Secret
+  </Button>
+</EmptyScreen>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { Button, FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { filteredSecretVaultInfos, secretVaultCategoryFilter, secretVaultSearchPattern } from '/@/stores/secret-vault';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+import { SecretVaultDescriptionColumn } from './columns/secret-vault-columns';
+import SecretVaultCategoryIcon from './columns/SecretVaultCategoryIcon.svelte';
+import SecretVaultExpiry from './columns/SecretVaultExpiry.svelte';
+import SecretVaultName from './columns/SecretVaultName.svelte';
+import SecretVaultStatus from './columns/SecretVaultStatus.svelte';
+import SecretVaultEmptyScreen from './SecretVaultEmptyScreen.svelte';
+
+type SecretVaultSelectable = SecretVaultInfo & { selected: boolean };
+
+type CategoryScreen = 'all' | 'api' | 'infra';
+let screen: CategoryScreen = $state('all');
+
+let searchTerm = $state('');
+
+$effect(() => {
+  secretVaultSearchPattern.set(searchTerm);
+});
+
+$effect(() => {
+  secretVaultCategoryFilter.set(screen);
+});
+
+function changeScreen(newScreen: CategoryScreen): void {
+  if (screen === newScreen) {
+    return;
+  }
+  screen = newScreen;
+}
+
+const row = new TableRow<SecretVaultSelectable>({});
+
+const iconColumn = new TableColumn<SecretVaultSelectable>('', {
+  width: '60px',
+  renderer: SecretVaultCategoryIcon,
+});
+
+const nameColumn = new TableColumn<SecretVaultSelectable>('Name', {
+  width: '2fr',
+  renderer: SecretVaultName,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+const expirationColumn = new TableColumn<SecretVaultSelectable>('Expiration', {
+  width: '120px',
+  renderer: SecretVaultExpiry,
+  comparator: (a, b): number =>
+    (a.expiration?.getTime() ?? Number.POSITIVE_INFINITY) - (b.expiration?.getTime() ?? Number.POSITIVE_INFINITY),
+});
+
+const statusColumn = new TableColumn<SecretVaultSelectable>('Status', {
+  width: '100px',
+  align: 'center',
+  renderer: SecretVaultStatus,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+const columns = [iconColumn, nameColumn, new SecretVaultDescriptionColumn(), expirationColumn, statusColumn];
+
+const secrets: SecretVaultSelectable[] = $derived(
+  $filteredSecretVaultInfos.map(secret => ({ ...secret, selected: false })),
+);
+
+function addSecret(): void {
+  // TODO: navigate to secret creation page
+}
+</script>
+
+<NavPage bind:searchTerm={searchTerm} title="Secret Vault">
+  {#snippet additionalActions()}
+    <Button icon={faPlus} onclick={addSecret}>
+      Add Secret
+    </Button>
+  {/snippet}
+
+  {#snippet tabs()}
+    <Button type="tab" onclick={(): void => { changeScreen('all'); }} selected={screen === 'all'}>
+      All secrets
+    </Button>
+    <Button type="tab" onclick={(): void => { changeScreen('api'); }} selected={screen === 'api'}>
+      API tokens
+    </Button>
+    <Button type="tab" onclick={(): void => { changeScreen('infra'); }} selected={screen === 'infra'}>
+      Infrastructure
+    </Button>
+  {/snippet}
+
+  {#snippet content()}
+    <div class="flex min-w-full h-full">
+      {#if secrets.length === 0}
+        {#if searchTerm}
+          <FilteredEmptyScreen icon={NoLogIcon} kind="secrets" bind:searchTerm={searchTerm} />
+        {:else}
+          <SecretVaultEmptyScreen onclick={addSecret} />
+        {/if}
+      {:else}
+        <Table
+          kind="secret-vault"
+          data={secrets}
+          columns={columns}
+          row={row}
+          defaultSortColumn="Name"
+        />
+      {/if}
+    </div>
+  {/snippet}
+</NavPage>

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultCategoryIcon.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultCategoryIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
+import { faServer } from '@fortawesome/free-solid-svg-icons/faServer';
+import Fa from 'svelte-fa';
+
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+interface Props {
+  object: SecretVaultInfo;
+}
+
+let { object }: Props = $props();
+
+const icon = $derived(object.category === 'api' ? faKey : faServer);
+</script>
+
+<div class="flex items-center justify-center" title={object.category === 'api' ? 'API token' : 'Infrastructure'}>
+  <Fa {icon} size="1.1x" />
+</div>

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultExpiry.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultExpiry.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+interface Props {
+  object: SecretVaultInfo;
+}
+
+let { object }: Props = $props();
+
+const isExpired = $derived(object.status === 'expired');
+</script>
+
+<div
+  class="overflow-hidden text-ellipsis whitespace-nowrap max-w-full {isExpired ? 'text-[var(--pd-status-terminated)]' : 'text-[var(--pd-table-body-text)]'}"
+  title={object.expiration?.toLocaleDateString() ?? '—'}>
+  {object.expiration?.toLocaleDateString() ?? '—'}
+</div>

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultName.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultName.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import Badge from '/@/lib/ui/Badge.svelte';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+interface Props {
+  object: SecretVaultInfo;
+}
+
+let { object }: Props = $props();
+
+const badgeColor = $derived(object.category === 'api' ? 'bg-[var(--pd-badge-sky)]' : 'bg-[var(--pd-badge-fuschia)]');
+</script>
+
+<div class="flex items-center gap-2 overflow-hidden max-w-full">
+  <span
+  class="text-[var(--pd-table-body-text-highlight)] text-[14px] font-semibold leading-normal overflow-hidden text-ellipsis whitespace-nowrap"
+    title={object.name}>
+    {object.name}
+  </span>
+  {#if object.type}
+    <Badge class="text-[6px] text-white" color={badgeColor} label={object.type} />
+  {/if}
+</div>

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultStatus.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultStatus.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+interface Props {
+  object: SecretVaultInfo;
+}
+
+let { object }: Props = $props();
+
+const statusColor = $derived(
+  object.status === 'active'
+    ? 'text-[var(--pd-status-running)]'
+    : object.status === 'expired'
+      ? 'text-[var(--pd-status-terminated)]'
+      : 'text-[var(--pd-status-waiting)]',
+);
+</script>
+
+<div
+  class="overflow-hidden text-ellipsis whitespace-nowrap max-w-full capitalize {statusColor}"
+  title={object.status.charAt(0).toUpperCase() + object.status.slice(1)}>
+  {object.status}
+</div>

--- a/packages/renderer/src/lib/secret-vault/columns/secret-vault-columns.ts
+++ b/packages/renderer/src/lib/secret-vault/columns/secret-vault-columns.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { TableColumn } from '@podman-desktop/ui-svelte';
+import SimpleColumn from '@podman-desktop/ui-svelte/TableSimpleColumn';
+
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+export class SecretVaultDescriptionColumn extends TableColumn<SecretVaultInfo, string> {
+  constructor() {
+    super('Description', {
+      width: '3fr',
+      renderMapping: (secret): string => secret.description ?? '',
+      renderer: SimpleColumn,
+      comparator: (a, b): number => (a.description ?? '').localeCompare(b.description ?? ''),
+    });
+  }
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-secret-vault.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-secret-vault.svelte.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
+
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+const count = $state(0);
+
+export function createNavigationSecretVaultEntry(): NavigationRegistryEntry {
+  const registry: NavigationRegistryEntry = {
+    name: 'Secret Vault',
+    icon: { faIcon: { definition: faKey, size: 'lg' } },
+    link: '/secret-vault',
+    tooltip: 'Secret Vault',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -28,6 +28,7 @@ import { createNavigationAgentWorkspacesEntry } from './navigation-registry-agen
 import { createNavigationExtensionEntry, createNavigationExtensionGroup } from './navigation-registry-extension.svelte';
 import { createNavigationMcpEntry } from './navigation-registry-mcp.svelte';
 import { createNavigationRagEntry } from './navigation-registry-rag.svelte';
+import { createNavigationSecretVaultEntry } from './navigation-registry-secret-vault.svelte';
 import { createNavigationSkillsEntry } from './navigation-registry-skills.svelte';
 
 export interface NavigationRegistryEntry {
@@ -61,17 +62,9 @@ let hiddenItems: string[] = [];
 let values: NavigationRegistryEntry[] = [];
 let initialized = false;
 const init = (): void => {
-  /*
-  Kaiden has no container or kubernetes provider connection creation, so we hide the related navigation items and only keep the ones relevant for MCP, Flows and Extensions for now.
-  values.push(createNavigationContainerEntry());
-  values.push(createNavigationPodEntry());
-  values.push(createNavigationImageEntry());
-  values.push(createNavigationVolumeEntry());
-  values.push(createNavigationNetworkEntry());
-  values.push(createNavigationKubernetesGroup());
-  */
   values.push(createNavigationAgentWorkspacesEntry());
   values.push(createNavigationMcpEntry());
+  values.push(createNavigationSecretVaultEntry());
   values.push(createNavigationSkillsEntry());
   values.push(createNavigationRagEntry());
   values.push(createNavigationExtensionEntry());

--- a/packages/renderer/src/stores/secret-vault.ts
+++ b/packages/renderer/src/stores/secret-vault.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
+
+import { findMatchInLeaves } from '/@/stores/search-util';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+// TODO: wire to backend data source
+export const secretVaultInfos: Writable<readonly SecretVaultInfo[]> = writable([]);
+
+export const secretVaultSearchPattern = writable('');
+
+export const secretVaultCategoryFilter = writable<'all' | 'api' | 'infra'>('all');
+
+export const filteredSecretVaultInfos = derived(
+  [secretVaultInfos, secretVaultSearchPattern, secretVaultCategoryFilter],
+  ([$secretVaultInfos, $secretVaultSearchPattern, $secretVaultCategoryFilter]) => {
+    let filtered = $secretVaultInfos;
+
+    if ($secretVaultCategoryFilter !== 'all') {
+      filtered = filtered.filter(secret => secret.category === $secretVaultCategoryFilter);
+    }
+
+    const pattern = $secretVaultSearchPattern.trim();
+    if (pattern.length) {
+      filtered = filtered.filter(secret => findMatchInLeaves(secret, pattern));
+    }
+
+    return filtered;
+  },
+);


### PR DESCRIPTION
## Summary
- Add Secret Vault list page following the existing SkillsList pattern 1-to-1 with layout guidance from the mockup
- Includes API type, store, navigation entry, list page with search, empty state, and Name/Description/Expiry/Status columns
- No backend wiring yet — page renders empty state with Add Secret button

Fixes https://github.com/openkaiden/kaiden/issues/1330

<img width="1569" height="966" alt="Screenshot From 2026-04-16 01-45-12" src="https://github.com/user-attachments/assets/a5f44dc9-02d3-44c2-835e-38532775f209" />

<img width="791" height="539" alt="image" src="https://github.com/user-attachments/assets/f6bdc438-dcc5-4540-a0a7-ea531df5d52c" />

compared to mockup

<img width="895" height="487" alt="image" src="https://github.com/user-attachments/assets/1451b0f7-9c20-4faa-9968-d4a95e91dd49" />


## Test plan
- [ ] Verify Secret Vault appears in sidebar navigation
- [ ] Verify clicking it shows the empty state with "Add Secret" button
- [ ] Verify search bar is functional
- [ ] Verify typecheck passes (`pnpm run typecheck:renderer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)