### PR TITLE
chore: remove demonstration video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 <img src="https://raw.githubusercontent.com/openkaiden/artwork/refs/heads/main/icon-1024.png" alt="A stylized bear wearing virtual reality goggles and a collared shirt with a letter K on it." width="256">
 
-## Demonstration video
-
-https://github.com/user-attachments/assets/2cbe186a-d7b8-4a31-8ac0-4f0964d72448
-
 ## Prerequisites: Prepare your environment
 
 You can develop on either: `Windows`, `macOS` or `Linux`.


### PR DESCRIPTION
Removed demonstration video link from README.

(it's outdated and not showcasing what is being added)