### PR TITLE
feat(secret-vault): adapt create secret page to CLI types and mockup

### DIFF
--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -530,7 +530,7 @@ describe('listServices', () => {
   ];
 
   test('executes kdn service list and returns services', async () => {
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(TEST_SERVICES)));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SERVICES })));
 
     const result = await kdnCli.listServices();
 
@@ -540,7 +540,7 @@ describe('listServices', () => {
   });
 
   test('returns services with optional fields when present', async () => {
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(TEST_SERVICES)));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SERVICES })));
 
     const result = await kdnCli.listServices();
 
@@ -554,7 +554,7 @@ describe('listServices', () => {
   });
 
   test('returns services without optional fields when omitted', async () => {
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(TEST_SERVICES)));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ items: TEST_SERVICES })));
 
     const result = await kdnCli.listServices();
 
@@ -563,7 +563,7 @@ describe('listServices', () => {
   });
 
   test('returns empty array when CLI returns no services', async () => {
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify([])));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ items: [] })));
 
     const result = await kdnCli.listServices();
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -184,6 +184,7 @@ export class KdnCli {
   }
 
   async listServices(): Promise<SecretService[]> {
-    return this.execCLI<SecretService[]>(['service', 'list']);
+    const response = await this.execCLI<{ items: SecretService[] }>(['service', 'list']);
+    return response.items;
   }
 }

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -72,5 +72,9 @@ export class SecretManager {
     this.ipcHandle('secret-manager:remove', async (_listener: unknown, name: string): Promise<SecretName> => {
       return this.remove(name);
     });
+
+    this.ipcHandle('secret-manager:list-services', async (): Promise<SecretService[]> => {
+      return this.listServices();
+    });
   }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -143,7 +143,7 @@ import type { ChunkProviderInfo } from '/@api/rag/chunk-provider-info';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { ExtensionBanner, RecommendedRegistry } from '/@api/recommendations/recommendations';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info';
-import type { SecretCreateOptions, SecretInfo, SecretName } from '/@api/secret-info';
+import type { SecretCreateOptions, SecretInfo, SecretName, SecretService } from '/@api/secret-info';
 import type { SkillFileContent, SkillFolderInfo, SkillInfo, SkillResourceEntry } from '/@api/skill/skill-info';
 import type { StatusBarEntryDescriptor } from '/@api/status-bar';
 import type { PinOption } from '/@api/status-bar/pin-option';
@@ -366,6 +366,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('removeSecret', async (name: string): Promise<SecretName> => {
     return ipcInvoke('secret-manager:remove', name);
+  });
+
+  contextBridge.exposeInMainWorld('listSecretServices', async (): Promise<SecretService[]> => {
+    return ipcInvoke('secret-manager:list-services');
   });
 
   contextBridge.exposeInMainWorld('listFlows', async (): Promise<Array<FlowInfo>> => {

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -171,6 +171,32 @@ test('submits Other secret with injection settings', async () => {
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
 });
 
+test('submits Other secret using default Authorization header when header name is not changed', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
+
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'custom-key' } });
+  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-abc' } });
+  await fireEvent.input(screen.getByLabelText('Host pattern'), { target: { value: 'api.custom.io' } });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
+
+  expect(window.createSecret).toHaveBeenCalledWith({
+    name: 'custom-key',
+    type: 'other',
+    value: 'sk-abc',
+    hosts: ['api.custom.io'],
+    header: 'Authorization',
+  });
+
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
+});
+
 test('submits predefined service type without injection fields', async () => {
   const { handleNavigation } = await import('/@/navigation');
 

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -18,28 +18,54 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { SecretService } from '/@api/secret-info';
 
 import SecretVaultCreate from './SecretVaultCreate.svelte';
 
 vi.mock(import('/@/navigation'));
 
+const MOCK_SERVICES: SecretService[] = [
+  {
+    name: 'github',
+    hostPattern: 'api.github.com',
+    headerName: 'Authorization',
+    headerTemplate: 'Bearer ${value}',
+    envVars: ['GH_TOKEN', 'GITHUB_TOKEN'],
+  },
+  {
+    name: 'gemini',
+    hostPattern: 'generativelanguage.googleapis.com',
+    headerName: 'x-goog-api-key',
+    headerTemplate: '${value}',
+    envVars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+  },
+];
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.createSecret).mockResolvedValue({ name: 'test' });
+  vi.mocked(window.listSecretServices).mockResolvedValue(MOCK_SERVICES);
 });
 
-test('renders type selector with GitHub, Gemini, and Other options', () => {
+test('renders type options from fetched services plus Other', async () => {
   render(SecretVaultCreate);
 
-  expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+  });
   expect(screen.getByLabelText('Gemini')).toBeInTheDocument();
   expect(screen.getByLabelText('Other')).toBeInTheDocument();
 });
 
