### PR TITLE
chore(gha): reduce triggers for pr-check

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -20,7 +20,6 @@ name: pr-check
 on:
   merge_group:
   pull_request:
-    types: [labeled, synchronize, opened, ready_for_review, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
Removed 'types' from pull_request event triggers.

it was triggering PR on label changes