### PR TITLE
fix(e2e): increase timeout for MCP server count restore check

### DIFF
--- a/tests/playwright/src/specs/provider-specs/mcp-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/mcp-smoke.spec.ts
@@ -54,7 +54,7 @@ test.describe('MCP Registry Management', { tag: '@smoke' }, () => {
     await editRegistriesTab.ensureRowDoesNotExist(MCP_REGISTRY_URL);
 
     await mcpPage.openInstallTab();
-    await installTab.verifyServerCountIsRestored(initialServerCount);
+    await installTab.verifyServerCountIsRestored(initialServerCount, SERVER_LIST_UPDATE_TIMEOUT);
   });
 
   test('[MCP-02] Add and remove MCP server: verify server list updates accordingly', async ({


### PR DESCRIPTION
## Summary
- Fixed flaky `[MCP-01]` E2E test in `mcp-smoke.spec.ts` by passing `SERVER_LIST_UPDATE_TIMEOUT` (120s) to `verifyServerCountIsRestored`, matching the timeout already used for `verifyServerCountIncreased`
- The default 10s timeout was insufficient for the server list to update after registry removal in CI

## Test plan
- [ ] Verify `[MCP-01]` MCP smoke test passes consistently in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)