### PR TITLE
feat(workspace): wire spawned MCP servers from create wizard to workspace config

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -50,6 +50,12 @@ export type CliInfo = cliComponents['schemas']['Info'];
  */
 export type NetworkConfiguration = configComponents['schemas']['NetworkConfiguration'];
 
+export type AgentWorkspaceMcpRemoteServer = configComponents['schemas']['McpServer'];
+
+export type AgentWorkspaceMcpCommandServer = configComponents['schemas']['McpCommand'];
+
+export type AgentWorkspaceMcpConfig = configComponents['schemas']['McpConfiguration'];
+
 /**
  * Options for creating (initializing) a new workspace via `kdn init`.
  */
@@ -63,4 +69,5 @@ export interface AgentWorkspaceCreateOptions {
   skills?: string[];
   network?: NetworkConfiguration;
   secrets?: string[];
+  mcp?: AgentWorkspaceMcpConfig;
 }

--- a/packages/api/src/mcp/mcp-server-info.ts
+++ b/packages/api/src/mcp/mcp-server-info.ts
@@ -18,12 +18,20 @@ export type MCPServerDetail = ValidatedServerDetail & {
   serverId: string;
 };
 
+export interface MCPCommandSpec {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
 export interface MCPRemoteServerInfo {
   id: string;
   infos: { internalProviderId: string; serverId: string; remoteId: number };
   name: string;
   description: string;
   url: string;
+  setupType?: 'remote' | 'package';
+  commandSpec?: MCPCommandSpec;
   tools: Record<string, { description?: string }>;
   isValidSchema?: boolean;
 }

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -69,6 +69,12 @@ function mockExecResult(stdout: string): RunResult {
   return { command: KAIDEN_CLI_PATH, stdout, stderr: '' };
 }
 
+function mockEnoent(): NodeJS.ErrnoException {
+  const err: NodeJS.ErrnoException = new Error('ENOENT');
+  err.code = 'ENOENT';
+  return err;
+}
+
 function mockRunError(overrides: Partial<RunError> = {}): RunError {
   const err = new Error(overrides.message ?? 'Command execution failed with exit code 1') as RunError;
   err.exitCode = overrides.exitCode ?? 1;
@@ -235,7 +241,7 @@ describe('create', () => {
 
   test('writes workspace.json with skills before calling kdn init', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
     await kdnCli.createWorkspace({
@@ -268,7 +274,7 @@ describe('create', () => {
 
   test('writes workspace.json with network before calling kdn init', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
     await kdnCli.createWorkspace({
@@ -283,7 +289,7 @@ describe('create', () => {
     expect(exec.exec).toHaveBeenCalled();
   });
 
-  test('does not write workspace.json when no skills or network provided', async () => {
+  test('does not write workspace.json when no skills, network, secrets, or mcp provided', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
@@ -310,7 +316,7 @@ describe('create', () => {
 
   test('writes workspace.json with both skills and network', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
     await kdnCli.createWorkspace({
@@ -327,7 +333,7 @@ describe('create', () => {
 
   test('writes workspace.json with secrets before calling kdn init', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
     await kdnCli.createWorkspace({
@@ -340,15 +346,6 @@ describe('create', () => {
     const parsed = JSON.parse(writtenContent);
     expect(parsed.secrets).toEqual(['github-token', 'anthropic-key']);
     expect(exec.exec).toHaveBeenCalled();
-  });
-
-  test('does not write workspace.json when no skills or secrets provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
-
-    await kdnCli.createWorkspace(defaultOptions);
-
-    expect(writeFile).not.toHaveBeenCalled();
   });
 
   test('merges secrets into existing workspace.json preserving other fields', async () => {
@@ -369,7 +366,7 @@ describe('create', () => {
 
   test('writes workspace.json with both skills and secrets', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
     await kdnCli.createWorkspace({
@@ -382,6 +379,75 @@ describe('create', () => {
     const parsed = JSON.parse(writtenContent);
     expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes']);
     expect(parsed.secrets).toEqual(['github-token', 'anthropic-key']);
+  });
+
+  test('writes workspace.json with command-based MCP servers and adds Python feature for uvx', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      mcp: {
+        commands: [{ name: 'pypi-server', command: 'uvx', args: ['mcp-server==1.0.0'], env: { API_KEY: 'test' } }],
+      },
+    });
+
+    const calls = vi.mocked(writeFile).mock.calls;
+    const configCall = calls.find(c => String(c[0]).endsWith('workspace.json'));
+    const parsed = JSON.parse(configCall![1] as string);
+    expect(parsed.mcp.commands).toEqual([
+      {
+        name: 'pypi-server',
+        command: 'uvx',
+        args: ['mcp-server==1.0.0'],
+        env: { API_KEY: 'test', UV_SYSTEM_CERTS: '1' },
+      },
+    ]);
+    expect(parsed.features).toEqual({ './uv-feature': {} });
+    expect(parsed.network).toBeUndefined();
+  });
+
+  test('writes workspace.json with both remote and command-based MCP servers', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      mcp: {
+        servers: [{ name: 'github', url: 'https://mcp.github.com/sse' }],
+        commands: [{ name: 'playwright', command: 'npx', args: ['-y', '@playwright/mcp'] }],
+      },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mcp.servers).toEqual([{ name: 'github', url: 'https://mcp.github.com/sse' }]);
+    expect(parsed.mcp.commands).toEqual([{ name: 'playwright', command: 'npx', args: ['-y', '@playwright/mcp'] }]);
+    expect(parsed.features).toEqual({ 'ghcr.io/devcontainers/features/node:1': { version: '22' } });
+  });
+
+  test('preserves existing feature config rather than overwriting', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({
+        features: { './uv-feature': { version: '3.12' } },
+      }),
+    );
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      mcp: {
+        commands: [{ name: 'pypi-server', command: 'uvx', args: ['mcp-server==1.0.0'] }],
+      },
+    });
+
+    const calls = vi.mocked(writeFile).mock.calls;
+    const configCall = calls.find(c => String(c[0]).endsWith('workspace.json'));
+    const parsed = JSON.parse(configCall![1] as string);
+    expect(parsed.features).toEqual({ './uv-feature': { version: '3.12' } });
   });
 });
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -24,6 +24,8 @@ import type { components as workspaceComponents } from '@openkaiden/workspace-co
 import { inject, injectable } from 'inversify';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { WorkspaceRequirements } from '/@/plugin/mcp/package/mcp-spawner.js';
+import { mcpSpawnerFactoryRegistry } from '/@/plugin/mcp/package/mcp-spawner-factory-registry.js';
 import { Exec } from '/@/plugin/util/exec.js';
 import type {
   AgentWorkspaceCreateOptions,
@@ -129,27 +131,95 @@ export class KdnCli {
   }
 
   async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
-    if (!options.skills?.length && !options.secrets?.length && !options.network) {
+    const mcpServers = options.mcp?.servers;
+    const mcpCommands = options.mcp?.commands;
+    const hasSkills = !!options.skills?.length;
+    const hasMcp = !!mcpServers?.length || !!mcpCommands?.length;
+    if (!hasSkills && !options.secrets?.length && !options.network && !hasMcp) {
       return;
     }
 
     const configDir = join(options.sourcePath, '.kaiden');
     const configPath = join(configDir, 'workspace.json');
+    await mkdir(configDir, { recursive: true });
 
     let existing: WorkspaceConfiguration = {};
     try {
       const content = await readFile(configPath, 'utf-8');
       existing = JSON.parse(content) as WorkspaceConfiguration;
-    } catch {
-      // file doesn't exist yet — start fresh
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw err;
+      }
     }
 
-    existing.skills = options.skills;
+    if (hasSkills) {
+      existing.skills = options.skills;
+    }
     existing.network = options.network;
     existing.secrets = options.secrets;
 
-    await mkdir(configDir, { recursive: true });
-    await writeFile(configPath, JSON.stringify(existing, undefined, 2) + '\n', 'utf-8');
+    if (hasMcp) {
+      const reqsByCommand = new Map<string, WorkspaceRequirements | undefined>();
+      for (const c of mcpCommands ?? []) {
+        if (!reqsByCommand.has(c.command)) {
+          reqsByCommand.set(c.command, mcpSpawnerFactoryRegistry.getByCommand(c.command)?.getWorkspaceRequirements());
+        }
+      }
+
+      const mcp: WorkspaceConfiguration['mcp'] = {};
+      if (mcpServers?.length) {
+        mcp.servers = mcpServers.map(s => ({
+          name: s.name,
+          url: s.url,
+          ...(s.headers && Object.keys(s.headers).length > 0 ? { headers: s.headers } : {}),
+        }));
+      }
+      if (mcpCommands?.length) {
+        mcp.commands = mcpCommands.map(c => {
+          const reqs = reqsByCommand.get(c.command);
+          const env = { ...reqs?.env, ...c.env };
+          return {
+            name: c.name,
+            command: c.command,
+            ...(c.args?.length ? { args: c.args } : {}),
+            ...(Object.keys(env).length > 0 ? { env } : {}),
+          };
+        });
+      }
+      existing.mcp = mcp;
+
+      const requiredHosts: string[] = [];
+      for (const [, reqs] of reqsByCommand) {
+        if (!reqs) continue;
+        for (const [key, value] of Object.entries(reqs.features)) {
+          existing.features = {
+            ...existing.features,
+            [key]: existing.features?.[key] ?? value,
+          };
+        }
+        if (reqs.ensureFeatures) {
+          await reqs.ensureFeatures(configDir);
+        }
+        requiredHosts.push(...reqs.hosts);
+      }
+
+      const network = existing.network;
+      if (requiredHosts.length > 0 && network?.mode === 'deny' && Array.isArray(network.hosts)) {
+        const missingHosts = requiredHosts.filter(h => !network.hosts!.includes(h));
+        if (missingHosts.length > 0) {
+          existing.network = {
+            ...network,
+            mode: 'deny',
+            hosts: [...network.hosts!, ...missingHosts],
+          };
+        }
+      }
+    }
+
+    const output = JSON.stringify(existing, undefined, 2) + '\n';
+    console.log(`[KdnCli] workspace.json:\n${output}`);
+    await writeFile(configPath, output, 'utf-8');
   }
 
   async listWorkspaces(): Promise<AgentWorkspaceSummary[]> {

--- a/packages/main/src/plugin/mcp/mcp-manager.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.ts
@@ -24,7 +24,7 @@ import { inject, injectable, preDestroy } from 'inversify';
 import { MCPExchanges, MCPMessageExchange } from '/@/plugin/mcp/mcp-exchanges.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import { IAsyncDisposable } from '/@api/async-disposable.js';
-import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info.js';
+import type { MCPCommandSpec, MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info.js';
 
 /**
  * experimental_createMCPClient return `Promise<MCPClient>` but they did not exported this type...
@@ -136,6 +136,7 @@ export class MCPManager implements IAsyncDisposable {
     url?: string,
     description?: string,
     isValidSchema?: boolean,
+    commandSpec?: MCPCommandSpec,
   ): Promise<void> {
     const key = this.getKey(internalProviderId, serverId, setupType, index);
 
@@ -161,6 +162,8 @@ export class MCPManager implements IAsyncDisposable {
       infos: { internalProviderId, remoteId: index, serverId },
       name: connectionName,
       url: url ?? '',
+      setupType,
+      commandSpec,
       description: description ?? '',
       tools,
       isValidSchema,

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -28,6 +28,7 @@ import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import { inject, injectable } from 'inversify';
 
 import { MCPPackage } from '/@/plugin/mcp/package/mcp-package.js';
+import type { CommandSpec } from '/@/plugin/mcp/package/mcp-spawner.js';
 import { formatArguments } from '/@/plugin/mcp/utils/arguments.js';
 import { formatKeyValueInputs } from '/@/plugin/mcp/utils/format-key-value-inputs.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
@@ -271,6 +272,7 @@ export class MCPRegistry {
             environmentVariables: config.environmentVariables,
           });
 
+          const cmdSpec = spawner.buildCommandSpec();
           const transport = await spawner.spawn();
           await this.mcpManager.registerMCPClient(
             INTERNAL_PROVIDER_ID,
@@ -282,6 +284,7 @@ export class MCPRegistry {
             undefined,
             server.description,
             server.isValidSchema,
+            cmdSpec,
           );
         }
       }
@@ -447,6 +450,7 @@ export class MCPRegistry {
 
     let transport: Transport;
     let config: StorageConfigFormat;
+    let cmdSpec: CommandSpec | undefined;
 
     let url: string | undefined;
 
@@ -510,6 +514,7 @@ export class MCPRegistry {
           runtimeArguments: config.runtimeArguments,
           environmentVariables: config.environmentVariables,
         });
+        cmdSpec = spawner.buildCommandSpec();
         transport = await spawner.spawn();
         break;
       }
@@ -530,6 +535,7 @@ export class MCPRegistry {
       url,
       description,
       isValidSchema,
+      cmdSpec,
     );
 
     // persist configuration

--- a/packages/main/src/plugin/mcp/package/mcp-package.spec.ts
+++ b/packages/main/src/plugin/mcp/package/mcp-package.spec.ts
@@ -19,19 +19,30 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { MCPPackage } from './mcp-package.js';
-import { NPMSpawner } from './npm-spawner.js';
-import { PyPiSpawner } from './pypi-spawner.js';
+import type { ResolvedServerPackage } from './mcp-spawner.js';
+import type { MCPSpawnerFactory } from './mcp-spawner-factory.js';
+import { mcpSpawnerFactoryRegistry } from './mcp-spawner-factory-registry.js';
 
-// Mock the spawner classes
-vi.mock(import('./npm-spawner.js'));
-vi.mock(import('./pypi-spawner.js'));
+vi.mock(import('./mcp-spawner-factory-registry.js'));
 
 describe('MCPPackage', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  test('should create NPMSpawner for npm registry type', () => {
+  test('should use factory from registry to create spawner', () => {
+    const mockSpawner = {
+      buildCommandSpec: vi.fn(),
+      spawn: vi.fn(),
+      asyncDispose: vi.fn(),
+    };
+    const mockFactory: MCPSpawnerFactory = {
+      command: 'npx',
+      getWorkspaceRequirements: vi.fn(),
+      create: vi.fn().mockReturnValue(mockSpawner),
+    };
+    vi.mocked(mcpSpawnerFactoryRegistry.get).mockReturnValue(mockFactory);
+
     const pack = {
       identifier: 'test-package',
       version: '1.0.0',
@@ -42,35 +53,30 @@ describe('MCPPackage', () => {
     const mcpPackage = new MCPPackage(pack);
 
     expect(mcpPackage).toBeDefined();
-    expect(vi.mocked(NPMSpawner)).toHaveBeenCalledWith(pack);
-    expect(vi.mocked(PyPiSpawner)).not.toHaveBeenCalled();
+    expect(mcpSpawnerFactoryRegistry.get).toHaveBeenCalledWith('npm');
+    expect(mockFactory.create).toHaveBeenCalledWith(pack);
   });
 
-  test('should create PyPiSpawner for pypi registry type', () => {
-    const pack = {
-      identifier: 'test-package',
-      version: '1.0.0',
-      registryType: 'pypi' as const,
-      transport: { type: 'stdio' as const },
-    };
-
-    const mcpPackage = new MCPPackage(pack);
-
-    expect(mcpPackage).toBeDefined();
-    expect(vi.mocked(PyPiSpawner)).toHaveBeenCalledWith(pack);
-    expect(vi.mocked(NPMSpawner)).not.toHaveBeenCalled();
-  });
-
-  test('should delegate buildCommandSpec to NPMSpawner', () => {
-    const pack = {
-      identifier: 'test-package',
-      version: '1.0.0',
-      registryType: 'npm' as const,
-      transport: { type: 'stdio' as const },
-    };
-
+  test('should delegate buildCommandSpec to spawner', () => {
     const mockSpec = { command: 'npx', args: ['test-package@1.0.0'] };
-    vi.mocked(NPMSpawner).prototype.buildCommandSpec = vi.fn().mockReturnValue(mockSpec);
+    const mockSpawner = {
+      buildCommandSpec: vi.fn().mockReturnValue(mockSpec),
+      spawn: vi.fn(),
+      asyncDispose: vi.fn(),
+    };
+    const mockFactory: MCPSpawnerFactory = {
+      command: 'npx',
+      getWorkspaceRequirements: vi.fn(),
+      create: vi.fn().mockReturnValue(mockSpawner),
+    };
+    vi.mocked(mcpSpawnerFactoryRegistry.get).mockReturnValue(mockFactory);
+
+    const pack = {
+      identifier: 'test-package',
+      version: '1.0.0',
+      registryType: 'npm' as const,
+      transport: { type: 'stdio' as const },
+    };
 
     const mcpPackage = new MCPPackage(pack);
     const result = mcpPackage.buildCommandSpec();
@@ -78,7 +84,20 @@ describe('MCPPackage', () => {
     expect(result).toBe(mockSpec);
   });
 
-  test('should delegate buildCommandSpec to PyPiSpawner', () => {
+  test('should delegate spawn to spawner', async () => {
+    const mockTransport = {};
+    const mockSpawner = {
+      buildCommandSpec: vi.fn(),
+      spawn: vi.fn().mockResolvedValue(mockTransport),
+      asyncDispose: vi.fn(),
+    };
+    const mockFactory: MCPSpawnerFactory = {
+      command: 'uvx',
+      getWorkspaceRequirements: vi.fn(),
+      create: vi.fn().mockReturnValue(mockSpawner),
+    };
+    vi.mocked(mcpSpawnerFactoryRegistry.get).mockReturnValue(mockFactory);
+
     const pack = {
       identifier: 'test-package',
       version: '1.0.0',
@@ -86,16 +105,25 @@ describe('MCPPackage', () => {
       transport: { type: 'stdio' as const },
     };
 
-    const mockSpec = { command: 'uvx', args: ['test-package==1.0.0'] };
-    vi.mocked(PyPiSpawner).prototype.buildCommandSpec = vi.fn().mockReturnValue(mockSpec);
-
     const mcpPackage = new MCPPackage(pack);
-    const result = mcpPackage.buildCommandSpec();
+    const result = await mcpPackage.spawn();
 
-    expect(result).toBe(mockSpec);
+    expect(result).toBe(mockTransport);
+  });
+
+  test('should throw error when registry_type is missing', () => {
+    const pack = {
+      identifier: 'test-package',
+      version: '1.0.0',
+      transport: { type: 'stdio' as const },
+    } as unknown as ResolvedServerPackage;
+
+    expect(() => new MCPPackage(pack)).toThrow('cannot determine how to spawn package: registry_type is missing');
   });
 
   test('should throw error for unsupported registry type', () => {
+    vi.mocked(mcpSpawnerFactoryRegistry.get).mockReturnValue(undefined);
+
     const pack = {
       identifier: 'test-package',
       version: '1.0.0',

--- a/packages/main/src/plugin/mcp/package/mcp-package.ts
+++ b/packages/main/src/plugin/mcp/package/mcp-package.ts
@@ -20,33 +20,16 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { IAsyncDisposable } from '/@api/async-disposable.js';
 
 import type { CommandSpec, MCPSpawner, ResolvedServerPackage } from './mcp-spawner.js';
-import { NPMSpawner } from './npm-spawner.js';
-import { PyPiSpawner } from './pypi-spawner.js';
+import { mcpSpawnerFactoryRegistry } from './mcp-spawner-factory-registry.js';
 
 export class MCPPackage implements IAsyncDisposable {
   readonly #spawner: MCPSpawner;
 
   constructor(pack: ResolvedServerPackage) {
-    // By destructuring `registry_type` and reconstructing the object, TypeScript can properly infer the narrowed type in each switch case.
-    const { registryType, ...rest } = pack;
-    if (!registryType) throw new Error('cannot determine how to spawn package: registry_type is missing');
-
-    switch (registryType) {
-      case 'npm':
-        this.#spawner = new NPMSpawner({
-          ...rest,
-          registryType: registryType,
-        });
-        break;
-      case 'pypi':
-        this.#spawner = new PyPiSpawner({
-          ...rest,
-          registryType,
-        });
-        break;
-      default:
-        throw new Error(`unsupported registry type: ${pack.registryType}`);
-    }
+    if (!pack.registryType) throw new Error('cannot determine how to spawn package: registry_type is missing');
+    const factory = mcpSpawnerFactoryRegistry.get(pack.registryType);
+    if (!factory) throw new Error(`unsupported registry type: ${pack.registryType}`);
+    this.#spawner = factory.create(pack);
   }
 
   buildCommandSpec(): CommandSpec {

--- a/packages/main/src/plugin/mcp/package/mcp-spawner-factory-registry.spec.ts
+++ b/packages/main/src/plugin/mcp/package/mcp-spawner-factory-registry.spec.ts
@@ -1,0 +1,103 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test, vi } from 'vitest';
+
+import type { MCPSpawnerFactory } from './mcp-spawner-factory.js';
+import { MCPSpawnerFactoryRegistry, mcpSpawnerFactoryRegistry } from './mcp-spawner-factory-registry.js';
+
+describe('MCPSpawnerFactoryRegistry', () => {
+  test('should register and retrieve a factory by registry type', () => {
+    const registry = new MCPSpawnerFactoryRegistry();
+    const factory: MCPSpawnerFactory = {
+      command: 'test-cmd',
+      getWorkspaceRequirements: vi.fn(),
+      create: vi.fn(),
+    };
+
+    registry.register('test', factory);
+
+    expect(registry.get('test')).toBe(factory);
+  });
+
+  test('should return undefined for unknown registry type', () => {
+    const registry = new MCPSpawnerFactoryRegistry();
+
+    expect(registry.get('unknown')).toBeUndefined();
+  });
+
+  test('should retrieve a factory by command', () => {
+    const registry = new MCPSpawnerFactoryRegistry();
+    const factory: MCPSpawnerFactory = {
+      command: 'my-cmd',
+      getWorkspaceRequirements: vi.fn(),
+      create: vi.fn(),
+    };
+
+    registry.register('custom', factory);
+
+    expect(registry.getByCommand('my-cmd')).toBe(factory);
+  });
+
+  test('should return undefined for unknown command', () => {
+    const registry = new MCPSpawnerFactoryRegistry();
+
+    expect(registry.getByCommand('no-such-cmd')).toBeUndefined();
+  });
+
+  test('should overwrite factory when registering same type twice', () => {
+    const registry = new MCPSpawnerFactoryRegistry();
+    const first: MCPSpawnerFactory = { command: 'a', getWorkspaceRequirements: vi.fn(), create: vi.fn() };
+    const second: MCPSpawnerFactory = { command: 'b', getWorkspaceRequirements: vi.fn(), create: vi.fn() };
+
+    registry.register('type', first);
+    registry.register('type', second);
+
+    expect(registry.get('type')).toBe(second);
+  });
+});
+
+describe('mcpSpawnerFactoryRegistry singleton', () => {
+  test('should have npm factory pre-registered', () => {
+    const factory = mcpSpawnerFactoryRegistry.get('npm');
+
+    expect(factory).toBeDefined();
+    expect(factory!.command).toBe('npx');
+  });
+
+  test('should have pypi factory pre-registered', () => {
+    const factory = mcpSpawnerFactoryRegistry.get('pypi');
+
+    expect(factory).toBeDefined();
+    expect(factory!.command).toBe('uvx');
+  });
+
+  test('should find npm factory by command npx', () => {
+    const factory = mcpSpawnerFactoryRegistry.getByCommand('npx');
+
+    expect(factory).toBeDefined();
+    expect(factory!.command).toBe('npx');
+  });
+
+  test('should find pypi factory by command uvx', () => {
+    const factory = mcpSpawnerFactoryRegistry.getByCommand('uvx');
+
+    expect(factory).toBeDefined();
+    expect(factory!.command).toBe('uvx');
+  });
+});

--- a/packages/main/src/plugin/mcp/package/mcp-spawner-factory-registry.ts
+++ b/packages/main/src/plugin/mcp/package/mcp-spawner-factory-registry.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { MCPSpawner, ResolvedServerPackage, WorkspaceRequirements } from './mcp-spawner.js';
+import type { MCPSpawnerFactory } from './mcp-spawner-factory.js';
+import { NPMSpawner } from './npm-spawner.js';
+import { PyPiSpawner } from './pypi-spawner.js';
+
+export class MCPSpawnerFactoryRegistry {
+  #factories = new Map<string, MCPSpawnerFactory>();
+
+  register(registryType: string, factory: MCPSpawnerFactory): void {
+    this.#factories.set(registryType, factory);
+  }
+
+  get(registryType: string): MCPSpawnerFactory | undefined {
+    return this.#factories.get(registryType);
+  }
+
+  getByCommand(command: string): MCPSpawnerFactory | undefined {
+    for (const factory of this.#factories.values()) {
+      if (factory.command === command) return factory;
+    }
+    return undefined;
+  }
+}
+
+export const mcpSpawnerFactoryRegistry = new MCPSpawnerFactoryRegistry();
+
+mcpSpawnerFactoryRegistry.register('npm', {
+  command: NPMSpawner.command,
+  getWorkspaceRequirements: (): WorkspaceRequirements => NPMSpawner.getWorkspaceRequirements(),
+  create: (pack: ResolvedServerPackage): MCPSpawner =>
+    new NPMSpawner(pack as ResolvedServerPackage & { registryType: 'npm' }),
+});
+
+mcpSpawnerFactoryRegistry.register('pypi', {
+  command: PyPiSpawner.command,
+  getWorkspaceRequirements: (): WorkspaceRequirements => PyPiSpawner.getWorkspaceRequirements(),
+  create: (pack: ResolvedServerPackage): MCPSpawner =>
+    new PyPiSpawner(pack as ResolvedServerPackage & { registryType: 'pypi' }),
+});

--- a/packages/main/src/plugin/mcp/package/mcp-spawner-factory.ts
+++ b/packages/main/src/plugin/mcp/package/mcp-spawner-factory.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { MCPSpawner, ResolvedServerPackage, WorkspaceRequirements } from './mcp-spawner.js';
+
+export interface MCPSpawnerFactory {
+  command: string;
+  getWorkspaceRequirements(): WorkspaceRequirements;
+  create(pack: ResolvedServerPackage): MCPSpawner;
+}

--- a/packages/main/src/plugin/mcp/package/mcp-spawner.ts
+++ b/packages/main/src/plugin/mcp/package/mcp-spawner.ts
@@ -19,6 +19,7 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { components } from '@openkaiden/mcp-registry-types';
 
 import type { IAsyncDisposable } from '/@api/async-disposable.js';
+import type { MCPCommandSpec } from '/@api/mcp/mcp-server-info.js';
 
 export type ResolvedServerPackage = Omit<
   components['schemas']['Package'],
@@ -29,10 +30,14 @@ export type ResolvedServerPackage = Omit<
   environmentVariables?: Record<string, string>;
 };
 
-export interface CommandSpec {
-  command: string;
-  args: string[];
+// Re-exported from the API layer so spawner internals use the same type as MCPRemoteServerInfo.
+export type CommandSpec = MCPCommandSpec;
+
+export interface WorkspaceRequirements {
+  hosts: string[];
+  features: Record<string, Record<string, unknown>>;
   env?: Record<string, string>;
+  ensureFeatures?: (configDir: string) => Promise<void>;
 }
 
 export abstract class MCPSpawner<T extends string = string> implements IAsyncDisposable {

--- a/packages/main/src/plugin/mcp/package/npm-spawner.spec.ts
+++ b/packages/main/src/plugin/mcp/package/npm-spawner.spec.ts
@@ -21,6 +21,27 @@ import { describe, expect, test } from 'vitest';
 import { NPMSpawner } from './npm-spawner.js';
 
 describe('NPMSpawner', () => {
+  test('command is npx', () => {
+    expect(NPMSpawner.command).toBe('npx');
+  });
+
+  describe('getWorkspaceRequirements', () => {
+    test('returns npm registry host', () => {
+      const reqs = NPMSpawner.getWorkspaceRequirements();
+      expect(reqs.hosts).toEqual(['registry.npmjs.org']);
+    });
+
+    test('returns node devcontainer feature', () => {
+      const reqs = NPMSpawner.getWorkspaceRequirements();
+      expect(reqs.features).toEqual({ 'ghcr.io/devcontainers/features/node:1': { version: '22' } });
+    });
+
+    test('does not provide ensureFeatures callback', () => {
+      const reqs = NPMSpawner.getWorkspaceRequirements();
+      expect(reqs.ensureFeatures).toBeUndefined();
+    });
+  });
+
   describe('buildCommandSpec', () => {
     test('uses npx command with identifier@version', () => {
       const spawner = new NPMSpawner({

--- a/packages/main/src/plugin/mcp/package/npm-spawner.ts
+++ b/packages/main/src/plugin/mcp/package/npm-spawner.ts
@@ -20,12 +20,21 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
 import type { IAsyncDisposable } from '/@api/async-disposable.js';
 
-import type { CommandSpec } from './mcp-spawner.js';
+import type { CommandSpec, WorkspaceRequirements } from './mcp-spawner.js';
 import { MCPSpawner } from './mcp-spawner.js';
 
 const NPX_COMMAND = 'npx';
 
 export class NPMSpawner extends MCPSpawner<'npm'> {
+  static readonly command = NPX_COMMAND;
+
+  static getWorkspaceRequirements(): WorkspaceRequirements {
+    return {
+      hosts: ['registry.npmjs.org'],
+      features: { 'ghcr.io/devcontainers/features/node:1': { version: '22' } },
+    };
+  }
+
   #disposables: Array<IAsyncDisposable> = [];
 
   buildCommandSpec(): CommandSpec {

--- a/packages/main/src/plugin/mcp/package/pypi-spawner.spec.ts
+++ b/packages/main/src/plugin/mcp/package/pypi-spawner.spec.ts
@@ -16,11 +16,63 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { describe, expect, test } from 'vitest';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PyPiSpawner } from './pypi-spawner.js';
 
+vi.mock(import('node:fs/promises'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
 describe('PyPiSpawner', () => {
+  test('command is uvx', () => {
+    expect(PyPiSpawner.command).toBe('uvx');
+  });
+
+  describe('getWorkspaceRequirements', () => {
+    test('returns pypi hosts', () => {
+      const reqs = PyPiSpawner.getWorkspaceRequirements();
+      expect(reqs.hosts).toEqual(['pypi.org', 'files.pythonhosted.org']);
+    });
+
+    test('returns uv-feature', () => {
+      const reqs = PyPiSpawner.getWorkspaceRequirements();
+      expect(reqs.features).toEqual({ './uv-feature': {} });
+    });
+
+    test('returns UV_SYSTEM_CERTS env', () => {
+      const reqs = PyPiSpawner.getWorkspaceRequirements();
+      expect(reqs.env).toEqual({ UV_SYSTEM_CERTS: '1' });
+    });
+
+    test('provides ensureFeatures callback', () => {
+      const reqs = PyPiSpawner.getWorkspaceRequirements();
+      expect(reqs.ensureFeatures).toBeDefined();
+    });
+
+    test('ensureFeatures creates uv-feature directory and writes correct files', async () => {
+      const reqs = PyPiSpawner.getWorkspaceRequirements();
+      await reqs.ensureFeatures!('/config');
+
+      expect(mkdir).toHaveBeenCalledWith(join('/config', 'uv-feature'), { recursive: true });
+      expect(writeFile).toHaveBeenCalledWith(
+        join('/config', 'uv-feature', 'devcontainer-feature.json'),
+        JSON.stringify({ id: 'uv', version: '0.1.0', name: 'uv Python package manager' }, undefined, 2) + '\n',
+        'utf-8',
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        join('/config', 'uv-feature', 'install.sh'),
+        '#!/bin/sh\npip install uv\n',
+        { encoding: 'utf-8', mode: 0o755 },
+      );
+    });
+  });
+
   describe('buildCommandSpec', () => {
     test('uses uvx command with identifier==version', () => {
       const spawner = new PyPiSpawner({

--- a/packages/main/src/plugin/mcp/package/pypi-spawner.ts
+++ b/packages/main/src/plugin/mcp/package/pypi-spawner.ts
@@ -14,12 +14,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
 import type { IAsyncDisposable } from '/@api/async-disposable.js';
 
-import type { CommandSpec } from './mcp-spawner.js';
+import type { CommandSpec, WorkspaceRequirements } from './mcp-spawner.js';
 import { MCPSpawner } from './mcp-spawner.js';
 
 const UVX_COMMAND = 'uvx';
@@ -28,6 +31,29 @@ const UVX_COMMAND = 'uvx';
  * PyPiSpawner handles spawning Python-based MCP servers from PyPI packages.
  */
 export class PyPiSpawner extends MCPSpawner<'pypi'> {
+  static readonly command = UVX_COMMAND;
+
+  static getWorkspaceRequirements(): WorkspaceRequirements {
+    return {
+      hosts: ['pypi.org', 'files.pythonhosted.org'],
+      features: { './uv-feature': {} },
+      env: { UV_SYSTEM_CERTS: '1' },
+      ensureFeatures: async (configDir: string): Promise<void> => {
+        const featureDir = join(configDir, 'uv-feature');
+        await mkdir(featureDir, { recursive: true });
+        await writeFile(
+          join(featureDir, 'devcontainer-feature.json'),
+          JSON.stringify({ id: 'uv', version: '0.1.0', name: 'uv Python package manager' }, undefined, 2) + '\n',
+          'utf-8',
+        );
+        await writeFile(join(featureDir, 'install.sh'), '#!/bin/sh\npip install uv\n', {
+          encoding: 'utf-8',
+          mode: 0o755,
+        });
+      },
+    };
+  }
+
   #disposables: Array<IAsyncDisposable> = [];
 
   buildCommandSpec(): CommandSpec {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -884,6 +884,46 @@ test('Expect createAgentWorkspace called with registry hosts plus custom host fo
   );
 });
 
+test('Expect createAgentWorkspace splits MCP servers into remote and command entries', async () => {
+  vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([
+    {
+      id: 'mcp-remote',
+      name: 'GitHub MCP',
+      description: 'Repos & PRs',
+      url: 'https://mcp.github.com/sse',
+      setupType: 'remote',
+      infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+      tools: { 'list-repos': {} },
+    },
+    {
+      id: 'mcp-pkg',
+      name: 'NPM MCP',
+      description: 'Node MCP server',
+      url: '',
+      setupType: 'package',
+      commandSpec: { command: 'npx', args: ['@example/mcp@1.0.0'] },
+      infos: { internalProviderId: 'p2', serverId: 's2', remoteId: 0 },
+      tools: {},
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mcp: {
+        servers: [{ name: 'GitHub MCP', url: 'https://mcp.github.com/sse' }],
+        commands: [{ name: 'NPM MCP', command: 'npx', args: ['@example/mcp@1.0.0'], env: undefined }],
+      },
+    }),
+  );
+});
+
 test('Expect createAgentWorkspace called with custom hosts only for Deny All with custom host', async () => {
   render(AgentWorkspaceCreate);
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -317,6 +317,21 @@ async function startWorkspace(): Promise<void> {
     const network = mapNetworkSelection(selectedNetwork, customHosts);
 
     const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
+
+    const selected = $mcpRemoteServerInfos.filter(m => selectedMcpIds.includes(m.id));
+    const remoteServers = selected
+      .filter(m => m.setupType === 'remote' || (!m.setupType && m.url))
+      .map(m => ({ name: m.name, url: m.url }));
+    const commandServers = selected
+      .filter(m => m.setupType === 'package' && m.commandSpec)
+      .map(m => ({
+        name: m.name,
+        command: m.commandSpec!.command,
+        args: m.commandSpec!.args,
+        env: m.commandSpec!.env,
+      }));
+    const hasMcp = remoteServers.length > 0 || commandServers.length > 0;
+
     await window.createAgentWorkspace({
       sourcePath,
       agent: agentDef?.cliAgent ?? selectedAgent,
@@ -325,6 +340,12 @@ async function startWorkspace(): Promise<void> {
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
       network,
       secrets: selectedSecretIds.length > 0 ? [...selectedSecretIds] : undefined,
+      mcp: hasMcp
+        ? {
+            ...(remoteServers.length > 0 ? { servers: remoteServers } : {}),
+            ...(commandServers.length > 0 ? { commands: commandServers } : {}),
+          }
+        : undefined,
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);


### PR DESCRIPTION
## Summary
wires mcp to backend


https://github.com/user-attachments/assets/68cf9d1a-6152-410e-b89f-d46bdcaf6958

https://bmahabirbu.github.io/mcp-registry-online/v1.2.3

use this link for registry testing

fixes: https://github.com/openkaiden/kaiden/issues/1548


## Test plan
See video and replicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)