### PR TITLE
feat: register bundled kdn binary via CliToolRegistry

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5124,7 +5124,7 @@ declare module '@openkaiden/api' {
     export function setValue(key: string, value: any, scope?: 'onboarding' | 'DockerCompatibility'): void;
   }
 
-  export type CliToolInstallationSource = 'extension' | 'external';
+  export type CliToolInstallationSource = 'extension' | 'external' | 'bundled';
 
   /**
    * Options to create new CliTool instance and register it in Kaiden
@@ -5149,8 +5149,9 @@ declare module '@openkaiden/api' {
 
     /**
      * How the cli tool has been installed
-     * - external: it has been installed by the user externally from podman desktop. Its update process is disable.
-     * - extension: it has been installed by podman desktop extension. It can be updated
+     * - external: it has been installed by the user externally from podman desktop. Its update process is disabled.
+     * - extension: it has been installed by a podman desktop extension. It can be updated.
+     * - bundled: it is shipped with the application itself, not via an extension.
      */
     installationSource?: CliToolInstallationSource;
   }

--- a/packages/main/src/plugin/agent-workspace/kdn-cli-tool.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/kdn-cli-tool.spec.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
 
 test('registers bundled kdn binary with version', async () => {
   vi.mocked(existsSync).mockReturnValue(true);
-  vi.spyOn(exec, 'exec').mockResolvedValue({ stdout: 'kdn version 0.5.0' } as RunResult);
+  vi.spyOn(exec, 'exec').mockResolvedValue({ stdout: '', stderr: 'kdn version 0.5.0' } as RunResult);
 
   await kdnCliTool.init();
 

--- a/packages/main/src/plugin/agent-workspace/kdn-cli-tool.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/kdn-cli-tool.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+
+import type { RunResult } from '@openkaiden/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { Proxy as ProxyType } from '/@/plugin/proxy.js';
+import { Exec } from '/@/plugin/util/exec.js';
+
+import { KdnCliTool } from './kdn-cli-tool.js';
+
+vi.mock(import('node:fs'));
+
+const cliToolRegistry = {
+  createCliTool: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+} as unknown as CliToolRegistry;
+
+const proxy = { isEnabled: vi.fn().mockReturnValue(false) } as unknown as ProxyType;
+const exec = new Exec(proxy);
+let kdnCliTool: KdnCliTool;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
+  vi.mocked(cliToolRegistry.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
+  kdnCliTool = new KdnCliTool(cliToolRegistry, exec);
+});
+
+test('registers bundled kdn binary with version', async () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.spyOn(exec, 'exec').mockResolvedValue({ stdout: '{"version":"0.5.0"}' } as RunResult);
+
+  await kdnCliTool.init();
+
+  expect(cliToolRegistry.createCliTool).toHaveBeenCalledWith(
+    expect.objectContaining({ id: 'kaiden' }),
+    expect.objectContaining({ name: 'kdn', version: '0.5.0' }),
+  );
+});
+
+test('skips registration when binary is not bundled', async () => {
+  vi.mocked(existsSync).mockReturnValue(false);
+
+  await kdnCliTool.init();
+
+  expect(cliToolRegistry.createCliTool).not.toHaveBeenCalled();
+});

