### PR TITLE
fix(ScrollableCardSelector): checkbox click not toggling selection

### DIFF
--- a/packages/renderer/src/lib/ui/ScrollableCardSelector.spec.ts
+++ b/packages/renderer/src/lib/ui/ScrollableCardSelector.spec.ts
@@ -33,6 +33,7 @@ function generateItems(count: number): ScrollableCardItem[] {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
 });
 
@@ -196,4 +197,24 @@ test('Expect items without description render without description element', () =
   render(ScrollableCardSelector, { items });
 
   expect(screen.getByText('No Desc Item')).toBeInTheDocument();
+});
+
+test('Expect clicking checkbox inside card toggles selection', async () => {
+  const items = generateItems(3);
+  render(ScrollableCardSelector, { items, selected: [] });
+
+  const checkbox = screen.getByRole('checkbox', { name: 'Item 0' });
+  await fireEvent.click(checkbox);
+
+  expect(screen.getByText('1 selected')).toBeInTheDocument();
+});
+
+test('Expect clicking checkbox inside selected card deselects it', async () => {
+  const items = generateItems(3);
+  render(ScrollableCardSelector, { items, selected: ['item-0'] });
+
+  const checkbox = screen.getByRole('checkbox', { name: 'Item 0' });
+  await fireEvent.click(checkbox);
+
+  expect(screen.getByText('0 selected')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/ui/ScrollableCardSelector.svelte
+++ b/packages/renderer/src/lib/ui/ScrollableCardSelector.svelte
@@ -111,8 +111,8 @@ $effect(() => {
                 hover:bg-[var(--pd-content-card-hover-inset-bg)]"
               onclick={(): void => toggle(item.id)}
               aria-label={item.name}>
-              <div class="flex-shrink-0">
-                <Checkbox checked={isSelected(item.id)} title={item.name} />
+              <div class="flex-shrink-0" onclick={(e): void => e.stopPropagation()}>
+                <Checkbox checked={isSelected(item.id)} title={item.name} onclick={(): void => toggle(item.id)} />
               </div>
               <div class="text-left min-w-0 flex-1">
                 <div class="text-xs font-medium text-[var(--pd-content-card-text)] truncate">{item.name}</div>


### PR DESCRIPTION
Click event bubbled to card handler, causing incorrect toggle behavior.
Stop propagation on wrapper div, wire onclick directly to Checkbox.

Fixes #1248