### PR TITLE
feat(workspace): wire skills from create wizard to workspace config

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -53,4 +53,5 @@ export interface AgentWorkspaceCreateOptions {
   runtime?: string;
   name?: string;
   project?: string;
+  skills?: string[];
 }

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import type { RunError, RunResult } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -29,6 +32,7 @@ import type { SecretCreateOptions, SecretInfo, SecretService } from '/@api/secre
 import { KdnCli } from './kdn-cli.js';
 
 vi.mock(import('/@/plugin/util/exec.js'));
+vi.mock(import('node:fs/promises'));
 
 const KAIDEN_CLI_PATH = '/usr/local/bin/kdn';
 
@@ -227,6 +231,48 @@ describe('create', () => {
     await expect(kdnCli.createWorkspace(defaultOptions)).rejects.toThrow(
       'failed to create runtime instance: exit status 125',
     );
+  });
+
+  test('writes workspace.json with skills before calling kdn init', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/kubernetes', '/home/user/.kaiden/skills/code-review'],
+    });
+
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/my-project', '.kaiden'), { recursive: true });
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes', '/home/user/.kaiden/skills/code-review']);
+    expect(exec.exec).toHaveBeenCalled();
+  });
+
+  test('does not write workspace.json when no skills provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace(defaultOptions);
+
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('merges skills into existing workspace.json', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ mcp: { servers: [] } }));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/kubernetes'],
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mcp).toEqual({ servers: [] });
+    expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes']);
   });
 });
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -16,7 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import type { RunError, RunOptions } from '@openkaiden/api';
+import type { components as workspaceComponents } from '@openkaiden/workspace-configuration';
 import { inject, injectable } from 'inversify';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
@@ -28,6 +32,8 @@ import type {
   CliInfo,
 } from '/@api/agent-workspace-info.js';
 import type { SecretCreateOptions, SecretInfo, SecretName, SecretService } from '/@api/secret-info.js';
+
+type WorkspaceConfiguration = workspaceComponents['schemas']['WorkspaceConfiguration'];
 
 /**
  * Low-level wrapper around the `kdn` CLI binary.
@@ -97,6 +103,8 @@ export class KdnCli {
   }
 
   async createWorkspace(options: AgentWorkspaceCreateOptions): Promise<AgentWorkspaceId> {
+    await this.writeWorkspaceConfig(options);
+
     const cliPath = this.getCliPath();
     const runtime = options.runtime ?? 'podman';
     const args = ['init', options.sourcePath, '--runtime', runtime, '--agent', options.agent, '--output', 'json'];
@@ -115,6 +123,28 @@ export class KdnCli {
       console.error(`kdn failed: ${cliPath} ${args.join(' ')} — ${detail}`);
       throw new Error(detail);
     }
+  }
+
+  async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
+    if (!options.skills?.length) {
+      return;
+    }
+
+    const configDir = join(options.sourcePath, '.kaiden');
+    const configPath = join(configDir, 'workspace.json');
+
+    let existing: WorkspaceConfiguration = {};
+    try {
+      const content = await readFile(configPath, 'utf-8');
+      existing = JSON.parse(content) as WorkspaceConfiguration;
+    } catch {
+      // file doesn't exist yet — start fresh
+    }
+
+    existing.skills = options.skills;
+
+    await mkdir(configDir, { recursive: true });
+    await writeFile(configPath, JSON.stringify(existing, undefined, 2) + '\n', 'utf-8');
   }
 
   async listWorkspaces(): Promise<AgentWorkspaceSummary[]> {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -375,4 +375,51 @@ test('Expect Manage Skills button navigates to skills page', async () => {
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'skills' });
 });
 
+test('Expect createAgentWorkspace called with skill paths', async () => {
+  vi.mocked(skillsStore).skillInfos = writable<SkillInfo[]>([
+    {
+      name: 'kubernetes',
+      description: 'Deploy & manage clusters',
+      path: '/home/user/.kaiden/skills/kubernetes',
+      enabled: true,
+      managed: false,
+    },
+    {
+      name: 'code-review',
+      description: 'Analyze code quality',
+      path: '/home/user/.kaiden/skills/code-review',
+      enabled: true,
+      managed: true,
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      skills: ['/home/user/.kaiden/skills/kubernetes', '/home/user/.kaiden/skills/code-review'],
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called without skills when none available', async () => {
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      skills: undefined,
+    }),
+  );
+});
+
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -199,10 +199,13 @@ async function startWorkspace(): Promise<void> {
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 
   try {
+    const selectedSkillPaths = $skillInfos.filter(s => selectedSkillIds.includes(s.name)).map(s => s.path);
+
     await window.createAgentWorkspace({
       sourcePath,
       agent: selectedAgent,
       name: sessionName,
+      skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);


### PR DESCRIPTION
## Summary
- Wires skill selections from the workspace creation wizard through to `.kaiden/workspace.json` so the `kdn` CLI can mount them into the container during `kdn init`
- Adds `skills?: string[]` to `AgentWorkspaceCreateOptions`
- Adds `writeWorkspaceConfig()` to `KdnCli` that writes skill paths to workspace.json, merging into existing config
- Passes selected skill paths (from `SkillInfo.path`) from the UI to `createAgentWorkspace()`

## Test plan
- [x] Unit tests pass (77 total: 45 kdn-cli, 32 renderer)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)