### PR TITLE
feat/onboarding agent step

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -221,6 +221,7 @@ import { INTERNAL_PROVIDER_ID, MCPRegistry } from './mcp/mcp-registry.js';
 import { MCPSchemaValidator } from './mcp/mcp-schema-validator.js';
 import { MessageBox } from './message-box.js';
 import { NavigationItemsInit } from './navigation-items-init.js';
+import { OnboardingInit } from './onboarding/onboarding-init.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
 import { OpenDevToolsInit } from './open-devtools-init.js';
 import { ProviderRegistry } from './provider-registry.js';
@@ -591,6 +592,7 @@ export class PluginSystem {
     container.bind<FilesystemMonitoring>(FilesystemMonitoring).toSelf().inSingletonScope();
     container.bind<CustomPickRegistry>(CustomPickRegistry).toSelf().inSingletonScope();
     container.bind<OnboardingRegistry>(OnboardingRegistry).toSelf().inSingletonScope();
+    container.bind<OnboardingInit>(OnboardingInit).toSelf().inSingletonScope();
     container.bind<KubernetesClient>(KubernetesClient).toSelf().inSingletonScope();
     container.bind<ChatManager>(ChatManager).toSelf().inSingletonScope();
     container.bind<SchedulerRegistry>(SchedulerRegistry).toSelf().inSingletonScope();
@@ -670,6 +672,8 @@ export class PluginSystem {
 
     const secretManager = container.get<SecretManager>(SecretManager);
     secretManager.init();
+    const onboardingInit = container.get<OnboardingInit>(OnboardingInit);
+    onboardingInit.init();
 
     const flowManager = container.get<FlowManager>(FlowManager);
     flowManager.init();

--- a/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
+import { OnboardingInit } from './onboarding-init.js';
+
+let registeredConfigs: IConfigurationNode[] = [];
+
+const configurationRegistry = {
+  registerConfigurations: vi.fn((configs: IConfigurationNode[]) => {
+    registeredConfigs = configs;
+  }),
+} as unknown as IConfigurationRegistry;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  registeredConfigs = [];
+});
+
+test('registers onboarding configuration with hidden properties', () => {
+  const init = new OnboardingInit(configurationRegistry);
+  init.init();
+
+  expect(configurationRegistry.registerConfigurations).toHaveBeenCalledOnce();
+  expect(registeredConfigs).toHaveLength(1);
+
+  const config = registeredConfigs.at(0);
+  expect(config).toBeDefined();
+  expect(config?.id).toBe('preferences.onboarding');
+  expect(config?.properties?.['onboarding.defaultAgent']).toEqual(
+    expect.objectContaining({ type: 'string', default: 'opencode', hidden: true }),
+  );
+});

--- a/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
@@ -46,6 +46,6 @@ test('registers onboarding configuration with hidden properties', () => {
   expect(config).toBeDefined();
   expect(config?.id).toBe('preferences.onboarding');
   expect(config?.properties?.['onboarding.defaultAgent']).toEqual(
-    expect.objectContaining({ type: 'string', default: 'opencode', hidden: true }),
+    expect.objectContaining({ type: 'string', default: '', hidden: true }),
   );
 });

--- a/packages/main/src/plugin/onboarding/onboarding-init.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.ts
@@ -35,7 +35,7 @@ export class OnboardingInit {
         [`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultAgent}`]: {
           description: 'Default coding agent selected during onboarding',
           type: 'string',
-          default: 'opencode',
+          default: '',
           hidden: true,
         },
       },

