### PR TITLE
feat(secret-vault): wire secret list and create pages to secret manager

### DIFF
--- a/packages/renderer/src/stores/navigation/navigation-registry-secret-vault.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-secret-vault.svelte.ts
@@ -18,9 +18,15 @@
 
 import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 
+import { secretVaultInfos } from '/@/stores/secret-vault';
+
 import type { NavigationRegistryEntry } from './navigation-registry';
 
-const count = $state(0);
+let count = $state(0);
+
+secretVaultInfos.subscribe(infos => {
+  count = infos.length;
+});
 
 export function createNavigationSecretVaultEntry(): NavigationRegistryEntry {
   const registry: NavigationRegistryEntry = {

--- a/packages/renderer/src/stores/secret-vault.ts
+++ b/packages/renderer/src/stores/secret-vault.ts
@@ -20,9 +20,22 @@ import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
 
 import { findMatchInLeaves } from '/@/stores/search-util';
+import type { SecretInfo } from '/@api/secret-info';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 
-// TODO: wire to backend data source
+import { EventStore } from './event-store';
+
+function secretInfoToVaultInfo(info: SecretInfo): SecretVaultInfo {
+  return {
+    id: info.name,
+    name: info.name,
+    category: 'api',
+    type: info.type,
+    description: info.description,
+    status: 'active',
+  };
+}
+
 export const secretVaultInfos: Writable<readonly SecretVaultInfo[]> = writable([]);
 
 export const secretVaultSearchPattern = writable('');
@@ -46,3 +59,27 @@ export const filteredSecretVaultInfos = derived(
     return filtered;
   },
 );
+
+let readyToUpdate = false;
+
+async function checkForUpdate(eventName: string): Promise<boolean> {
+  if ('system-ready' === eventName) {
+    readyToUpdate = true;
+  }
+  return readyToUpdate;
+}
+
+const listSecrets = async (): Promise<readonly SecretVaultInfo[]> => {
+  const items = await window.listSecrets();
+  return items.map(secretInfoToVaultInfo);
+};
+
+export const secretVaultEventStore = new EventStore<readonly SecretVaultInfo[]>(
+  'secret-vault',
+  secretVaultInfos,
+  checkForUpdate,
+  ['secret-manager-update'],
+  ['system-ready'],
+  listSecrets,
+);
+secretVaultEventStore.setup();


### PR DESCRIPTION
Connect the secret vault UI to the kdn CLI backend via the existing IPC surface (secret-manager:list) replacing the previous stub implementations. The wiring to the secret creation is implemented on issue #1455 

Closes #1444