### PR TITLE
fix(docling): set UVICORN_WORKERS=1 to prevent task routing 404s

### DIFF
--- a/extensions/docling/src/docling-extension.spec.ts
+++ b/extensions/docling/src/docling-extension.spec.ts
@@ -390,6 +390,20 @@ describe('DoclingExtension', () => {
       expect(result.containerId).toBe('test-container-id');
     });
 
+    test('should set UVICORN_WORKERS=1 to avoid multi-worker task routing issues', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+      } as Response);
+
+      await doclingExtension.launchContainer(containerExtensionAPI);
+
+      expect(dockerodeMock.createContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Env: expect.arrayContaining(['UVICORN_WORKERS=1']),
+        }),
+      );
+    });
+
     test('should pull image if not available', async () => {
       // Mock image not found
       vi.mocked(imageMock.inspect).mockRejectedValue(new Error('Image not found'));

--- a/extensions/docling/src/docling-extension.ts
+++ b/extensions/docling/src/docling-extension.ts
@@ -108,6 +108,10 @@ export class DoclingExtension {
         'ai.openkaiden.docling.port': `${containerPort}`,
       },
       Image: DOCLING_IMAGE,
+      // Single worker required: LocalOrchestrator stores tasks in per-worker memory.
+      // Multiple workers cause 404 "Task result not found" on internal polls.
+      // See https://github.com/docling-project/docling-serve/issues/467
+      Env: ['UVICORN_WORKERS=1'],
       HostConfig: {
         AutoRemove: true,
         PortBindings: {


### PR DESCRIPTION
docling-serve defaults to multiple uvicorn workers, each with its own in-memory LocalOrchestrator task store. Internal task submissions can be polled by a different worker that has no record of the task, causing 404 "Task result not found" errors.

Force single worker mode so all tasks stay in the same process.

Ref: https://github.com/docling-project/docling-serve/issues/467

Made-with: Cursor

Fixes https://github.com/openkaiden/kaiden/issues/1351