### PR TITLE
feat(kdn): wire kdn extension to download binary automatically during startup

### DIFF
--- a/extensions/kdn/src/kdn-download.spec.ts
+++ b/extensions/kdn/src/kdn-download.spec.ts
@@ -167,4 +167,37 @@ describe('getLatestVersion', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => ({ tag_name: 'v1.2.3' }) }));
     expect(await getLatestVersion()).toBe('1.2.3');
   });
+
+  test('passes signal to fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => ({ tag_name: 'v1.0.0' }) });
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+
+    await getLatestVersion(controller.signal);
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal: controller.signal }));
+  });
+});
+
+describe('downloadKdn signal', () => {
+  test('passes signal through to fetch calls', async () => {
+    const fetchMock: ReturnType<typeof vi.fn> = vi.fn((url: string) => {
+      if (String(url).includes('checksums')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve('abc123  kdn_0.5.0_linux_amd64.tar.gz\n') });
+      }
+      return Promise.resolve({ ok: true, body: new PassThrough() });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    vi.mocked(tar.extract).mockImplementation(async (opts: { cwd?: string }) => {
+      fileMap.set(normPath(path.join(opts.cwd ?? '', 'kdn')), true);
+    });
+
+    const controller = new AbortController();
+    await downloadKdn('0.5.0', 'linux', 'x64', '/output', controller.signal);
+
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]).toEqual(expect.objectContaining({ signal: controller.signal }));
+    }
+  });
 });

--- a/extensions/kdn/src/kdn-download.ts
+++ b/extensions/kdn/src/kdn-download.ts
@@ -29,7 +29,7 @@ import { sha256 } from './sha256';
 
 const KDN_REPO = 'openkaiden/kdn';
 
