### PR TITLE
refactor(Secret list): aligned secret list with the mockup

### DIFF
--- a/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
@@ -11,6 +11,7 @@ import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 import SecretVaultAccount from './columns/SecretVaultAccount.svelte';
 import SecretVaultIntegration from './columns/SecretVaultIntegration.svelte';
 import SecretVaultMaskedSecret from './columns/SecretVaultMaskedSecret.svelte';
+import { isKnownService, KNOWN_GROUP_LABEL, OTHER_GROUP_LABEL } from './secret-vault-utils';
 import SecretVaultEmptyScreen from './SecretVaultEmptyScreen.svelte';
 
 type SecretVaultSelectable = SecretVaultInfo & { selected: boolean };
@@ -46,6 +47,12 @@ const secrets: SecretVaultSelectable[] = $derived(
   $filteredSecretVaultInfos.map(secret => ({ ...secret, selected: false })),
 );
 
+const knownSecrets: SecretVaultSelectable[] = $derived(secrets.filter(s => isKnownService(s.type)));
+
+const otherSecrets: SecretVaultSelectable[] = $derived(secrets.filter(s => !isKnownService(s.type)));
+
+const hasBothGroups: boolean = $derived(knownSecrets.length > 0 && otherSecrets.length > 0);
+
 function addSecret(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT_CREATE });
 }
@@ -66,7 +73,7 @@ function addSecret(): void {
         {:else}
           <SecretVaultEmptyScreen onclick={addSecret} />
         {/if}
-      {:else}
+      {:else if !hasBothGroups}
         <Table
           kind="secret-vault"
           data={secrets}
@@ -74,6 +81,29 @@ function addSecret(): void {
           row={row}
           defaultSortColumn="Integration"
         />
+      {:else}
+        <div class="flex flex-col w-full">
+          <div class="mx-5 pt-2 text-sm font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]">{KNOWN_GROUP_LABEL}</div>
+          <div class="flex min-w-full">
+            <Table
+              kind="secret-vault"
+              data={knownSecrets}
+              columns={columns}
+              row={row}
+              defaultSortColumn="Integration"
+            />
+          </div>
+          <div class="mx-5 pt-2 text-sm font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]">{OTHER_GROUP_LABEL}</div>
+          <div class="flex min-w-full">
+            <Table
+              kind="secret-vault"
+              data={otherSecrets}
+              columns={columns}
+              row={row}
+              defaultSortColumn="Integration"
+            />
+          </div>
+        </div>
       {/if}
     </div>
   {/snippet}

--- a/packages/renderer/src/lib/secret-vault/secret-vault-utils.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/secret-vault-utils.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  getSecretGroupLabel,
+  isKnownService,
+  KNOWN_GROUP_LABEL,
+  KNOWN_SERVICES,
+  OTHER_GROUP_LABEL,
+} from './secret-vault-utils';
+
+describe('KNOWN_SERVICES', () => {
+  test('contains expected service names', () => {
+    expect(KNOWN_SERVICES.has('github')).toBeTruthy();
+    expect(KNOWN_SERVICES.has('gemini')).toBeTruthy();
+    expect(KNOWN_SERVICES.has('anthropic')).toBeTruthy();
+  });
+
+  test('does not contain other or unknown types', () => {
+    expect(KNOWN_SERVICES.has('other')).toBeFalsy();
+    expect(KNOWN_SERVICES.has('unknown')).toBeFalsy();
+  });
+});
+
+describe('isKnownService', () => {
+  test.each(['github', 'gemini', 'anthropic'])('returns true for known service %s', type => {
+    expect(isKnownService(type)).toBeTruthy();
+  });
+
+  test.each(['other', 'custom', 'unknown'])('returns false for non-known type %s', type => {
+    expect(isKnownService(type)).toBeFalsy();
+  });
+
+  test('returns false when called without argument', () => {
+    expect(isKnownService()).toBeFalsy();
+  });
+});
+
+describe('getSecretGroupLabel', () => {
+  test.each(['github', 'gemini', 'anthropic'])('returns known group label for %s', type => {
+    expect(getSecretGroupLabel(type)).toBe(KNOWN_GROUP_LABEL);
+  });
+
+  test.each(['other', 'custom'])('returns other group label for %s', type => {
+    expect(getSecretGroupLabel(type)).toBe(OTHER_GROUP_LABEL);
+  });
+
+  test('returns other group label when called without argument', () => {
+    expect(getSecretGroupLabel()).toBe(OTHER_GROUP_LABEL);
+  });
+});

--- a/packages/renderer/src/lib/secret-vault/secret-vault-utils.ts
+++ b/packages/renderer/src/lib/secret-vault/secret-vault-utils.ts
@@ -34,6 +34,18 @@ const SERVICE_LABELS: Record<string, string> = {
 
 export const OTHER_TYPE = 'other';
 
+export const KNOWN_SERVICES = new Set(Object.keys(SERVICE_LABELS));
+export const KNOWN_GROUP_LABEL = 'Built-in integrations';
+export const OTHER_GROUP_LABEL = 'Other secrets';
+
+export function isKnownService(type?: string): boolean {
+  return !!type && KNOWN_SERVICES.has(type);
+}
+
+export function getSecretGroupLabel(type?: string): string {
+  return isKnownService(type) ? KNOWN_GROUP_LABEL : OTHER_GROUP_LABEL;
+}
+
 export function getServiceIcon(name: string): IconDefinition {
   return SERVICE_ICONS[name] ?? faPlug;
 }


### PR DESCRIPTION
Aligns the secret list with the mockup 

Inbuilt + generic secrets
<img width="1012" height="827" alt="Screenshot 2026-04-30 at 16 07 58" src="https://github.com/user-attachments/assets/236f704c-f195-422c-a993-757d22ed9dbd" />

Only inbuilt
<img width="1188" height="827" alt="Screenshot 2026-04-30 at 16 12 28" src="https://github.com/user-attachments/assets/97b45454-dae9-4653-ab21-a3e609445017" />

Open to discuss the label for each table 

Closes https://github.com/openkaiden/kaiden/issues/1522