### PR TITLE
refactor(workspace-networking): aligned networking step with the mockup

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -489,4 +489,62 @@ test('Expect Manage Knowledges button navigates to rag environments page', async
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'rag-environments' });
 });
 
+async function navigateToNetworkingStep(): Promise<void> {
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  // Workspace → Agent & Model → Tools & Secrets → File System → Networking
+  for (let i = 0; i < 4; i++) {
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  }
+}
+
+test('Expect networking step shows Network Policy heading', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect(screen.getByText('Network Policy')).toBeInTheDocument();
+  expect(screen.getByText('Outbound network for this workspace sandbox')).toBeInTheDocument();
+});
+
+test('Expect all four network options rendered', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect(screen.getByRole('button', { name: 'Deny All' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Developer Preset' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Agent mode' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Unrestricted' })).toBeInTheDocument();
+});
+
+test('Expect Developer Preset selected by default on networking step', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).toBeChecked();
+  expect(screen.getByRole('radio', { name: 'Use Deny All' })).not.toBeChecked();
+});
+
+test('Expect allowlists hint text displayed on networking step', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect(screen.getByText(/Fine-grained host allowlists and static egress rules/)).toBeInTheDocument();
+});
+
+test('Expect selecting a different network option updates the radio', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Unrestricted' }));
+
+  expect(screen.getByRole('radio', { name: 'Use Unrestricted' })).toBeChecked();
+  expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).not.toBeChecked();
+});
+
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -7,6 +7,7 @@ import { toast } from 'svelte-sonner';
 import AgentWorkspaceCreateStepAgentModel from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte';
 import type { FileAccessOption } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
 import AgentWorkspaceCreateStepFileSystem from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
+import type { NetworkAccessOption } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte';
 import AgentWorkspaceCreateStepNetworking from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte';
 import AgentWorkspaceCreateStepToolsSecrets from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte';
 import AgentWorkspaceCreateStepWorkspace from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte';
@@ -79,6 +80,38 @@ const fileAccessOptions: FileAccessOption[] = [
   },
 ];
 
+const networkOptions: NetworkAccessOption[] = [
+  {
+    value: 'blocked',
+    name: 'Deny All',
+    description: 'No outbound HTTP/HTTPS from the sandbox.',
+    access: 'None',
+    notes: 'Strict',
+  },
+  {
+    value: 'registries',
+    name: 'Developer Preset',
+    description: 'Allow npm, PyPI, and similar registries — not arbitrary public hosts.',
+    access: 'Registries',
+    notes: 'Balanced default',
+    badge: 'Recommended',
+  },
+  {
+    value: 'agent_mode',
+    name: 'Agent mode',
+    description: 'The agent requests each outbound access; you approve before traffic leaves the sandbox.',
+    access: 'Per request',
+    notes: 'Human in the loop',
+  },
+  {
+    value: 'open',
+    name: 'Unrestricted',
+    description: 'Permit all outbound traffic. Best for trusted dev setups.',
+    access: 'All hosts',
+    notes: 'Trusted setups',
+  },
+];
+
 const wizardSteps = [
   { id: 'workspace', title: 'Workspace' },
   { id: 'agent-model', title: 'Agent & Model' },
@@ -120,6 +153,7 @@ let sessionName = $state('');
 let description = $state('');
 let selectedAgent = $state('opencode');
 let selectedFileAccess = $state('workspace');
+let selectedNetwork = $state('registries');
 let selectedSkillIds = $derived(skillItems.map(s => s.id));
 let selectedMcpIds = $derived(mcpItems.map(m => m.id));
 let selectedSecretIds = $derived($secretVaultInfos.map(s => s.id));
@@ -281,7 +315,7 @@ async function startWorkspace(): Promise<void> {
                 onRemoveCustomPath={removeCustomPath}
                 onUpdateCustomPath={updateCustomPath} />
             {:else if currentStepId === 'networking'}
-              <AgentWorkspaceCreateStepNetworking />
+              <AgentWorkspaceCreateStepNetworking {networkOptions} bind:selectedNetwork />
             {/if}
           </div>
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
@@ -1,1 +1,74 @@
-<!-- TODO: network mode and allowed hosts configuration -->
+<script lang="ts">
+import { faShieldHalved } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+export interface NetworkAccessOption {
+  value: string;
+  name: string;
+  description: string;
+  access: string;
+  notes: string;
+  badge?: string;
+}
+
+interface Props {
+  networkOptions: NetworkAccessOption[];
+  selectedNetwork: string;
+}
+
+let { networkOptions, selectedNetwork = $bindable() }: Props = $props();
+
+function selectOption(value: string): void {
+  selectedNetwork = value;
+}
+</script>
+
+<div class="flex items-center gap-3 mb-5">
+  <div class="w-9 h-9 rounded-[9px] flex items-center justify-center bg-[var(--pd-label-quaternary-bg)] text-[var(--pd-label-quaternary-text)]">
+    <Icon icon={faShieldHalved} class="text-xl" />
+  </div>
+  <div>
+    <span class="text-lg font-semibold text-[var(--pd-modal-text)]">Network Policy</span>
+    <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 mt-0.5">Outbound network for this workspace sandbox</p>
+  </div>
+</div>
+
+<div class="rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] overflow-hidden">
+  {#each networkOptions as option, idx (option.value)}
+    {#if idx > 0}
+      <div class="mx-3 border-t border-[var(--pd-content-card-border)] opacity-30"></div>
+    {/if}
+    <button
+      class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
+        {selectedNetwork === option.value
+          ? 'bg-[var(--pd-content-card-hover-inset-bg)]'
+          : 'hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+      onclick={selectOption.bind(null, option.value)}
+      aria-label={option.name}>
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2">
+          <span class="text-[13px] font-medium text-[var(--pd-table-body-text-highlight)]">{option.name}</span>
+          {#if option.badge}
+            <span class="text-[10px] text-[var(--pd-table-body-text)] bg-[var(--pd-content-card-inset-bg)] rounded px-1.5 py-0.5">{option.badge}</span>
+          {/if}
+        </div>
+        <div class="text-[11px] text-[var(--pd-table-body-text)] mt-0.5">{option.description}</div>
+      </div>
+      <div class="flex items-center gap-4 flex-shrink-0 text-xs text-[var(--pd-table-body-text)]">
+        <span class="w-20">{option.access}</span>
+        <span class="w-24">{option.notes}</span>
+        <input
+          type="radio"
+          name="networkAccess"
+          value={option.value}
+          checked={selectedNetwork === option.value}
+          aria-label="Use {option.name}"
+          class="accent-[var(--pd-button-primary-bg)] w-4 h-4 cursor-pointer pointer-events-none" />
+      </div>
+    </button>
+  {/each}
+</div>
+
+<p class="mt-4 text-xs text-[var(--pd-content-card-text)] opacity-70 leading-relaxed max-w-2xl">
+  <strong class="text-[var(--pd-modal-text)]">Allowlists and more</strong> — Fine-grained host allowlists and static egress rules live in project or workspace settings when you need them.
+</p>


### PR DESCRIPTION
This PR updates the networking step to match the mockup 

<img width="1178" height="956" alt="Screenshot 2026-04-30 at 10 02 58" src="https://github.com/user-attachments/assets/dc131963-e896-4b79-aaea-93a5e4121418" />

Closes https://github.com/openkaiden/kaiden/issues/1467