--- a/packages/main/src/plugin/agent-workspace/kdn-cli-tool.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/kdn-cli-tool.spec.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
 
 test('registers bundled kdn binary with version', async () => {
   vi.mocked(existsSync).mockReturnValue(true);
-  vi.spyOn(exec, 'exec').mockResolvedValue({ stdout: '{"version":"0.5.0"}' } as RunResult);
+  vi.spyOn(exec, 'exec').mockResolvedValue({ stdout: 'kdn version 0.5.0' } as RunResult);
 
   await kdnCliTool.init();
 

--- a/packages/main/src/plugin/agent-workspace/kdn-cli-tool.ts
+++ b/packages/main/src/plugin/agent-workspace/kdn-cli-tool.ts
@@ -50,9 +50,10 @@ export class KdnCliTool implements Disposable {
 
   private async getVersion(binaryPath: string): Promise<string | undefined> {
     try {
-      const result = await this.exec.exec(binaryPath, ['version', '--output', 'json']);
-      const parsed = JSON.parse(result.stdout) as { version?: string };
-      return parsed.version;
+      const result = await this.exec.exec(binaryPath, ['version']);
+      // output format: "kdn version 0.5.0"
+      const parts = result.stdout.trim().split(' ');
+      return parts[parts.length - 1];
     } catch {
       return undefined;
     }

--- a/packages/main/src/plugin/agent-workspace/kdn-cli-tool.ts
+++ b/packages/main/src/plugin/agent-workspace/kdn-cli-tool.ts
@@ -51,8 +51,9 @@ export class KdnCliTool implements Disposable {
   private async getVersion(binaryPath: string): Promise<string | undefined> {
     try {
       const result = await this.exec.exec(binaryPath, ['version']);
-      // output format: "kdn version 0.5.0"
-      const parts = result.stdout.trim().split(' ');
+      // kdn writes version to stderr: "kdn version 0.5.0"
+      const output = (result.stdout || result.stderr).trim();
+      const parts = output.split(' ');
       return parts[parts.length - 1];
     } catch {
       return undefined;

--- a/packages/main/src/plugin/agent-workspace/kdn-cli-tool.ts
+++ b/packages/main/src/plugin/agent-workspace/kdn-cli-tool.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Disposable } from '@openkaiden/api';
+import { inject, injectable, preDestroy } from 'inversify';
+
+import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { Exec } from '/@/plugin/util/exec.js';
+
+@injectable()
+export class KdnCliTool implements Disposable {
+  private cliToolDisposable: Disposable | undefined;
+
+  constructor(
+    @inject(CliToolRegistry)
+    private readonly cliToolRegistry: CliToolRegistry,
+    @inject(Exec)
+    private readonly exec: Exec,
+  ) {}
+
+  private getBundledPath(): string | undefined {
+    if (!process.resourcesPath) {
+      return undefined;
+    }
+    const binaryName = process.platform === 'win32' ? 'kdn.exe' : 'kdn';
+    const bundledPath = join(process.resourcesPath, 'kdn', binaryName);
+    if (existsSync(bundledPath)) {
+      return bundledPath;
+    }
+    return undefined;
+  }
+
+  private async getVersion(binaryPath: string): Promise<string | undefined> {
+    try {
+      const result = await this.exec.exec(binaryPath, ['version', '--output', 'json']);
+      const parsed = JSON.parse(result.stdout) as { version?: string };
+      return parsed.version;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async init(): Promise<void> {
+    const bundledPath = this.getBundledPath();
+    if (!bundledPath) {
+      return;
+    }
+
+    const version = await this.getVersion(bundledPath);
+
+    this.cliToolDisposable = this.cliToolRegistry.createCliTool(
+      { id: 'kaiden', label: 'Kaiden' },
+      {
+        name: 'kdn',
+        displayName: 'kdn',
+        markdownDescription: 'Kaiden CLI for managing agent workspaces',
+        images: {},
+        version,
+        path: bundledPath,
+        installationSource: 'bundled',
+      },
+    );
+  }
+
+  @preDestroy()
+  dispose(): void {
+    this.cliToolDisposable?.dispose();
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -53,6 +53,7 @@ import { Container } from 'inversify';
 import { lookup } from 'mime-types';
 
 import { AgentWorkspaceManager } from '/@/plugin/agent-workspace/agent-workspace-manager.js';
+import { KdnCliTool } from '/@/plugin/agent-workspace/kdn-cli-tool.js';
 import { IPCHandle, IPCMainOn, WebContentsType } from '/@/plugin/api.js';
 import { ChunkProviderRegistry } from '/@/plugin/chunk-provider-registry.js';
 import { ContainerfileParser } from '/@/plugin/containerfile-parser.js';
@@ -580,6 +581,7 @@ export class PluginSystem {
     container.bind<MCPManager>(MCPManager).toSelf().inSingletonScope();
     container.bind<CliToolRegistry>(CliToolRegistry).toSelf().inSingletonScope();
     container.bind<AgentWorkspaceManager>(AgentWorkspaceManager).toSelf().inSingletonScope();
+    container.bind<KdnCliTool>(KdnCliTool).toSelf().inSingletonScope();
     container.bind<FlowManager>(FlowManager).toSelf().inSingletonScope();
     container.bind<SkillManager>(SkillManager).toSelf().inSingletonScope();
     container.bind<TrayMenuRegistry>(TrayMenuRegistry).toSelf().inSingletonScope();
@@ -660,6 +662,9 @@ export class PluginSystem {
 
     const mcpManager = container.get<MCPManager>(MCPManager);
     mcpManager.init();
+
+    const kdnCliTool = container.get<KdnCliTool>(KdnCliTool);
+    await kdnCliTool.init();
 
     const agentWorkspaceManager = container.get<AgentWorkspaceManager>(AgentWorkspaceManager);
     agentWorkspaceManager.init();


### PR DESCRIPTION
## Summary
- Register the embedded kdn CLI binary via `CliToolRegistry` so `AgentWorkspaceManager` resolves the bundled path directly instead of relying solely on PATH lookup
- Add `'bundled'` to `CliToolInstallationSource` to distinguish app-shipped binaries from extension-managed (`'extension'`) or user-installed (`'external'`) tools
- `KdnCliTool` is initialized before `AgentWorkspaceManager` so the tool is registered before anything tries to look it up

<img width="1030" height="696" alt="Screenshot From 2026-04-20 16-13-11" src="https://github.com/user-attachments/assets/cf6eba0b-9977-48d9-85f3-2d3b0a68d3ba" />

Fixes: https://github.com/openkaiden/kaiden/issues/1363

## Design note

The `CliToolRegistry` API uses `extensionInfo` as the first parameter to `createCliTool()`, which is a naming artifact from when only extensions registered CLI tools. kdn is **not** an extension — it is the core backend shipped with the application. The new `'bundled'` installation source makes this distinction explicit. A broader rename of `extensionInfo` in the registry API is out of scope for this PR.

## How to test locally

### Step 1: Build the download script (all platforms)

```bash
pnpm run build:main
```

### Step 2: Download kdn into Electron's dev resources dir

<details>
<summary><strong>Linux (x64)</strong></summary>

```bash
node packages/main/dist/download-kdn.cjs \
  --output=node_modules/electron/dist/resources/kdn \
  --platform=linux \
  --arch=x64
```
</details>

<details>
<summary><strong>macOS (Apple Silicon)</strong></summary>

```bash
node packages/main/dist/download-kdn.cjs \
  --output=node_modules/electron/dist/resources/kdn \
  --platform=darwin \
  --arch=arm64
```
</details>

<details>
<summary><strong>macOS (Intel)</strong></summary>

```bash
node packages/main/dist/download-kdn.cjs \
  --output=node_modules/electron/dist/resources/kdn \
  --platform=darwin \
  --arch=x64
```
</details>

<details>
<summary><strong>Windows (x64)</strong></summary>

```bash
node packages/main/dist/download-kdn.cjs \
  --output=node_modules/electron/dist/resources/kdn \
  --platform=win32 \
  --arch=x64
```
</details>

### Step 3: Start dev mode and verify

```bash
pnpm watch
```

Open **Settings > CLI Tools** — kdn should appear with its version and path.

## Test plan
- [x] Unit tests pass for `kdn-cli-tool.spec.ts` (2 tests)
- [x] Existing `agent-workspace-manager.spec.ts` tests unaffected (34 tests)
- [x] Existing `cli-tool-registry.spec.ts` tests unaffected (24 tests)
- [x] Typecheck passes
- [ ] Verify kdn appears in Settings > CLI Tools with correct version and path

🤖 Generated with [Claude Code](https://claude.com/claude-code)