### PR TITLE
fix(kdn): use GitHub native asset digests and improve discovery logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist
 yarn.lock
 extensions/podman/assets/
 extensions-extra/
+kdn-binary/
 .claude
 output/
 __mocks__/@openkaiden/api.ts

--- a/extensions/kdn/src/kdn-download.spec.ts
+++ b/extensions/kdn/src/kdn-download.spec.ts
@@ -24,7 +24,7 @@ import { PassThrough } from 'node:stream';
 import * as tar from 'tar';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { downloadKdn, getLatestVersion } from './kdn-download';
+import { downloadKdn, getLatestRelease } from './kdn-download';
 import { sha256 } from './sha256';
 
 const getEntriesMock = vi.fn();
@@ -46,21 +46,15 @@ function normPath(p: string): string {
   return path.posix.normalize(String(p).replace(/\\/g, '/'));
 }
 
-function stubFetch(checksumLine: string): void {
+function stubFetch(): void {
   vi.stubGlobal(
     'fetch',
-    vi.fn((url: string) => {
-      if (String(url).includes('checksums')) {
-        return Promise.resolve({
-          ok: true,
-          text: () => Promise.resolve(checksumLine),
-        });
-      }
-      return Promise.resolve({
+    vi.fn(() =>
+      Promise.resolve({
         ok: true,
         body: new PassThrough(),
-      });
-    }),
+      }),
+    ),
   );
 }
 
@@ -90,32 +84,34 @@ describe('downloadKdn', () => {
       }),
     );
 
-    await downloadKdn('0.5.0', 'linux', 'x64', '/output');
+    await downloadKdn('0.5.0', 'linux', 'x64', '/output', new Map());
   });
 
   test('re-downloads when binary is missing but version marker exists', async () => {
     fileMap.set('/output/.kdn-version', true);
     fileMap.set('/output/kdn', false);
     vi.mocked(readFile).mockResolvedValue('0.5.0-linux-x64');
-    stubFetch('abc123  kdn_0.5.0_linux_amd64.tar.gz\n');
+    stubFetch();
+    const digests = new Map([['kdn_0.5.0_linux_amd64.tar.gz', 'abc123']]);
 
     vi.mocked(tar.extract).mockImplementation(async (opts: { cwd?: string }) => {
       fileMap.set(normPath(path.join(opts.cwd ?? '', 'kdn')), true);
     });
 
-    await downloadKdn('0.5.0', 'linux', 'x64', '/output');
+    await downloadKdn('0.5.0', 'linux', 'x64', '/output', digests);
 
     expect(vi.mocked(tar.extract)).toHaveBeenCalled();
   });
 
   test('extracts tar.gz and writes version marker (linux)', async () => {
-    stubFetch('abc123  kdn_0.5.0_linux_amd64.tar.gz\n');
+    stubFetch();
+    const digests = new Map([['kdn_0.5.0_linux_amd64.tar.gz', 'abc123']]);
 
     vi.mocked(tar.extract).mockImplementation(async (opts: { cwd?: string }) => {
       fileMap.set(normPath(path.join(opts.cwd ?? '', 'kdn')), true);
     });
 
-    await downloadKdn('0.5.0', 'linux', 'x64', '/output');
+    await downloadKdn('0.5.0', 'linux', 'x64', '/output', digests);
 
     expect(vi.mocked(tar.extract)).toHaveBeenCalledWith({
       file: expect.stringContaining('kdn_0.5.0_linux_amd64.tar.gz'),
@@ -130,11 +126,12 @@ describe('downloadKdn', () => {
   });
 
   test('extracts zip entries safely and writes version marker (win32)', async () => {
-    stubFetch('abc123  kdn_0.5.0_windows_amd64.zip\n');
+    stubFetch();
+    const digests = new Map([['kdn_0.5.0_windows_amd64.zip', 'abc123']]);
     const fileData = Buffer.from('binary-content');
     getEntriesMock.mockReturnValue([{ entryName: 'kdn.exe', isDirectory: false, getData: (): Buffer => fileData }]);
 
-    await downloadKdn('0.5.0', 'win32', 'x64', '/output');
+    await downloadKdn('0.5.0', 'win32', 'x64', '/output', digests);
 
     expect(getEntriesMock).toHaveBeenCalled();
     expect(mkdir).toHaveBeenCalledWith(expect.stringContaining('output'), { recursive: true });
@@ -147,24 +144,43 @@ describe('downloadKdn', () => {
   });
 
   test('throws on checksum mismatch', async () => {
-    stubFetch('wrongchecksum  kdn_0.5.0_linux_amd64.tar.gz\n');
+    stubFetch();
+    const digests = new Map([['kdn_0.5.0_linux_amd64.tar.gz', 'wrongchecksum']]);
 
-    await expect(downloadKdn('0.5.0', 'linux', 'x64', '/output')).rejects.toThrow('checksum mismatch');
+    await expect(downloadKdn('0.5.0', 'linux', 'x64', '/output', digests)).rejects.toThrow('checksum mismatch');
   });
 
   test('rejects unsafe zip paths', async () => {
-    stubFetch('abc123  kdn_0.5.0_windows_amd64.zip\n');
+    stubFetch();
+    const digests = new Map([['kdn_0.5.0_windows_amd64.zip', 'abc123']]);
     getEntriesMock.mockReturnValue([
       { entryName: '../evil.sh', isDirectory: false, getData: (): Buffer => Buffer.from('bad') },
     ]);
 
-    await expect(downloadKdn('0.5.0', 'win32', 'x64', '/output')).rejects.toThrow('unsafe path');
+    await expect(downloadKdn('0.5.0', 'win32', 'x64', '/output', digests)).rejects.toThrow('unsafe path');
   });
 });
 
-describe('getLatestVersion', () => {
-  test('strips v prefix from tag_name', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => ({ tag_name: 'v1.2.3' }) }));
-    expect(await getLatestVersion()).toBe('1.2.3');
+describe('getLatestRelease', () => {
+  test('strips v prefix and builds digest map', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          tag_name: 'v1.2.3',
+          assets: [
+            { name: 'kdn_1.2.3_linux_amd64.tar.gz', digest: 'sha256:abc123' },
+            { name: 'kdn_1.2.3_darwin_arm64.tar.gz', digest: 'sha256:def456' },
+            { name: 'no-digest-asset.txt', digest: null },
+          ],
+        }),
+      }),
+    );
+    const release = await getLatestRelease();
+    expect(release.version).toBe('1.2.3');
+    expect(release.digests.get('kdn_1.2.3_linux_amd64.tar.gz')).toBe('abc123');
+    expect(release.digests.get('kdn_1.2.3_darwin_arm64.tar.gz')).toBe('def456');
+    expect(release.digests.has('no-digest-asset.txt')).toBe(false);
   });
 });

