### PR TITLE
fix: handle workspace state

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.spec.ts
@@ -19,10 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 import AgentWorkspaceCard from './AgentWorkspaceCard.svelte';
@@ -48,7 +49,7 @@ beforeEach(() => {
   vi.mocked(window.listAgentWorkspaces).mockResolvedValue([]);
   vi.mocked(window.startAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
   vi.mocked(window.stopAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
-  agentWorkspaceStatuses.clear();
+  agentWorkspaces.set([{ ...workspace }]);
 });
 
 test('Expect card displays workspace name', () => {
@@ -156,28 +157,24 @@ test('Expect clicking start button calls startAgentWorkspace', async () => {
   await fireEvent.click(startButton);
 
   await vi.waitFor(() => {
-    expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+    expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('running');
   });
 });
 
 test('Expect stop button is rendered when workspace is running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
-
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceCard, { workspace: { ...workspace, state: 'running' } });
 
   expect(screen.getByRole('button', { name: 'Stop workspace api-refactor' })).toBeInTheDocument();
 });
 
 test('Expect clicking stop button calls stopAgentWorkspace', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
-
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceCard, { workspace: { ...workspace, state: 'running' } });
 
   const stopButton = screen.getByRole('button', { name: 'Stop workspace api-refactor' });
   await fireEvent.click(stopButton);
 
   await vi.waitFor(() => {
-    expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+    expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopped');
   });
 });
 
