### PR TITLE
feat(workspace): add Knowledge Bases section to create workspace wizard

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -64,6 +64,7 @@ export enum NavigationPage {
   AGENT_WORKSPACE_CREATE = 'agent-workspace-create',
   SKILLS = 'skills',
   SKILL_DETAILS = 'skill-details',
+  RAG_ENVIRONMENTS = 'rag-environments',
   RAG_ENVIRONMENT_DETAILS = 'rag-environment-details',
   SECRET_VAULT = 'secret-vault',
   SECRET_VAULT_CREATE = 'secret-vault-create',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -82,6 +82,7 @@ export interface NavigationParameters {
   [NavigationPage.SKILL_DETAILS]: {
     name: string;
   };
+  [NavigationPage.RAG_ENVIRONMENTS]: never;
   [NavigationPage.RAG_ENVIRONMENT_DETAILS]: {
     name: string;
   };

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -23,9 +23,13 @@ import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as mcpStore from '/@/stores/mcp-remote-servers';
+import * as providerStore from '/@/stores/providers';
+import * as ragStore from '/@/stores/rag-environments';
 import * as secretVaultStore from '/@/stores/secret-vault';
 import * as skillsStore from '/@/stores/skills';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
+import type { ProviderInfo } from '/@api/provider-info';
+import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 import type { SkillInfo } from '/@api/skill/skill-info';
 
@@ -35,6 +39,8 @@ vi.mock(import('/@/navigation'));
 vi.mock(import('/@/stores/skills'));
 vi.mock(import('/@/stores/mcp-remote-servers'));
 vi.mock(import('/@/stores/secret-vault'));
+vi.mock(import('/@/stores/providers'));
+vi.mock(import('/@/stores/rag-environments'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -46,6 +52,8 @@ beforeEach(() => {
   vi.mocked(skillsStore).skillInfos = writable<SkillInfo[]>([]);
   vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([]);
   vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([]);
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
 });
 
 test('Expect page title displayed', () => {
@@ -221,7 +229,7 @@ async function navigateToToolsSecretsStep(): Promise<void> {
 }
 
 async function expandCustomize(): Promise<void> {
-  await fireEvent.click(screen.getByRole('button', { name: /Customize skills, MCP servers, and vault/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Customize skills, MCP servers, vault, and knowledges/ }));
 }
 
 test('Expect summary card and customize toggle on tools & secrets step', async () => {
@@ -230,7 +238,9 @@ test('Expect summary card and customize toggle on tools & secrets step', async (
   await navigateToToolsSecretsStep();
 
   expect(screen.getByText(/Everything available is included/)).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /Customize skills, MCP servers, and vault/ })).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /Customize skills, MCP servers, vault, and knowledges/ }),
+  ).toBeInTheDocument();
 });
 
 test('Expect secrets section visible after expanding customize', async () => {
@@ -420,6 +430,63 @@ test('Expect createAgentWorkspace called without skills when none available', as
       skills: undefined,
     }),
   );
+});
+
+test('Expect Knowledges section visible after expanding customize', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('Knowledges')).toBeInTheDocument();
+  expect(screen.getByText('Optional retrieval context for the agent')).toBeInTheDocument();
+});
+
+test('Expect Knowledges empty state shown when no knowledge bases available', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('No knowledge bases available yet.')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Manage Knowledges' })).toBeInTheDocument();
+});
+
+test('Expect knowledge bases listed with provider display name and source count', async () => {
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([{ id: 'milvus', name: 'Milvus' } as ProviderInfo]);
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'kubernetes-knowledges',
+      ragConnection: { name: 'my-connection', providerId: 'milvus' },
+      chunkerId: 'docling',
+      mcpServer: { id: 'kb-mcp', name: 'kb-mcp' } as MCPRemoteServerInfo,
+      files: [
+        { path: '/docs/k8s.md', status: 'indexed' },
+        { path: '/docs/pods.md', status: 'indexed' },
+      ],
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('kubernetes-knowledges')).toBeInTheDocument();
+  expect(screen.getByText('Milvus · 2 sources')).toBeInTheDocument();
+  expect(screen.queryByText('No knowledge bases available yet.')).not.toBeInTheDocument();
+});
+
+test('Expect Manage Knowledges button navigates to rag environments page', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+  await fireEvent.click(screen.getByRole('button', { name: 'Manage Knowledges' }));
+
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'rag-environments' });
 });
 
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -16,6 +16,8 @@ import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
+import { providerInfos } from '/@/stores/providers';
+import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
 import { NavigationPage } from '/@api/navigation-page';
