### PR TITLE
feat(workspace): wire knowledge bases to MCP commands in workspace config

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -45,6 +45,22 @@ export type AgentWorkspaceConfiguration = configComponents['schemas']['Workspace
 export type CliInfo = cliComponents['schemas']['Info'];
 
 /**
+ * A URL-based MCP server to attach to the workspace.
+ */
+export interface AgentWorkspaceMcpServer {
+  name: string;
+  url: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * MCP configuration for workspace creation.
+ */
+export interface AgentWorkspaceMcpConfig {
+  servers?: AgentWorkspaceMcpServer[];
+}
+
+/**
  * Options for creating (initializing) a new workspace via `kdn init`.
  */
 export interface AgentWorkspaceCreateOptions {
@@ -53,4 +69,5 @@ export interface AgentWorkspaceCreateOptions {
   runtime?: string;
   name?: string;
   project?: string;
+  mcp?: AgentWorkspaceMcpConfig;
 }

--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -58,6 +58,20 @@ export interface AgentWorkspaceMcpServer {
  */
 export interface AgentWorkspaceMcpConfig {
   servers?: AgentWorkspaceMcpServer[];
+  commands?: AgentWorkspaceMcpCommand[];
+}
+
+/**
+ * Options for creating (initializing) a new workspace via `kdn init`.
+ */
+/**
+ * A command-based MCP server to attach to the workspace.
+ */
+export interface AgentWorkspaceMcpCommand {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
 }
 
 /**
@@ -70,4 +84,5 @@ export interface AgentWorkspaceCreateOptions {
   name?: string;
   project?: string;
   mcp?: AgentWorkspaceMcpConfig;
+  knowledgeBases?: string[];
 }

--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -22,6 +22,7 @@ export enum NavigationPage {
   FLOW_CREATE = 'flow-create',
   FLOW_DETAILS = 'flow-details',
   FLOW_RUN = 'flow-run',
+  MCPS = 'mcps',
   MCP_INSTALL_FROM_REGISTRY = 'mcp-install-from-registry',
   CONTAINERS = 'containers',
   CONTAINER_EXPORT = 'container-export',

--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -65,6 +65,7 @@ export enum NavigationPage {
   AGENT_WORKSPACE_CREATE = 'agent-workspace-create',
   SKILLS = 'skills',
   SKILL_DETAILS = 'skill-details',
+  RAG_ENVIRONMENTS = 'rag-environments',
   RAG_ENVIRONMENT_DETAILS = 'rag-environment-details',
   SECRET_VAULT = 'secret-vault',
   SECRET_VAULT_CREATE = 'secret-vault-create',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -83,6 +83,7 @@ export interface NavigationParameters {
   [NavigationPage.SKILL_DETAILS]: {
     name: string;
   };
+  [NavigationPage.RAG_ENVIRONMENTS]: never;
   [NavigationPage.RAG_ENVIRONMENT_DETAILS]: {
     name: string;
   };

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -70,6 +70,7 @@ export interface NavigationParameters {
     connectionName: string;
     flowId: string;
   };
+  [NavigationPage.MCPS]: never;
   [NavigationPage.MCP_DETAILS]: {
     id: string;
   };

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -26,6 +26,8 @@ import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
+import type { MCPRegistry } from '/@/plugin/mcp/mcp-registry.js';
+import type { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type { Task } from '/@/plugin/tasks/tasks.js';
 import type { Exec } from '/@/plugin/util/exec.js';
@@ -95,6 +97,14 @@ const filesystemMonitoring = {
   createFileSystemWatcher: vi.fn().mockReturnValue(mockWatcher),
 } as unknown as FilesystemMonitoring;
 
+const ragEnvironmentRegistry = {
+  getEnvironment: vi.fn(),
+} as unknown as RagEnvironmentRegistry;
+
+const mcpRegistry = {
+  getInternalMCPServer: vi.fn(),
+} as unknown as MCPRegistry;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(taskManager.createTask).mockReturnValue(mockTask);
@@ -102,7 +112,15 @@ beforeEach(() => {
   mockTask.status = '' as TaskStatus;
   mockTask.error = '';
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
-  manager = new AgentWorkspaceManager(apiSender, ipcHandle, kdnCli, taskManager, filesystemMonitoring);
+  manager = new AgentWorkspaceManager(
+    apiSender,
+    ipcHandle,
+    kdnCli,
+    taskManager,
+    filesystemMonitoring,
+    ragEnvironmentRegistry,
+    mcpRegistry,
+  );
   manager.init();
 });
 
@@ -377,5 +395,76 @@ describe('stop', () => {
     vi.mocked(kdnCli.stopWorkspace).mockRejectedValue(new Error('workspace not found: unknown-id'));
 
     await expect(manager.stop('unknown-id')).rejects.toThrow('workspace not found: unknown-id');
+  });
+});
+
+describe('resolveKnowledgeBases', () => {
+  test('resolves knowledge base to MCP command from package spec', () => {
+    vi.mocked(ragEnvironmentRegistry.getEnvironment).mockReturnValue({
+      name: 'k8s-kb',
+      ragConnection: { name: 'Milvus', providerId: 'milvus' },
+      chunkerId: 'docling',
+      files: [],
+      mcpServer: {
+        id: 'mcp-k8s',
+        name: 'kaiden.milvus.mcp-server-milvus-k8s-kb',
+        description: 'Milvus MCP Server',
+        url: '',
+        infos: { internalProviderId: 'internal', serverId: 'srv-1', remoteId: 0 },
+        tools: {},
+      },
+    });
+    vi.mocked(mcpRegistry.getInternalMCPServer).mockReturnValue({
+      serverId: 'srv-1',
+      name: 'kaiden.milvus.mcp-server-milvus-k8s-kb',
+      description: 'Milvus MCP Server',
+      version: '0.1.1',
+      packages: [
+        {
+          registryType: 'pypi',
+          identifier: 'mcp-server-milvus',
+          version: '0.1.1',
+          runtimeHint: 'uvx',
+          transport: { type: 'stdio' },
+          packageArguments: [
+            { isRequired: true, format: 'string', value: '--milvus-uri', isSecret: false },
+            { isRequired: true, format: 'string', value: 'http://localhost:19530', isSecret: false },
+          ],
+        },
+      ],
+    });
+
+    const result = manager.resolveKnowledgeBases(['k8s-kb']);
+
+    expect(result).toEqual([
+      {
+        name: 'kaiden.milvus.mcp-server-milvus-k8s-kb',
+        command: 'uvx',
+        args: ['mcp-server-milvus', '--milvus-uri', 'http://localhost:19530'],
+      },
+    ]);
+  });
+
+  test('skips knowledge base without MCP server', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(ragEnvironmentRegistry.getEnvironment).mockReturnValue({
+      name: 'no-mcp',
+      ragConnection: { name: 'Milvus', providerId: 'milvus' },
+      chunkerId: 'docling',
+      files: [],
+    });
+
+    const result = manager.resolveKnowledgeBases(['no-mcp']);
+
+    expect(result).toEqual([]);
+  });
+
+  test('skips unknown knowledge base name', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(ragEnvironmentRegistry.getEnvironment).mockReturnValue(undefined);
+
+    const result = manager.resolveKnowledgeBases(['unknown']);
+
+    expect(result).toEqual([]);
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -26,11 +26,14 @@ import { inject, injectable, preDestroy } from 'inversify';
 import { IPCHandle } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
+import { MCPRegistry } from '/@/plugin/mcp/mcp-registry.js';
+import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type {
   AgentWorkspaceConfiguration,
   AgentWorkspaceCreateOptions,
   AgentWorkspaceId,
+  AgentWorkspaceMcpCommand,
   AgentWorkspaceSummary,
   CliInfo,
 } from '/@api/agent-workspace-info.js';
@@ -54,6 +57,10 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly taskManager: TaskManager,
     @inject(FilesystemMonitoring)
     private readonly filesystemMonitoring: FilesystemMonitoring,
+    @inject(RagEnvironmentRegistry)
+    private readonly ragEnvironmentRegistry: RagEnvironmentRegistry,
+    @inject(MCPRegistry)
+    private readonly mcpRegistry: MCPRegistry,
   ) {}
 
   async getCliInfo(): Promise<CliInfo> {
@@ -61,6 +68,19 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   async create(options: AgentWorkspaceCreateOptions): Promise<AgentWorkspaceId> {
+    if (options.knowledgeBases?.length) {
+      const commands = this.resolveKnowledgeBases(options.knowledgeBases);
+      if (commands.length > 0) {
+        options = {
+          ...options,
+          mcp: {
+            ...options.mcp,
+            commands: [...(options.mcp?.commands ?? []), ...commands],
+          },
+        };
+      }
+    }
+
     const suffix = options.name ? ` "${options.name}"` : '';
     const task = this.taskManager.createTask({ title: `Creating workspace${suffix}` });
     task.state = 'running';
@@ -167,6 +187,38 @@ export class AgentWorkspaceManager implements Disposable {
     this.instancesWatcher.onDidChange(notify);
     this.instancesWatcher.onDidCreate(notify);
     this.instancesWatcher.onDidDelete(notify);
+  }
+
+  resolveKnowledgeBases(names: string[]): AgentWorkspaceMcpCommand[] {
+    const commands: AgentWorkspaceMcpCommand[] = [];
+    for (const name of names) {
+      const env = this.ragEnvironmentRegistry.getEnvironment(name);
+      if (!env?.mcpServer) {
+        console.warn(`Knowledge base "${name}" not found or has no MCP server, skipping`);
+        continue;
+      }
+      const serverDetail = this.mcpRegistry.getInternalMCPServer(env.mcpServer.infos.serverId);
+      if (!serverDetail?.packages?.[0]) {
+        console.warn(`No package config found for knowledge base "${name}", skipping`);
+        continue;
+      }
+      const pkg = serverDetail.packages[0];
+      const runtimeHint = pkg.runtimeHint ?? 'uvx';
+      const pkgArgs = (pkg.packageArguments ?? []).filter(a => a.value !== undefined).map(a => String(a.value));
+      const envVars: Record<string, string> = {};
+      for (const v of pkg.environmentVariables ?? []) {
+        if (v.name && v.value !== undefined) {
+          envVars[v.name] = String(v.value);
+        }
+      }
+      commands.push({
+        name: serverDetail.name,
+        command: runtimeHint,
+        args: [pkg.identifier, ...pkgArgs],
+        ...(Object.keys(envVars).length > 0 ? { env: envVars } : {}),
+      });
+    }
+    return commands;
   }
 
   @preDestroy()

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import type { RunError, RunResult } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -29,6 +32,7 @@ import type { SecretCreateOptions, SecretInfo, SecretService } from '/@api/secre
 import { KdnCli } from './kdn-cli.js';
 
 vi.mock(import('/@/plugin/util/exec.js'));
+vi.mock(import('node:fs/promises'));
 
 const KAIDEN_CLI_PATH = '/usr/local/bin/kdn';
 
@@ -227,6 +231,54 @@ describe('create', () => {
     await expect(kdnCli.createWorkspace(defaultOptions)).rejects.toThrow(
       'failed to create runtime instance: exit status 125',
     );
+  });
+
+  test('writes workspace.json with MCP config before calling kdn init', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      mcp: {
+        servers: [{ name: 'github', url: 'https://mcp.github.com/sse' }],
+      },
+    });
+
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/my-project', '.kaiden'), { recursive: true });
+    expect(writeFile).toHaveBeenCalledWith(
+      join('/tmp/my-project', '.kaiden', 'workspace.json'),
+      expect.stringContaining('"github"'),
+      'utf-8',
+    );
+    expect(exec.exec).toHaveBeenCalled();
+  });
+
+  test('does not write workspace.json when no MCP config provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace(defaultOptions);
+
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('merges MCP config into existing workspace.json', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ skills: ['/path/to/skill'] }));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      mcp: {
+        servers: [{ name: 'github', url: 'https://mcp.github.com/sse' }],
+      },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/path/to/skill']);
+    expect(parsed.mcp.servers).toEqual([{ name: 'github', url: 'https://mcp.github.com/sse' }]);
   });
 });
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -16,7 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import type { RunError, RunOptions } from '@openkaiden/api';
+import type { components as workspaceComponents } from '@openkaiden/workspace-configuration';
 import { inject, injectable } from 'inversify';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
@@ -28,6 +32,8 @@ import type {
   CliInfo,
 } from '/@api/agent-workspace-info.js';
 import type { SecretCreateOptions, SecretInfo, SecretName, SecretService } from '/@api/secret-info.js';
+
+type WorkspaceConfiguration = workspaceComponents['schemas']['WorkspaceConfiguration'];
 
 /**
  * Low-level wrapper around the `kdn` CLI binary.
@@ -97,6 +103,8 @@ export class KdnCli {
   }
 
   async createWorkspace(options: AgentWorkspaceCreateOptions): Promise<AgentWorkspaceId> {
+    await this.writeWorkspaceConfig(options);
+
     const cliPath = this.getCliPath();
     const runtime = options.runtime ?? 'podman';
     const args = ['init', options.sourcePath, '--runtime', runtime, '--agent', options.agent, '--output', 'json'];
@@ -115,6 +123,36 @@ export class KdnCli {
       console.error(`kdn failed: ${cliPath} ${args.join(' ')} — ${detail}`);
       throw new Error(detail);
     }
+  }
+
+  async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
+    const mcpServers = options.mcp?.servers;
+    if (!mcpServers?.length) {
+      return;
+    }
+
+    const configDir = join(options.sourcePath, '.kaiden');
+    const configPath = join(configDir, 'workspace.json');
+
+    let existing: WorkspaceConfiguration = {};
+    try {
+      const content = await readFile(configPath, 'utf-8');
+      existing = JSON.parse(content) as WorkspaceConfiguration;
+    } catch {
+      // file doesn't exist yet — start fresh
+    }
+
+    existing.mcp = {
+      ...existing.mcp,
+      servers: mcpServers.map(s => ({
+        name: s.name,
+        url: s.url,
+        ...(s.headers && Object.keys(s.headers).length > 0 ? { headers: s.headers } : {}),
+      })),
+    };
+
+    await mkdir(configDir, { recursive: true });
+    await writeFile(configPath, JSON.stringify(existing, undefined, 2) + '\n', 'utf-8');
   }
 
   async listWorkspaces(): Promise<AgentWorkspaceSummary[]> {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -127,7 +127,8 @@ export class KdnCli {
 
   async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
     const mcpServers = options.mcp?.servers;
-    if (!mcpServers?.length) {
+    const mcpCommands = options.mcp?.commands;
+    if (!mcpServers?.length && !mcpCommands?.length) {
       return;
     }
 
@@ -142,14 +143,24 @@ export class KdnCli {
       // file doesn't exist yet — start fresh
     }
 
-    existing.mcp = {
-      ...existing.mcp,
-      servers: mcpServers.map(s => ({
+    existing.mcp = { ...existing.mcp };
+
+    if (mcpServers?.length) {
+      existing.mcp.servers = mcpServers.map(s => ({
         name: s.name,
         url: s.url,
         ...(s.headers && Object.keys(s.headers).length > 0 ? { headers: s.headers } : {}),
-      })),
-    };
+      }));
+    }
+
+    if (mcpCommands?.length) {
+      existing.mcp.commands = mcpCommands.map(c => ({
+        name: c.name,
+        command: c.command,
+        ...(c.args?.length ? { args: c.args } : {}),
+        ...(c.env && Object.keys(c.env).length > 0 ? { env: c.env } : {}),
+      }));
+    }
 
     await mkdir(configDir, { recursive: true });
     await writeFile(configPath, JSON.stringify(existing, undefined, 2) + '\n', 'utf-8');

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -23,9 +23,11 @@ import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as mcpStore from '/@/stores/mcp-remote-servers';
+import * as ragStore from '/@/stores/rag-environments';
 import * as secretVaultStore from '/@/stores/secret-vault';
 import * as skillsStore from '/@/stores/skills';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
+import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 import type { SkillInfo } from '/@api/skill/skill-info';
 
@@ -35,6 +37,7 @@ vi.mock(import('/@/navigation'));
 vi.mock(import('/@/stores/skills'));
 vi.mock(import('/@/stores/mcp-remote-servers'));
 vi.mock(import('/@/stores/secret-vault'));
+vi.mock(import('/@/stores/rag-environments'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -46,6 +49,7 @@ beforeEach(() => {
   vi.mocked(skillsStore).skillInfos = writable<SkillInfo[]>([]);
   vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([]);
   vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
 });
 
 test('Expect page title displayed', () => {
@@ -221,7 +225,7 @@ async function navigateToToolsSecretsStep(): Promise<void> {
 }
 
 async function expandCustomize(): Promise<void> {
-  await fireEvent.click(screen.getByRole('button', { name: /Customize skills, MCP servers, and vault/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Customize skills, MCP servers, vault, and knowledges/ }));
 }
 
 test('Expect summary card and customize toggle on tools & secrets step', async () => {
@@ -230,7 +234,9 @@ test('Expect summary card and customize toggle on tools & secrets step', async (
   await navigateToToolsSecretsStep();
 
   expect(screen.getByText(/Everything available is included/)).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /Customize skills, MCP servers, and vault/ })).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /Customize skills, MCP servers, vault, and knowledges/ }),
+  ).toBeInTheDocument();
 });
 
 test('Expect secrets section visible after expanding customize', async () => {
@@ -478,6 +484,68 @@ test('Expect createAgentWorkspace called without MCP when no servers exist', asy
       mcp: undefined,
     }),
   );
+});
+
+test('Expect Knowledges section visible after expanding customize', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('Knowledges')).toBeInTheDocument();
+  expect(screen.getByText('Optional retrieval context for the agent')).toBeInTheDocument();
+});
+
+test('Expect Knowledges empty state shown when no knowledge bases available', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('No knowledge bases available yet.')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Manage Knowledges' })).toBeInTheDocument();
+});
+
+test('Expect knowledge bases listed when store has entries with MCP servers', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'kubernetes-knowledges',
+      ragConnection: { name: 'Milvus', providerId: 'milvus' },
+      chunkerId: 'docling',
+      files: [
+        { path: '/docs/k8s.md', status: 'indexed' },
+        { path: '/docs/pods.md', status: 'indexed' },
+      ],
+      mcpServer: {
+        id: 'mcp-k8s',
+        name: 'kaiden.milvus.mcp-server-milvus-kubernetes-knowledges',
+        description: 'Milvus MCP Server',
+        url: '',
+        infos: { internalProviderId: 'internal', serverId: 's1', remoteId: 0 },
+        tools: { search: {} },
+      },
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('kubernetes-knowledges')).toBeInTheDocument();
+  expect(screen.queryByText('No knowledge bases available yet.')).not.toBeInTheDocument();
+});
+
+test('Expect Manage Knowledges button navigates to rag environments page', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+  await fireEvent.click(screen.getByRole('button', { name: 'Manage Knowledges' }));
+
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'rag-environments' });
 });
 
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -375,4 +375,109 @@ test('Expect Manage Skills button navigates to skills page', async () => {
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'skills' });
 });
 
+test('Expect MCP section visible after expanding customize', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('MCP Servers')).toBeInTheDocument();
+  expect(screen.getByText('Connect to Model Context Protocol servers for extended capabilities')).toBeInTheDocument();
+});
+
+test('Expect MCP empty state shown when no servers connected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('No MCP servers connected yet.')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Add Server' })).toBeInTheDocument();
+});
+
+test('Expect MCP servers listed when store has entries', async () => {
+  vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([
+    {
+      id: 'mcp-1',
+      name: 'GitHub MCP',
+      description: 'Repos, issues & PRs',
+      url: 'https://mcp.github.com/sse',
+      infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+      tools: { 'list-repos': {}, 'create-issue': {} },
+    },
+    {
+      id: 'mcp-2',
+      name: 'RHEL MCP',
+      description: 'System management',
+      url: 'https://mcp.redhat.com/sse',
+      infos: { internalProviderId: 'p2', serverId: 's2', remoteId: 2 },
+      tools: {},
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+
+  expect(screen.getByText('GitHub MCP')).toBeInTheDocument();
+  expect(screen.getByText('RHEL MCP')).toBeInTheDocument();
+  expect(screen.queryByText('No MCP servers connected yet.')).not.toBeInTheDocument();
+});
+
+test('Expect Add Server button navigates to MCP page', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+  await expandCustomize();
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Server' }));
+
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'mcps' });
+});
+
+test('Expect createAgentWorkspace called with MCP server data', async () => {
+  vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([
+    {
+      id: 'mcp-1',
+      name: 'GitHub MCP',
+      description: 'Repos & PRs',
+      url: 'https://mcp.github.com/sse',
+      infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+      tools: { 'list-repos': {} },
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mcp: {
+        servers: [{ name: 'GitHub MCP', url: 'https://mcp.github.com/sse' }],
+      },
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called without MCP when no servers exist', async () => {
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mcp: undefined,
+    }),
+  );
+});
+
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -548,4 +548,36 @@ test('Expect Manage Knowledges button navigates to rag environments page', async
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'rag-environments' });
 });
 
+test('Expect createAgentWorkspace called with knowledge base names', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'k8s-kb',
+      ragConnection: { name: 'Milvus', providerId: 'milvus' },
+      chunkerId: 'docling',
+      files: [],
+      mcpServer: {
+        id: 'mcp-k8s',
+        name: 'kaiden.milvus.mcp-server-milvus-k8s-kb',
+        description: 'Milvus MCP Server',
+        url: '',
+        infos: { internalProviderId: 'internal', serverId: 's1', remoteId: 0 },
+        tools: {},
+      },
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      knowledgeBases: ['k8s-kb'],
+    }),
+  );
+});
+
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -13,7 +13,6 @@ import AgentWorkspaceCreateStepWorkspace from '/@/lib/agent-workspaces/AgentWork
 import type { CardSelectorOption } from '/@/lib/ui/CardSelector.svelte';
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
-import type { ScrollableCardItem } from '/@/lib/ui/ScrollableCardSelector.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
@@ -94,8 +93,16 @@ let skillItems: ChecklistItem[] = $derived(
     group: s.managed ? 'Custom' : 'Pre-built',
   })),
 );
-let mcpItems: ScrollableCardItem[] = $derived(
-  $mcpRemoteServerInfos.map(m => ({ id: m.id, name: m.name, description: m.description })),
+let mcpItems: ChecklistItem[] = $derived(
+  $mcpRemoteServerInfos.map(m => {
+    const toolCount = Object.keys(m.tools).length;
+    const toolsLabel = toolCount > 0 ? `${toolCount} tool${toolCount !== 1 ? 's' : ''}` : '';
+    return {
+      id: m.id,
+      name: m.name,
+      description: [toolsLabel, m.description].filter(Boolean).join(' · '),
+    };
+  }),
 );
 
 // --- Form state ---
@@ -199,10 +206,15 @@ async function startWorkspace(): Promise<void> {
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 
   try {
+    const selectedServers = $mcpRemoteServerInfos
+      .filter(m => selectedMcpIds.includes(m.id))
+      .map(m => ({ name: m.name, url: m.url }));
+
     await window.createAgentWorkspace({
       sourcePath,
       agent: selectedAgent,
       name: sessionName,
+      mcp: selectedServers.length > 0 ? { servers: selectedServers } : undefined,
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -16,6 +16,7 @@ import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
+import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
 import { NavigationPage } from '/@api/navigation-page';
@@ -104,6 +105,19 @@ let mcpItems: ChecklistItem[] = $derived(
     };
   }),
 );
+let knowledgeItems: ChecklistItem[] = $derived(
+  $ragEnvironments
+    .filter(r => r.mcpServer !== undefined)
+    .map(r => {
+      const sourceCount = r.files.length;
+      const sourcesLabel = sourceCount > 0 ? `${sourceCount} source${sourceCount !== 1 ? 's' : ''}` : '';
+      return {
+        id: r.name,
+        name: r.name,
+        description: [r.ragConnection.name, sourcesLabel].filter(Boolean).join(' · '),
+      };
+    }),
+);
 
 // --- Form state ---
 let sourcePath = $state('');
@@ -114,6 +128,7 @@ let selectedFileAccess = $state('workspace');
 let selectedSkillIds = $derived(skillItems.map(s => s.id));
 let selectedMcpIds = $derived(mcpItems.map(m => m.id));
 let selectedSecretIds = $derived($secretVaultInfos.map(s => s.id));
+let selectedKnowledgeIds = $derived(knowledgeItems.map(k => k.id));
 let customPaths = $state<string[]>(['']);
 
 // --- Step 1 UI state ---
@@ -260,7 +275,9 @@ async function startWorkspace(): Promise<void> {
                 bind:selectedSkillIds
                 {mcpItems}
                 bind:selectedMcpIds
-                bind:selectedSecretIds />
+                bind:selectedSecretIds
+                {knowledgeItems}
+                bind:selectedKnowledgeIds />
             {:else if currentStepId === 'filesystem'}
               <AgentWorkspaceCreateStepFileSystem
                 {fileAccessOptions}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -230,6 +230,7 @@ async function startWorkspace(): Promise<void> {
       agent: selectedAgent,
       name: sessionName,
       mcp: selectedServers.length > 0 ? { servers: selectedServers } : undefined,
+      knowledgeBases: selectedKnowledgeIds.length > 0 ? selectedKnowledgeIds : undefined,
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 import { faKey, faServer, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { Button, Expandable } from '@podman-desktop/ui-svelte';
-import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import ChecklistPanel from '/@/lib/ui/ChecklistPanel.svelte';
-import type { ScrollableCardItem } from '/@/lib/ui/ScrollableCardSelector.svelte';
-import ScrollableCardSelector from '/@/lib/ui/ScrollableCardSelector.svelte';
 import { handleNavigation } from '/@/navigation';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { NavigationPage } from '/@api/navigation-page';
@@ -14,7 +11,7 @@ import { NavigationPage } from '/@api/navigation-page';
 interface Props {
   skillItems: ChecklistItem[];
   selectedSkillIds: string[];
-  mcpItems: ScrollableCardItem[];
+  mcpItems: ChecklistItem[];
   selectedMcpIds: string[];
   selectedSecretIds: string[];
 }
@@ -53,6 +50,10 @@ function navigateToSkills(): void {
   handleNavigation({ page: NavigationPage.SKILLS });
 }
 
+function navigateToMcps(): void {
+  handleNavigation({ page: NavigationPage.MCPS });
+}
+
 function navigateToSecretVault(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT });
 }
@@ -87,20 +88,17 @@ function navigateToSecretVault(): void {
         {/snippet}
       </ChecklistPanel>
 
-      {#if mcpItems.length > 0}
-        <div>
-          <div class="flex items-center gap-3 mb-5">
-            <div class="w-9 h-9 rounded-[9px] flex items-center justify-center bg-[var(--pd-label-secondary-bg)] text-[var(--pd-label-secondary-text)]">
-              <Icon icon={faServer} class="text-xl" />
-            </div>
-            <div>
-              <span class="text-lg font-semibold text-[var(--pd-modal-text)]">MCP Servers</span>
-              <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 mt-0.5">Connect to Model Context Protocol servers for extended capabilities</p>
-            </div>
-          </div>
-          <ScrollableCardSelector items={mcpItems} bind:selected={selectedMcpIds} placeholder="Search MCP servers..." />
-        </div>
-      {/if}
+      <ChecklistPanel
+        title="MCP Servers"
+        subtitle="Connect to Model Context Protocol servers for extended capabilities"
+        icon={faServer}
+        items={mcpItems}
+        bind:selected={selectedMcpIds}
+        emptyMessage="No MCP servers connected yet.">
+        {#snippet headerAction()}
+          <Button type="secondary" onclick={navigateToMcps}>Add Server</Button>
+        {/snippet}
+      </ChecklistPanel>
 
       <ChecklistPanel
         title="Secret Vault"

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faKey, faServer, faWrench } from '@fortawesome/free-solid-svg-icons';
+import { faBook, faKey, faServer, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { Button, Expandable } from '@podman-desktop/ui-svelte';
 
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
@@ -14,6 +14,8 @@ interface Props {
   mcpItems: ChecklistItem[];
   selectedMcpIds: string[];
   selectedSecretIds: string[];
+  knowledgeItems: ChecklistItem[];
+  selectedKnowledgeIds: string[];
 }
 
 let {
@@ -22,6 +24,8 @@ let {
   mcpItems,
   selectedMcpIds = $bindable(),
   selectedSecretIds = $bindable(),
+  knowledgeItems,
+  selectedKnowledgeIds = $bindable(),
 }: Props = $props();
 
 let secretItems: ChecklistItem[] = $derived(
@@ -35,7 +39,8 @@ let secretItems: ChecklistItem[] = $derived(
 let allIncluded: boolean = $derived(
   selectedSkillIds.length === skillItems.length &&
     selectedMcpIds.length === mcpItems.length &&
-    selectedSecretIds.length === secretItems.length,
+    selectedSecretIds.length === secretItems.length &&
+    selectedKnowledgeIds.length === knowledgeItems.length,
 );
 
 let summaryParts: string[] = $derived(
@@ -43,6 +48,7 @@ let summaryParts: string[] = $derived(
     skillItems.length > 0 ? `${selectedSkillIds.length}/${skillItems.length} skills` : '',
     mcpItems.length > 0 ? `${selectedMcpIds.length}/${mcpItems.length} MCP servers` : '',
     secretItems.length > 0 ? `${selectedSecretIds.length}/${secretItems.length} vault credentials` : '',
+    knowledgeItems.length > 0 ? `${selectedKnowledgeIds.length}/${knowledgeItems.length} knowledges` : '',
   ].filter(Boolean),
 );
 
@@ -56,6 +62,10 @@ function navigateToMcps(): void {
 
 function navigateToSecretVault(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT });
+}
+
+function navigateToKnowledges(): void {
+  handleNavigation({ page: NavigationPage.RAG_ENVIRONMENTS });
 }
 </script>
 
@@ -74,7 +84,7 @@ function navigateToSecretVault(): void {
 
 <div class="rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] px-4 py-3">
   <Expandable expanded={false}>
-    {#snippet title()}<span class="text-sm font-medium text-[var(--pd-modal-text)]">Customize skills, MCP servers, and vault</span>{/snippet}
+    {#snippet title()}<span class="text-sm font-medium text-[var(--pd-modal-text)]">Customize skills, MCP servers, vault, and knowledges</span>{/snippet}
     <div class="space-y-6 pt-3">
       <ChecklistPanel
         title="Skills"
@@ -109,6 +119,18 @@ function navigateToSecretVault(): void {
         emptyMessage="No secrets in your vault yet.">
         {#snippet headerAction()}
           <Button type="secondary" onclick={navigateToSecretVault}>Open Vault</Button>
+        {/snippet}
+      </ChecklistPanel>
+
+      <ChecklistPanel
+        title="Knowledges"
+        subtitle="Optional retrieval context for the agent"
+        icon={faBook}
+        items={knowledgeItems}
+        bind:selected={selectedKnowledgeIds}
+        emptyMessage="No knowledge bases available yet.">
+        {#snippet headerAction()}
+          <Button type="secondary" onclick={navigateToKnowledges}>Manage Knowledges</Button>
         {/snippet}
       </ChecklistPanel>
     </div>

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -188,6 +188,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.SKILL_DETAILS:
       router.goto(`/skills/${encodeURIComponent(request.parameters.name)}/summary`);
       break;
+    case NavigationPage.RAG_ENVIRONMENTS:
+      router.goto('/rag-environments/');
+      break;
     case NavigationPage.RAG_ENVIRONMENT_DETAILS:
       router.goto(`/rag-environments/${encodeURIComponent(request.parameters.name)}/summary`);
       break;

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -58,6 +58,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
         `/flows/${encodeURIComponent(request.parameters.providerId)}/${encodeURIComponent(request.parameters.connectionName)}/${encodeURIComponent(request.parameters.flowId)}/run`,
       );
       break;
+    case NavigationPage.MCPS:
+      router.goto('/mcps/');
+      break;
     case NavigationPage.MCP_INSTALL_FROM_REGISTRY:
       router.goto(`/mcp-install-from-registry/${encodeURIComponent(request.parameters.serverId)}`);
       break;


### PR DESCRIPTION
## Summary
- Resolves selected knowledge base names to MCP command entries via `RagEnvironmentRegistry` and `MCPRegistry`
- Writes `mcp.commands` entries to `.kaiden/workspace.json` so the kdn CLI configures the agent with the Milvus MCP server
- Adds `knowledgeBases?: string[]` to `AgentWorkspaceCreateOptions` and `AgentWorkspaceMcpCommand` type
- Passes `selectedKnowledgeIds` from the UI to `createAgentWorkspace()`

**Depends on:** #1519 (knowledge base UI section)

## Test plan
- [x] Unit tests pass (124 total: 41 renderer, 38 manager, 45 kdn-cli)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)