### PR TITLE
chore(deps): bump @openkaiden/kdn-api from 0.8.0 to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@eslint/compat": "^2.0.1",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
-    "@openkaiden/kdn-api": "^0.8.0",
+    "@openkaiden/kdn-api": "^0.9.0",
     "@openkaiden/workspace-configuration": "^0.8.0",
     "@openkaiden/api": "workspace:",
     "@openkaiden/mcp-registry-types": "^1.3.10",

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -48,6 +48,7 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     state: 'stopped',
     model: 'gpt-4o',
     paths: { source: '/tmp/ws1', configuration: '/tmp/ws1/.kaiden' },
+    timestamps: { created: 1700000000 },
   },
   {
     id: 'ws-2',
@@ -56,6 +57,7 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     agent: 'coder-v2',
     state: 'running',
     paths: { source: '/tmp/ws2', configuration: '/tmp/ws2/.kaiden' },
+    timestamps: { created: 1700000001, started: 1700000002 },
   },
 ];
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -41,6 +41,7 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     state: 'stopped',
     model: 'gpt-4o',
     paths: { source: '/tmp/ws1', configuration: '/tmp/ws1/.kaiden' },
+    timestamps: { created: 1700000000 },
   },
   {
     id: 'ws-2',
@@ -49,6 +50,7 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     agent: 'coder-v2',
     state: 'running',
     paths: { source: '/tmp/ws2', configuration: '/tmp/ws2/.kaiden' },
+    timestamps: { created: 1700000001, started: 1700000002 },
   },
 ];
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
@@ -37,6 +37,7 @@ const workspace: AgentWorkspaceSummary = {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
+  timestamps: { created: 1700000000 },
 };
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -53,6 +53,7 @@ const workspaceSummary: AgentWorkspaceSummary = {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
+  timestamps: { created: 1700000000 },
 };
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSummary.spec.ts
@@ -36,6 +36,7 @@ const workspaceSummary: AgentWorkspaceSummary = {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
+  timestamps: { created: 1700000000 },
 };
 
 const configuration: AgentWorkspaceConfiguration = {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -55,6 +55,7 @@ test('Expect workspace rows displayed with total count', () => {
         source: '/home/user/projects/backend',
         configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
       },
+      timestamps: { created: 1700000000 },
     },
     {
       id: 'ws-2',
@@ -66,6 +67,7 @@ test('Expect workspace rows displayed with total count', () => {
         source: '/home/user/projects/frontend',
         configuration: '/home/user/.config/kaiden/workspaces/frontend-redesign.yaml',
       },
+      timestamps: { created: 1700000001, started: 1700000002 },
     },
   ];
   agentWorkspaces.set(workspaces);

--- a/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
@@ -33,6 +33,7 @@ const workspace: AgentWorkspaceSummary = {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
+  timestamps: { created: 1700000000 },
 };
 
 beforeEach(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,8 +210,8 @@ importers:
         specifier: 'workspace:'
         version: link:packages/extension-api
       '@openkaiden/kdn-api':
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.9.0
+        version: 0.9.0
       '@openkaiden/mcp-registry-types':
         specifier: ^1.3.10
         version: 1.3.10
@@ -1818,8 +1818,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@openkaiden/kdn-api@0.8.0':
-    resolution: {integrity: sha512-e/38HVpaZsHa/fzTiXmKWQwpvZgOQuEFflCgkuPXvgz3TwPllZk+j4MGnn10INVTWr/k/YeZB2zbeec3bojHNw==}
+  '@openkaiden/kdn-api@0.9.0':
+    resolution: {integrity: sha512-Tc0btrG95VrdGjHQDTIFPYhdwsMhQfjbQur3qeheze78FQJVBydTeEkCsa+ilcp5L/JlmPZ875MdT39APS04Vg==}
 
   '@openkaiden/mcp-registry-types@1.3.10':
     resolution: {integrity: sha512-3DJ7Pi+FtnkBC5ynYPDqK0jP9l9KkUS4GLgC/+uv0vTYRXXn/NrjOnqXqPqCmlyLTTYtwEegIR4X5vKUU2dDaw==}
@@ -8806,7 +8806,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openkaiden/kdn-api@0.8.0': {}
+  '@openkaiden/kdn-api@0.9.0': {}
 
   '@openkaiden/mcp-registry-types@1.3.10':
     dependencies:


### PR DESCRIPTION
## Summary
- Bump `@openkaiden/kdn-api` dependency from `^0.8.0` to `^0.9.0`

## Test plan
- [ ] Verify `pnpm install` resolves successfully
- [ ] Verify no breaking changes from the API version update

🤖 Generated with [Claude Code](https://claude.com/claude-code)