@@ -96,6 +98,21 @@ let skillItems: ChecklistItem[] = $derived(
 let mcpItems: ChecklistItem[] = $derived(
   $mcpRemoteServerInfos.map(m => ({ id: m.id, name: m.name, description: m.description })),
 );
+let knowledgeItems: ChecklistItem[] = $derived(
+  $ragEnvironments
+    .filter(r => r.mcpServer)
+    .map(r => {
+      const sourceCount = r.files.length;
+      const sourcesLabel = sourceCount > 0 ? `${sourceCount} source${sourceCount !== 1 ? 's' : ''}` : '';
+      const providerName =
+        $providerInfos.find(p => p.id === r.ragConnection.providerId)?.name ?? r.ragConnection.providerId;
+      return {
+        id: r.name,
+        name: r.name,
+        description: [providerName, sourcesLabel].filter(Boolean).join(' · '),
+      };
+    }),
+);
 
 // --- Form state ---
 let sourcePath = $state('');
@@ -106,6 +123,7 @@ let selectedFileAccess = $state('workspace');
 let selectedSkillIds = $derived(skillItems.map(s => s.id));
 let selectedMcpIds = $derived(mcpItems.map(m => m.id));
 let selectedSecretIds = $derived($secretVaultInfos.map(s => s.id));
+let selectedKnowledgeIds = $derived(knowledgeItems.map(k => k.id));
 let customPaths = $state<string[]>(['']);
 
 // --- Step 1 UI state ---
@@ -250,7 +268,9 @@ async function startWorkspace(): Promise<void> {
                 bind:selectedSkillIds
                 {mcpItems}
                 bind:selectedMcpIds
-                bind:selectedSecretIds />
+                bind:selectedSecretIds
+                {knowledgeItems}
+                bind:selectedKnowledgeIds />
             {:else if currentStepId === 'filesystem'}
               <AgentWorkspaceCreateStepFileSystem
                 {fileAccessOptions}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faKey, faServer, faWrench } from '@fortawesome/free-solid-svg-icons';
+import { faBook, faKey, faServer, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { Button, Expandable } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
@@ -15,6 +15,8 @@ interface Props {
   mcpItems: ChecklistItem[];
   selectedMcpIds: string[];
   selectedSecretIds: string[];
+  knowledgeItems: ChecklistItem[];
+  selectedKnowledgeIds: string[];
 }
 
 let {
@@ -23,6 +25,8 @@ let {
   mcpItems,
   selectedMcpIds = $bindable(),
   selectedSecretIds = $bindable(),
+  knowledgeItems,
+  selectedKnowledgeIds = $bindable(),
 }: Props = $props();
 
 let secretItems: ChecklistItem[] = $derived(
@@ -36,7 +40,8 @@ let secretItems: ChecklistItem[] = $derived(
 let allIncluded: boolean = $derived(
   selectedSkillIds.length === skillItems.length &&
     selectedMcpIds.length === mcpItems.length &&
-    selectedSecretIds.length === secretItems.length,
+    selectedSecretIds.length === secretItems.length &&
+    selectedKnowledgeIds.length === knowledgeItems.length,
 );
 
 let summaryParts: string[] = $derived(
@@ -44,6 +49,7 @@ let summaryParts: string[] = $derived(
     skillItems.length > 0 ? `${selectedSkillIds.length}/${skillItems.length} skills` : '',
     mcpItems.length > 0 ? `${selectedMcpIds.length}/${mcpItems.length} MCP servers` : '',
     secretItems.length > 0 ? `${selectedSecretIds.length}/${secretItems.length} vault credentials` : '',
+    knowledgeItems.length > 0 ? `${selectedKnowledgeIds.length}/${knowledgeItems.length} knowledges` : '',
   ].filter(Boolean),
 );
 
@@ -57,6 +63,10 @@ function navigateToMcp(): void {
 
 function navigateToSecretVault(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT });
+}
+
+function navigateToKnowledges(): void {
+  handleNavigation({ page: NavigationPage.RAG_ENVIRONMENTS });
 }
 </script>
 
@@ -75,7 +85,7 @@ function navigateToSecretVault(): void {
 
 <div class="rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] px-4 py-3">
   <Expandable expanded={false}>
-    {#snippet title()}<span class="text-sm font-medium text-[var(--pd-modal-text)]">Customize skills, MCP servers, and vault</span>{/snippet}
+    {#snippet title()}<span class="text-sm font-medium text-[var(--pd-modal-text)]">Customize skills, MCP servers, vault, and knowledges</span>{/snippet}
     <div class="space-y-6 pt-3">
       <ChecklistPanel
         title="Skills"
@@ -110,6 +120,18 @@ function navigateToSecretVault(): void {
         emptyMessage="No secrets in your vault yet.">
         {#snippet headerAction()}
           <Button type="secondary" onclick={navigateToSecretVault}>Open Vault</Button>
+        {/snippet}
+      </ChecklistPanel>
+
+      <ChecklistPanel
+        title="Knowledges"
+        subtitle="Optional retrieval context for the agent"
+        icon={faBook}
+        items={knowledgeItems}
+        bind:selected={selectedKnowledgeIds}
+        emptyMessage="No knowledge bases available yet.">
+        {#snippet headerAction()}
+          <Button type="secondary" onclick={navigateToKnowledges}>Manage Knowledges</Button>
         {/snippet}
       </ChecklistPanel>
     </div>

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -185,6 +185,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.SKILL_DETAILS:
       router.goto(`/skills/${encodeURIComponent(request.parameters.name)}/summary`);
       break;
+    case NavigationPage.RAG_ENVIRONMENTS:
+      router.goto('/rag-environments/');
+      break;
     case NavigationPage.RAG_ENVIRONMENT_DETAILS:
       router.goto(`/rag-environments/${encodeURIComponent(request.parameters.name)}/summary`);
       break;

--- a/tests/playwright/src/model/pages/agent-workspace-create-page.ts
+++ b/tests/playwright/src/model/pages/agent-workspace-create-page.ts
@@ -52,7 +52,7 @@ export class AgentWorkspaceCreatePage extends BasePage {
     this.descriptionInput = this.page.getByPlaceholder('Short note for your team (optional)');
     this.agentSelector = this.page.getByRole('region', { name: 'Select Coding Agent' });
     this.toolsSummary = this.page.getByText(/Everything available is included|Expand.*Customize/);
-    this.customizeExpandable = this.page.getByText('Customize skills, MCP servers, and vault');
+    this.customizeExpandable = this.page.getByText('Customize skills, MCP servers, vault, and knowledges');
     this.mcpServersPanel = this.page.getByText('MCP Servers', { exact: true });
     this.fileAccessHeading = this.page.getByText('File System Access');
     this.firstCustomPathInput = this.page.getByPlaceholder('/path/to/allowed/directory').first();


### PR DESCRIPTION
## Summary
- Adds a Knowledges ChecklistPanel to the Tools & Secrets step of the workspace creation wizard
- Shows knowledge bases that have an active MCP server, with database name and source count
- Includes a "Manage Knowledges" button navigating to the RAG environments page
- Adds `NavigationPage.RAG_ENVIRONMENTS` enum and route handler
- UI-only — backend wiring to resolve knowledge bases to MCP commands will follow in a separate PR

Fixes: https://github.com/openkaiden/kaiden/issues/1465

<img width="892" height="960" alt="Screenshot From 2026-04-30 21-07-14" src="https://github.com/user-attachments/assets/9e5d66d2-fdec-4c09-bfee-da4b73ef44ea" />

In order to test create a new database in setting for the milvus extension then create an emtpy knowledge base (some bugs with chunking at the moment) then in the mcp servers youll see the name of your milvus database spawn it and you should be good to go


## Test plan
- [x] Unit tests pass (40 renderer tests)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)