### PR TITLE
feat(secret-vault): add secret details page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -67,5 +67,6 @@ export enum NavigationPage {
   RAG_ENVIRONMENT_DETAILS = 'rag-environment-details',
   SECRET_VAULT = 'secret-vault',
   SECRET_VAULT_CREATE = 'secret-vault-create',
+  SECRET_VAULT_DETAILS = 'secret-vault-details',
   MODELS = 'models',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -87,6 +87,9 @@ export interface NavigationParameters {
   };
   [NavigationPage.SECRET_VAULT]: never;
   [NavigationPage.SECRET_VAULT_CREATE]: never;
+  [NavigationPage.SECRET_VAULT_DETAILS]: {
+    id: string;
+  };
   [NavigationPage.MODELS]: never;
 }
 

--- a/packages/api/src/secret-vault/secret-vault-info.ts
+++ b/packages/api/src/secret-vault/secret-vault-info.ts
@@ -22,5 +22,8 @@ export interface SecretVaultInfo {
   type?: string;
   description?: string;
   hosts?: string[];
-  expiration?: Date;
+  path?: string;
+  header?: string;
+  headerTemplate?: string;
+  envs?: string[];
 }

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -85,6 +85,7 @@ import PreferencesPage from './lib/preferences/PreferencesPage.svelte';
 import PVCDetails from './lib/pvc/PVCDetails.svelte';
 import PVCList from './lib/pvc/PVCList.svelte';
 import SecretVaultCreate from './lib/secret-vault/SecretVaultCreate.svelte';
+import SecretVaultDetails from './lib/secret-vault/SecretVaultDetails.svelte';
 import SecretVaultList from './lib/secret-vault/SecretVaultList.svelte';
 import ServiceDetails from './lib/service/ServiceDetails.svelte';
 import ServicesList from './lib/service/ServicesList.svelte';
@@ -281,12 +282,15 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
 
         <!-- Secret Vault -->
-        <Route path="/secret-vault/*" breadcrumb="Secret Vault" navigationHint="root">
-          <Route path="/">
+        <Route path="/secret-vault/*" breadcrumb="Secret Vault" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Secret Vault" navigationHint="root">
             <SecretVaultList />
           </Route>
           <Route path="/create" breadcrumb="Add Secret" navigationHint="details">
             <SecretVaultCreate />
