### PR TITLE
feat(agent-workspaces): watch ~/.kdn/instances.json for external changes

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -19,11 +19,12 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { RunError, RunResult } from '@openkaiden/api';
+import type { FileSystemWatcher, RunError, RunResult } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import type { Proxy as ProxyType } from '/@/plugin/proxy.js';
 import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type { Task } from '/@/plugin/tasks/tasks.js';
@@ -87,6 +88,16 @@ const taskManager = {
   createTask: vi.fn().mockReturnValue(mockTask),
 } as unknown as TaskManager;
 
+const mockWatcher = {
+  onDidChange: vi.fn(),
+  onDidCreate: vi.fn(),
+  onDidDelete: vi.fn(),
+  dispose: vi.fn(),
+} as unknown as FileSystemWatcher;
+const filesystemMonitoring = {
+  createFileSystemWatcher: vi.fn().mockReturnValue(mockWatcher),
+} as unknown as FilesystemMonitoring;
+
 const KAIDEN_CLI_PATH = '/usr/local/bin/kdn';
 
 function mockExecResult(stdout: string): RunResult {
@@ -113,7 +124,8 @@ beforeEach(() => {
   mockTask.state = '' as TaskState;
   mockTask.status = '' as TaskStatus;
   mockTask.error = '';
-  manager = new AgentWorkspaceManager(apiSender, ipcHandle, exec, cliToolRegistry, taskManager);
+  vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
+  manager = new AgentWorkspaceManager(apiSender, ipcHandle, exec, cliToolRegistry, taskManager, filesystemMonitoring);
   manager.init();
 });
 
@@ -140,6 +152,37 @@ describe('init', () => {
 
   test('registers IPC handler for stop', () => {
     expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:stop', expect.any(Function));
+  });
+});
+
+describe('watchInstancesFile', () => {
+  test('watches ~/.kdn/instances.json on init', () => {
+    expect(filesystemMonitoring.createFileSystemWatcher).toHaveBeenCalledWith(
+      expect.stringMatching(/\.kdn[\\/]instances\.json$/),
+    );
+  });
+
+  test('sends agent-workspace-update on file change', () => {
+    const changeCallback = vi.mocked(mockWatcher.onDidChange).mock.calls[0]![0] as () => void;
+    changeCallback();
+    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
+  });
+
+  test('sends agent-workspace-update on file create', () => {
+    const createCallback = vi.mocked(mockWatcher.onDidCreate).mock.calls[0]![0] as () => void;
+    createCallback();
+    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
+  });
+
+  test('sends agent-workspace-update on file delete', () => {
+    const deleteCallback = vi.mocked(mockWatcher.onDidDelete).mock.calls[0]![0] as () => void;
+    deleteCallback();
+    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
+  });
+
+  test('disposes watcher on dispose', () => {
+    manager.dispose();
+    expect(mockWatcher.dispose).toHaveBeenCalled();
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -17,13 +17,15 @@
  ***********************************************************************/
 
 import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import type { Disposable, RunError } from '@openkaiden/api';
+import type { Disposable, FileSystemWatcher, RunError } from '@openkaiden/api';
 import { inject, injectable, preDestroy } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Exec } from '/@/plugin/util/exec.js';
 import type {
@@ -39,6 +41,8 @@ import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
  */
 @injectable()
 export class AgentWorkspaceManager implements Disposable {
+  private instancesWatcher: FileSystemWatcher | undefined;
+
   constructor(
     @inject(ApiSenderType)
     private readonly apiSender: ApiSenderType,
@@ -50,6 +54,8 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly cliToolRegistry: CliToolRegistry,
     @inject(TaskManager)
     private readonly taskManager: TaskManager,
+    @inject(FilesystemMonitoring)
+    private readonly filesystemMonitoring: FilesystemMonitoring,
   ) {}
 
   private getCliPath(): string {
@@ -200,10 +206,24 @@ export class AgentWorkspaceManager implements Disposable {
     this.ipcHandle('agent-workspace:stop', async (_listener: unknown, id: string): Promise<AgentWorkspaceId> => {
       return this.stop(id);
     });
+
+    this.watchInstancesFile();
+  }
+
+  private watchInstancesFile(): void {
+    this.instancesWatcher?.dispose();
+    const instancesPath = join(homedir(), '.kdn', 'instances.json');
+    this.instancesWatcher = this.filesystemMonitoring.createFileSystemWatcher(instancesPath);
+    const notify = (): void => {
+      this.apiSender.send('agent-workspace-update');
+    };
+    this.instancesWatcher.onDidChange(notify);
+    this.instancesWatcher.onDidCreate(notify);
+    this.instancesWatcher.onDidDelete(notify);
   }
 
   @preDestroy()
   dispose(): void {
-    // no-op for now; will clean up CLI process handles if needed
+    this.instancesWatcher?.dispose();
   }
 }


### PR DESCRIPTION
Auto-refresh workspace list when kdn CLI adds or removes workspaces
outside of Kaiden, by watching the instances file via chokidar.

This is a stopgap solution until kdn can provide a more fine-grained eventing mechanism (https://github.com/openkaiden/kdn/issues/322), where we'd be able to watch starting and stopping events

With the current workspace UI:

https://github.com/user-attachments/assets/c6674e25-3e79-4e7b-b22e-5036f70115bb



With the new row layout from https://github.com/openkaiden/kaiden/pull/1418

https://github.com/user-attachments/assets/ba26f40e-c4ab-4f44-a6c1-1ae3aa1d2387