-export async function getLatestVersion(): Promise<string> {
+export async function getLatestVersion(signal?: AbortSignal): Promise<string> {
   const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
   const token = process.env['GITHUB_TOKEN'];
   if (token) {
@@ -38,6 +38,7 @@ export async function getLatestVersion(): Promise<string> {
   const res = await fetch(`https://api.github.com/repos/${KDN_REPO}/releases/latest`, {
     headers,
     redirect: 'follow',
+    signal,
   });
   if (!res.ok) {
     throw new Error(`failed to fetch latest kdn release: ${res.status} ${res.statusText}`);
@@ -49,17 +50,22 @@ export async function getLatestVersion(): Promise<string> {
 const PLATFORM_MAP: Record<string, string> = { darwin: 'darwin', linux: 'linux', win32: 'windows' };
 const ARCH_MAP: Record<string, string> = { x64: 'amd64', arm64: 'arm64' };
 
-export async function download(url: string, dest: string): Promise<void> {
-  const res = await fetch(url, { redirect: 'follow' });
+export async function download(url: string, dest: string, signal?: AbortSignal): Promise<void> {
+  const res = await fetch(url, { redirect: 'follow', signal });
   if (!res.ok || !res.body) {
     throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
   }
   await pipeline(res.body, createWriteStream(dest));
 }
 
-export async function verifyChecksum(version: string, assetFileName: string, filePath: string): Promise<void> {
+export async function verifyChecksum(
+  version: string,
+  assetFileName: string,
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<void> {
   const checksumsUrl = `https://github.com/${KDN_REPO}/releases/download/v${version}/kdn_${version}_checksums.txt`;
-  const res = await fetch(checksumsUrl, { redirect: 'follow' });
+  const res = await fetch(checksumsUrl, { redirect: 'follow', signal });
   if (!res.ok) {
     throw new Error(`failed to download checksums: ${res.status} ${res.statusText}`);
   }
@@ -111,7 +117,13 @@ export async function extract(archive: string, outDir: string): Promise<void> {
   }
 }
 
-export async function downloadKdn(version: string, platform: string, arch: string, outputDir: string): Promise<void> {
+export async function downloadKdn(
+  version: string,
+  platform: string,
+  arch: string,
+  outputDir: string,
+  signal?: AbortSignal,
+): Promise<void> {
   const versionFile = join(outputDir, '.kdn-version');
   const versionMarker = `${version}-${platform}-${arch}`;
   const binaryPath = join(outputDir, platform === 'win32' ? 'kdn.exe' : 'kdn');
@@ -137,8 +149,8 @@ export async function downloadKdn(version: string, platform: string, arch: strin
   const archivePath = join(outputDir, assetFileName);
 
   console.log(`downloading kdn ${version} for ${platform}/${arch}...`);
-  await download(url, archivePath);
-  await verifyChecksum(version, assetFileName, archivePath);
+  await download(url, archivePath, signal);
+  await verifyChecksum(version, assetFileName, archivePath, signal);
 
   console.log(`extracting to ${outputDir}...`);
   await extract(archivePath, outputDir);
@@ -174,7 +186,14 @@ function parseArgs(args: string[]): { output: string; platform: string; arch: st
   return { output: values.output, platform: values.platform, arch: values.arch };
 }
 
-if (!process.env['VITEST']) {
+// This module is both a library (imported by kdn-extension.ts) and a standalone
+// CLI script (invoked by electron-builder via `node kdn-download.js --output=...`).
+// Only run parseArgs when executed directly; Electron's argv contains positional
+// args like "." that cause parseArgs with strict mode to throw.
+const isDirectExecution =
+  !process.env['VITEST'] && process.argv[1] && normalize(process.argv[1]) === normalize(__filename);
+
+if (isDirectExecution) {
   const { output, platform, arch } = parseArgs(process.argv.slice(2));
   getLatestVersion()
     .then(version => downloadKdn(version, platform, arch, output))

--- a/extensions/kdn/src/kdn-extension.spec.ts
+++ b/extensions/kdn/src/kdn-extension.spec.ts
@@ -19,13 +19,15 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { ExtensionContext } from '@openkaiden/api';
+import type { CancellationToken, ExtensionContext, Progress } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
 import { afterAll, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import { downloadKdn, getLatestVersion } from './kdn-download';
 import { KdnExtension } from './kdn-extension';
 
 vi.mock(import('node:fs'));
+vi.mock(import('./kdn-download'));
 
 let extensionContext: ExtensionContext;
 let kdnExtension: KdnExtension;
@@ -58,9 +60,20 @@ beforeEach(() => {
   } as unknown as ExtensionContext;
 
   kdnExtension = new KdnExtension(extensionContext);
+
+  vi.mocked(getLatestVersion).mockResolvedValue('0.5.0');
+
+  vi.mocked(extensionApi.window.withProgress).mockImplementation(async (_options, task) => {
+    const progress = { report: vi.fn() } as unknown as Progress<{ message?: string; increment?: number }>;
+    const token = {
+      isCancellationRequested: false,
+      onCancellationRequested: vi.fn(),
+    } as unknown as CancellationToken;
+    return task(progress, token);
+  });
 });
 
-test('registers from extension storage when binary exists', async () => {
+test('registers from extension storage when binary exists without downloading', async () => {
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(extensionApi.process.exec).mockResolvedValue({
     command: 'kdn',
@@ -71,6 +84,8 @@ test('registers from extension storage when binary exists', async () => {
 
   await kdnExtension.activate();
 
+  expect(getLatestVersion).not.toHaveBeenCalled();
+  expect(downloadKdn).not.toHaveBeenCalled();
   expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith(
     expect.objectContaining({
       name: 'kdn',
@@ -81,7 +96,7 @@ test('registers from extension storage when binary exists', async () => {
   );
 });
 
-test('registers from system PATH when not in extension storage', async () => {
+test('falls back to system PATH before attempting download', async () => {
   vi.mocked(existsSync).mockReturnValue(false);
   vi.mocked(extensionApi.process.exec).mockResolvedValue({
     command: 'kdn',
@@ -92,6 +107,7 @@ test('registers from system PATH when not in extension storage', async () => {
 
   await kdnExtension.activate();
 
+  expect(downloadKdn).not.toHaveBeenCalled();
   expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith(
     expect.objectContaining({
       name: 'kdn',
@@ -102,17 +118,16 @@ test('registers from system PATH when not in extension storage', async () => {
   );
 });
 
-test('registers from bundled resources when not in extension storage or PATH', async () => {
+test('falls back to bundled resources before attempting download', async () => {
   vi.mocked(existsSync).mockReturnValueOnce(false).mockReturnValueOnce(true);
-  vi.mocked(extensionApi.process.exec).mockRejectedValueOnce(new Error('not found')).mockResolvedValueOnce({
-    command: 'kdn',
-    stdout: '',
-    stderr: 'kdn version 0.4.0',
-  });
+  vi.mocked(extensionApi.process.exec)
+    .mockRejectedValueOnce(new Error('not found'))
+    .mockResolvedValueOnce({ command: 'kdn', stdout: '', stderr: 'kdn version 0.4.0' });
   vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
 
   await kdnExtension.activate();
 
+  expect(downloadKdn).not.toHaveBeenCalled();
   expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith(
     expect.objectContaining({
       name: 'kdn',
@@ -123,9 +138,53 @@ test('registers from bundled resources when not in extension storage or PATH', a
   );
 });
 
-test('does not register when not found anywhere', async () => {
+test('downloads binary when not found locally', async () => {
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(extensionApi.process.exec)
+    .mockRejectedValueOnce(new Error('not found'))
+    .mockResolvedValueOnce({ command: 'kdn', stdout: '', stderr: 'kdn version 0.5.0' });
+  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
+
+  await kdnExtension.activate();
+
+  expect(extensionApi.window.withProgress).toHaveBeenCalledWith(
+    expect.objectContaining({ title: 'Downloading kdn CLI' }),
+    expect.any(Function),
+  );
+  expect(getLatestVersion).toHaveBeenCalledWith(expect.any(AbortSignal));
+  expect(downloadKdn).toHaveBeenCalledWith(
+    '0.5.0',
+    process.platform,
+    expect.any(String),
+    join('/storage', 'bin'),
+    expect.any(AbortSignal),
+  );
+  expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith(
+    expect.objectContaining({
+      version: '0.5.0',
+      path: join('/storage', 'bin', 'kdn'),
+      installationSource: 'extension',
+    }),
+  );
+});
+
+test('throws with all failed sources when download fails and no binary found', async () => {
   vi.mocked(existsSync).mockReturnValue(false);
   vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('not found'));
+  vi.mocked(extensionApi.window.withProgress).mockRejectedValue(new Error('network error'));
+
+  await expect(kdnExtension.activate()).rejects.toThrow(
+    'kdn CLI not found in extension storage, PATH, or bundled resources',
+  );
+  expect(extensionApi.cli.createCliTool).not.toHaveBeenCalled();
+});
+
+test('deactivate aborts in-flight download and skips registration', async () => {
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('not found'));
+  vi.mocked(downloadKdn).mockImplementation(async () => {
+    await kdnExtension.deactivate();
+  });
 
   await kdnExtension.activate();
 

--- a/extensions/kdn/src/kdn-extension.ts
+++ b/extensions/kdn/src/kdn-extension.ts
@@ -17,12 +17,20 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
+import { arch } from 'node:os';
 import { join } from 'node:path';
 
 import type { CliToolInstallationSource, ExtensionContext } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
 
+import { downloadKdn, getLatestVersion } from './kdn-download';
+
+const DOWNLOAD_TIMEOUT_MS = 60_000;
+
 export class KdnExtension {
+  private downloadAbortController: AbortController | undefined;
+  private deactivated = false;
+
   constructor(private readonly extensionContext: ExtensionContext) {}
 
   async activate(): Promise<void> {
@@ -39,6 +47,9 @@ export class KdnExtension {
       if (version) {
         binaryPath = localBinaryPath;
         installationSource = 'extension';
+        console.log('binary found in extension storage');
+      } else {
+        console.warn(`binary exists at ${localBinaryPath} but failed to report a version`);
       }
     }
 
@@ -48,6 +59,9 @@ export class KdnExtension {
         binaryPath = 'kdn';
         version = systemResult.version;
         installationSource = 'external';
+        console.log('kdn binary found in system PATH');
+      } else {
+        console.warn('kdn not found in system PATH');
       }
     }
 
@@ -60,16 +74,39 @@ export class KdnExtension {
           if (version) {
             binaryPath = bundledBinaryPath;
             installationSource = 'extension';
+            console.log('binary found in bundled resources');
+          } else {
+            console.warn(`bundled binary at ${bundledBinaryPath} failed to report a version`);
           }
+        } else {
+          console.warn(`bundled binary not found at ${bundledBinaryPath}`);
         }
       }
     }
 
-    if (!binaryPath) {
-      console.error('kdn CLI not found in extension storage, PATH, or bundled resources');
+    if (binaryPath) {
+      this.registerCliTool(binaryPath, version, installationSource);
       return;
     }
 
+    try {
+      await this.downloadAndRegister(localBinaryPath, binDir);
+    } catch (err: unknown) {
+      console.error('failed to download kdn CLI', err);
+      throw new Error('kdn CLI not found in extension storage, PATH, or bundled resources', { cause: err });
+    }
+  }
+
+  async deactivate(): Promise<void> {
+    this.deactivated = true;
+    this.downloadAbortController?.abort();
+  }
+
+  private registerCliTool(
+    binaryPath: string,
+    version: string | undefined,
+    installationSource: CliToolInstallationSource,
+  ): void {
     const cliTool = extensionApi.cli.createCliTool({
       name: 'kdn',
       displayName: 'kdn',
@@ -82,7 +119,33 @@ export class KdnExtension {
     this.extensionContext.subscriptions.push(cliTool);
   }
 
-  async deactivate(): Promise<void> {}
+  private async downloadAndRegister(localBinaryPath: string, binDir: string): Promise<void> {
+    await extensionApi.window.withProgress(
+      { location: extensionApi.ProgressLocation.TASK_WIDGET, title: 'Downloading kdn CLI' },
+      async (_progress, token) => {
+        const abortController = new AbortController();
+        this.downloadAbortController = abortController;
+        const timeoutId = setTimeout(() => abortController.abort(), DOWNLOAD_TIMEOUT_MS);
+        token.onCancellationRequested(() => abortController.abort());
+
+        try {
+          console.log('downloading binary from GitHub');
+          const latestVersion = await getLatestVersion(abortController.signal);
+          await downloadKdn(latestVersion, process.platform, arch(), binDir, abortController.signal);
+          if (this.deactivated) return;
+          const version = await this.getVersion(localBinaryPath);
+          if (version) {
+            this.registerCliTool(localBinaryPath, version, 'extension');
+          } else {
+            throw new Error(`kdn binary downloaded to ${localBinaryPath} but failed to report a version`);
+          }
+        } finally {
+          clearTimeout(timeoutId);
+          this.downloadAbortController = undefined;
+        }
+      },
+    );
+  }
 
   private parseVersion(output: string): string | undefined {
     const parts = output.trim().split(/\s+/);
@@ -104,7 +167,7 @@ export class KdnExtension {
       const version = this.parseVersion(result.stdout || result.stderr);
       if (version) return { version };
     } catch {
-      // not on PATH
+      // handled by caller
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary
- Wire up auto-download logic in kdn extension `activate()` so the kdn CLI binary is downloaded from GitHub releases when not found in extension storage
- Fix `kdn-download.ts` CLI entry point guard to prevent `parseArgs` crash when the module is imported at runtime in Electron
- Throw error when binary not found anywhere so the extension properly shows as failed in the UI instead of silently succeeding
- Add console logs for each binary resolution path (extension storage, GitHub download, system PATH, bundled resources)

Fixes: https://github.com/openkaiden/kaiden/issues/1469

## Test plan
- [x] Unit tests pass (`pnpm test:unit extensions/kdn/src/kdn-extension.spec.ts`) — 6 tests
- [ ] Delete extension storage binary, launch app, verify auto-download from GitHub
- [ ] Verify extension shows as failed when download fails and binary not available elsewhere
- [ ] Verify no GitHub API call when binary already exists in extension storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)