### PR TITLE
fix(tests): fix flaky saveImage cancellation test on Ubuntu

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -5693,7 +5693,7 @@ test('saveImage canceled during image saving on filesystem', async () => {
 
   const tmpdir = os.tmpdir();
   const savePromise = containerRegistry.saveImage('podman1', 'an-image', path.join(tmpdir, 'image-to-save'), token);
-  await expect(savePromise).rejects.toThrowError('The operation was aborted');
+  await expect(savePromise).rejects.toThrowError(/(The operation was aborted|Premature close)/);
 });
 
 describe('provider update', () => {


### PR DESCRIPTION
## Summary
- The `saveImage canceled during image saving on filesystem` test in `container-registry.spec.ts` fails intermittently on Ubuntu CI
- On Linux, stream cancellation can produce `'Premature close'` instead of `'The operation was aborted'` — both are valid abort-related errors
- Updated the assertion to accept either error message via regex

## Test plan
- [x] All 179 tests in `container-registry.spec.ts` pass locally
- [ ] Verify Ubuntu CI unit tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)