### PR TITLE
feat: add OpenCode coding agent to agent workspace wizard 

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -69,6 +69,7 @@ test('Expect coding agent options displayed', () => {
   expect(screen.getByText('Claude')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Cursor' })).toBeInTheDocument();
   expect(screen.getByText('Goose')).toBeInTheDocument();
+  expect(screen.getByText('OpenCode')).toBeInTheDocument();
 });
 
 test('Expect agent badges displayed', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -5,6 +5,7 @@ import {
   faGears,
   faHome,
   faLock,
+  faO,
   faPlus,
   faRobot,
   faServer,
@@ -27,6 +28,13 @@ import { NavigationPage } from '/@api/navigation-page';
 
 // Mock coding agents until real provider connections are available
 const agentOptions = [
+  {
+    title: 'OpenCode',
+    badge: 'Anomaly',
+    value: 'opencode',
+    icon: faO,
+    description: 'Open-source terminal-based coding agent',
+  },
   {
     title: 'Claude',
     badge: 'Anthropic',


### PR DESCRIPTION
Added OpenCode to the list of hard coded agents

<img width="1192" height="1102" alt="Screenshot 2026-04-16 at 14 57 12" src="https://github.com/user-attachments/assets/f3858f08-335b-4987-a2cf-0658e5730002" />

Added first in the list as it'll be the default recommendation (as per latest mockups).
combined with #1231, the created workspace properly opens with open code and its default model.

Fixes #1367
