### PR TITLE
feat(agent-workspaces): expose CLI info (agents and runtimes) via workspace manager

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -39,6 +39,12 @@ export type AgentWorkspaceId = cliComponents['schemas']['WorkspaceId'];
 export type AgentWorkspaceConfiguration = configComponents['schemas']['WorkspaceConfiguration'];
 
 /**
+ * CLI environment info returned by `kdn info --output json`.
+ * Contains the CLI version, supported agents, and available runtimes.
+ */
+export type CliInfo = cliComponents['schemas']['Info'];
+
+/**
  * Options for creating (initializing) a new workspace via `kdn init`.
  */
 export interface AgentWorkspaceCreateOptions {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -214,14 +214,14 @@ describe('getCliInfo', () => {
     expect(result).toEqual({ version: '0.1.0', agents: ['claude', 'opencode'], runtimes: ['podman'] });
   });
 
-  test('returns empty arrays when CLI returns response without agents or runtimes', async () => {
+  test('preserves extra fields from future CLI versions', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ version: '0.1.0' })));
+    const payload = { version: '0.2.0', agents: ['opencode'], runtimes: ['podman'], newField: 'hello' };
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify(payload)));
 
     const result = await manager.getCliInfo();
 
-    expect(result).toEqual({ version: '0.1.0', agents: [], runtimes: [] });
+    expect(result).toEqual(payload);
   });
 
   test('returns defaults when CLI returns non-object response', async () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -153,6 +153,10 @@ describe('init', () => {
   test('registers IPC handler for stop', () => {
     expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:stop', expect.any(Function));
   });
+
+  test('registers IPC handler for getCliInfo', () => {
+    expect(ipcHandle).toHaveBeenCalledWith('cli-info:get', expect.any(Function));
+  });
 });
 
 describe('watchInstancesFile', () => {
@@ -194,6 +198,59 @@ describe('getCliPath', () => {
     await manager.list();
 
     expect(exec.exec).toHaveBeenCalledWith('kdn', ['workspace', 'list', '--output', 'json'], undefined);
+  });
+});
+
+describe('getCliInfo', () => {
+  test('executes kdn info and returns agents, runtimes, and version', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(exec, 'exec').mockResolvedValue(
+      mockExecResult(JSON.stringify({ version: '0.1.0', agents: ['claude', 'opencode'], runtimes: ['podman'] })),
+    );
+
+    const result = await manager.getCliInfo();
+
+    expect(exec.exec).toHaveBeenCalledWith(KAIDEN_CLI_PATH, ['info', '--output', 'json']);
+    expect(result).toEqual({ version: '0.1.0', agents: ['claude', 'opencode'], runtimes: ['podman'] });
+  });
+
+  test('returns empty arrays when CLI returns response without agents or runtimes', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult(JSON.stringify({ version: '0.1.0' })));
+
+    const result = await manager.getCliInfo();
+
+    expect(result).toEqual({ version: '0.1.0', agents: [], runtimes: [] });
+  });
+
+  test('returns defaults when CLI returns non-object response', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(exec, 'exec').mockResolvedValue(mockExecResult('"unexpected string"'));
+
+    const result = await manager.getCliInfo();
+
+    expect(result).toEqual({ version: '', agents: [], runtimes: [] });
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(exec, 'exec').mockRejectedValue(new Error('command not found'));
+
+    await expect(manager.getCliInfo()).rejects.toThrow('command not found');
+  });
+
+  test('extracts kdn JSON error from stdout on failure', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'failed to read --storage flag' }),
+    });
+    vi.spyOn(exec, 'exec').mockRejectedValue(runError);
+
+    await expect(manager.getCliInfo()).rejects.toThrow('failed to read --storage flag');
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -155,7 +155,7 @@ describe('init', () => {
   });
 
   test('registers IPC handler for getCliInfo', () => {
-    expect(ipcHandle).toHaveBeenCalledWith('cli-info:get', expect.any(Function));
+    expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:getCliInfo', expect.any(Function));
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -197,7 +197,7 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   init(): void {
-    this.ipcHandle('cli-info:get', async (): Promise<CliInfo> => {
+    this.ipcHandle('agent-workspace:getCliInfo', async (): Promise<CliInfo> => {
       return this.getCliInfo();
     });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -116,15 +116,7 @@ export class AgentWorkspaceManager implements Disposable {
         console.warn('kdn info returned non-object, falling back to defaults', result.stdout);
         return { version: '', agents: [], runtimes: [] };
       }
-      const record = info as Record<string, unknown>;
-      const version = record['version'];
-      const agents = record['agents'];
-      const runtimes = record['runtimes'];
-      return {
-        version: typeof version === 'string' ? version : '',
-        agents: Array.isArray(agents) && agents.every(a => typeof a === 'string') ? (agents as string[]) : [],
-        runtimes: Array.isArray(runtimes) && runtimes.every(r => typeof r === 'string') ? (runtimes as string[]) : [],
-      };
+      return info as CliInfo;
     } catch (err: unknown) {
       const detail = this.extractCliError(err);
       console.error(`kdn failed: ${cliPath} ${args.join(' ')} — ${detail}`);

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -33,6 +33,7 @@ import type {
   AgentWorkspaceCreateOptions,
   AgentWorkspaceId,
   AgentWorkspaceSummary,
+  CliInfo,
 } from '/@api/agent-workspace-info.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
@@ -100,6 +101,33 @@ export class AgentWorkspaceManager implements Disposable {
     } catch (err: unknown) {
       const detail = this.extractCliError(err);
       console.error(`kdn failed: ${cliPath} ${fullArgs.join(' ')} — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+
+  async getCliInfo(): Promise<CliInfo> {
+    const cliPath = this.getCliPath();
+    const args = ['info', '--output', 'json'];
+    console.log(`Executing: ${cliPath} ${args.join(' ')}`);
+    try {
+      const result = await this.exec.exec(cliPath, args);
+      const info: unknown = JSON.parse(result.stdout);
+      if (typeof info !== 'object' || info === null) {
+        console.warn('kdn info returned non-object, falling back to defaults', result.stdout);
+        return { version: '', agents: [], runtimes: [] };
+      }
+      const record = info as Record<string, unknown>;
+      const version = record['version'];
+      const agents = record['agents'];
+      const runtimes = record['runtimes'];
+      return {
+        version: typeof version === 'string' ? version : '',
+        agents: Array.isArray(agents) && agents.every(a => typeof a === 'string') ? (agents as string[]) : [],
+        runtimes: Array.isArray(runtimes) && runtimes.every(r => typeof r === 'string') ? (runtimes as string[]) : [],
+      };
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      console.error(`kdn failed: ${cliPath} ${args.join(' ')} — ${detail}`);
       throw new Error(detail);
     }
   }
@@ -177,6 +205,10 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   init(): void {
+    this.ipcHandle('cli-info:get', async (): Promise<CliInfo> => {
+      return this.getCliInfo();
+    });
+
     this.ipcHandle(
       'agent-workspace:create',
       async (_listener: unknown, options: AgentWorkspaceCreateOptions): Promise<AgentWorkspaceId> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -49,6 +49,7 @@ import type {
   AgentWorkspaceCreateOptions,
   AgentWorkspaceId,
   AgentWorkspaceSummary,
+  CliInfo,
 } from '/@api/agent-workspace-info';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type';
 import type { AuthenticationProviderInfo } from '/@api/authentication/authentication';
@@ -316,6 +317,11 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('listPods', async (): Promise<PodInfo[]> => {
     return ipcInvoke('container-provider-registry:listPods');
+  });
+
+  // CLI Info
+  contextBridge.exposeInMainWorld('getCliInfo', async (): Promise<CliInfo> => {
+    return ipcInvoke('cli-info:get');
   });
 
   // Agent Workspaces

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -321,7 +321,7 @@ export function initExposure(): void {
 
   // CLI Info
   contextBridge.exposeInMainWorld('getCliInfo', async (): Promise<CliInfo> => {
-    return ipcInvoke('cli-info:get');
+    return ipcInvoke('agent-workspace:getCliInfo');
   });
 
   // Agent Workspaces


### PR DESCRIPTION

Add getCliInfo() to AgentWorkspaceManager to call `kdn info --output json` and return the full CliInfo (version, agents, runtimes). Wire it through IPC (cli-info:get) and the preload bridge (window.getCliInfo) so the renderer can query supported agents and runtimes at runtime.

Closes #1386

Made-with: Cursor