-test('defaults to Generic type with appropriate form fields', () => {
+test('defaults to Other type with full form fields', async () => {
   render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
 
   expect(screen.getByText('Other Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
@@ -52,33 +78,53 @@ test('defaults to Generic type with appropriate form fields', () => {
   expect(screen.getByLabelText('Value format')).toBeInTheDocument();
 });
 
-test('hides injection fields when a predefined type is selected', async () => {
+test('hides injection fields when a predefined service type is selected', async () => {
   render(SecretVaultCreate);
 
-  const githubCard = screen.getByLabelText('GitHub');
-  await fireEvent.click(githubCard);
+  await waitFor(() => {
+    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+  });
 
-  expect(screen.getByText('GitHub Secret')).toBeInTheDocument();
+  await fireEvent.click(screen.getByLabelText('Github'));
+
+  expect(screen.getByText('Github Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
   expect(screen.getByLabelText('Secret value')).toBeInTheDocument();
   expect(screen.queryByLabelText('Host pattern')).not.toBeInTheDocument();
   expect(screen.queryByText('Injection settings')).not.toBeInTheDocument();
 });
 
-test('Add Secret button is disabled when required fields are empty', () => {
+test('shows subtitle with service details for predefined type', async () => {
   render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByLabelText('Github'));
+
+  expect(screen.getByText(/Automatically injected as Authorization for api\.github\.com/)).toBeInTheDocument();
+});
+
+test('Add Secret button is disabled when required fields are empty', async () => {
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
 
   expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
 });
 
-test('Add Secret button is disabled for generic type without host pattern', async () => {
+test('Add Secret button is disabled for Other type without host pattern', async () => {
   render(SecretVaultCreate);
 
-  const nameInput = screen.getByLabelText('Name');
-  const secretInput = screen.getByLabelText('Secret value');
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
 
-  await fireEvent.input(nameInput, { target: { value: 'my-secret' } });
-  await fireEvent.input(secretInput, { target: { value: 'secret-value' } });
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-secret' } });
+  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'secret-value' } });
 
   expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
 });
@@ -94,10 +140,14 @@ test('cancel navigates back to secret vault', async () => {
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
 });
 
-test('submits generic secret with injection settings', async () => {
+test('submits Other secret with injection settings', async () => {
   const { handleNavigation } = await import('/@/navigation');
 
   render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
 
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-api-key' } });
   await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-123' } });
@@ -106,8 +156,7 @@ test('submits generic secret with injection settings', async () => {
   await fireEvent.input(screen.getByLabelText('Header name'), { target: { value: 'Authorization' } });
   await fireEvent.input(screen.getByLabelText('Value format'), { target: { value: 'Bearer {value}' } });
 
-  const addButton = screen.getByRole('button', { name: 'Add Secret' });
-  await fireEvent.click(addButton);
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
 
   expect(window.createSecret).toHaveBeenCalledWith({
     name: 'my-api-key',
@@ -122,17 +171,20 @@ test('submits generic secret with injection settings', async () => {
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
 });
 
-test('submits predefined type secret without injection fields', async () => {
+test('submits predefined service type without injection fields', async () => {
   const { handleNavigation } = await import('/@/navigation');
 
   render(SecretVaultCreate);
 
-  await fireEvent.click(screen.getByLabelText('GitHub'));
+  await waitFor(() => {
+    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByLabelText('Github'));
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'gh-token' } });
   await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'ghp_abc123' } });
 
-  const addButton = screen.getByRole('button', { name: 'Add Secret' });
-  await fireEvent.click(addButton);
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
 
   expect(window.createSecret).toHaveBeenCalledWith({
     name: 'gh-token',
@@ -148,26 +200,48 @@ test('displays error when createSecret fails', async () => {
 
   render(SecretVaultCreate);
 
-  await fireEvent.click(screen.getByLabelText('GitHub'));
+  await waitFor(() => {
+    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByLabelText('Github'));
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'test' } });
   await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'val' } });
 
   await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
 
-  expect(screen.getByText('Storage unavailable')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByText('Storage unavailable')).toBeInTheDocument();
+  });
 });
 
 test('injection settings section can be collapsed and expanded', async () => {
   render(SecretVaultCreate);
 
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
+
   expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
 
-  const toggleButton = screen.getByText('Injection settings');
-  await fireEvent.click(toggleButton);
+  await fireEvent.click(screen.getByText('Injection settings'));
 
   expect(screen.queryByLabelText('Path pattern')).not.toBeInTheDocument();
 
-  await fireEvent.click(toggleButton);
+  await fireEvent.click(screen.getByText('Injection settings'));
 
   expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
+});
+
+test('still renders form when listSecretServices fails', async () => {
+  vi.mocked(window.listSecretServices).mockRejectedValueOnce(new Error('CLI not found'));
+
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
+
+  expect(screen.getByText('Other Secret')).toBeInTheDocument();
+  expect(screen.getByLabelText('Name')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -45,6 +45,7 @@ const MOCK_SERVICES: SecretService[] = [
 ];
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
   vi.mocked(window.createSecret).mockResolvedValue({ name: 'test' });
   vi.mocked(window.listSecretServices).mockResolvedValue(MOCK_SERVICES);
@@ -54,7 +55,7 @@ test('renders type options from fetched services plus Other', async () => {
   render(SecretVaultCreate);
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
   });
   expect(screen.getByLabelText('Gemini')).toBeInTheDocument();
   expect(screen.getByLabelText('Other')).toBeInTheDocument();
@@ -82,28 +83,29 @@ test('hides injection fields when a predefined service type is selected', async 
   render(SecretVaultCreate);
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
   });
 
-  await fireEvent.click(screen.getByLabelText('Github'));
+  await fireEvent.click(screen.getByLabelText('GitHub'));
 
-  expect(screen.getByText('Github Secret')).toBeInTheDocument();
+  expect(screen.getByText('GitHub Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
   expect(screen.getByLabelText('Secret value')).toBeInTheDocument();
   expect(screen.queryByLabelText('Host pattern')).not.toBeInTheDocument();
   expect(screen.queryByText('Injection settings')).not.toBeInTheDocument();
 });
 
-test('shows subtitle with service details for predefined type', async () => {
+test('shows no subtitle for predefined service type', async () => {
   render(SecretVaultCreate);
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
   });
 
-  await fireEvent.click(screen.getByLabelText('Github'));
+  await fireEvent.click(screen.getByLabelText('GitHub'));
 
-  expect(screen.getByText(/Automatically injected as Authorization for api\.github\.com/)).toBeInTheDocument();
+  expect(screen.queryByText(/Configure a custom secret/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Automatically injected/)).not.toBeInTheDocument();
 });
 
 test('Add Secret button is disabled when required fields are empty', async () => {
@@ -203,10 +205,10 @@ test('submits predefined service type without injection fields', async () => {
   render(SecretVaultCreate);
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
   });
 
-  await fireEvent.click(screen.getByLabelText('Github'));
+  await fireEvent.click(screen.getByLabelText('GitHub'));
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'gh-token' } });
   await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'ghp_abc123' } });
 
@@ -227,10 +229,10 @@ test('displays error when createSecret fails', async () => {
   render(SecretVaultCreate);
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Github')).toBeInTheDocument();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
   });
 
-  await fireEvent.click(screen.getByLabelText('Github'));
+  await fireEvent.click(screen.getByLabelText('GitHub'));
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'test' } });
   await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'val' } });
 

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -44,6 +44,7 @@ test('defaults to Generic type with appropriate form fields', () => {
   expect(screen.getByText('Other Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
   expect(screen.getByLabelText('Secret value')).toBeInTheDocument();
+  expect(screen.getByLabelText('Description')).toBeInTheDocument();
   expect(screen.getByLabelText('Host pattern')).toBeInTheDocument();
   expect(screen.getByText('Injection settings')).toBeInTheDocument();
   expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
@@ -100,6 +101,7 @@ test('submits generic secret with injection settings', async () => {
 
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-api-key' } });
   await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-123' } });
+  await fireEvent.input(screen.getByLabelText('Description'), { target: { value: 'Production API key' } });
   await fireEvent.input(screen.getByLabelText('Host pattern'), { target: { value: 'api.example.com' } });
   await fireEvent.input(screen.getByLabelText('Header name'), { target: { value: 'Authorization' } });
   await fireEvent.input(screen.getByLabelText('Value format'), { target: { value: 'Bearer {value}' } });
@@ -111,6 +113,7 @@ test('submits generic secret with injection settings', async () => {
     name: 'my-api-key',
     type: 'other',
     value: 'sk-123',
+    description: 'Production API key',
     hosts: ['api.example.com'],
     header: 'Authorization',
     headerTemplate: 'Bearer ${value}',

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -27,27 +27,62 @@ vi.mock(import('/@/navigation'));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.createSecret).mockResolvedValue({ name: 'test' });
 });
 
-test('Expect form elements rendered correctly', () => {
+test('renders type selector with GitHub, Gemini, and Other options', () => {
   render(SecretVaultCreate);
 
-  const headings = screen.getAllByText('Add Secret');
-  expect(headings.length).toBeGreaterThanOrEqual(1);
-
-  expect(screen.getByPlaceholderText('e.g. GitHub · docs repo')).toBeInTheDocument();
-  expect(screen.getByText('API Token')).toBeInTheDocument();
-  expect(screen.getByText('Infrastructure')).toBeInTheDocument();
-  expect(screen.getByLabelText('Credential type')).toBeInTheDocument();
-  expect(screen.getByPlaceholderText('Paste token or key')).toBeInTheDocument();
-  expect(screen.getByLabelText('Expiration date')).toBeInTheDocument();
-  expect(screen.getByLabelText('No expiry')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Save Secret' })).toBeDisabled();
-  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-  expect(screen.getByText(/you can connect this credential from agent workspaces/i)).toBeInTheDocument();
+  expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+  expect(screen.getByLabelText('Gemini')).toBeInTheDocument();
+  expect(screen.getByLabelText('Other')).toBeInTheDocument();
 });
 
-test('Expect cancel navigates back to secret vault', async () => {
+test('defaults to Generic type with appropriate form fields', () => {
+  render(SecretVaultCreate);
+
+  expect(screen.getByText('Other Secret')).toBeInTheDocument();
+  expect(screen.getByLabelText('Name')).toBeInTheDocument();
+  expect(screen.getByLabelText('Secret value')).toBeInTheDocument();
+  expect(screen.getByLabelText('Host pattern')).toBeInTheDocument();
+  expect(screen.getByText('Injection settings')).toBeInTheDocument();
+  expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
+  expect(screen.getByLabelText('Header name')).toBeInTheDocument();
+  expect(screen.getByLabelText('Value format')).toBeInTheDocument();
+});
+
+test('hides injection fields when a predefined type is selected', async () => {
+  render(SecretVaultCreate);
+
+  const githubCard = screen.getByLabelText('GitHub');
+  await fireEvent.click(githubCard);
+
+  expect(screen.getByText('GitHub Secret')).toBeInTheDocument();
+  expect(screen.getByLabelText('Name')).toBeInTheDocument();
+  expect(screen.getByLabelText('Secret value')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Host pattern')).not.toBeInTheDocument();
+  expect(screen.queryByText('Injection settings')).not.toBeInTheDocument();
+});
+
+test('Add Secret button is disabled when required fields are empty', () => {
+  render(SecretVaultCreate);
+
+  expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
+});
+
+test('Add Secret button is disabled for generic type without host pattern', async () => {
+  render(SecretVaultCreate);
+
+  const nameInput = screen.getByLabelText('Name');
+  const secretInput = screen.getByLabelText('Secret value');
+
+  await fireEvent.input(nameInput, { target: { value: 'my-secret' } });
+  await fireEvent.input(secretInput, { target: { value: 'secret-value' } });
+
+  expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
+});
+
+test('cancel navigates back to secret vault', async () => {
   const { handleNavigation } = await import('/@/navigation');
 
   render(SecretVaultCreate);
@@ -56,4 +91,80 @@ test('Expect cancel navigates back to secret vault', async () => {
   await fireEvent.click(cancelButton);
 
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
+});
+
+test('submits generic secret with injection settings', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+
+  render(SecretVaultCreate);
+
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-api-key' } });
+  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-123' } });
+  await fireEvent.input(screen.getByLabelText('Host pattern'), { target: { value: 'api.example.com' } });
+  await fireEvent.input(screen.getByLabelText('Header name'), { target: { value: 'Authorization' } });
+  await fireEvent.input(screen.getByLabelText('Value format'), { target: { value: 'Bearer {value}' } });
+
+  const addButton = screen.getByRole('button', { name: 'Add Secret' });
+  await fireEvent.click(addButton);
+
+  expect(window.createSecret).toHaveBeenCalledWith({
+    name: 'my-api-key',
+    type: 'other',
+    value: 'sk-123',
+    hosts: ['api.example.com'],
+    header: 'Authorization',
+    headerTemplate: 'Bearer ${value}',
+  });
+
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
+});
+
+test('submits predefined type secret without injection fields', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+
+  render(SecretVaultCreate);
+
+  await fireEvent.click(screen.getByLabelText('GitHub'));
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'gh-token' } });
+  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'ghp_abc123' } });
+
+  const addButton = screen.getByRole('button', { name: 'Add Secret' });
+  await fireEvent.click(addButton);
+
+  expect(window.createSecret).toHaveBeenCalledWith({
+    name: 'gh-token',
+    type: 'github',
+    value: 'ghp_abc123',
+  });
+
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
+});
+
+test('displays error when createSecret fails', async () => {
+  vi.mocked(window.createSecret).mockRejectedValueOnce(new Error('Storage unavailable'));
+
+  render(SecretVaultCreate);
+
+  await fireEvent.click(screen.getByLabelText('GitHub'));
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'test' } });
+  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'val' } });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
+
+  expect(screen.getByText('Storage unavailable')).toBeInTheDocument();
+});
+
+test('injection settings section can be collapsed and expanded', async () => {
+  render(SecretVaultCreate);
+
+  expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
+
+  const toggleButton = screen.getByText('Injection settings');
+  await fireEvent.click(toggleButton);
+
+  expect(screen.queryByLabelText('Path pattern')).not.toBeInTheDocument();
+
+  await fireEvent.click(toggleButton);
+
+  expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -217,14 +217,6 @@ async function addSecret(): Promise<void> {
               {#if injectionOpen}
                 <div id="injection-settings" class="px-4 pb-4 pt-2 space-y-4 bg-(--pd-content-card-inset-bg)">
                   <div>
-                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
-                      Path pattern
-                      <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
-                    </span>
-                    <Input bind:value={pathPattern} placeholder="e.g. /v1/*" aria-label="Path pattern" />
-                  </div>
-
-                  <div>
                     <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Header name</span>
                     <Input bind:value={headerName} placeholder="Authorization" aria-label="Header name" />
                   </div>
@@ -238,6 +230,14 @@ async function addSecret(): Promise<void> {
                     <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
                       Use {'{value}'} as a placeholder for the secret. Defaults to the raw value.
                     </p>
+                  </div>
+
+                  <div>
+                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                      Path pattern
+                      <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
+                    </span>
+                    <Input bind:value={pathPattern} placeholder="e.g. /v1/*" aria-label="Path pattern" />
                   </div>
                 </div>
               {/if}

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -1,61 +1,23 @@
 <script lang="ts">
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faChevronDown, faChevronUp, faGear, faKey } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { onMount } from 'svelte';
 
+import type { CardSelectorOption } from '/@/lib/ui/CardSelector.svelte';
 import CardSelector from '/@/lib/ui/CardSelector.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
-import type { SecretCreateOptions } from '/@api/secret-info';
+import type { SecretCreateOptions, SecretService } from '/@api/secret-info';
 
-interface TypeMeta {
-  title: string;
-  subtitle: string;
-}
+const OTHER_TYPE = 'other';
 
-const TYPE_META: Record<string, TypeMeta> = {
-  github: {
-    title: 'GitHub Secret',
-    subtitle: 'Store a GitHub personal access token. Automatically injected as a Bearer token for api.github.com.',
-  },
-  gemini: {
-    title: 'Gemini Secret',
-    subtitle: 'Store a Gemini API key. Automatically injected for Google AI endpoints.',
-  },
-  other: {
-    title: 'Other Secret',
-    subtitle: 'Configure a custom secret to inject as a header into matching requests.',
-  },
-};
+let services = $state<SecretService[]>([]);
+let loading = $state(true);
 
-const typeOptions = [
-  {
-    title: 'GitHub',
-    badge: 'GitHub',
-    value: 'github',
-    icon: faGithub,
-    description: 'Personal access token for GitHub API',
-  },
-  {
-    title: 'Gemini',
-    badge: 'Gemini',
-    value: 'gemini',
-    icon: faKey,
-    description: 'API key for Google Gemini',
-  },
-  {
-    title: 'Other',
-    badge: 'Custom',
-    value: 'other',
-    icon: faKey,
-    description: 'Custom secret with configurable injection',
-  },
-];
-
-let type = $state('other');
+let type = $state(OTHER_TYPE);
 let name = $state('');
 let secret = $state('');
 let description = $state('');
@@ -67,14 +29,56 @@ let injectionOpen = $state(true);
 let saving = $state(false);
 let error = $state('');
 
-let effectiveType = $derived(type || 'other');
-let meta = $derived(TYPE_META[effectiveType] ?? TYPE_META.other);
-let isGeneric = $derived(effectiveType === 'other');
+let serviceMap = $derived(new Map(services.map(s => [s.name, s])));
+
+let typeOptions = $derived<CardSelectorOption[]>([
+  ...services.map(s => ({
+    title: s.name.charAt(0).toUpperCase() + s.name.slice(1),
+    badge: s.name.charAt(0).toUpperCase() + s.name.slice(1),
+    value: s.name,
+    icon: faKey,
+    description: `Inject as ${s.headerName} for ${s.hostPattern}`,
+  })),
+  {
+    title: 'Other',
+    badge: 'Custom',
+    value: OTHER_TYPE,
+    icon: faKey,
+    description: 'Custom secret with configurable injection',
+  },
+]);
+
+let effectiveType = $derived(type || OTHER_TYPE);
+let isOther = $derived(!serviceMap.has(effectiveType));
+
+let title = $derived.by(() => {
+  if (isOther) return 'Other Secret';
+  const svc = serviceMap.get(effectiveType);
+  if (!svc) return 'Other Secret';
+  return `${svc.name.charAt(0).toUpperCase() + svc.name.slice(1)} Secret`;
+});
+
+let subtitle = $derived.by(() => {
+  if (isOther) return 'Configure a custom secret to inject as a header into matching requests.';
+  const svc = serviceMap.get(effectiveType);
+  if (!svc) return '';
+  return `Automatically injected as ${svc.headerName} for ${svc.hostPattern}.`;
+});
 
 let canSave = $derived.by(() => {
   if (!name.trim() || !secret.trim()) return false;
-  if (isGeneric && (!hostPattern.trim() || !headerName.trim())) return false;
+  if (isOther && (!hostPattern.trim() || !headerName.trim())) return false;
   return true;
+});
+
+onMount(async () => {
+  try {
+    services = await window.listSecretServices();
+  } catch (err: unknown) {
+    console.error('Failed to load secret services', err);
+  } finally {
+    loading = false;
+  }
 });
 
 function cancel(): void {
@@ -100,7 +104,7 @@ async function addSecret(): Promise<void> {
       options.description = description.trim();
     }
 
-    if (isGeneric) {
+    if (isOther) {
       options.hosts = [hostPattern.trim()];
       options.header = headerName.trim();
       if (pathPattern.trim()) {
@@ -127,15 +131,19 @@ async function addSecret(): Promise<void> {
       <div class="bg-(--pd-content-card-bg) py-6">
         <div class="flex flex-col px-6 max-w-4xl mx-auto space-y-5">
 
-          <CardSelector
-            label="Secret type"
-            options={typeOptions}
-            bind:selected={type}
-          />
+          {#if loading}
+            <p class="text-sm text-(--pd-content-card-text) opacity-70">Loading secret types…</p>
+          {:else}
+            <CardSelector
+              label="Secret type"
+              options={typeOptions}
+              bind:selected={type}
+            />
+          {/if}
 
           <div>
-            <h1 class="text-2xl font-bold text-(--pd-modal-text)">{meta.title}</h1>
-            <p class="text-sm text-(--pd-content-card-text) opacity-70 mt-2">{meta.subtitle}</p>
+            <h1 class="text-2xl font-bold text-(--pd-modal-text)">{title}</h1>
+            <p class="text-sm text-(--pd-content-card-text) opacity-70 mt-2">{subtitle}</p>
           </div>
 
           <div>
@@ -163,7 +171,7 @@ async function addSecret(): Promise<void> {
             <Input bind:value={description} placeholder="What this secret is used for" aria-label="Description" />
           </div>
 
-          {#if isGeneric}
+          {#if isOther}
             <div>
               <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Host pattern</span>
               <Input bind:value={hostPattern} placeholder="e.g. api.example.com or *.example.com" aria-label="Host pattern" />

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -58,6 +58,7 @@ const typeOptions = [
 let type = $state('other');
 let name = $state('');
 let secret = $state('');
+let description = $state('');
 let hostPattern = $state('');
 let pathPattern = $state('');
 let headerName = $state('');
@@ -94,6 +95,10 @@ async function addSecret(): Promise<void> {
       type: effectiveType,
       value: secret,
     };
+
+    if (description.trim()) {
+      options.description = description.trim();
+    }
 
     if (isGeneric) {
       options.hosts = [hostPattern.trim()];
@@ -148,6 +153,14 @@ async function addSecret(): Promise<void> {
             <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
               Encrypted at rest. You won't be able to view this value again.
             </p>
+          </div>
+
+          <div>
+            <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+              Description
+              <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
+            </span>
+            <Input bind:value={description} placeholder="What this secret is used for" aria-label="Description" />
           </div>
 
           {#if isGeneric}

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -22,8 +22,18 @@ const SERVICE_ICONS: Record<string, IconDefinition> = {
   anthropic: faClaude,
 };
 
+const SERVICE_LABELS: Record<string, string> = {
+  github: 'GitHub',
+  gemini: 'Gemini',
+  anthropic: 'Anthropic',
+};
+
 function getServiceIcon(name: string): IconDefinition {
   return SERVICE_ICONS[name] ?? faPlug;
+}
+
+function getServiceLabel(name: string): string {
+  return SERVICE_LABELS[name] ?? name.charAt(0).toUpperCase() + name.slice(1);
 }
 
 let services = $state<SecretService[]>([]);
@@ -45,8 +55,8 @@ let serviceMap = $derived(new Map(services.map(s => [s.name, s])));
 
 let typeOptions = $derived<CardSelectorOption[]>([
   ...services.map(s => ({
-    title: s.name.charAt(0).toUpperCase() + s.name.slice(1),
-    badge: s.name.charAt(0).toUpperCase() + s.name.slice(1),
+    title: getServiceLabel(s.name),
+    badge: getServiceLabel(s.name),
     value: s.name,
     icon: getServiceIcon(s.name),
   })),
@@ -66,17 +76,16 @@ let title = $derived.by(() => {
   if (isOther) return 'Other Secret';
   const svc = serviceMap.get(effectiveType);
   if (!svc) return 'Other Secret';
-  return `${svc.name.charAt(0).toUpperCase() + svc.name.slice(1)} Secret`;
+  return `${getServiceLabel(svc.name)} Secret`;
 });
 
 let subtitle = $derived.by(() => {
   if (isOther) return 'Configure a custom secret to inject as a header into matching requests.';
-  const svc = serviceMap.get(effectiveType);
-  if (!svc) return '';
-  return `Automatically injected as ${svc.headerName} for ${svc.hostPattern}.`;
+  return '';
 });
 
 let canSave = $derived.by(() => {
+  if (loading) return false;
   if (!name.trim() || !secret.trim()) return false;
   if (isOther && (!hostPattern.trim() || !headerName.trim())) return false;
   return true;

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { faChevronDown, faChevronUp, faGear, faKey } from '@fortawesome/free-solid-svg-icons';
+import { faClaude, faGithub, faGoogle } from '@fortawesome/free-brands-svg-icons';
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faChevronUp, faGear, faKey, faPlug } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
@@ -14,6 +16,16 @@ import type { SecretCreateOptions, SecretService } from '/@api/secret-info';
 
 const OTHER_TYPE = 'other';
 
+const SERVICE_ICONS: Record<string, IconDefinition> = {
+  github: faGithub,
+  gemini: faGoogle,
+  anthropic: faClaude,
+};
+
+function getServiceIcon(name: string): IconDefinition {
+  return SERVICE_ICONS[name] ?? faPlug;
+}
+
 let services = $state<SecretService[]>([]);
 let loading = $state(true);
 
@@ -23,7 +35,7 @@ let secret = $state('');
 let description = $state('');
 let hostPattern = $state('');
 let pathPattern = $state('');
-let headerName = $state('');
+let headerName = $state('Authorization');
 let valueFormat = $state('');
 let injectionOpen = $state(true);
 let saving = $state(false);
@@ -36,8 +48,7 @@ let typeOptions = $derived<CardSelectorOption[]>([
     title: s.name.charAt(0).toUpperCase() + s.name.slice(1),
     badge: s.name.charAt(0).toUpperCase() + s.name.slice(1),
     value: s.name,
-    icon: faKey,
-    description: `Inject as ${s.headerName} for ${s.hostPattern}`,
+    icon: getServiceIcon(s.name),
   })),
   {
     title: 'Other',
@@ -182,6 +193,7 @@ async function addSecret(): Promise<void> {
 
             <div class="rounded-lg border border-(--pd-content-card-border) overflow-hidden">
               <button
+                type="button"
                 class="w-full flex items-center gap-3 px-4 py-3 bg-(--pd-content-card-inset-bg)
                   hover:bg-(--pd-content-card-hover-inset-bg) cursor-pointer"
                 aria-expanded={injectionOpen}

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -1,66 +1,112 @@
 <script lang="ts">
-import { faKey, faServer, faShieldHalved } from '@fortawesome/free-solid-svg-icons';
-import { Button, Checkbox, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { faChevronDown, faChevronUp, faGear, faKey } from '@fortawesome/free-solid-svg-icons';
+import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
-import { Textarea } from '/@/lib/chat/components/ui/textarea';
 import CardSelector from '/@/lib/ui/CardSelector.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
+import type { SecretCreateOptions } from '/@api/secret-info';
 
-const categoryOptions = [
+interface TypeMeta {
+  title: string;
+  subtitle: string;
+}
+
+const TYPE_META: Record<string, TypeMeta> = {
+  github: {
+    title: 'GitHub Secret',
+    subtitle: 'Store a GitHub personal access token. Automatically injected as a Bearer token for api.github.com.',
+  },
+  gemini: {
+    title: 'Gemini Secret',
+    subtitle: 'Store a Gemini API key. Automatically injected for Google AI endpoints.',
+  },
+  other: {
+    title: 'Other Secret',
+    subtitle: 'Configure a custom secret to inject as a header into matching requests.',
+  },
+};
+
+const typeOptions = [
   {
-    title: 'API Token',
-    badge: 'API',
-    value: 'api',
+    title: 'GitHub',
+    badge: 'GitHub',
+    value: 'github',
+    icon: faGithub,
+    description: 'Personal access token for GitHub API',
+  },
+  {
+    title: 'Gemini',
+    badge: 'Gemini',
+    value: 'gemini',
     icon: faKey,
-    description: 'API keys, access tokens, and service credentials',
+    description: 'API key for Google Gemini',
   },
   {
-    title: 'Infrastructure',
-    badge: 'Infra',
-    value: 'infra',
-    icon: faServer,
-    description: 'Cluster tokens, platform keys, and infrastructure secrets',
+    title: 'Other',
+    badge: 'Custom',
+    value: 'other',
+    icon: faKey,
+    description: 'Custom secret with configurable injection',
   },
 ];
 
-const credentialTypes = [
-  { value: 'pat', label: 'Personal access token (PAT)' },
-  { value: 'oauth', label: 'OAuth / refresh token' },
-  { value: 'bot', label: 'Bot token' },
-  { value: 'project', label: 'Fine-grained / project token' },
-  { value: 'apikey', label: 'Generic API key' },
-  { value: 'cluster', label: 'Cluster or platform token' },
-  { value: 'service', label: 'Service account' },
-  { value: 'other', label: 'Other' },
-];
-
+let type = $state('other');
 let name = $state('');
-let category = $state('api');
-let type = $state('pat');
 let secret = $state('');
-let description = $state('');
-// TODO: backend not wired yet — using $derived(noExpiry ? '' : expiration) triggers no-unused-vars lint.
-// When the IPC save call is implemented, rename this to expirationInput and add: let expiration = $derived(noExpiry ? '' : expirationInput);
-let expiration = $state('');
-let noExpiry = $state(false);
+let hostPattern = $state('');
+let pathPattern = $state('');
+let headerName = $state('');
+let valueFormat = $state('');
+let injectionOpen = $state(true);
 let saving = $state(false);
 let error = $state('');
+
+let effectiveType = $derived(type || 'other');
+let meta = $derived(TYPE_META[effectiveType] ?? TYPE_META.other);
+let isGeneric = $derived(effectiveType === 'other');
+
+let canSave = $derived.by(() => {
+  if (!name.trim() || !secret.trim()) return false;
+  if (isGeneric && (!hostPattern.trim() || !headerName.trim())) return false;
+  return true;
+});
 
 function cancel(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT });
 }
 
-async function saveSecret(): Promise<void> {
-  if (!name.trim() || !secret.trim()) return;
+function toggleInjection(): void {
+  injectionOpen = !injectionOpen;
+}
 
+async function addSecret(): Promise<void> {
+  if (!canSave) return;
   saving = true;
   error = '';
   try {
-    // TODO: send { name, category, type, secret, description, expiration } via IPC to SafeStorageRegistry
+    const options: SecretCreateOptions = {
+      name: name.trim(),
+      type: effectiveType,
+      value: secret,
+    };
+
+    if (isGeneric) {
+      options.hosts = [hostPattern.trim()];
+      options.header = headerName.trim();
+      if (pathPattern.trim()) {
+        options.path = pathPattern.trim();
+      }
+      if (valueFormat.trim()) {
+        options.headerTemplate = valueFormat.trim().replaceAll('{value}', '${value}');
+      }
+    }
+
+    await window.createSecret(options);
     handleNavigation({ page: NavigationPage.SECRET_VAULT });
   } catch (err: unknown) {
     error = err instanceof Error ? err.message : String(err);
@@ -73,112 +119,97 @@ async function saveSecret(): Promise<void> {
 <FormPage title="Add Secret">
   {#snippet content()}
     <div class="px-5 pb-5 min-w-full">
-      <div class="bg-[var(--pd-content-card-bg)] py-6">
+      <div class="bg-(--pd-content-card-bg) py-6">
         <div class="flex flex-col px-6 max-w-4xl mx-auto space-y-5">
 
+          <CardSelector
+            label="Secret type"
+            options={typeOptions}
+            bind:selected={type}
+          />
+
           <div>
-            <h1 class="text-2xl font-bold text-[var(--pd-modal-text)]">Add Secret</h1>
-            <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 mt-2">
-              Store API tokens, OAuth secrets, and infrastructure keys in one place.
-              Values are encrypted and only exposed to agents and flows you attach them to.
-            </p>
+            <h1 class="text-2xl font-bold text-(--pd-modal-text)">{meta.title}</h1>
+            <p class="text-sm text-(--pd-content-card-text) opacity-70 mt-2">{meta.subtitle}</p>
           </div>
 
-          <!-- Info callout -->
-          <div class="flex gap-3 p-4 rounded-lg border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)]">
-            <div class="flex-shrink-0 mt-0.5 text-[var(--pd-content-card-text)]">
-              <Icon icon={faShieldHalved} />
-            </div>
-            <p class="text-sm text-[var(--pd-content-card-text)] opacity-80 leading-relaxed">
-              After saving, you can connect this credential from agent workspaces, MCP servers, and Settings integrations.
-              You won't be able to read the full secret back — only rotate or replace it.
-            </p>
+          <div>
+            <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Name</span>
+            <Input bind:value={name} placeholder="e.g. GitHub Token" aria-label="Name" />
           </div>
 
-          <!-- Form -->
-          <section class="rounded-lg border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)] p-6 space-y-5">
-
-            <!-- Display name -->
-            <div>
-              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">Display name</span>
-              <Input bind:value={name} placeholder="e.g. GitHub · docs repo" aria-label="Display name" />
-            </div>
-
-            <!-- Category -->
-            <CardSelector
-              label="Category"
-              options={categoryOptions}
-              bind:selected={category}
+          <div>
+            <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Secret value</span>
+            <PasswordInput
+              bind:password={secret}
+              placeholder="Enter secret value"
+              aria-label="Secret value"
             />
+            <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
+              Encrypted at rest. You won't be able to view this value again.
+            </p>
+          </div>
 
-            <!-- Credential type -->
+          {#if isGeneric}
             <div>
-              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">Credential type</span>
-              <Dropdown
-                name="credentialType"
-                bind:value={type}
-                ariaLabel="Credential type"
-                options={credentialTypes}
-              />
+              <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Host pattern</span>
+              <Input bind:value={hostPattern} placeholder="e.g. api.example.com or *.example.com" aria-label="Host pattern" />
+              <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
+                The host this secret applies to. Use *.example.com for wildcard subdomains.
+              </p>
             </div>
 
-            <!-- Secret value -->
-            <div>
-              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">Secret value</span>
-              <PasswordInput
-                bind:password={secret}
-                placeholder="Paste token or key"
-                aria-label="Secret value"
-              />
-            </div>
+            <div class="rounded-lg border border-(--pd-content-card-border) overflow-hidden">
+              <button
+                class="w-full flex items-center gap-3 px-4 py-3 bg-(--pd-content-card-inset-bg)
+                  hover:bg-(--pd-content-card-hover-inset-bg) cursor-pointer"
+                aria-expanded={injectionOpen}
+                aria-controls="injection-settings"
+                onclick={toggleInjection}
+              >
+                <Icon icon={faGear} size="sm" />
+                <span class="text-sm font-semibold text-(--pd-modal-text) flex-1 text-left">Injection settings</span>
+                <Icon icon={injectionOpen ? faChevronUp : faChevronDown} size="sm" />
+              </button>
 
-            <!-- Description -->
-            <div>
-              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">
-                Description
-                <span class="font-normal text-[var(--pd-content-card-text)] opacity-60">(optional)</span>
-              </span>
-              <Textarea
-                bind:value={description}
-                placeholder="Where it's used, scopes, or rotation notes"
-                rows={3}
-                class="bg-muted min-h-[24px] resize-none rounded-lg !text-sm dark:border-zinc-700"
-              />
-            </div>
+              {#if injectionOpen}
+                <div id="injection-settings" class="px-4 pb-4 pt-2 space-y-4 bg-(--pd-content-card-inset-bg)">
+                  <div>
+                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                      Path pattern
+                      <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
+                    </span>
+                    <Input bind:value={pathPattern} placeholder="e.g. /v1/*" aria-label="Path pattern" />
+                  </div>
 
-            <!-- Expiration -->
-            <div>
-              <span class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">
-                Expiration
-                <span class="font-normal text-[var(--pd-content-card-text)] opacity-60">(optional)</span>
-              </span>
-              <div class="flex items-center gap-4">
-                <input
-                  type="date"
-                  bind:value={expiration}
-                  disabled={noExpiry}
-                  class="max-w-[280px] p-2 rounded-lg text-sm outline-hidden
-                    bg-[var(--pd-input-field-bg)] text-[var(--pd-input-field-text)]
-                    border border-[var(--pd-input-field-stroke)]
-                    hover:border-[var(--pd-input-field-hover-stroke)]
-                    focus:border-[var(--pd-input-field-focused-stroke)]
-                    disabled:opacity-50 disabled:cursor-not-allowed"
-                  aria-label="Expiration date"
-                />
-                <Checkbox bind:checked={noExpiry} title="No expiry" />
-              </div>
+                  <div>
+                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Header name</span>
+                    <Input bind:value={headerName} placeholder="Authorization" aria-label="Header name" />
+                  </div>
+
+                  <div>
+                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                      Value format
+                      <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
+                    </span>
+                    <Input bind:value={valueFormat} placeholder="Bearer {'{value}'}" aria-label="Value format" />
+                    <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
+                      Use {'{value}'} as a placeholder for the secret. Defaults to the raw value.
+                    </p>
+                  </div>
+                </div>
+              {/if}
             </div>
-          </section>
+          {/if}
 
           {#if error}
             <ErrorMessage error={error} />
           {/if}
 
-          <!-- Footer actions -->
-          <div class="flex items-center justify-end gap-3 pt-4 border-t border-[var(--pd-content-card-border)]">
+          <div class="flex items-center justify-end gap-3 pt-4 border-t border-(--pd-content-card-border)">
             <Button onclick={cancel}>Cancel</Button>
-            <Button disabled={!name.trim() || !secret.trim() || saving} onclick={saveSecret}>
-              {saving ? 'Saving...' : 'Save Secret'}
+            <Button disabled={!canSave || saving} onclick={addSecret}>
+              {saving ? 'Adding...' : 'Add Secret'}
             </Button>
           </div>
 


### PR DESCRIPTION
Align the create secret form with the CLI definition (github, gemini, other) and wire it to the SecretManager IPC. Replace the old UI-only categories and credential types with a type selector that dynamically shows injection settings for the "other" type.

<img width="1389" height="905" alt="Captura de pantalla 2026-04-27 a las 13 39 02" src="https://github.com/user-attachments/assets/6280079b-d725-4061-8530-6cfe118e81c6" />

<img width="1400" height="718" alt="Captura de pantalla 2026-04-27 a las 13 39 10" src="https://github.com/user-attachments/assets/58093038-df63-4259-9cce-a15a24571170" />

Closes #1453