--- a/packages/main/src/plugin/onboarding/onboarding-init.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
+import { OnboardingSettings } from './onboarding-settings.js';
+
+@injectable()
+export class OnboardingInit {
+  constructor(@inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry) {}
+
+  init(): void {
+    const onboardingConfiguration: IConfigurationNode = {
+      id: 'preferences.onboarding',
+      title: 'Onboarding',
+      type: 'object',
+      properties: {
+        [`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultAgent}`]: {
+          description: 'Default coding agent selected during onboarding',
+          type: 'string',
+          default: 'opencode',
+          hidden: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([onboardingConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/onboarding/onboarding-settings.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-settings.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum OnboardingSettings {
+  SectionName = 'onboarding',
+  DefaultAgent = 'defaultAgent',
+}

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import CodingAgentStep from './CodingAgentStep.svelte';
+import type { OnboardingState } from './guided-setup-steps';
+import { createDefaultOnboardingState } from './guided-setup-steps';
+
+let onboarding: OnboardingState;
+
+function stubLocalInference(hasConnection: boolean): void {
+  const providers = hasConnection
+    ? [{ id: 'ollama', inferenceConnections: [{ type: 'local', status: 'started' }] }]
+    : [{ id: 'ollama', inferenceConnections: [] }];
+  (window as unknown as Record<string, unknown>).getProviderInfos = vi.fn().mockResolvedValue(providers);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+  onboarding = createDefaultOnboardingState();
+  vi.stubGlobal(
+    'getCliInfo',
+    vi.fn().mockResolvedValue({ version: '0.1.0', agents: ['opencode'], runtimes: ['podman'] }),
+  );
+  stubLocalInference(false);
+});
+
+function renderStep(overrides: Partial<OnboardingState> = {}): void {
+  Object.assign(onboarding, overrides);
+  render(CodingAgentStep, {
+    stepId: 'coding-agent',
+    title: 'Choose your coding agent',
+    description: 'Pick one runtime for kdn.',
+    onboarding,
+  });
+}
+
+test('renders the OpenCode agent tile', () => {
+  renderStep();
+
+  expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+});
+
+test('OpenCode is selected by default', () => {
+  renderStep();
+
+  const tile = screen.getByRole('button', { name: 'OpenCode' });
+  expect(tile.className).toContain('border-[var(--pd-content-card-border-selected)]');
+});
+
+test('shows Recommended badge on OpenCode', () => {
+  renderStep();
+
+  expect(screen.getByText('Recommended')).toBeInTheDocument();
+});
+
+test('shows local runtime panel when OpenCode is selected', () => {
+  renderStep();
+
+  expect(screen.getByTestId('opencode-panel')).toBeInTheDocument();
+  expect(screen.getByText('Local Runtime')).toBeInTheDocument();
+});
+
+test('shows probe checking state on mount with OpenCode selected', async () => {
+  (window as unknown as Record<string, unknown>).getProviderInfos = vi.fn().mockReturnValue(new Promise(() => {}));
+
+  renderStep();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('probe-checking')).toBeInTheDocument();
+  });
+});
+
+test('shows detected state when a local inference connection exists', async () => {
+  stubLocalInference(true);
+
+  renderStep();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('probe-detected')).toBeInTheDocument();
+  });
+});
+
+test('shows not-found state when no local inference connections exist', async () => {
+  renderStep();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('probe-not-found')).toBeInTheDocument();
+  });
+});
+
+test('Check again button retries the probe', async () => {
+  renderStep();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('probe-not-found')).toBeInTheDocument();
+  });
+
+  stubLocalInference(true);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('probe-detected')).toBeInTheDocument();
+  });
+});
+
+test('step title and description are rendered', () => {
+  renderStep();
+
+  expect(screen.getByText('Choose your coding agent')).toBeInTheDocument();
+  expect(screen.getByText('Pick one runtime for kdn.')).toBeInTheDocument();
+});
+
+test('card selector region has correct aria-label', () => {
+  renderStep();
+
+  expect(screen.getByRole('region', { name: 'Coding agent' })).toBeInTheDocument();
+});
+
+test('falls back to all registry entries when getCliInfo fails', async () => {
+  vi.stubGlobal('getCliInfo', vi.fn().mockRejectedValue(new Error('kdn not found')));
+
+  renderStep();
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { type Writable } from 'svelte/store';
+import type { Writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { fetchProviders, providerInfos } from '/@/stores/providers';

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -31,7 +31,7 @@ function stubLocalInference(hasConnection: boolean): void {
   const providers = hasConnection
     ? [{ id: 'ollama', inferenceConnections: [{ type: 'local', status: 'started' }] }]
     : [{ id: 'ollama', inferenceConnections: [] }];
-  (window as unknown as Record<string, unknown>).getProviderInfos = vi.fn().mockResolvedValue(providers);
+  vi.stubGlobal('getProviderInfos', vi.fn().mockResolvedValue(providers));
 }
 
 beforeEach(() => {
@@ -82,7 +82,7 @@ test('shows local runtime panel when OpenCode is selected', () => {
 });
 
 test('shows probe checking state on mount with OpenCode selected', async () => {
-  (window as unknown as Record<string, unknown>).getProviderInfos = vi.fn().mockReturnValue(new Promise(() => {}));
+  vi.stubGlobal('getProviderInfos', vi.fn().mockReturnValue(new Promise(() => {})));
 
   renderStep();
 

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -138,6 +138,16 @@ test('card selector region has correct aria-label', () => {
   expect(screen.getByRole('region', { name: 'Coding agent' })).toBeInTheDocument();
 });
 
+test('falls back to all registry entries when CLI returns empty agents', async () => {
+  vi.stubGlobal('getCliInfo', vi.fn().mockResolvedValue({ version: '0.1.0', agents: [], runtimes: [] }));
+
+  renderStep();
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+  });
+});
+
 test('falls back to all registry entries when getCliInfo fails', async () => {
   vi.stubGlobal('getCliInfo', vi.fn().mockRejectedValue(new Error('kdn not found')));
 

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -19,11 +19,23 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { type Writable } from 'svelte/store';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { fetchProviders, providerInfos } from '/@/stores/providers';
+import type { ProviderInfo } from '/@api/provider-info';
 
 import CodingAgentStep from './CodingAgentStep.svelte';
 import type { OnboardingState } from './guided-setup-steps';
 import { createDefaultOnboardingState } from './guided-setup-steps';
+
+vi.mock(import('/@/stores/providers'), async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    providerInfos: writable<ProviderInfo[]>([]),
+    fetchProviders: vi.fn().mockResolvedValue([]),
+  };
+});
 
 let onboarding: OnboardingState;
 
@@ -31,7 +43,7 @@ function stubLocalInference(hasConnection: boolean): void {
   const providers = hasConnection
     ? [{ id: 'ollama', inferenceConnections: [{ type: 'local', status: 'started' }] }]
     : [{ id: 'ollama', inferenceConnections: [] }];
-  vi.stubGlobal('getProviderInfos', vi.fn().mockResolvedValue(providers));
+  (providerInfos as Writable<ProviderInfo[]>).set(providers as unknown as ProviderInfo[]);
 }
 
 beforeEach(() => {
@@ -55,105 +67,123 @@ function renderStep(overrides: Partial<OnboardingState> = {}): void {
   });
 }
 
-test('renders the OpenCode agent tile', () => {
-  renderStep();
+describe('rendering', () => {
+  test('renders the OpenCode agent tile', () => {
+    renderStep();
 
-  expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
-});
-
-test('OpenCode is selected by default', () => {
-  renderStep();
-
-  const tile = screen.getByRole('button', { name: 'OpenCode' });
-  expect(tile.className).toContain('border-[var(--pd-content-card-border-selected)]');
-});
-
-test('shows Recommended badge on OpenCode', () => {
-  renderStep();
-
-  expect(screen.getByText('Recommended')).toBeInTheDocument();
-});
-
-test('shows local runtime panel when OpenCode is selected', () => {
-  renderStep();
-
-  expect(screen.getByTestId('opencode-panel')).toBeInTheDocument();
-  expect(screen.getByText('Local Runtime')).toBeInTheDocument();
-});
-
-test('shows probe checking state on mount with OpenCode selected', async () => {
-  vi.stubGlobal('getProviderInfos', vi.fn().mockReturnValue(new Promise(() => {})));
-
-  renderStep();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('probe-checking')).toBeInTheDocument();
-  });
-});
-
-test('shows detected state when a local inference connection exists', async () => {
-  stubLocalInference(true);
-
-  renderStep();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('probe-detected')).toBeInTheDocument();
-  });
-});
-
-test('shows not-found state when no local inference connections exist', async () => {
-  renderStep();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('probe-not-found')).toBeInTheDocument();
-  });
-});
-
-test('Check again button retries the probe', async () => {
-  renderStep();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('probe-not-found')).toBeInTheDocument();
-  });
-
-  stubLocalInference(true);
-
-  await fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
-
-  await waitFor(() => {
-    expect(screen.getByTestId('probe-detected')).toBeInTheDocument();
-  });
-});
-
-test('step title and description are rendered', () => {
-  renderStep();
-
-  expect(screen.getByText('Choose your coding agent')).toBeInTheDocument();
-  expect(screen.getByText('Pick one runtime for kdn.')).toBeInTheDocument();
-});
-
-test('card selector region has correct aria-label', () => {
-  renderStep();
-
-  expect(screen.getByRole('region', { name: 'Coding agent' })).toBeInTheDocument();
-});
-
-test('falls back to all registry entries when CLI returns empty agents', async () => {
-  vi.stubGlobal('getCliInfo', vi.fn().mockResolvedValue({ version: '0.1.0', agents: [], runtimes: [] }));
-
-  renderStep();
-
-  await waitFor(() => {
     expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
   });
+
+  test('OpenCode is selected by default', () => {
+    renderStep();
+
+    const tile = screen.getByRole('button', { name: 'OpenCode' });
+    expect(tile.className).toContain('border-[var(--pd-content-card-border-selected)]');
+  });
+
+  test('shows Recommended badge on OpenCode', () => {
+    renderStep();
+
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+  });
+
+  test('shows local runtime panel when OpenCode is selected', () => {
+    renderStep();
+
+    expect(screen.getByTestId('opencode-panel')).toBeInTheDocument();
+    expect(screen.getByText('Local Runtime')).toBeInTheDocument();
+  });
+
+  test('step title and description are rendered', () => {
+    renderStep();
+
+    expect(screen.getByText('Choose your coding agent')).toBeInTheDocument();
+    expect(screen.getByText('Pick one runtime for kdn.')).toBeInTheDocument();
+  });
+
+  test('card selector region has correct aria-label', () => {
+    renderStep();
+
+    expect(screen.getByRole('region', { name: 'Coding agent' })).toBeInTheDocument();
+  });
 });
 
