### PR TITLE
feat(secret-vault): add secret creation form page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -65,4 +65,6 @@ export enum NavigationPage {
   SKILLS = 'skills',
   SKILL_DETAILS = 'skill-details',
   RAG_ENVIRONMENT_DETAILS = 'rag-environment-details',
+  SECRET_VAULT = 'secret-vault',
+  SECRET_VAULT_CREATE = 'secret-vault-create',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -85,6 +85,8 @@ export interface NavigationParameters {
   [NavigationPage.RAG_ENVIRONMENT_DETAILS]: {
     name: string;
   };
+  [NavigationPage.SECRET_VAULT]: never;
+  [NavigationPage.SECRET_VAULT_CREATE]: never;
 }
 
 // the parameters property is optional when the NavigationParameters say it is

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -83,6 +83,7 @@ import PodsList from './lib/pod/PodsList.svelte';
 import PreferencesPage from './lib/preferences/PreferencesPage.svelte';
 import PVCDetails from './lib/pvc/PVCDetails.svelte';
 import PVCList from './lib/pvc/PVCList.svelte';
+import SecretVaultCreate from './lib/secret-vault/SecretVaultCreate.svelte';
 import SecretVaultList from './lib/secret-vault/SecretVaultList.svelte';
 import ServiceDetails from './lib/service/ServiceDetails.svelte';
 import ServicesList from './lib/service/ServicesList.svelte';
@@ -274,8 +275,13 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
 
         <!-- Secret Vault -->
-        <Route path="/secret-vault" breadcrumb="Secret Vault" navigationHint="root">
-          <SecretVaultList />
+        <Route path="/secret-vault/*" breadcrumb="Secret Vault" navigationHint="root">
+          <Route path="/">
+            <SecretVaultList />
+          </Route>
+          <Route path="/create" breadcrumb="Add Secret" navigationHint="details">
+            <SecretVaultCreate />
+          </Route>
         </Route>
 
         <Route path="/containers" breadcrumb="Containers" navigationHint="root">

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import SecretVaultCreate from './SecretVaultCreate.svelte';
+
+vi.mock(import('/@/navigation'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect form elements rendered correctly', () => {
+  render(SecretVaultCreate);
+
+  const headings = screen.getAllByText('Add Secret');
+  expect(headings.length).toBeGreaterThanOrEqual(1);
+
+  expect(screen.getByPlaceholderText('e.g. GitHub · docs repo')).toBeInTheDocument();
+  expect(screen.getByText('API Token')).toBeInTheDocument();
+  expect(screen.getByText('Infrastructure')).toBeInTheDocument();
+  expect(screen.getByRole('combobox', { name: 'Credential type' })).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('Paste token or key')).toBeInTheDocument();
+  expect(screen.getByLabelText('Expiration date')).toBeInTheDocument();
+  expect(screen.getByLabelText('No expiry')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Save Secret' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  expect(screen.getByText(/you can connect this credential from agent workspaces/i)).toBeInTheDocument();
+});
+
+test('Expect cancel navigates back to secret vault', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+
+  render(SecretVaultCreate);
+
+  const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+  await fireEvent.click(cancelButton);
+
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
+});

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+import { faKey, faServer, faShieldHalved } from '@fortawesome/free-solid-svg-icons';
+import { Button, Input } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import { Textarea } from '/@/lib/chat/components/ui/textarea';
+import CardSelector from '/@/lib/ui/CardSelector.svelte';
+import FormPage from '/@/lib/ui/FormPage.svelte';
+import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
+
+const categoryOptions = [
+  {
+    title: 'API Token',
+    badge: 'API',
+    value: 'api',
+    icon: faKey,
+    description: 'API keys, access tokens, and service credentials',
+  },
+  {
+    title: 'Infrastructure',
+    badge: 'Infra',
+    value: 'infra',
+    icon: faServer,
+    description: 'Cluster tokens, platform keys, and infrastructure secrets',
+  },
+];
+
+const credentialTypes = [
+  { value: 'pat', label: 'Personal access token (PAT)' },
+  { value: 'oauth', label: 'OAuth / refresh token' },
+  { value: 'bot', label: 'Bot token' },
+  { value: 'project', label: 'Fine-grained / project token' },
+  { value: 'apikey', label: 'Generic API key' },
+  { value: 'cluster', label: 'Cluster or platform token' },
+  { value: 'service', label: 'Service account' },
+  { value: 'other', label: 'Other' },
+];
+
+let name = $state('');
+let category = $state('api');
+let type = $state('pat');
+let secret = $state('');
+let description = $state('');
+// TODO: backend not wired yet — using $derived(noExpiry ? '' : expiration) triggers no-unused-vars lint.
+// When the IPC save call is implemented, rename this to expirationInput and add: let expiration = $derived(noExpiry ? '' : expirationInput);
+let expiration = $state('');
+let noExpiry = $state(false);
+let saving = $state(false);
+let error = $state('');
+
+function cancel(): void {
+  handleNavigation({ page: NavigationPage.SECRET_VAULT });
+}
+
+async function saveSecret(): Promise<void> {
+  if (!name.trim() || !secret.trim()) return;
+
+  saving = true;
+  error = '';
+  try {
+    // TODO: send { name, category, type, secret, description, expiration } via IPC to SafeStorageRegistry
+    handleNavigation({ page: NavigationPage.SECRET_VAULT });
+  } catch (err: unknown) {
+    error = err instanceof Error ? err.message : String(err);
+  } finally {
+    saving = false;
+  }
+}
+</script>
+
+<FormPage title="Add Secret">
+  {#snippet content()}
+    <div class="px-5 pb-5 min-w-full">
+      <div class="bg-[var(--pd-content-card-bg)] py-6">
+        <div class="flex flex-col px-6 max-w-4xl mx-auto space-y-5">
+
+          <div>
+            <h1 class="text-2xl font-bold text-[var(--pd-modal-text)]">Add Secret</h1>
+            <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 mt-2">
+              Store API tokens, OAuth secrets, and infrastructure keys in one place.
+              Values are encrypted and only exposed to agents and flows you attach them to.
+            </p>
+          </div>
+
+          <!-- Info callout -->
+          <div class="flex gap-3 p-4 rounded-lg border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)]">
+            <div class="flex-shrink-0 mt-0.5 text-[var(--pd-content-card-text)]">
+              <Icon icon={faShieldHalved} />
+            </div>
+            <p class="text-sm text-[var(--pd-content-card-text)] opacity-80 leading-relaxed">
+              After saving, you can connect this credential from agent workspaces, MCP servers, and Settings integrations.
+              You won't be able to read the full secret back — only rotate or replace it.
+            </p>
+          </div>
+
+          <!-- Form -->
+          <section class="rounded-lg border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)] p-6 space-y-5">
+
+            <!-- Display name -->
+            <div>
+              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">Display name</span>
+              <Input bind:value={name} placeholder="e.g. GitHub · docs repo" aria-label="Display name" />
+            </div>
+
+            <!-- Category -->
+            <CardSelector
+              label="Category"
+              options={categoryOptions}
+              bind:selected={category}
+            />
+
+            <!-- Credential type -->
+            <div>
+              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">Credential type</span>
+              <select
+                bind:value={type}
+                class="w-full p-2 rounded-lg text-sm outline-hidden cursor-pointer
+                  bg-[var(--pd-select-bg)] text-[var(--pd-content-card-text)]
+                  border-r-8 border-transparent"
+                aria-label="Credential type"
+              >
+                {#each credentialTypes as ct (ct.value)}
+                  <option value={ct.value}>{ct.label}</option>
+                {/each}
+              </select>
+            </div>
+
+            <!-- Secret value -->
+            <div>
+              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">Secret value</span>
+              <PasswordInput
+                bind:password={secret}
+                placeholder="Paste token or key"
+                aria-label="Secret value"
+              />
+            </div>
+
+            <!-- Description -->
+            <div>
+              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">
+                Description
+                <span class="font-normal text-[var(--pd-content-card-text)] opacity-60">(optional)</span>
+              </span>
+              <Textarea
+                bind:value={description}
+                placeholder="Where it's used, scopes, or rotation notes"
+                rows={3}
+                class="bg-muted min-h-[24px] resize-none rounded-lg !text-sm dark:border-zinc-700"
+              />
+            </div>
+
+            <!-- Expiration -->
+            <div>
+              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">
+                Expiration
+                <span class="font-normal text-[var(--pd-content-card-text)] opacity-60">(optional)</span>
+              </span>
+              <div class="flex items-center gap-4">
+                <input
+                  type="date"
+                  bind:value={expiration}
+                  disabled={noExpiry}
+                  class="max-w-[280px] p-2 rounded-lg text-sm outline-hidden
+                    bg-[var(--pd-input-field-bg)] text-[var(--pd-input-field-text)]
+                    border border-[var(--pd-input-field-stroke)]
+                    hover:border-[var(--pd-input-field-hover-stroke)]
+                    focus:border-[var(--pd-input-field-focused-stroke)]
+                    disabled:opacity-50 disabled:cursor-not-allowed"
+                  aria-label="Expiration date"
+                />
+                <label class="inline-flex items-center gap-2 text-sm text-[var(--pd-content-card-text)] cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    bind:checked={noExpiry}
+                    class="w-4 h-4 accent-[var(--pd-button-primary-bg)] cursor-pointer"
+                  />
+                  No expiry
+                </label>
+              </div>
+            </div>
+          </section>
+
+          {#if error}
+            <div class="text-sm text-red-400 bg-red-900/20 rounded-lg p-3">{error}</div>
+          {/if}
+
+          <!-- Footer actions -->
+          <div class="flex items-center justify-end gap-3 pt-4 border-t border-[var(--pd-content-card-border)]">
+            <Button onclick={cancel}>Cancel</Button>
+            <Button disabled={!name.trim() || !secret.trim() || saving} onclick={saveSecret}>
+              {saving ? 'Saving...' : 'Save Secret'}
+            </Button>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  {/snippet}
+</FormPage>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
@@ -3,7 +3,9 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { Button, FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { handleNavigation } from '/@/navigation';
 import { filteredSecretVaultInfos, secretVaultCategoryFilter, secretVaultSearchPattern } from '/@/stores/secret-vault';
+import { NavigationPage } from '/@api/navigation-page';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 
 import { SecretVaultDescriptionColumn } from './columns/secret-vault-columns';
@@ -69,7 +71,7 @@ const secrets: SecretVaultSelectable[] = $derived(
 );
 
 function addSecret(): void {
-  // TODO: navigate to secret creation page
+  handleNavigation({ page: NavigationPage.SECRET_VAULT_CREATE });
 }
 </script>
 

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -188,5 +188,11 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.RAG_ENVIRONMENT_DETAILS:
       router.goto(`/rag-environments/${encodeURIComponent(request.parameters.name)}/summary`);
       break;
+    case NavigationPage.SECRET_VAULT:
+      router.goto('/secret-vault');
+      break;
+    case NavigationPage.SECRET_VAULT_CREATE:
+      router.goto('/secret-vault/create');
+      break;
   }
 };


### PR DESCRIPTION
## Summary
- Adds the "Add Secret" form page (`SecretVaultCreate.svelte`) with fields for display name, category (via `CardSelector`), credential type dropdown, secret value (password input), description, and expiration
- Registers `SECRET_VAULT` and `SECRET_VAULT_CREATE` navigation entries and routes
- Wires the "Add Secret" button on the list page to navigate to the create form

Fixes: https://github.com/openkaiden/kaiden/issues/1331

<img width="1214" height="976" alt="Screenshot From 2026-04-19 23-46-13" src="https://github.com/user-attachments/assets/b0627fd1-4eb6-4730-8ec7-e6017c8f5bb3" />



## Test plan
- [ ] Navigate to Secret Vault and click "Add Secret"
- [ ] Verify breadcrumb shows "Secret Vault > Add Secret"
- [ ] Fill out form fields and verify inputs work (category selector, dropdown, password toggle, date picker, no-expiry checkbox)
- [ ] Click Cancel and verify navigation back to list
- [ ] Verify Save Secret button is disabled until required fields (name, secret) are filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)