### PR TITLE
fix(agent-workspaces): prevent text overflow in workspace cards and reposition session count

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCard.svelte
@@ -76,30 +76,30 @@ function handleRemove(): void {
 </script>
 
 <div
-  class="flex flex-col gap-3 p-4 bg-(--pd-content-card-carousel-card-bg) hover:bg-(--pd-content-card-carousel-card-hover-bg) rounded-md cursor-pointer"
+  class="flex flex-col gap-3 p-4 bg-(--pd-content-card-carousel-card-bg) hover:bg-(--pd-content-card-carousel-card-hover-bg) rounded-md cursor-pointer overflow-hidden"
   role="button"
   aria-label="workspace {workspace.name}"
   onclick={handleOpen}
   onkeydown={handleKeydown}
   tabindex="0">
-  <div class="flex items-center justify-between text-start">
-    <span class="text-(--pd-invert-content-card-text) font-semibold text-base">{workspace.name}</span>
-    <span class="flex items-center gap-1 text-xs text-(--pd-invert-content-card-text) opacity-70">
+  <div class="flex items-center justify-between text-start gap-2 min-w-0">
+    <span class="text-(--pd-invert-content-card-text) font-semibold text-base truncate min-w-0">{workspace.name}</span>
+    <span class="flex items-center gap-1 text-xs text-(--pd-invert-content-card-text) opacity-70 shrink-0 max-w-[50%]">
       <Icon icon={faCubes} class="shrink-0" />
-      {workspace.project}
+      <span class="truncate">{workspace.project}</span>
     </span>
   </div>
   <div class="flex flex-col gap-2 text-sm">
-    <div class="flex items-center gap-2 text-(--pd-invert-content-card-text)" title={workspace.paths.source}>
+    <div class="flex items-center gap-2 text-(--pd-invert-content-card-text) min-w-0" title={workspace.paths.source}>
       <Icon icon={faFolder} class="shrink-0 opacity-70" />
       <span class="truncate">{workspace.paths.source}</span>
     </div>
-    <div class="flex items-center gap-2 text-(--pd-invert-content-card-text)" title={workspace.paths.configuration}>
+    <div class="flex items-center gap-2 text-(--pd-invert-content-card-text) min-w-0" title={workspace.paths.configuration}>
       <Icon icon={faGear} class="shrink-0 opacity-70" />
       <span class="truncate">{workspace.paths.configuration}</span>
     </div>
     {#if workspace.model}
-      <div class="flex items-center gap-2 text-(--pd-invert-content-card-text)" title={workspace.model}>
+      <div class="flex items-center gap-2 text-(--pd-invert-content-card-text) min-w-0" title={workspace.model}>
         <Icon icon={faBrain} class="shrink-0 opacity-70" />
         <span class="truncate">{workspace.model}</span>
       </div>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -70,7 +70,7 @@ test('Expect workspace cards displayed with total count', () => {
   expect(screen.getByText('frontend-redesign')).toBeInTheDocument();
   expect(screen.getByText('/home/user/projects/backend')).toBeInTheDocument();
   expect(screen.getByText('/home/user/projects/frontend')).toBeInTheDocument();
-  expect(screen.getByText('2 total sessions')).toBeInTheDocument();
+  expect(screen.getByText('2 total workspaces')).toBeInTheDocument();
 });
 
 test('Expect page title to be Agent Workspaces', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -37,12 +37,6 @@ test('Expect empty screen when no workspaces', () => {
   expect(screen.getByText('No agent workspaces')).toBeInTheDocument();
 });
 
-test('Expect total count displayed as 0 total sessions when empty', () => {
-  render(AgentWorkspaceList);
-
-  expect(screen.getByText('0 total sessions')).toBeInTheDocument();
-});
-
 test('Expect workspace cards displayed with total count', () => {
   const workspaces: AgentWorkspaceSummary[] = [
     {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -25,8 +25,8 @@ function navigateToCreate(): void {
         <AgentWorkspaceEmptyScreen />
       {:else}
         <div class="flex flex-col gap-4 p-5 w-full h-fit">
-          <span class="text-sm text-(--pd-content-text) opacity-70">{$agentWorkspaces.length} total sessions</span>
-          <div class="grid grid-cols-3 gap-4 w-full">
+          <span class="text-sm text-(--pd-content-text) opacity-70">{$agentWorkspaces.length} total {$agentWorkspaces.length === 1 ? 'workspace' : 'workspaces'}</span>
+          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 w-full">
             {#each $agentWorkspaces as workspace (workspace.id)}
               <AgentWorkspaceCard {workspace} />
             {/each}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -16,8 +16,7 @@ function navigateToCreate(): void {
 
 <NavPage searchEnabled={false} title="Agent Workspaces">
   {#snippet additionalActions()}
-    <Button icon={faPlus} onclick={navigateToCreate}>Create Workspace</Button>
-    <span class="text-(--pd-content-text)">{$agentWorkspaces.length} total sessions</span>
+  <Button icon={faPlus} onclick={navigateToCreate}>Create Workspace</Button>
   {/snippet}
 
   {#snippet content()}
@@ -25,10 +24,13 @@ function navigateToCreate(): void {
       {#if $agentWorkspaces.length === 0}
         <AgentWorkspaceEmptyScreen />
       {:else}
-        <div class="grid grid-cols-3 gap-4 p-5 w-full h-fit">
-          {#each $agentWorkspaces as workspace (workspace.id)}
-            <AgentWorkspaceCard {workspace} />
-          {/each}
+        <div class="flex flex-col gap-4 p-5 w-full h-fit">
+          <span class="text-sm text-(--pd-content-text) opacity-70">{$agentWorkspaces.length} total sessions</span>
+          <div class="grid grid-cols-3 gap-4 w-full">
+            {#each $agentWorkspaces as workspace (workspace.id)}
+              <AgentWorkspaceCard {workspace} />
+            {/each}
+          </div>
         </div>
       {/if}
     </div>


### PR DESCRIPTION
Long workspace names and project paths were overflowing outside card boundaries. Also moved the "total sessions" label from the header bar into the content area, displayed only when workspaces exist.

Before:
<img width="431" height="261" alt="Captura de pantalla 2026-04-21 a las 13 48 31" src="https://github.com/user-attachments/assets/4da0fb64-ae3a-4945-94c2-1f66646c19a7" />
<img width="1065" height="128" alt="Captura de pantalla 2026-04-21 a las 14 14 25" src="https://github.com/user-attachments/assets/b1269941-842c-4eac-a062-0ca1fa67862e" />

After:
<img width="337" height="282" alt="Captura de pantalla 2026-04-21 a las 14 13 41" src="https://github.com/user-attachments/assets/b39ee862-d51f-4453-97a6-9ad5cc49a1f5" />
<img width="968" height="114" alt="Captura de pantalla 2026-04-21 a las 14 13 26" src="https://github.com/user-attachments/assets/f62866cf-884b-4b2b-846e-ce66c4becdf9" />