+          </Route>
+          <Route path="/:id/*" let:meta breadcrumb="Secret Details" navigationHint="details">
+            <SecretVaultDetails id={decodeURIComponent(meta.params.id)} />
           </Route>
         </Route>
 

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetails.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetails.spec.ts
@@ -1,0 +1,136 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as secretVaultStore from '/@/stores/secret-vault';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+import SecretVaultDetails from './SecretVaultDetails.svelte';
+
+vi.mock(import('tinro'));
+vi.mock(import('/@/stores/secret-vault'));
+
+const routerStore = writable({
+  path: '/secret-vault/github-pat/summary',
+  url: '/secret-vault/github-pat/summary',
+  from: '/',
+  query: {} as Record<string, string>,
+  hash: '',
+});
+
+const githubSecret: SecretVaultInfo = {
+  id: 'github-pat',
+  name: 'GitHub',
+  type: 'github',
+  description: 'Repos, pull requests, and issues across the organization.',
+  hosts: ['github.com', 'api.github.com'],
+  path: '/v3',
+  header: 'Authorization',
+  headerTemplate: 'token {{secret}}',
+};
+
+const minimalSecret: SecretVaultInfo = {
+  id: 'my-other-secret',
+  name: 'Other secret',
+  type: 'other',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.mocked(router).subscribe.mockImplementation(routerStore.subscribe);
+  vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([githubSecret, minimalSecret]);
+  vi.mocked(window.removeSecret).mockResolvedValue({ name: 'github-pat' });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+});
+
+test('should display secret name as page title', () => {
+  render(SecretVaultDetails, { id: 'github-pat' });
+
+  expect(screen.getByRole('heading', { name: 'GitHub', level: 1 })).toBeInTheDocument();
+});
+
+test('should show Summary tab', () => {
+  render(SecretVaultDetails, { id: 'github-pat' });
+
+  expect(screen.getByText('Summary')).toBeInTheDocument();
+});
+
+test('should show fallback title when secret not found', () => {
+  vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
+
+  render(SecretVaultDetails, { id: 'nonexistent' });
+
+  expect(screen.getByRole('heading', { name: 'nonexistent', level: 1 })).toBeInTheDocument();
+});
+
+test('should display remove button', () => {
+  render(SecretVaultDetails, { id: 'github-pat' });
+
+  expect(screen.getByRole('button', { name: 'Remove Secret' })).toBeInTheDocument();
+});
+
+test('should show confirmation dialog when remove button clicked', async () => {
+  render(SecretVaultDetails, { id: 'github-pat' });
+
+  const removeButton = screen.getByRole('button', { name: 'Remove Secret' });
+  await fireEvent.click(removeButton);
+
+  expect(window.showMessageBox).toHaveBeenCalledOnce();
+});
+
+test('should remove secret and navigate to list when user confirms removal', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  render(SecretVaultDetails, { id: 'github-pat' });
+
+  const removeButton = screen.getByRole('button', { name: 'Remove Secret' });
+  await fireEvent.click(removeButton);
+
+  await waitFor(() => {
+    expect(window.removeSecret).toHaveBeenCalledWith('github-pat');
+  });
+
+  expect(router.goto).toHaveBeenCalledWith('/secret-vault');
+});
+
+test('should not remove secret when user cancels removal', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+
+  render(SecretVaultDetails, { id: 'github-pat' });
+
+  const removeButton = screen.getByRole('button', { name: 'Remove Secret' });
+  await fireEvent.click(removeButton);
+
+  expect(window.removeSecret).not.toHaveBeenCalled();
+  expect(router.goto).not.toHaveBeenCalled();
+});
+
+test('should fallback to id when secret is not found', () => {
+  vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
+
+  render(SecretVaultDetails, { id: 'some-missing-id' });
+
+  expect(screen.getByRole('heading', { name: 'some-missing-id', level: 1 })).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetails.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetails.spec.ts
@@ -77,12 +77,12 @@ test('should show Summary tab', () => {
   expect(screen.getByText('Summary')).toBeInTheDocument();
 });
 
-test('should show fallback title when secret not found', () => {
+test.each(['nonexistent', 'some-missing-id'])('should fallback to id when secret is not found (%s)', id => {
   vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
 
-  render(SecretVaultDetails, { id: 'nonexistent' });
+  render(SecretVaultDetails, { id });
 
-  expect(screen.getByRole('heading', { name: 'nonexistent', level: 1 })).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: id, level: 1 })).toBeInTheDocument();
 });
 
 test('should display remove button', () => {
@@ -125,12 +125,4 @@ test('should not remove secret when user cancels removal', async () => {
 
   expect(window.removeSecret).not.toHaveBeenCalled();
   expect(router.goto).not.toHaveBeenCalled();
-});
-
-test('should fallback to id when secret is not found', () => {
-  vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
-
-  render(SecretVaultDetails, { id: 'some-missing-id' });
-
-  expect(screen.getByRole('heading', { name: 'some-missing-id', level: 1 })).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Tab } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import { getSecretIcon, getServiceLabel } from '/@/lib/secret-vault/secret-vault-utils';
+import Badge from '/@/lib/ui/Badge.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
@@ -20,6 +23,7 @@ interface Props {
 let { id }: Props = $props();
 
 const secretInfo: SecretVaultInfo | undefined = $derived($secretVaultInfos.find(s => s.id === id));
+const secretIcon = $derived(getSecretIcon(secretInfo?.type));
 
 function handleRemove(): void {
   withConfirmation(
@@ -36,7 +40,25 @@ function handleRemove(): void {
 }
 </script>
 
-<DetailsPage title={secretInfo?.name ?? id}>
+<DetailsPage title=" ">
+  {#snippet iconSnippet()}
+    <div class="flex items-center gap-3">
+      <div class="shrink-0 flex items-center justify-center w-10 h-10 rounded-lg bg-(--pd-content-card-inset-bg) border border-(--pd-content-divider)">
+        <Icon icon={secretIcon} size="lg" />
+      </div>
+      <div class="flex flex-col">
+        <div class="flex items-center gap-2">
+          <h1 class="text-xl font-bold leading-tight text-[var(--pd-content-header)]">{secretInfo?.name ?? id}</h1>
+          {#if secretInfo?.type}
+            <Badge class="text-white" color="bg-(--pd-badge-sky)" label={getServiceLabel(secretInfo.type)} />
+          {/if}
+        </div>
+        {#if secretInfo?.description}
+          <span class="text-sm text-(--pd-content-card-text) opacity-60">{secretInfo.description}</span>
+        {/if}
+      </div>
+    </div>
+  {/snippet}
   {#snippet actionsSnippet()}
     <ListItemButtonIcon title="Remove Secret" onClick={handleRemove} icon={faTrash} />
   {/snippet}

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetails.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { Tab } from '@podman-desktop/ui-svelte';
+import { router } from 'tinro';
+
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
+import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
+import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
+import Route from '/@/Route.svelte';
+import { secretVaultInfos } from '/@/stores/secret-vault';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+import SecretVaultDetailsSummary from './SecretVaultDetailsSummary.svelte';
+
+interface Props {
+  id: string;
+}
+
+let { id }: Props = $props();
+
+const secretInfo: SecretVaultInfo | undefined = $derived($secretVaultInfos.find(s => s.id === id));
+
+function handleRemove(): void {
+  withConfirmation(
+    async () => {
+      try {
+        await window.removeSecret(id);
+        router.goto('/secret-vault');
+      } catch (error: unknown) {
+        console.error('Failed to remove secret', error);
+      }
+    },
+    `remove secret ${secretInfo?.name ?? id}`,
+  );
+}
+</script>
+
+<DetailsPage title={secretInfo?.name ?? id}>
+  {#snippet actionsSnippet()}
+    <ListItemButtonIcon title="Remove Secret" onClick={handleRemove} icon={faTrash} />
+  {/snippet}
+  {#snippet tabsSnippet()}
+    <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
+  {/snippet}
+  {#snippet contentSnippet()}
+    <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+      <SecretVaultDetailsSummary {secretInfo} />
+    </Route>
+  {/snippet}
+</DetailsPage>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetailsSummary.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetailsSummary.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-import DetailsCell from '/@/lib/details/DetailsCell.svelte';
-import DetailsTable from '/@/lib/details/DetailsTable.svelte';
-import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
 import { getServiceLabel } from '/@/lib/secret-vault/secret-vault-utils';
 import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
 import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
@@ -63,67 +60,78 @@ $effect(() => {
     current = false;
   };
 });
+
+interface DetailField {
+  label: string;
+  value: string;
+}
+
+const detailFields: DetailField[] = $derived.by(() => {
+  if (!secretInfo) return [];
+  const fields: DetailField[] = [];
+
+  if (secretInfo.type) {
+    fields.push({ label: 'Type', value: getServiceLabel(secretInfo.type) });
+  }
+  if (secretInfo.description) {
+    fields.push({ label: 'Description', value: secretInfo.description });
+  }
+  if (secretInfo.hosts?.length) {
+    fields.push({ label: 'Hosts', value: secretInfo.hosts.join(', ') });
+  }
+  if (secretInfo.path) {
+    fields.push({ label: 'Path', value: secretInfo.path });
+  }
+  if (secretInfo.header) {
+    fields.push({ label: 'Header', value: secretInfo.header });
+  }
+  if (secretInfo.headerTemplate) {
+    fields.push({ label: 'Header template', value: secretInfo.headerTemplate });
+  }
+  if (secretInfo.envs?.length) {
+    fields.push({ label: 'Environment variables', value: secretInfo.envs.join(', ') });
+  }
+  return fields;
+});
 </script>
 
-<div class="h-min">
-  <DetailsTable>
-    {#if secretInfo?.type}
-      <tr>
-        <DetailsCell>Type</DetailsCell>
-        <DetailsCell>{getServiceLabel(secretInfo.type)}</DetailsCell>
-      </tr>
-    {/if}
-    {#if secretInfo?.description}
-      <tr>
-        <DetailsCell>Description</DetailsCell>
-        <DetailsCell>{secretInfo.description}</DetailsCell>
-      </tr>
-    {/if}
-    {#if secretInfo?.hosts?.length}
-      <tr>
-        <DetailsCell>Hosts</DetailsCell>
-        <DetailsCell>{secretInfo.hosts.join(', ')}</DetailsCell>
-      </tr>
-    {/if}
-    {#if secretInfo?.path}
-      <tr>
-        <DetailsCell>Path</DetailsCell>
-        <DetailsCell>{secretInfo.path}</DetailsCell>
-      </tr>
-    {/if}
-    {#if secretInfo?.header}
-      <tr>
-        <DetailsCell>Header</DetailsCell>
-        <DetailsCell>{secretInfo.header}</DetailsCell>
-      </tr>
-    {/if}
-    {#if secretInfo?.headerTemplate}
-      <tr>
-        <DetailsCell>Header template</DetailsCell>
-        <DetailsCell>{secretInfo.headerTemplate}</DetailsCell>
-      </tr>
-    {/if}
-    {#if secretInfo?.envs?.length}
-      <tr>
-        <DetailsTitle>Environment variables</DetailsTitle>
-      </tr>
-      {#each secretInfo.envs as env (env)}
-        <tr>
-          <DetailsCell>{env}</DetailsCell>
-          <DetailsCell></DetailsCell>
-        </tr>
-      {/each}
-    {/if}
-    {#if usedBy.length}
-      <tr>
-        <DetailsTitle>Used by</DetailsTitle>
-      </tr>
-      {#each usedBy as entry (entry.id)}
-        <tr>
-          <DetailsCell>{entry.name}</DetailsCell>
-          <DetailsCell>{entry.kind}</DetailsCell>
-        </tr>
-      {/each}
-    {/if}
-  </DetailsTable>
+<div class="flex flex-col gap-5 px-5 py-5 overflow-auto" data-testid="secret-vault-details-summary">
+  <!-- Details card -->
+  {#if detailFields.length > 0}
+    <div
+      class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
+      data-testid="details-card">
+      <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-4">
+        Details
+      </h3>
+      <div class="grid grid-cols-[160px_1fr] gap-y-3">
+        {#each detailFields as field (field.label)}
+          <span class="text-sm text-(--pd-content-card-text) opacity-60">{field.label}</span>
+          <span class="text-sm text-(--pd-content-card-text)">{field.value}</span>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Used by card -->
+  {#if usedBy.length > 0}
+    <div
+      class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
+      data-testid="used-by-card">
+      <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-4">
+        Used By
+      </h3>
+      <div class="flex flex-col">
+        {#each usedBy as entry, i (entry.id)}
+          <div
+            class="flex items-center justify-between py-3"
+            class:border-t={i > 0}
+            class:border-(--pd-content-divider)={i > 0}>
+            <span class="text-sm font-medium text-(--pd-content-card-text)">{entry.name}</span>
+            <span class="text-sm text-(--pd-content-card-text) opacity-50">{entry.kind}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
 </div>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetailsSummary.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetailsSummary.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+import DetailsCell from '/@/lib/details/DetailsCell.svelte';
+import DetailsTable from '/@/lib/details/DetailsTable.svelte';
+import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
+import { getServiceLabel } from '/@/lib/secret-vault/secret-vault-utils';
+import { agentWorkspaces } from '/@/stores/agent-workspaces.svelte';
+import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+interface Props {
+  secretInfo: SecretVaultInfo | undefined;
+}
+
+let { secretInfo }: Props = $props();
+
+interface UsedByEntry {
+  name: string;
+  kind: string;
+}
+
+let usedBy: UsedByEntry[] = $state([]);
+
+function workspaceUsesSecret(config: AgentWorkspaceConfiguration, secretName: string): boolean {
+  if (config.secrets?.includes(secretName)) return true;
+  if (config.environment?.some(e => e.secret === secretName)) return true;
+  return false;
+}
+
+$effect(() => {
+  const name = secretInfo?.name;
+  if (!name) {
+    usedBy = [];
+    return;
+  }
+
+  const workspaces = $agentWorkspaces;
+  let current = true;
+
+  Promise.all(
+    workspaces.map(async ws => {
+      try {
+        const config = await window.getAgentWorkspaceConfiguration(ws.id);
+        if (workspaceUsesSecret(config, name)) {
+          return { name: ws.name, kind: 'Workspace' } satisfies UsedByEntry;
+        }
+      } catch {
+        // skip workspaces whose configuration cannot be read
+      }
+      return undefined;
+    }),
+  )
+    .then(results => {
+      if (current) {
+        usedBy = results.filter((r): r is UsedByEntry => r !== undefined);
+      }
+    })
+    .catch(() => {
+      if (current) usedBy = [];
+    });
+
+  return (): void => {
+    current = false;
+  };
+});
+</script>
+
+<div class="h-min">
+  <DetailsTable>
+    {#if secretInfo?.type}
+      <tr>
+        <DetailsCell>Type</DetailsCell>
+        <DetailsCell>{getServiceLabel(secretInfo.type)}</DetailsCell>
+      </tr>
+    {/if}
+    {#if secretInfo?.description}
+      <tr>
+        <DetailsCell>Description</DetailsCell>
+        <DetailsCell>{secretInfo.description}</DetailsCell>
+      </tr>
+    {/if}
+    {#if secretInfo?.hosts?.length}
+      <tr>
+        <DetailsCell>Hosts</DetailsCell>
+        <DetailsCell>{secretInfo.hosts.join(', ')}</DetailsCell>
+      </tr>
+    {/if}
+    {#if secretInfo?.path}
+      <tr>
+        <DetailsCell>Path</DetailsCell>
+        <DetailsCell>{secretInfo.path}</DetailsCell>
+      </tr>
+    {/if}
+    {#if secretInfo?.header}
+      <tr>
+        <DetailsCell>Header</DetailsCell>
+        <DetailsCell>{secretInfo.header}</DetailsCell>
+      </tr>
+    {/if}
+    {#if secretInfo?.headerTemplate}
+      <tr>
+        <DetailsCell>Header template</DetailsCell>
+        <DetailsCell>{secretInfo.headerTemplate}</DetailsCell>
+      </tr>
+    {/if}
+    {#if secretInfo?.envs?.length}
+      <tr>
+        <DetailsTitle>Environment variables</DetailsTitle>
+      </tr>
+      {#each secretInfo.envs as env (env)}
+        <tr>
+          <DetailsCell>{env}</DetailsCell>
+          <DetailsCell></DetailsCell>
+        </tr>
+      {/each}
+    {/if}
+    {#if usedBy.length}
+      <tr>
+        <DetailsTitle>Used by</DetailsTitle>
+      </tr>
+      {#each usedBy as entry (entry.name)}
+        <tr>
+          <DetailsCell>{entry.name}</DetailsCell>
+          <DetailsCell>{entry.kind}</DetailsCell>
+        </tr>
+      {/each}
+    {/if}
+  </DetailsTable>
+</div>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultDetailsSummary.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultDetailsSummary.svelte
@@ -14,6 +14,7 @@ interface Props {
 let { secretInfo }: Props = $props();
 
 interface UsedByEntry {
+  id: string;
   name: string;
   kind: string;
 }
@@ -41,7 +42,7 @@ $effect(() => {
       try {
         const config = await window.getAgentWorkspaceConfiguration(ws.id);
         if (workspaceUsesSecret(config, name)) {
-          return { name: ws.name, kind: 'Workspace' } satisfies UsedByEntry;
+          return { id: ws.id, name: ws.name, kind: 'Workspace' } satisfies UsedByEntry;
         }
       } catch {
         // skip workspaces whose configuration cannot be read
@@ -117,7 +118,7 @@ $effect(() => {
       <tr>
         <DetailsTitle>Used by</DetailsTitle>
       </tr>
-      {#each usedBy as entry (entry.name)}
+      {#each usedBy as entry (entry.id)}
         <tr>
           <DetailsCell>{entry.name}</DetailsCell>
           <DetailsCell>{entry.kind}</DetailsCell>

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultIntegration.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultIntegration.svelte
@@ -23,7 +23,7 @@ function openDetails(): void {
 }
 </script>
 
-<button class="flex items-center gap-3 overflow-hidden max-w-full" onclick={openDetails}>
+<button class="group flex items-center gap-3 overflow-hidden max-w-full" onclick={openDetails}>
   <div class="shrink-0 flex items-center justify-center">
     <Icon {icon} size="1.5x" />
   </div>

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultIntegration.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultIntegration.svelte
@@ -3,6 +3,8 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { getSecretIcon, getServiceLabel } from '/@/lib/secret-vault/secret-vault-utils';
 import Badge from '/@/lib/ui/Badge.svelte';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 
 interface Props {
@@ -12,16 +14,23 @@ interface Props {
 let { object }: Props = $props();
 
 const icon = $derived(getSecretIcon(object.type));
+
+function openDetails(): void {
+  handleNavigation({
+    page: NavigationPage.SECRET_VAULT_DETAILS,
+    parameters: { id: object.id },
+  });
+}
 </script>
 
-<div class="flex items-center gap-3 overflow-hidden max-w-full">
+<button class="flex items-center gap-3 overflow-hidden max-w-full" onclick={openDetails}>
   <div class="shrink-0 flex items-center justify-center">
     <Icon {icon} size="1.5x" />
   </div>
-  <div class="flex flex-col overflow-hidden min-w-0">
+  <div class="flex flex-col overflow-hidden min-w-0 text-left">
     <div class="flex items-center gap-2">
       <span
-        class="text-(--pd-table-body-text-highlight) text-[14px] font-semibold leading-normal overflow-hidden text-ellipsis whitespace-nowrap"
+        class="text-(--pd-table-body-text-highlight) text-[14px] font-semibold leading-normal overflow-hidden text-ellipsis whitespace-nowrap group-hover:text-(--pd-link)"
         title={object.name}>
         {object.name}
       </span>
@@ -37,4 +46,4 @@ const icon = $derived(getSecretIcon(object.type));
       </span>
     {/if}
   </div>
-</div>
+</button>

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -194,5 +194,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.SECRET_VAULT_CREATE:
       router.goto('/secret-vault/create');
       break;
+    case NavigationPage.SECRET_VAULT_DETAILS:
+      router.goto(`/secret-vault/${encodeURIComponent(request.parameters.id)}/summary`);
+      break;
   }
 };

--- a/packages/renderer/src/stores/secret-vault.ts
+++ b/packages/renderer/src/stores/secret-vault.ts
@@ -31,6 +31,11 @@ function secretInfoToVaultInfo(info: SecretInfo): SecretVaultInfo {
     name: info.name,
     type: info.type,
     description: info.description,
+    hosts: info.hosts,
+    path: info.path,
+    header: info.header,
+    headerTemplate: info.headerTemplate,
+    envs: info.envs,
   };
 }
 


### PR DESCRIPTION
Introduce a details page for secrets, accessible by clicking a secret in the list following the mockup. The page displays all CLI-available metadata and dynamically resolves which workspaces reference the secret. Also it add a "remove" button for removing the secret.

Mockup:
<img width="809" height="771" alt="Captura de pantalla 2026-04-30 a las 10 26 03" src="https://github.com/user-attachments/assets/14b8a5fd-8726-42e1-bee1-f8004fce6d40" />

App:
<img width="1022" height="652" alt="Captura de pantalla 2026-04-30 a las 10 21 27" src="https://github.com/user-attachments/assets/12ef8f2a-dcdc-4106-8b59-332ce7a9badd" />

<img width="1022" height="634" alt="Captura de pantalla 2026-04-30 a las 10 21 51" src="https://github.com/user-attachments/assets/ebfd9c07-af0a-41b8-b1b2-67ea8f9c0b6c" />


Closes #1370