@@ -199,7 +196,7 @@ test('Expect error dialog shown when start fails', async () => {
     );
   });
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopped');
 });
 
 test('Expect error dialog uses workspace name when start fails', async () => {
@@ -220,10 +217,9 @@ test('Expect error dialog uses workspace name when start fails', async () => {
 });
 
 test('Expect error dialog shown when stop fails', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));
 
-  render(AgentWorkspaceCard, { workspace });
+  render(AgentWorkspaceCard, { workspace: { ...workspace, state: 'running' } });
 
   const stopButton = screen.getByRole('button', { name: 'Stop workspace api-refactor' });
   await fireEvent.click(stopButton);
@@ -238,5 +234,5 @@ test('Expect error dialog shown when stop fails', async () => {
     );
   });
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('running');
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
@@ -5,19 +5,21 @@ import { router } from 'tinro';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import LoadingIcon from '/@/lib/ui/LoadingIcon.svelte';
-import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces.svelte';
-import { agentWorkspaceStatuses, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
-import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+import {
+  type AgentWorkspaceSummaryUI,
+  startAgentWorkspace,
+  stopAgentWorkspace,
+} from '/@/stores/agent-workspaces.svelte';
 
 interface Props {
-  workspace: AgentWorkspaceSummary;
+  workspace: AgentWorkspaceSummaryUI;
 }
 
 let { workspace }: Props = $props();
 
-const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspace.id) ?? 'stopped');
-const isRunning = $derived(status === 'running' || status === 'stopping');
-const inProgress = $derived(status === 'starting' || status === 'stopping');
+const state = $derived(workspace.state);
+const isRunning = $derived(state === 'running' || state === 'stopping');
+const inProgress = $derived(state === 'starting' || state === 'stopping');
 
 function handleOpen(): void {
   router.goto(`/agent-workspaces/${encodeURIComponent(workspace.id)}/summary`);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -23,7 +23,7 @@ import { get, writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaces, agentWorkspaceStatuses } from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceConfiguration, AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 import AgentWorkspaceDetails from './AgentWorkspaceDetails.svelte';
@@ -64,8 +64,7 @@ beforeEach(() => {
   vi.mocked(window.stopAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
   vi.mocked(window.removeAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
-  agentWorkspaces.set([workspaceSummary]);
-  agentWorkspaceStatuses.clear();
+  agentWorkspaces.set([{ ...workspaceSummary }]);
 });
 
 test('Expect page title to use workspace summary name', async () => {
@@ -131,12 +130,12 @@ test('Expect clicking start button transitions workspace to running', async () =
   await fireEvent.click(startButton);
 
   await waitFor(() => {
-    expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+    expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('running');
   });
 });
 
 test('Expect stop button is rendered when workspace is running', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 
@@ -146,7 +145,7 @@ test('Expect stop button is rendered when workspace is running', async () => {
 });
 
 test('Expect clicking stop button transitions workspace to stopped', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 
@@ -158,7 +157,7 @@ test('Expect clicking stop button transitions workspace to stopped', async () =>
   await fireEvent.click(stopButton);
 
   await waitFor(() => {
-    expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+    expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopped');
   });
 });
 
@@ -240,7 +239,7 @@ test('Expect error dialog shown when start fails', async () => {
     );
   });
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopped');
 });
 
 test('Expect error dialog uses workspace name when start fails', async () => {
@@ -265,7 +264,7 @@ test('Expect error dialog uses workspace name when start fails', async () => {
 });
 
 test('Expect error dialog shown when stop fails', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));
 
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
@@ -287,7 +286,7 @@ test('Expect error dialog shown when stop fails', async () => {
     );
   });
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('running');
 });
 
 test('Expect no navigation when removal fails', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -9,13 +9,7 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
-import type { AgentWorkspaceStatus } from '/@/stores/agent-workspaces.svelte';
-import {
-  agentWorkspaces,
-  agentWorkspaceStatuses,
-  startAgentWorkspace,
-  stopAgentWorkspace,
-} from '/@/stores/agent-workspaces.svelte';
+import { agentWorkspaces, startAgentWorkspace, stopAgentWorkspace } from '/@/stores/agent-workspaces.svelte';
 
 interface Props {
   workspaceId: string;
@@ -28,7 +22,7 @@ let configurationError: string | undefined = $state(undefined);
 
 const workspaceSummary = $derived($agentWorkspaces.find(ws => ws.id === workspaceId));
 
-const status: AgentWorkspaceStatus = $derived(agentWorkspaceStatuses.get(workspaceId) ?? 'stopped');
+const status = $derived(workspaceSummary?.state ?? 'stopped');
 const isRunning = $derived(status === 'running' || status === 'stopping');
 const inProgress = $derived(status === 'starting' || status === 'stopping');
 
@@ -49,13 +43,13 @@ $effect(() => {
 });
 
 async function handleStartStop(): Promise<void> {
-  if (inProgress) return;
+  if (inProgress || workspaceSummary === undefined) return;
   const name = workspaceSummary?.name ?? workspaceId;
   try {
     if (isRunning) {
-      await stopAgentWorkspace(workspaceId);
+      await stopAgentWorkspace(workspaceSummary.id);
     } else {
-      await startAgentWorkspace(workspaceId);
+      await startAgentWorkspace(workspaceSummary.id);
     }
   } catch (error: unknown) {
     const action = isRunning ? 'stopping' : 'starting';

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSummary.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSummary.svelte
@@ -2,10 +2,11 @@
 import DetailsCell from '/@/lib/details/DetailsCell.svelte';
 import DetailsTable from '/@/lib/details/DetailsTable.svelte';
 import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
-import type { AgentWorkspaceConfiguration, AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
+import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
 
 interface Props {
-  workspaceSummary: AgentWorkspaceSummary | undefined;
+  workspaceSummary: AgentWorkspaceSummaryUI | undefined;
   configuration: AgentWorkspaceConfiguration;
 }
 

--- a/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
@@ -16,13 +16,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { agentWorkspaceStatuses, startAgentWorkspace, stopAgentWorkspace } from './agent-workspaces.svelte';
+import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+
+import { agentWorkspaces, startAgentWorkspace, stopAgentWorkspace } from './agent-workspaces.svelte';
+
+const workspace: AgentWorkspaceSummary = {
+  id: 'ws-1',
+  name: 'api-refactor',
+  project: 'backend',
+  agent: 'coder-v1',
+  state: 'stopped',
+  paths: {
+    source: '/home/user/projects/backend',
+    configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
+  },
+};
 
 beforeEach(() => {
   vi.resetAllMocks();
-  agentWorkspaceStatuses.clear();
+  agentWorkspaces.set([{ ...workspace }]);
 });
 
 test('startAgentWorkspace should transition status from stopped to running', async () => {
@@ -31,7 +46,7 @@ test('startAgentWorkspace should transition status from stopped to running', asy
   await startAgentWorkspace('ws-1');
 
   expect(window.startAgentWorkspace).toHaveBeenCalledWith('ws-1');
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('running');
 });
 
 test('startAgentWorkspace should set starting status during the call', async () => {
@@ -44,12 +59,12 @@ test('startAgentWorkspace should set starting status during the call', async () 
 
   const promise = startAgentWorkspace('ws-1');
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('starting');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('starting');
 
   resolveStart({ id: 'ws-1' });
   await promise;
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('running');
 });
 
 test('startAgentWorkspace should revert to stopped on failure and re-throw', async () => {
@@ -57,21 +72,21 @@ test('startAgentWorkspace should revert to stopped on failure and re-throw', asy
 
   await expect(startAgentWorkspace('ws-1')).rejects.toThrow('start failed');
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopped');
 });
 
 test('stopAgentWorkspace should transition status from running to stopped', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
   vi.mocked(window.stopAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
 
   await stopAgentWorkspace('ws-1');
 
   expect(window.stopAgentWorkspace).toHaveBeenCalledWith('ws-1');
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopped');
 });
 
 test('stopAgentWorkspace should set stopping status during the call', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
 
   let resolveStop: (value: { id: string }) => void = () => {};
   vi.mocked(window.stopAgentWorkspace).mockReturnValue(
@@ -82,19 +97,19 @@ test('stopAgentWorkspace should set stopping status during the call', async () =
 
   const promise = stopAgentWorkspace('ws-1');
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopping');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopping');
 
   resolveStop({ id: 'ws-1' });
   await promise;
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('stopped');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('stopped');
 });
 
 test('stopAgentWorkspace should revert to running on failure and re-throw', async () => {
-  agentWorkspaceStatuses.set('ws-1', 'running');
+  agentWorkspaces.set([{ ...workspace, state: 'running' }]);
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop failed'));
 
   await expect(stopAgentWorkspace('ws-1')).rejects.toThrow('stop failed');
 
-  expect(agentWorkspaceStatuses.get('ws-1')).toBe('running');
+  expect(get(agentWorkspaces).find(w => w.id === 'ws-1')?.state).toBe('running');
 });

--- a/packages/renderer/src/stores/agent-workspaces.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.ts
@@ -16,17 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { SvelteMap } from 'svelte/reactivity';
-import { type Writable, writable } from 'svelte/store';
+import { get, type Writable, writable } from 'svelte/store';
 
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
 import { EventStore } from './event-store';
 
-export type AgentWorkspaceStatus = 'stopped' | 'running' | 'starting' | 'stopping';
+export type AgentWorkspaceState = AgentWorkspaceSummary['state'] | 'starting' | 'stopping';
 
-export const agentWorkspaces: Writable<AgentWorkspaceSummary[]> = writable([]);
-export const agentWorkspaceStatuses = new SvelteMap<string, AgentWorkspaceStatus>();
+export const agentWorkspaces: Writable<AgentWorkspaceSummaryUI[]> = writable([]);
+
+export type AgentWorkspaceSummaryUI = Omit<AgentWorkspaceSummary, 'state'> & { state: AgentWorkspaceState };
 
 let readyToUpdate = false;
 
@@ -37,9 +37,11 @@ export async function checkForUpdate(eventName: string): Promise<boolean> {
   return readyToUpdate;
 }
 
-const listWorkspaces = (): Promise<AgentWorkspaceSummary[]> => window.listAgentWorkspaces();
+const listWorkspaces = async (): Promise<AgentWorkspaceSummaryUI[]> => {
+  return (await window.listAgentWorkspaces()) as AgentWorkspaceSummaryUI[];
+};
 
-export const agentWorkspacesEventStore = new EventStore<AgentWorkspaceSummary[]>(
+export const agentWorkspacesEventStore = new EventStore<AgentWorkspaceSummaryUI[]>(
   'agent-workspaces',
   agentWorkspaces,
   checkForUpdate,
@@ -50,24 +52,32 @@ export const agentWorkspacesEventStore = new EventStore<AgentWorkspaceSummary[]>
 agentWorkspacesEventStore.setup();
 
 export async function startAgentWorkspace(id: string): Promise<void> {
-  agentWorkspaceStatuses.set(id, 'starting');
+  const workspace = get(agentWorkspaces).find(ws => ws.id === id);
+  if (workspace === undefined) {
+    throw new Error(`Invalid workspace id: ${id}`);
+  }
+  workspace.state = 'starting';
   try {
-    await window.startAgentWorkspace(id);
-    agentWorkspaceStatuses.set(id, 'running');
+    await window.startAgentWorkspace(workspace.id);
+    workspace.state = 'running';
   } catch (error: unknown) {
-    agentWorkspaceStatuses.set(id, 'stopped');
+    workspace.state = 'stopped';
     console.error('Failed to start agent workspace', error);
     throw error;
   }
 }
 
 export async function stopAgentWorkspace(id: string): Promise<void> {
-  agentWorkspaceStatuses.set(id, 'stopping');
+  const workspace = get(agentWorkspaces).find(ws => ws.id === id);
+  if (workspace === undefined) {
+    throw new Error(`Invalid workspace id: ${id}`);
+  }
+  workspace.state = 'stopping';
   try {
-    await window.stopAgentWorkspace(id);
-    agentWorkspaceStatuses.set(id, 'stopped');
+    await window.stopAgentWorkspace(workspace.id);
+    workspace.state = 'stopped';
   } catch (error: unknown) {
-    agentWorkspaceStatuses.set(id, 'running');
+    workspace.state = 'running';
     console.error('Failed to stop agent workspace', error);
     throw error;
   }

--- a/packages/renderer/src/stores/agent-workspaces.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { get, type Writable, writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 
 import type { AgentWorkspaceSummary } from '/@api/agent-workspace-info';
 
@@ -51,33 +51,44 @@ export const agentWorkspacesEventStore = new EventStore<AgentWorkspaceSummaryUI[
 );
 agentWorkspacesEventStore.setup();
 
+function setWorkspaceState(id: string, state: AgentWorkspaceState): boolean {
+  let found = false;
+  agentWorkspaces.update(workspaces => {
+    const updatedWorkspaces = workspaces.map(workspace => {
+      if (workspace.id !== id) {
+        return workspace;
+      }
+      found = true;
+      return { ...workspace, state };
+    });
+    return found ? updatedWorkspaces : workspaces;
+  });
+  return found;
+}
+
 export async function startAgentWorkspace(id: string): Promise<void> {
-  const workspace = get(agentWorkspaces).find(ws => ws.id === id);
-  if (workspace === undefined) {
+  if (!setWorkspaceState(id, 'starting')) {
     throw new Error(`Invalid workspace id: ${id}`);
   }
-  workspace.state = 'starting';
   try {
-    await window.startAgentWorkspace(workspace.id);
-    workspace.state = 'running';
+    await window.startAgentWorkspace(id);
+    setWorkspaceState(id, 'running');
   } catch (error: unknown) {
-    workspace.state = 'stopped';
+    setWorkspaceState(id, 'stopped');
     console.error('Failed to start agent workspace', error);
     throw error;
   }
 }
 
 export async function stopAgentWorkspace(id: string): Promise<void> {
-  const workspace = get(agentWorkspaces).find(ws => ws.id === id);
-  if (workspace === undefined) {
+  if (!setWorkspaceState(id, 'stopping')) {
     throw new Error(`Invalid workspace id: ${id}`);
   }
-  workspace.state = 'stopping';
   try {
-    await window.stopAgentWorkspace(workspace.id);
-    workspace.state = 'stopped';
+    await window.stopAgentWorkspace(id);
+    setWorkspaceState(id, 'stopped');
   } catch (error: unknown) {
-    workspace.state = 'running';
+    setWorkspaceState(id, 'running');
     console.error('Failed to stop agent workspace', error);
     throw error;
   }


### PR DESCRIPTION
To test:

- have a stopped workspace
- start Kaiden
- verify workspace page allows to start the workspace
- start the workspace
- restart kaiden
- verifies workspace page allows to stop the workspace
 
Fixes #1390