### PR TITLE
fix: update GitHub MCP server ID in chat suggested actions

### DIFF
--- a/packages/renderer/src/lib/chat/components/suggested-actions.svelte
+++ b/packages/renderer/src/lib/chat/components/suggested-actions.svelte
@@ -35,7 +35,7 @@ const suggestedActions: SuggestedAction[] = [
     action: 'What are the last 5 issues of GitHub repository podman-desktop/podman-desktop?',
     requiredMcp: [
       {
-        mcpId: 'com.github.mcp',
+        mcpId: 'ai.openkaiden.registry/github',
         tools: ['list_issues'],
       },
     ],


### PR DESCRIPTION
The mcpId for the GitHub MCP was changed in #1338 but the suggested
actions reference was not updated, preventing the sample message from
working as the GitHub MCP server was not found.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