--- a/extensions/kdn/src/kdn-download.ts
+++ b/extensions/kdn/src/kdn-download.ts
@@ -29,7 +29,12 @@ import { sha256 } from './sha256';
 
 const KDN_REPO = 'openkaiden/kdn';
 
-export async function getLatestVersion(): Promise<string> {
+interface ReleaseInfo {
+  version: string;
+  digests: Map<string, string>;
+}
+
+export async function getLatestRelease(): Promise<ReleaseInfo> {
   const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
   const token = process.env['GITHUB_TOKEN'];
   if (token) {
@@ -42,8 +47,15 @@ export async function getLatestVersion(): Promise<string> {
   if (!res.ok) {
     throw new Error(`failed to fetch latest kdn release: ${res.status} ${res.statusText}`);
   }
-  const data = (await res.json()) as { tag_name: string };
-  return data.tag_name.replace(/^v/, '');
+  const data = (await res.json()) as { tag_name: string; assets: { name: string; digest: string | null }[] };
+  const version = data.tag_name.replace(/^v/, '');
+  const digests = new Map<string, string>();
+  for (const asset of data.assets) {
+    if (asset.digest) {
+      digests.set(asset.name, asset.digest.replace(/^sha256:/, ''));
+    }
+  }
+  return { version, digests };
 }
 
 const PLATFORM_MAP: Record<string, string> = { darwin: 'darwin', linux: 'linux', win32: 'windows' };
@@ -57,23 +69,16 @@ export async function download(url: string, dest: string): Promise<void> {
   await pipeline(res.body, createWriteStream(dest));
 }
 
-export async function verifyChecksum(version: string, assetFileName: string, filePath: string): Promise<void> {
-  const checksumsUrl = `https://github.com/${KDN_REPO}/releases/download/v${version}/kdn_${version}_checksums.txt`;
-  const res = await fetch(checksumsUrl, { redirect: 'follow' });
-  if (!res.ok) {
-    throw new Error(`failed to download checksums: ${res.status} ${res.statusText}`);
+export async function verifyChecksum(
+  digests: Map<string, string>,
+  assetFileName: string,
+  filePath: string,
+): Promise<void> {
+  const expected = digests.get(assetFileName);
+  if (!expected) {
+    throw new Error(`no digest found for ${assetFileName} in release assets`);
   }
 
-  const content = await res.text();
-  const line = content.split('\n').find(l => {
-    const parts = l.trim().split(/\s+/);
-    return parts.length >= 2 && parts[parts.length - 1] === assetFileName;
-  });
-  if (!line) {
-    throw new Error(`no checksum found for ${assetFileName}`);
-  }
-
-  const expected = line.trim().split(/\s+/)[0]!;
   const actual = await sha256(filePath);
   if (actual !== expected) {
     throw new Error(`checksum mismatch for ${assetFileName}: expected ${expected}, got ${actual}`);
@@ -111,7 +116,13 @@ export async function extract(archive: string, outDir: string): Promise<void> {
   }
 }
 
-export async function downloadKdn(version: string, platform: string, arch: string, outputDir: string): Promise<void> {
+export async function downloadKdn(
+  version: string,
+  platform: string,
+  arch: string,
+  outputDir: string,
+  digests: Map<string, string>,
+): Promise<void> {
   const versionFile = join(outputDir, '.kdn-version');
   const versionMarker = `${version}-${platform}-${arch}`;
   const binaryPath = join(outputDir, platform === 'win32' ? 'kdn.exe' : 'kdn');
@@ -138,7 +149,7 @@ export async function downloadKdn(version: string, platform: string, arch: strin
 
   console.log(`downloading kdn ${version} for ${platform}/${arch}...`);
   await download(url, archivePath);
-  await verifyChecksum(version, assetFileName, archivePath);
+  await verifyChecksum(digests, assetFileName, archivePath);
 
   console.log(`extracting to ${outputDir}...`);
   await extract(archivePath, outputDir);
@@ -176,8 +187,8 @@ function parseArgs(args: string[]): { output: string; platform: string; arch: st
 
 if (!process.env['VITEST']) {
   const { output, platform, arch } = parseArgs(process.argv.slice(2));
-  getLatestVersion()
-    .then(version => downloadKdn(version, platform, arch, output))
+  getLatestRelease()
+    .then(({ version, digests }) => downloadKdn(version, platform, arch, output, digests))
     .catch((error: unknown) => {
       console.error(error);
       process.exit(1);

--- a/extensions/kdn/src/kdn-extension.spec.ts
+++ b/extensions/kdn/src/kdn-extension.spec.ts
@@ -123,12 +123,13 @@ test('registers from bundled resources when not in extension storage or PATH', a
   );
 });
 
-test('does not register when not found anywhere', async () => {
+test('throws when not found anywhere', async () => {
   vi.mocked(existsSync).mockReturnValue(false);
   vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('not found'));
 
-  await kdnExtension.activate();
-
+  await expect(kdnExtension.activate()).rejects.toThrow(
+    'kdn CLI not found in extension storage, PATH, or bundled resources',
+  );
   expect(extensionApi.cli.createCliTool).not.toHaveBeenCalled();
 });
 

--- a/extensions/kdn/src/kdn-extension.ts
+++ b/extensions/kdn/src/kdn-extension.ts
@@ -39,6 +39,9 @@ export class KdnExtension {
       if (version) {
         binaryPath = localBinaryPath;
         installationSource = 'extension';
+        console.log('binary found in extension storage');
+      } else {
+        console.warn(`binary exists at ${localBinaryPath} but failed to report a version`);
       }
     }
 
@@ -48,6 +51,9 @@ export class KdnExtension {
         binaryPath = 'kdn';
         version = systemResult.version;
         installationSource = 'external';
+        console.log('kdn binary found in system PATH');
+      } else {
+        console.warn('kdn not found in system PATH');
       }
     }
 
@@ -60,14 +66,18 @@ export class KdnExtension {
           if (version) {
             binaryPath = bundledBinaryPath;
             installationSource = 'extension';
+            console.log('binary found in bundled resources');
+          } else {
+            console.warn(`bundled binary at ${bundledBinaryPath} failed to report a version`);
           }
+        } else {
+          console.warn(`bundled binary not found at ${bundledBinaryPath}`);
         }
       }
     }
 
     if (!binaryPath) {
-      console.error('kdn CLI not found in extension storage, PATH, or bundled resources');
-      return;
+      throw new Error('kdn CLI not found in extension storage, PATH, or bundled resources');
     }
 
     const cliTool = extensionApi.cli.createCliTool({


### PR DESCRIPTION
## Summary
- Replace separate `checksums.txt` download with GitHub's native release asset `digest` API field
- kdn v0.6.0 removed `checksums.txt` (openkaiden/kdn#143), breaking `pnpm run compile`
- Add console.log/warn at each kdn binary discovery step for diagnosability
- Throw an error instead of silently returning when the binary is not found
- Add `kdn-binary/` to `.gitignore` as a build artifact

## Test plan
- [x] All 12 unit tests pass (7 kdn-download + 5 kdn-extension)
- [x] Verified `pnpm run compile` downloads and verifies kdn v0.6.0 successfully
- [x] Confirmed compiled app launches and registers kdn CLI v0.6.0
- [x] `pnpm typecheck` and `pnpm lint:check` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)