### PR TITLE
chore: update the README.md icon path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kaiden
 
-<img src="https://raw.githubusercontent.com/openkaiden/artwork/refs/heads/main/logo-1093.png" alt="A stylized bear wearing virtual reality goggles and a collared shirt with a letter K on it." width="400">
+<img src="https://raw.githubusercontent.com/openkaiden/artwork/refs/heads/main/icon-1024.png" alt="A stylized bear wearing virtual reality goggles and a collared shirt with a letter K on it." width="400">
 
 ## Demonstration video
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kaiden
 
-<img src="https://raw.githubusercontent.com/openkaiden/artwork/refs/heads/main/icon-1024.png" alt="A stylized bear wearing virtual reality goggles and a collared shirt with a letter K on it." width="400">
+<img src="https://raw.githubusercontent.com/openkaiden/artwork/refs/heads/main/icon-1024.png" alt="A stylized bear wearing virtual reality goggles and a collared shirt with a letter K on it." width="256">
 
 ## Demonstration video
 


### PR DESCRIPTION
This PR updates the `README.md` image on top: replaces the monochromatic logo with the app icon.

- Resolves #1492

<img width="2074" height="2824" alt="CleanShot 2026-04-29 at 10 59 09@2x" src="https://github.com/user-attachments/assets/8775cd22-9888-4160-8491-5455bcb21d9e" />