-test('falls back to all registry entries when getCliInfo fails', async () => {
-  vi.stubGlobal('getCliInfo', vi.fn().mockRejectedValue(new Error('kdn not found')));
+describe('local runtime probe', () => {
+  test('shows detected state when a local inference connection exists', async () => {
+    stubLocalInference(true);
 
-  renderStep();
+    renderStep();
 
-  await waitFor(() => {
-    expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-detected')).toBeInTheDocument();
+    });
+  });
+
+  test('shows not-found state when no local inference connections exist', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-not-found')).toBeInTheDocument();
+    });
+  });
+
+  test('shows checking state while retry probe is in-flight', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-not-found')).toBeInTheDocument();
+    });
+
+    vi.mocked(fetchProviders).mockReturnValue(new Promise(() => {}));
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-checking')).toBeInTheDocument();
+    });
+  });
+
+  test('Check again button retries the probe', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-not-found')).toBeInTheDocument();
+    });
+
+    vi.mocked(fetchProviders).mockImplementation(async () => {
+      const data = [
+        { id: 'ollama', inferenceConnections: [{ type: 'local', status: 'started' }] },
+      ] as unknown as ProviderInfo[];
+      (providerInfos as Writable<ProviderInfo[]>).set(data);
+      return data;
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-detected')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('CLI fallback', () => {
+  test('falls back to all registry entries when CLI returns empty agents', async () => {
+    vi.mocked(window.getCliInfo).mockResolvedValue({ version: '0.1.0', agents: [], runtimes: [] });
+
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+    });
+  });
+
+  test('falls back to all registry entries when getCliInfo fails', async () => {
+    vi.mocked(window.getCliInfo).mockRejectedValue(new Error('kdn not found'));
+
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
@@ -12,12 +12,13 @@ let { title, description, onboarding }: GuidedSetupStepProps = $props();
 let cliAgents: string[] | undefined = $state();
 
 onMount(async () => {
+  const fallback = agentDefinitions.map(d => d.cliName);
   try {
     const info = await window.getCliInfo();
-    cliAgents = info.agents;
+    cliAgents = info.agents.length > 0 ? info.agents : fallback;
   } catch (err) {
     console.warn('Failed to fetch CLI agents, showing all registry entries', err);
-    cliAgents = agentDefinitions.map(d => d.cliName);
+    cliAgents = fallback;
   }
 });
 

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
@@ -22,9 +22,11 @@ onMount(async () => {
   }
 });
 
-let filteredDefinitions = $derived(
-  cliAgents ? agentDefinitions.filter(d => cliAgents!.includes(d.cliName)) : agentDefinitions,
-);
+let filteredDefinitions = $derived.by(() => {
+  if (!cliAgents) return agentDefinitions;
+  const filtered = agentDefinitions.filter(d => cliAgents!.includes(d.cliName));
+  return filtered.length > 0 ? filtered : agentDefinitions;
+});
 
 const definitionsByAgent = $derived(new Map<string, AgentDefinition>(filteredDefinitions.map(d => [d.cliName, d])));
 

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+import { onMount, untrack } from 'svelte';
+
+import type { CardSelectorOption } from '/@/lib/ui/CardSelector.svelte';
+import CardSelector from '/@/lib/ui/CardSelector.svelte';
+
+import { type AgentDefinition, agentDefinitions } from './agent-registry';
+import type { CliAgent, GuidedSetupStepProps } from './guided-setup-steps';
+
+let { title, description, onboarding }: GuidedSetupStepProps = $props();
+
+let cliAgents: string[] | undefined = $state();
+
+onMount(async () => {
+  try {
+    const info = await window.getCliInfo();
+    cliAgents = info.agents;
+  } catch (err) {
+    console.warn('Failed to fetch CLI agents, showing all registry entries', err);
+    cliAgents = agentDefinitions.map(d => d.cliName);
+  }
+});
+
+let filteredDefinitions = $derived(
+  cliAgents ? agentDefinitions.filter(d => cliAgents!.includes(d.cliName)) : agentDefinitions,
+);
+
+const definitionsByAgent = $derived(new Map<string, AgentDefinition>(filteredDefinitions.map(d => [d.cliName, d])));
+
+const agentOptions: CardSelectorOption[] = $derived(
+  filteredDefinitions.map(d => ({
+    value: d.cliName,
+    title: d.title,
+    badge: d.badge,
+    description: d.description,
+    icon: d.icon,
+  })),
+);
+
+let selectedAgent = $state(untrack(() => onboarding.agent));
+let activeDefinition: AgentDefinition | undefined = $derived(definitionsByAgent.get(selectedAgent));
+
+$effect(() => {
+  if (definitionsByAgent.has(selectedAgent)) {
+    onboarding.agent = selectedAgent as CliAgent;
+  } else if (filteredDefinitions.length > 0) {
+    selectedAgent = filteredDefinitions[0]!.cliName;
+  }
+});
+</script>
+
+<div class="mx-auto max-w-3xl py-4">
+  <h2 class="text-xl font-semibold text-(--pd-content-card-text) mb-1">{title}</h2>
+  <p class="text-sm text-(--pd-content-card-text) opacity-60 mb-6">
+    {description}
+  </p>
+
+  <div class="mb-8">
+    <CardSelector label="Coding agent" options={agentOptions} bind:selected={selectedAgent} required />
+  </div>
+
+  {#if activeDefinition?.panel}
+    <activeDefinition.panel />
+  {/if}
+</div>

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -22,7 +22,7 @@ import { faBrain, faCheckCircle, faRobot } from '@fortawesome/free-solid-svg-ico
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { GuidedSetupStep } from './guided-setup-steps';
+import type { GuidedSetupStep, OnboardingState } from './guided-setup-steps';
 import GuidedSetup from './GuidedSetup.svelte';
 
 vi.mock(import('./guided-setup-steps'), async importOriginal => {
@@ -58,6 +58,9 @@ vi.mock(import('./guided-setup-steps'), async importOriginal => {
         isSkippable: false,
       },
     ] satisfies GuidedSetupStep[],
+    createDefaultOnboardingState: (): OnboardingState => ({
+      agent: 'opencode',
+    }),
   };
 });
 
@@ -66,6 +69,7 @@ const closeMock = vi.fn();
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
+  vi.stubGlobal('updateConfigurationValue', vi.fn().mockResolvedValue(undefined));
 });
 
 test('renders stepper with all step labels', () => {
@@ -92,7 +96,7 @@ test('first step is active on mount', () => {
 test('"Continue" advances to next step', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
-  const continueButton = screen.getByRole('button', { name: 'Continue' });
+  const continueButton = screen.getByRole('button', { name: /Continue/ });
   await fireEvent.click(continueButton);
 
   const secondStepButton = screen.getByRole('button', { name: 'Step B step' });
@@ -112,7 +116,7 @@ test('"Skip" advances to next step', async () => {
 test('completed steps are tracked after Continue', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
-  const continueButton = screen.getByRole('button', { name: 'Continue' });
+  const continueButton = screen.getByRole('button', { name: /Continue/ });
   await fireEvent.click(continueButton);
 
   const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
@@ -133,21 +137,22 @@ test('skipped steps are not marked completed', async () => {
 test('last step shows "Go to Dashboard" instead of "Continue"', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
 
-  expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Go to Dashboard' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Continue/ })).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Go to Dashboard/ })).toBeInTheDocument();
 });
 
 test('dispatches close event when finishing on last step', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
 
-  const dashboardButton = screen.getByRole('button', { name: 'Go to Dashboard' });
+  const dashboardButton = screen.getByRole('button', { name: /Go to Dashboard/ });
   await fireEvent.click(dashboardButton);
+  await vi.advanceTimersByTimeAsync(0);
 
   expect(closeMock).toHaveBeenCalled();
 });
@@ -155,7 +160,7 @@ test('dispatches close event when finishing on last step', async () => {
 test('clicking on completed step navigates back to it', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
 
   const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
   await fireEvent.click(firstStepButton);
@@ -184,8 +189,57 @@ test('stepper progress bar has correct number of connector lines', () => {
 test('Skip button is not shown for non-skippable steps', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
 
   expect(screen.queryByRole('button', { name: 'Skip' })).not.toBeInTheDocument();
+});
+
+test('persists default agent to settings.json when wizard completes', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
+});
+
+test('persists defaults when skipping to the end', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
+});
+
+test('closes wizard even when persistence fails', async () => {
+  const persistError = new Error('write failed');
+  vi.stubGlobal('updateConfigurationValue', vi.fn().mockRejectedValue(persistError));
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to persist onboarding defaults', persistError);
+  expect(closeMock).toHaveBeenCalled();
+
+  consoleErrorSpy.mockRestore();
+  vi.stubGlobal('updateConfigurationValue', vi.fn().mockResolvedValue(undefined));
+});
+
+test('does not persist defaults when advancing to intermediate steps', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+
+  expect(window.updateConfigurationValue).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { faBrain, faCheckCircle, faRobot } from '@fortawesome/free-solid-svg-icons';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { GuidedSetupStep, OnboardingState } from './guided-setup-steps';
@@ -152,9 +152,10 @@ test('dispatches close event when finishing on last step', async () => {
 
   const dashboardButton = screen.getByRole('button', { name: /Go to Dashboard/ });
   await fireEvent.click(dashboardButton);
-  await vi.advanceTimersByTimeAsync(0);
 
-  expect(closeMock).toHaveBeenCalled();
+  await waitFor(() => {
+    expect(closeMock).toHaveBeenCalled();
+  });
 });
 
 test('clicking on completed step navigates back to it', async () => {
@@ -201,9 +202,10 @@ test('persists default agent to settings.json when wizard completes', async () =
   await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
   await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
   await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
-  await vi.advanceTimersByTimeAsync(0);
 
-  expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
+  await waitFor(() => {
+    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
+  });
 });
 
 test('persists defaults when skipping to the end', async () => {
@@ -212,9 +214,10 @@ test('persists defaults when skipping to the end', async () => {
   await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
   await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
   await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
-  await vi.advanceTimersByTimeAsync(0);
 
-  expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
+  await waitFor(() => {
+    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
+  });
 });
 
 test('closes wizard even when persistence fails', async () => {
@@ -227,10 +230,11 @@ test('closes wizard even when persistence fails', async () => {
   await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
   await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
   await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
-  await vi.advanceTimersByTimeAsync(0);
 
-  expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to persist onboarding defaults', persistError);
-  expect(closeMock).toHaveBeenCalled();
+  await waitFor(() => {
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to persist onboarding defaults', persistError);
+    expect(closeMock).toHaveBeenCalled();
+  });
 });
 
 test('does not persist defaults when advancing to intermediate steps', async () => {

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -231,9 +231,6 @@ test('closes wizard even when persistence fails', async () => {
 
   expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to persist onboarding defaults', persistError);
   expect(closeMock).toHaveBeenCalled();
-
-  consoleErrorSpy.mockRestore();
-  vi.stubGlobal('updateConfigurationValue', vi.fn().mockResolvedValue(undefined));
 });
 
 test('does not persist defaults when advancing to intermediate steps', async () => {

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -4,7 +4,7 @@ import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { SvelteSet } from 'svelte/reactivity';
 
-import { guidedSetupSteps } from './guided-setup-steps';
+import { createDefaultOnboardingState, guidedSetupSteps } from './guided-setup-steps';
 
 interface Props {
   onclose: () => void;
@@ -14,6 +14,7 @@ let { onclose }: Props = $props();
 
 let currentStepIndex = $state(0);
 let completedSteps = new SvelteSet<string>();
+let onboardingState = $state(createDefaultOnboardingState());
 
 let hasSteps = $derived(guidedSetupSteps.length > 0);
 let currentStep = $derived(guidedSetupSteps[currentStepIndex]);
@@ -27,8 +28,17 @@ function getStepState(index: number): 'completed' | 'active' | 'upcoming' {
   return 'upcoming';
 }
 
-function advance(): void {
+async function persistOnboardingDefaults(): Promise<void> {
+  await window.updateConfigurationValue('onboarding.defaultAgent', onboardingState.agent);
+}
+
+async function advance(): Promise<void> {
   if (!hasSteps || isLastStep) {
+    try {
+      await persistOnboardingDefaults();
+    } catch (err: unknown) {
+      console.error('Failed to persist onboarding defaults', err);
+    }
     onclose();
   } else {
     currentStepIndex++;
@@ -37,23 +47,27 @@ function advance(): void {
 
 function handleContinue(): void {
   completedSteps.add(currentStep.id);
-  advance();
+  advance().catch((err: unknown) => {
+    console.error('advance failed', err);
+  });
 }
 
 function handleSkip(): void {
-  advance();
+  advance().catch((err: unknown) => {
+    console.error('advance failed', err);
+  });
 }
 
 function handleStepClick(index: number): void {
-  const state = getStepState(index);
-  if (state === 'completed' || index === currentStepIndex) {
+  const stepState = getStepState(index);
+  if (stepState === 'completed' || index === currentStepIndex) {
     currentStepIndex = index;
   }
 }
 </script>
 
 <div
-  class="fixed inset-0 z-50 flex flex-col bg-[var(--pd-content-card-bg)]"
+  class="fixed inset-0 z-50 flex flex-col bg-(--pd-content-card-bg)"
   role="dialog"
   aria-label="Guided Setup">
 
@@ -64,8 +78,8 @@ function handleStepClick(index: number): void {
       {#if index > 0}
         <div
           class="h-0.5 w-12 mx-1 transition-colors {state === 'upcoming'
-            ? 'bg-[var(--pd-content-divider)]'
-            : 'bg-[var(--pd-button-primary-bg)]'}"
+            ? 'bg-(--pd-content-divider)'
+            : 'bg-(--pd-button-primary-bg)'}"
           aria-hidden="true">
         </div>
       {/if}
@@ -82,15 +96,15 @@ function handleStepClick(index: number): void {
             {state === 'completed'
               ? 'bg-green-600 text-white'
               : state === 'active'
-                ? 'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-text)]'
-                : 'bg-[var(--pd-content-card-inset-bg)] text-[var(--pd-content-card-text)]'}">
+                ? 'bg-(--pd-button-primary-bg) text-(--pd-button-text)'
+                : 'bg-(--pd-content-card-inset-bg) text-(--pd-content-card-text)'}">
           {#if state === 'completed'}
             <Icon icon={faCheck} size="0.8x" />
           {:else}
             {index + 1}
           {/if}
         </div>
-        <span class="text-xs text-[var(--pd-content-card-text)] whitespace-nowrap">{step.title}</span>
+        <span class="text-xs text-(--pd-content-card-text) whitespace-nowrap">{step.title}</span>
       </button>
     {/each}
   </nav>
@@ -99,16 +113,16 @@ function handleStepClick(index: number): void {
   <div class="flex-1 overflow-y-auto px-8" aria-label="Step content">
     {#each guidedSetupSteps as step, index (step.id)}
       {#if index === currentStepIndex}
-        <step.component stepId={step.id} title={step.title} description={step.description} />
+        <step.component stepId={step.id} title={step.title} description={step.description} onboarding={onboardingState} />
       {/if}
     {/each}
   </div>
 
   <!-- Footer -->
-  <footer class="flex justify-end gap-3 px-8 py-6 bg-[var(--pd-content-bg)]">
+  <footer class="flex justify-end gap-3 px-8 py-6 bg-(--pd-content-bg)">
     {#if currentStep?.isSkippable}
       <Button type="secondary" aria-label="Skip" onclick={handleSkip}>Skip</Button>
     {/if}
-    <Button type="primary" aria-label={continueLabel} onclick={handleContinue}>{continueLabel}</Button>
+    <Button type="primary" aria-label={continueLabel} onclick={handleContinue}>{continueLabel} &rsaquo;</Button>
   </footer>
 </div>

--- a/packages/renderer/src/lib/guided-setup/agent-registry.ts
+++ b/packages/renderer/src/lib/guided-setup/agent-registry.ts
@@ -17,49 +17,29 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
-import { faRobot } from '@fortawesome/free-solid-svg-icons';
+import { faDesktop } from '@fortawesome/free-solid-svg-icons';
 import type { Component } from 'svelte';
 
-import CodingAgentStep from './CodingAgentStep.svelte';
+import type { CliAgent } from './guided-setup-steps';
+import OpenCodePanel from './panels/OpenCodePanel.svelte';
 
-export type CliAgent = 'opencode';
-
-export interface OnboardingState {
-  agent: CliAgent;
-}
-
-export interface GuidedSetupStepProps {
-  stepId: string;
+export interface AgentDefinition {
+  cliName: CliAgent;
   title: string;
   description: string;
-  onboarding: OnboardingState;
-}
-
-export interface GuidedSetupStep {
-  id: string;
-  title: string;
-  description: string;
+  badge: string;
   icon: IconDefinition;
-  component: Component<GuidedSetupStepProps>;
-  isComplete: () => boolean;
-  isSkippable: boolean;
+  panel?: Component;
 }
 
-export function createDefaultOnboardingState(): OnboardingState {
-  return {
-    agent: 'opencode',
-  };
-}
-
-export const guidedSetupSteps: GuidedSetupStep[] = [
+export const agentDefinitions: AgentDefinition[] = [
   {
-    id: 'coding-agent',
-    title: 'Choose your coding agent',
+    cliName: 'opencode',
+    title: 'OpenCode',
     description:
-      'Pick the default coding agent runtime. The API notes below update for your choice. You can change this later in settings.',
-    icon: faRobot,
-    component: CodingAgentStep,
-    isComplete: (): boolean => false,
-    isSkippable: true,
+      'Open-source agent on your machine - local models via Ollama or Ramalama, or cloud APIs (OpenAI, Gemini, and other providers OpenCode supports).',
+    badge: 'Recommended',
+    icon: faDesktop,
+    panel: OpenCodePanel,
   },
 ];

--- a/packages/renderer/src/lib/guided-setup/panels/OpenCodePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/OpenCodePanel.svelte
@@ -70,25 +70,25 @@ $effect(() => {
     </div>
   {:else if probeStatus === 'detected'}
     <div
-      class="flex items-center gap-3 rounded-lg bg-green-900/20 border border-green-700/30 p-4"
+      class="flex items-center gap-3 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-success) p-4"
       role="status"
       aria-live="polite"
       data-testid="probe-detected">
-      <Icon icon={faCircleCheck} size="lg" class="text-green-400" />
+      <Icon icon={faCircleCheck} size="lg" class="text-(--pd-state-success)" />
       <div>
-        <strong class="text-sm text-green-300">Local runtime detected</strong>
-        <p class="text-xs text-green-300/70 mt-0.5">You can pick a default from the local catalog on the next step.</p>
+        <strong class="text-sm text-(--pd-state-success)">Local runtime detected</strong>
+        <p class="text-xs text-(--pd-content-card-text) opacity-70 mt-0.5">You can pick a default from the local catalog on the next step.</p>
       </div>
     </div>
   {:else if probeStatus === 'not-found'}
     <div
-      class="flex items-start gap-3 rounded-lg bg-amber-900/20 border border-amber-700/30 p-4"
+      class="flex items-start gap-3 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-warning) p-4"
       role="alert"
       data-testid="probe-not-found">
-      <Icon icon={faTriangleExclamation} size="lg" class="text-amber-400 shrink-0 mt-0.5" />
+      <Icon icon={faTriangleExclamation} size="lg" class="text-(--pd-state-warning) shrink-0 mt-0.5" />
       <div>
-        <strong class="text-sm text-amber-300">No local model server detected</strong>
-        <p class="text-xs text-amber-300/70 mt-1 leading-relaxed">
+        <strong class="text-sm text-(--pd-state-warning)">No local model server detected</strong>
+        <p class="text-xs text-(--pd-content-card-text) opacity-70 mt-1 leading-relaxed">
           Install and start
           <Link on:click={openOllamaLink}>Ollama</Link>
           or

--- a/packages/renderer/src/lib/guided-setup/panels/OpenCodePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/OpenCodePanel.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+import { faCircleCheck, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { Button, Link, Spinner } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+type ProbeStatus = 'idle' | 'checking' | 'detected' | 'not-found';
+let probeStatus: ProbeStatus = $state('idle');
+
+async function hasLocalInferenceConnection(): Promise<boolean> {
+  try {
+    const providers = await window.getProviderInfos();
+    return providers.some(p => p.inferenceConnections.some(c => c.type === 'local' && c.status === 'started'));
+  } catch {
+    return false;
+  }
+}
+
+async function probeLocalRuntime(): Promise<void> {
+  probeStatus = 'checking';
+  probeStatus = (await hasLocalInferenceConnection()) ? 'detected' : 'not-found';
+}
+
+function openOllamaLink(): void {
+  window.openExternal('https://ollama.com').catch(() => {});
+}
+
+function openRamalamaLink(): void {
+  window.openExternal('https://github.com/containers/ramalama').catch(() => {});
+}
+
+function handleRetryProbe(): void {
+  probeLocalRuntime().catch((err: unknown) => {
+    console.error('Local runtime probe failed', err);
+  });
+}
+
+$effect(() => {
+  if (probeStatus === 'idle') {
+    probeLocalRuntime().catch((err: unknown) => {
+      console.error('Local runtime probe failed', err);
+    });
+  }
+});
+</script>
+
+<div
+  class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
+  data-testid="opencode-panel">
+  <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+    Local Runtime
+  </h3>
+  <p class="text-xs text-(--pd-content-card-text) opacity-50 mb-4 leading-relaxed">
+    We check for local inference providers (such as <strong>Ollama</strong> or <strong>Ramalama</strong>) registered
+    with the extension system. Results update the default-model step.
+  </p>
+
+  {#if probeStatus === 'checking'}
+    <div
+      class="flex items-center gap-3 rounded-lg bg-(--pd-content-card-bg) p-4"
+      role="status"
+      aria-live="polite"
+      data-testid="probe-checking">
+      <Spinner size="1.25em" />
+      <div>
+        <strong class="text-sm text-(--pd-content-card-text)">Checking local runtimes…</strong>
+        <p class="text-xs text-(--pd-content-card-text) opacity-50 mt-0.5">
+          Looking for Ollama or Ramalama on this machine.
+        </p>
+      </div>
+    </div>
+  {:else if probeStatus === 'detected'}
+    <div
+      class="flex items-center gap-3 rounded-lg bg-green-900/20 border border-green-700/30 p-4"
+      role="status"
+      aria-live="polite"
+      data-testid="probe-detected">
+      <Icon icon={faCircleCheck} size="lg" class="text-green-400" />
+      <div>
+        <strong class="text-sm text-green-300">Local runtime detected</strong>
+        <p class="text-xs text-green-300/70 mt-0.5">You can pick a default from the local catalog on the next step.</p>
+      </div>
+    </div>
+  {:else if probeStatus === 'not-found'}
+    <div
+      class="flex items-start gap-3 rounded-lg bg-amber-900/20 border border-amber-700/30 p-4"
+      role="alert"
+      data-testid="probe-not-found">
+      <Icon icon={faTriangleExclamation} size="lg" class="text-amber-400 shrink-0 mt-0.5" />
+      <div>
+        <strong class="text-sm text-amber-300">No local model server detected</strong>
+        <p class="text-xs text-amber-300/70 mt-1 leading-relaxed">
+          Install and start
+          <Link on:click={openOllamaLink}>Ollama</Link>
+          or
+          <Link on:click={openRamalamaLink}>Ramalama</Link>, pull at least one model, then run
+          <strong>Check again</strong>.
+        </p>
+        <Button type="secondary" class="mt-3" aria-label="Check again" onclick={handleRetryProbe}>Check again</Button>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/guided-setup/panels/OpenCodePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/OpenCodePanel.svelte
@@ -3,22 +3,13 @@ import { faCircleCheck, faTriangleExclamation } from '@fortawesome/free-solid-sv
 import { Button, Link, Spinner } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
-type ProbeStatus = 'idle' | 'checking' | 'detected' | 'not-found';
-let probeStatus: ProbeStatus = $state('idle');
+import { fetchProviders, providerInfos } from '/@/stores/providers';
 
-async function hasLocalInferenceConnection(): Promise<boolean> {
-  try {
-    const providers = await window.getProviderInfos();
-    return providers.some(p => p.inferenceConnections.some(c => c.type === 'local' && c.status === 'started'));
-  } catch {
-    return false;
-  }
-}
+let checking = $state(false);
 
-async function probeLocalRuntime(): Promise<void> {
-  probeStatus = 'checking';
-  probeStatus = (await hasLocalInferenceConnection()) ? 'detected' : 'not-found';
-}
+let hasLocalInference = $derived(
+  $providerInfos.some(p => p.inferenceConnections.some(c => c.type === 'local' && c.status === 'started')),
+);
 
 function openOllamaLink(): void {
   window.openExternal('https://ollama.com').catch(() => {});
@@ -29,18 +20,15 @@ function openRamalamaLink(): void {
 }
 
 function handleRetryProbe(): void {
-  probeLocalRuntime().catch((err: unknown) => {
-    console.error('Local runtime probe failed', err);
-  });
-}
-
-$effect(() => {
-  if (probeStatus === 'idle') {
-    probeLocalRuntime().catch((err: unknown) => {
+  checking = true;
+  fetchProviders()
+    .catch((err: unknown) => {
       console.error('Local runtime probe failed', err);
+    })
+    .finally(() => {
+      checking = false;
     });
-  }
-});
+}
 </script>
 
 <div
@@ -54,7 +42,7 @@ $effect(() => {
     with the extension system. Results update the default-model step.
   </p>
 
-  {#if probeStatus === 'checking'}
+  {#if checking}
     <div
       class="flex items-center gap-3 rounded-lg bg-(--pd-content-card-bg) p-4"
       role="status"
@@ -68,7 +56,7 @@ $effect(() => {
         </p>
       </div>
     </div>
-  {:else if probeStatus === 'detected'}
+  {:else if hasLocalInference}
     <div
       class="flex items-center gap-3 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-success) p-4"
       role="status"
@@ -80,7 +68,7 @@ $effect(() => {
         <p class="text-xs text-(--pd-content-card-text) opacity-70 mt-0.5">You can pick a default from the local catalog on the next step.</p>
       </div>
     </div>
-  {:else if probeStatus === 'not-found'}
+  {:else}
     <div
       class="flex items-start gap-3 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-warning) p-4"
       role="alert"
@@ -95,7 +83,7 @@ $effect(() => {
           <Link on:click={openRamalamaLink}>Ramalama</Link>, pull at least one model, then run
           <strong>Check again</strong>.
         </p>
-        <Button type="secondary" class="mt-3" aria-label="Check again" onclick={handleRetryProbe}>Check again</Button>
+        <Button type="secondary" class="mt-3" onclick={handleRetryProbe}>Check again</Button>
       </div>
     </div>
   {/if}

--- a/packages/renderer/src/lib/ui/CardSelector.spec.ts
+++ b/packages/renderer/src/lib/ui/CardSelector.spec.ts
@@ -130,3 +130,12 @@ test('Expect deselection when clicking the already selected option', async () =>
 
   expect(buttonA.className).toContain('border-[var(--pd-content-card-border)]');
 });
+
+test('Expect no deselection when required is true', async () => {
+  render(CardSelector, { options, selected: 'a', required: true });
+
+  const buttonA = screen.getByRole('button', { name: 'Option A' });
+  await fireEvent.click(buttonA);
+
+  expect(buttonA.className).toContain('border-[var(--pd-content-card-border-selected)]');
+});

--- a/packages/renderer/src/lib/ui/CardSelector.svelte
+++ b/packages/renderer/src/lib/ui/CardSelector.svelte
@@ -14,12 +14,13 @@ interface Props {
   label?: string;
   options: CardSelectorOption[];
   selected?: string;
+  required?: boolean;
 }
 
-let { label, options, selected = $bindable('') }: Props = $props();
+let { label, options, selected = $bindable(''), required = false }: Props = $props();
 
 function handleClick(value: string): void {
-  selected = selected === value ? '' : value;
+  selected = !required && selected === value ? '' : value;
 }
 </script>
 

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -32,6 +32,11 @@ import type { TelemetryMessages } from '/@api/telemetry';
 
 import WelcomePage from './WelcomePage.svelte';
 
+vi.mock(import('/@/lib/guided-setup/guided-setup-steps'), async importOriginal => ({
+  ...(await importOriginal()),
+  guidedSetupSteps: [],
+}));
+
 // fake the window.events object
 beforeEach(() => {
   vi.resetAllMocks();


### PR DESCRIPTION
## Summary

- Add the coding agent selection step (step 1) to the onboarding wizard with an OpenCode agent tile and local runtime probe (Ollama/Ramalama detection)
- Introduce a two-layer architecture: an `agent-registry.ts` for tile metadata and separate panel components per agent, so adding a new agent is just one registry entry + an optional panel
- Filter available agents at runtime via `window.getCliInfo()` (backed by `kdn info --output json`), falling back to all registry entries when the CLI is unavailable or returns no agents
- Persist the selected default agent to `settings.json` via `ConfigurationRegistry` when the wizard completes, so workspace creation can read it later
- Add `required` prop to `CardSelector` to prevent deselection in single-choice contexts

> **Note:** Providers that require API keys are not included in this step until the credentials system redesign is complete.

https://github.com/user-attachments/assets/b1f12e5a-2e6e-4079-ba9c-403149b1f403

## Test plan

- [ ] Open the app for the first time (or reset the welcome flag / delete `settings.json`) so the onboarding wizard shows
- [ ] Verify OpenCode is selected by default with the "Recommended" badge
- [ ] Select OpenCode — confirm the local runtime probe runs (shows "Checking…", then "detected" or "not found" depending on whether Ollama/Ramalama is running)
- [ ] Click "Check again" after starting Ollama — confirm status updates to "detected"
- [ ] Complete the wizard — confirm `onboarding.defaultAgent` is written to `settings.json`
- [ ] Complete the wizard with no kdn installed — confirm it still closes gracefully (fallback shows all agents, persistence error is caught)

Closes #1316