### PR TITLE
feat(onboarding): add Claude agent to the guided setup

### DIFF
--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -52,8 +52,11 @@ beforeEach(() => {
   onboarding = createDefaultOnboardingState();
   vi.stubGlobal(
     'getCliInfo',
-    vi.fn().mockResolvedValue({ version: '0.1.0', agents: ['opencode'], runtimes: ['podman'] }),
+    vi.fn().mockResolvedValue({ version: '0.1.0', agents: ['opencode', 'claude'], runtimes: ['podman'] }),
   );
+  vi.stubGlobal('listSecrets', vi.fn().mockResolvedValue([]));
+  vi.stubGlobal('createSecret', vi.fn().mockResolvedValue({ name: 'anthropic' }));
+  vi.stubGlobal('createInferenceProviderConnection', vi.fn().mockResolvedValue(undefined));
   stubLocalInference(false);
 });
 
@@ -163,6 +166,65 @@ describe('local runtime probe', () => {
     await waitFor(() => {
       expect(screen.getByTestId('probe-detected')).toBeInTheDocument();
     });
+  });
+});
+
+describe('Claude agent tile', () => {
+  test('renders the Claude Code agent tile when CLI includes claude', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Claude Code' })).toBeInTheDocument();
+    });
+  });
+
+  test('shows Cloud badge on Claude Code tile', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByText('Cloud')).toBeInTheDocument();
+    });
+  });
+
+  test('shows Claude panel when Claude Code is selected', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Claude Code' })).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Claude Code' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('claude-panel')).toBeInTheDocument();
+      expect(screen.getByText('API Key')).toBeInTheDocument();
+    });
+  });
+
+  test('updates onboarding.agent when Claude is selected', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Claude Code' })).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Claude Code' }));
+
+    await waitFor(() => {
+      expect(onboarding.agent).toBe('claude');
+    });
+  });
+
+  test('does not show Claude tile when CLI only returns opencode', async () => {
+    vi.mocked(window.getCliInfo).mockResolvedValue({ version: '0.1.0', agents: ['opencode'], runtimes: ['podman'] });
+
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Claude Code' })).not.toBeInTheDocument();
   });
 });
 

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
@@ -63,6 +63,6 @@ $effect(() => {
   </div>
 
   {#if activeDefinition?.panel}
-    <activeDefinition.panel />
+    <activeDefinition.panel definition={activeDefinition} {onboarding} />
   {/if}
 </div>

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -64,10 +64,16 @@ async function handleContinue(): Promise<void> {
   }
 }
 
-function handleSkip(): void {
-  advance().catch((err: unknown) => {
+async function handleSkip(): Promise<void> {
+  if (advancing) return;
+  advancing = true;
+  try {
+    await advance();
+  } catch (err: unknown) {
     console.error('advance failed', err);
-  });
+  } finally {
+    advancing = false;
+  }
 }
 
 function handleStepClick(index: number): void {
@@ -133,7 +139,7 @@ function handleStepClick(index: number): void {
   <!-- Footer -->
   <footer class="flex justify-end gap-3 px-8 py-6 bg-(--pd-content-bg)">
     {#if currentStep?.isSkippable}
-      <Button type="secondary" aria-label="Skip" onclick={handleSkip}>Skip</Button>
+      <Button type="secondary" aria-label="Skip" onclick={handleSkip} disabled={advancing}>Skip</Button>
     {/if}
     <Button type="primary" aria-label={continueLabel} onclick={handleContinue} disabled={advancing}>{continueLabel} &rsaquo;</Button>
   </footer>

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -45,11 +45,23 @@ async function advance(): Promise<void> {
   }
 }
 
-function handleContinue(): void {
-  completedSteps.add(currentStep.id);
-  advance().catch((err: unknown) => {
+let advancing = $state(false);
+
+async function handleContinue(): Promise<void> {
+  if (advancing) return;
+  advancing = true;
+  try {
+    if (onboardingState.beforeAdvance) {
+      const ok = await onboardingState.beforeAdvance();
+      if (!ok) return;
+    }
+    completedSteps.add(currentStep.id);
+    await advance();
+  } catch (err: unknown) {
     console.error('advance failed', err);
-  });
+  } finally {
+    advancing = false;
+  }
 }
 
 function handleSkip(): void {
@@ -123,6 +135,6 @@ function handleStepClick(index: number): void {
     {#if currentStep?.isSkippable}
       <Button type="secondary" aria-label="Skip" onclick={handleSkip}>Skip</Button>
     {/if}
-    <Button type="primary" aria-label={continueLabel} onclick={handleContinue}>{continueLabel} &rsaquo;</Button>
+    <Button type="primary" aria-label={continueLabel} onclick={handleContinue} disabled={advancing}>{continueLabel} &rsaquo;</Button>
   </footer>
 </div>

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -77,6 +77,7 @@ async function handleSkip(): Promise<void> {
 }
 
 function handleStepClick(index: number): void {
+  if (advancing) return;
   const stepState = getStepState(index);
   if (stepState === 'completed' || index === currentStepIndex) {
     currentStepIndex = index;

--- a/packages/renderer/src/lib/guided-setup/agent-registry.ts
+++ b/packages/renderer/src/lib/guided-setup/agent-registry.ts
@@ -17,10 +17,12 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
+import { faClaude } from '@fortawesome/free-brands-svg-icons';
 import { faDesktop } from '@fortawesome/free-solid-svg-icons';
 import type { Component } from 'svelte';
 
 import type { CliAgent } from './guided-setup-steps';
+import ClaudePanel from './panels/ClaudePanel.svelte';
 import OpenCodePanel from './panels/OpenCodePanel.svelte';
 
 export interface AgentDefinition {
@@ -30,6 +32,8 @@ export interface AgentDefinition {
   badge: string;
   icon: IconDefinition;
   panel?: Component;
+  extensionId?: string;
+  secretType?: string;
 }
 
 export const agentDefinitions: AgentDefinition[] = [
@@ -41,5 +45,15 @@ export const agentDefinitions: AgentDefinition[] = [
     badge: 'Recommended',
     icon: faDesktop,
     panel: OpenCodePanel,
+  },
+  {
+    cliName: 'claude',
+    title: 'Claude Code',
+    description: 'Anthropic\u2019s cloud agent \u2014 connect with an API key to access Claude models.',
+    badge: 'Cloud',
+    icon: faClaude,
+    panel: ClaudePanel,
+    extensionId: 'claude',
+    secretType: 'anthropic',
   },
 ];

--- a/packages/renderer/src/lib/guided-setup/agent-registry.ts
+++ b/packages/renderer/src/lib/guided-setup/agent-registry.ts
@@ -32,7 +32,8 @@ export interface AgentDefinition {
   badge: string;
   icon: IconDefinition;
   panel?: Component;
-  extensionId?: string;
+  /** Compound selector in the form `extensionId:providerId` (e.g. `kaiden.claude:claude`). */
+  providerSelector?: string;
   secretType?: string;
 }
 
@@ -53,7 +54,7 @@ export const agentDefinitions: AgentDefinition[] = [
     badge: 'Cloud',
     icon: faClaude,
     panel: ClaudePanel,
-    extensionId: 'claude',
+    providerSelector: 'kaiden.claude:claude',
     secretType: 'anthropic',
   },
 ];

--- a/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
+++ b/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
@@ -22,10 +22,11 @@ import type { Component } from 'svelte';
 
 import CodingAgentStep from './CodingAgentStep.svelte';
 
-export type CliAgent = 'opencode';
+export type CliAgent = 'opencode' | 'claude';
 
 export interface OnboardingState {
   agent: CliAgent;
+  beforeAdvance?: () => Promise<boolean>;
 }
 
 export interface GuidedSetupStepProps {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -44,7 +44,7 @@ const claudeDefinition: AgentDefinition = {
   description: 'Cloud agent',
   badge: 'Cloud',
   icon: faClaude,
-  extensionId: 'claude',
+  providerSelector: 'kaiden.claude:claude',
   secretType: 'anthropic',
 };
 

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -1,0 +1,231 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { faClaude } from '@fortawesome/free-brands-svg-icons';
+import { render, screen } from '@testing-library/svelte';
+import type { Writable } from 'svelte/store';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { fetchProviders, providerInfos } from '/@/stores/providers';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import type { AgentDefinition } from '../agent-registry';
+import type { OnboardingState } from '../guided-setup-steps';
+import ClaudePanel from './ClaudePanel.svelte';
+
+vi.mock(import('/@/stores/providers'), async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    providerInfos: writable<ProviderInfo[]>([]),
+    fetchProviders: vi.fn().mockResolvedValue([]),
+  };
+});
+
+const claudeDefinition: AgentDefinition = {
+  cliName: 'claude',
+  title: 'Claude Code',
+  description: 'Cloud agent',
+  badge: 'Cloud',
+  icon: faClaude,
+  extensionId: 'claude',
+  secretType: 'anthropic',
+};
+
+function stubClaudeProvider(options?: { withModels?: boolean }): void {
+  const models = options?.withModels ? [{ label: 'claude-sonnet-4-20250514' }] : [];
+  const providers = [
+    {
+      id: 'claude',
+      internalId: 'claude-internal-1',
+      inferenceConnections: models.length > 0 ? [{ type: 'cloud', status: 'started', models }] : [],
+      inferenceProviderConnectionCreation: true,
+    },
+  ];
+  (providerInfos as Writable<ProviderInfo[]>).set(providers as unknown as ProviderInfo[]);
+}
+
+function stubNoProvider(): void {
+  (providerInfos as Writable<ProviderInfo[]>).set([]);
+}
+
+let onboarding: OnboardingState;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+  onboarding = { agent: 'claude' };
+  vi.stubGlobal('createSecret', vi.fn().mockResolvedValue({ name: 'anthropic' }));
+  vi.stubGlobal('createInferenceProviderConnection', vi.fn().mockResolvedValue(undefined));
+  stubClaudeProvider();
+});
+
+function renderPanel(definition: AgentDefinition = claudeDefinition): void {
+  render(ClaudePanel, { definition, onboarding });
+}
+
+describe('rendering', () => {
+  test('renders the Claude panel with API Key heading', () => {
+    renderPanel();
+
+    expect(screen.getByTestId('claude-panel')).toBeInTheDocument();
+    expect(screen.getByText('API Key')).toBeInTheDocument();
+  });
+
+  test('shows the API key input form', () => {
+    renderPanel();
+
+    expect(screen.getByTestId('claude-form')).toBeInTheDocument();
+    expect(screen.getByLabelText('Anthropic API key')).toBeInTheDocument();
+  });
+
+  test('shows warning when Claude provider extension is not detected', () => {
+    stubNoProvider();
+    renderPanel();
+
+    expect(screen.getByTestId('claude-provider-missing')).toBeInTheDocument();
+    expect(screen.getByLabelText('Anthropic API key')).toBeDisabled();
+  });
+
+  test('does not show error message initially', () => {
+    renderPanel();
+
+    expect(screen.queryByText(/Please enter your Anthropic API key/)).not.toBeInTheDocument();
+  });
+});
+
+describe('beforeAdvance callback', () => {
+  test('registers beforeAdvance on onboarding state', () => {
+    renderPanel();
+
+    expect(onboarding.beforeAdvance).toBeDefined();
+    expect(typeof onboarding.beforeAdvance).toBe('function');
+  });
+
+  test('returns false and shows error when API key is empty', async () => {
+    renderPanel();
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+    expect(screen.getByText(/Please enter your Anthropic API key/)).toBeInTheDocument();
+  });
+
+  test('returns false when provider is not available', async () => {
+    stubNoProvider();
+    renderPanel();
+
+    // Simulate user typing a key via the onboarding's beforeAdvance
+    // The input is disabled when provider is missing, but test the validation path
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+  });
+
+  test('creates secret and inference connection when API key is provided', async () => {
+    vi.mocked(fetchProviders).mockImplementation(async () => {
+      stubClaudeProvider({ withModels: true });
+      return [] as ProviderInfo[];
+    });
+
+    renderPanel();
+
+    const input = screen.getByLabelText('Anthropic API key') as HTMLInputElement;
+    // Svelte 5 bind:value reads from the input's value property
+    Object.defineProperty(input, 'value', { value: 'sk-ant-test-key', writable: true });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(true);
+    expect(window.createSecret).toHaveBeenCalledWith({
+      name: 'anthropic',
+      type: 'anthropic',
+      value: 'sk-ant-test-key',
+    });
+    expect(window.createInferenceProviderConnection).toHaveBeenCalledWith(
+      'claude-internal-1',
+      { 'claude.factory.apiKey': 'sk-ant-test-key' },
+      expect.any(Symbol),
+      expect.any(Function),
+      undefined,
+      undefined,
+    );
+  });
+
+  test('continues if secret already exists', async () => {
+    vi.mocked(window.createSecret).mockRejectedValue(new Error('secret already exists: anthropic'));
+    vi.mocked(fetchProviders).mockImplementation(async () => {
+      stubClaudeProvider({ withModels: true });
+      return [] as ProviderInfo[];
+    });
+
+    renderPanel();
+
+    const input = screen.getByLabelText('Anthropic API key') as HTMLInputElement;
+    Object.defineProperty(input, 'value', { value: 'sk-ant-test-key', writable: true });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(true);
+  });
+
+  test('returns false and shows error when inference connection fails', async () => {
+    vi.mocked(window.createInferenceProviderConnection).mockRejectedValue(new Error('invalid apiKey'));
+
+    renderPanel();
+
+    const input = screen.getByLabelText('Anthropic API key') as HTMLInputElement;
+    Object.defineProperty(input, 'value', { value: 'bad-key', writable: true });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+    expect(screen.getByText('invalid apiKey')).toBeInTheDocument();
+  });
+
+  test('returns false and shows error when secret creation fails', async () => {
+    vi.mocked(window.createSecret).mockRejectedValue(new Error('vault locked'));
+
+    renderPanel();
+
+    const input = screen.getByLabelText('Anthropic API key') as HTMLInputElement;
+    Object.defineProperty(input, 'value', { value: 'sk-ant-test-key', writable: true });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+    expect(screen.getByText(/vault locked/)).toBeInTheDocument();
+  });
+});
+
+describe('cleanup', () => {
+  test('clears beforeAdvance when component is destroyed', () => {
+    const { unmount } = render(ClaudePanel, { definition: claudeDefinition, onboarding });
+
+    expect(onboarding.beforeAdvance).toBeDefined();
+
+    unmount();
+
+    expect(onboarding.beforeAdvance).toBeUndefined();
+  });
+});

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -131,11 +131,10 @@ describe('beforeAdvance callback', () => {
     stubNoProvider();
     renderPanel();
 
-    // Simulate user typing a key via the onboarding's beforeAdvance
-    // The input is disabled when provider is missing, but test the validation path
     const result = await onboarding.beforeAdvance!();
 
     expect(result).toBe(false);
+    expect(screen.getByText(/Claude provider extension is not available/)).toBeInTheDocument();
   });
 
   test('creates secret and inference connection when API key is provided', async () => {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -15,13 +15,18 @@ interface Props {
 
 let { definition, onboarding }: Props = $props();
 
-const extensionId = $derived(definition?.extensionId ?? 'claude');
+function parseSelector(selector?: string): { extensionId: string; providerId: string } {
+  const [extensionId = 'kaiden.claude', providerId = 'claude'] = (selector ?? 'kaiden.claude:claude').split(':');
+  return { extensionId, providerId };
+}
+
+const { providerId } = $derived(parseSelector(definition?.providerSelector));
 const secretType = $derived(definition?.secretType ?? 'anthropic');
 
 let apiKey = $state('');
 let errorMessage = $state('');
 
-let claudeProvider = $derived($providerInfos.find(p => p.id === extensionId));
+let claudeProvider = $derived($providerInfos.find(p => p.id === providerId));
 
 async function validate(): Promise<boolean> {
   errorMessage = '';

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -26,13 +26,13 @@ let claudeProvider = $derived($providerInfos.find(p => p.id === extensionId));
 async function validate(): Promise<boolean> {
   errorMessage = '';
 
-  if (!apiKey.trim()) {
-    errorMessage = 'Please enter your Anthropic API key.';
+  if (!claudeProvider) {
+    errorMessage = 'Claude provider extension is not available. Make sure the Claude extension is enabled.';
     return false;
   }
 
-  if (!claudeProvider) {
-    errorMessage = 'Claude provider extension is not available. Make sure the Claude extension is enabled.';
+  if (!apiKey.trim()) {
+    errorMessage = 'Please enter your Anthropic API key.';
     return false;
   }
 

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import { fetchProviders, providerInfos } from '/@/stores/providers';
+
+import type { AgentDefinition } from '../agent-registry';
+import type { OnboardingState } from '../guided-setup-steps';
+
+interface Props {
+  definition?: AgentDefinition;
+  onboarding?: OnboardingState;
+}
+
+let { definition, onboarding }: Props = $props();
+
+const extensionId = $derived(definition?.extensionId ?? 'claude');
+const secretType = $derived(definition?.secretType ?? 'anthropic');
+
+let apiKey = $state('');
+let errorMessage = $state('');
+
+let claudeProvider = $derived($providerInfos.find(p => p.id === extensionId));
+
+async function validate(): Promise<boolean> {
+  errorMessage = '';
+
+  if (!apiKey.trim()) {
+    errorMessage = 'Please enter your Anthropic API key.';
+    return false;
+  }
+
+  if (!claudeProvider) {
+    errorMessage = 'Claude provider extension is not available. Make sure the Claude extension is enabled.';
+    return false;
+  }
+
+  try {
+    await window.createSecret({
+      name: secretType,
+      type: secretType,
+      value: apiKey.trim(),
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes('already exists')) {
+      errorMessage = `Failed to store secret: ${msg}`;
+      return false;
+    }
+  }
+
+  try {
+    const loggerKey = Symbol('onboarding-claude');
+    const noop = (): void => {};
+    await window.createInferenceProviderConnection(
+      claudeProvider.internalId,
+      { 'claude.factory.apiKey': apiKey.trim() },
+      loggerKey,
+      noop,
+      undefined,
+      undefined,
+    );
+
+    await fetchProviders();
+    return true;
+  } catch (err: unknown) {
+    errorMessage = err instanceof Error ? err.message : String(err);
+    return false;
+  }
+}
+
+$effect(() => {
+  if (onboarding) {
+    onboarding.beforeAdvance = validate;
+  }
+  return (): void => {
+    if (onboarding?.beforeAdvance === validate) {
+      onboarding.beforeAdvance = undefined;
+    }
+  };
+});
+</script>
+
+<div
+  class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
+  data-testid="claude-panel">
+  <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+    API Key
+  </h3>
+  <p class="text-xs text-(--pd-content-card-text) opacity-50 mb-4 leading-relaxed">
+    Enter your Anthropic API key. It will be verified and stored when you continue to the next step.
+  </p>
+
+  <div class="flex flex-col gap-3" data-testid="claude-form">
+    {#if !claudeProvider}
+      <div
+        class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-warning) p-3"
+        role="alert"
+        data-testid="claude-provider-missing">
+        <Icon icon={faTriangleExclamation} size="sm" class="text-(--pd-state-warning) shrink-0" />
+        <span class="text-xs text-(--pd-state-warning)">Claude provider extension not detected.</span>
+      </div>
+    {/if}
+
+    <Input
+      type="password"
+      placeholder="sk-ant-..."
+      bind:value={apiKey}
+      aria-label="Anthropic API key"
+      disabled={!claudeProvider} />
+
+    {#if errorMessage}
+      <ErrorMessage error={errorMessage} />
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
Add Anthropic's Claude Code as a selectable agent in onboarding step 1. The agent definition carries extensionId and secretType so that on Continue the panel stores a kdn secret and creates an inference provider connection, making Claude models retrievable in step 2.

https://github.com/user-attachments/assets/2aa5a192-9475-41d2-b462-9f525cba0ee2


Closes #1439