### PR TITLE
refactor(workspace): align MCP server UI in workspace creation to skills and secrets

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -13,7 +13,6 @@ import AgentWorkspaceCreateStepWorkspace from '/@/lib/agent-workspaces/AgentWork
 import type { CardSelectorOption } from '/@/lib/ui/CardSelector.svelte';
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
-import type { ScrollableCardItem } from '/@/lib/ui/ScrollableCardSelector.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
@@ -94,7 +93,7 @@ let skillItems: ChecklistItem[] = $derived(
     group: s.managed ? 'Custom' : 'Pre-built',
   })),
 );
-let mcpItems: ScrollableCardItem[] = $derived(
+let mcpItems: ChecklistItem[] = $derived(
   $mcpRemoteServerInfos.map(m => ({ id: m.id, name: m.name, description: m.description })),
 );
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 import { faKey, faServer, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { Button, Expandable } from '@podman-desktop/ui-svelte';
-import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { router } from 'tinro';
 
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import ChecklistPanel from '/@/lib/ui/ChecklistPanel.svelte';
-import type { ScrollableCardItem } from '/@/lib/ui/ScrollableCardSelector.svelte';
-import ScrollableCardSelector from '/@/lib/ui/ScrollableCardSelector.svelte';
 import { handleNavigation } from '/@/navigation';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { NavigationPage } from '/@api/navigation-page';
@@ -14,7 +12,7 @@ import { NavigationPage } from '/@api/navigation-page';
 interface Props {
   skillItems: ChecklistItem[];
   selectedSkillIds: string[];
-  mcpItems: ScrollableCardItem[];
+  mcpItems: ChecklistItem[];
   selectedMcpIds: string[];
   selectedSecretIds: string[];
 }
@@ -53,6 +51,10 @@ function navigateToSkills(): void {
   handleNavigation({ page: NavigationPage.SKILLS });
 }
 
+function navigateToMcp(): void {
+  router.goto('/mcps');
+}
+
 function navigateToSecretVault(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT });
 }
@@ -87,20 +89,17 @@ function navigateToSecretVault(): void {
         {/snippet}
       </ChecklistPanel>
 
-      {#if mcpItems.length > 0}
-        <div>
-          <div class="flex items-center gap-3 mb-5">
-            <div class="w-9 h-9 rounded-[9px] flex items-center justify-center bg-[var(--pd-label-secondary-bg)] text-[var(--pd-label-secondary-text)]">
-              <Icon icon={faServer} class="text-xl" />
-            </div>
-            <div>
-              <span class="text-lg font-semibold text-[var(--pd-modal-text)]">MCP Servers</span>
-              <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 mt-0.5">Connect to Model Context Protocol servers for extended capabilities</p>
-            </div>
-          </div>
-          <ScrollableCardSelector items={mcpItems} bind:selected={selectedMcpIds} placeholder="Search MCP servers..." />
-        </div>
-      {/if}
+      <ChecklistPanel
+        title="MCP Servers"
+        subtitle="Connect to Model Context Protocol servers for extended capabilities"
+        icon={faServer}
+        items={mcpItems}
+        bind:selected={selectedMcpIds}
+        emptyMessage="No MCP servers available yet.">
+        {#snippet headerAction()}
+          <Button type="secondary" onclick={navigateToMcp}>Manage Servers</Button>
+        {/snippet}
+      </ChecklistPanel>
 
       <ChecklistPanel
         title="Secret Vault"

--- a/tests/playwright/src/model/pages/agent-workspace-create-page.ts
+++ b/tests/playwright/src/model/pages/agent-workspace-create-page.ts
@@ -31,7 +31,7 @@ export class AgentWorkspaceCreatePage extends BasePage {
   readonly agentSelector: Locator;
   readonly toolsSummary: Locator;
   readonly customizeExpandable: Locator;
-  readonly mcpServersSearchInput: Locator;
+  readonly mcpServersPanel: Locator;
   readonly fileAccessHeading: Locator;
   readonly firstCustomPathInput: Locator;
   readonly addPathButton: Locator;
@@ -53,7 +53,7 @@ export class AgentWorkspaceCreatePage extends BasePage {
     this.agentSelector = this.page.getByRole('region', { name: 'Select Coding Agent' });
     this.toolsSummary = this.page.getByText(/Everything available is included|Expand.*Customize/);
     this.customizeExpandable = this.page.getByText('Customize skills, MCP servers, and vault');
-    this.mcpServersSearchInput = this.page.getByPlaceholder('Search MCP servers...');
+    this.mcpServersPanel = this.page.getByText('MCP Servers', { exact: true });
     this.fileAccessHeading = this.page.getByText('File System Access');
     this.firstCustomPathInput = this.page.getByPlaceholder('/path/to/allowed/directory').first();
     this.addPathButton = this.page.getByRole('button', { name: 'Add Another Path' });

--- a/tests/playwright/src/specs/workspaces-smoke.spec.ts
+++ b/tests/playwright/src/specs/workspaces-smoke.spec.ts
@@ -280,7 +280,7 @@ test.describe('Workspaces page - MCP integration', { tag: '@smoke' }, () => {
     await createPage.navigateToStep(WIZARD_STEP.TOOLS_SECRETS);
     await createPage.expandCustomize();
 
-    await expect(createPage.mcpServersSearchInput).toBeVisible();
+    await expect(createPage.mcpServersPanel).toBeVisible();
     await expect(createPage.getCardByName(githubServer.serverName)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Replaced the `ScrollableCardSelector` (search bar, card grid, pagination arrows) for MCP servers with `ChecklistPanel` — the same table/checkbox pattern used by Skills and Secret Vault
- Added a "Manage Servers" button that navigates to the MCP Ready page (`/mcps`)

<img width="923" height="771" alt="Screenshot From 2026-04-30 23-12-00" src="https://github.com/user-attachments/assets/9f7b6c4b-4301-4fc8-85b3-1c8c74c28b96" />


Fixes: https://github.com/openkaiden/kaiden/issues/1463

## Test plan
- [x] All 774 unit test files pass (5354 tests)
- [x] Svelte type checking passes with 0 errors
- [ ] Verify MCP Servers section renders as a checklist table in workspace creation
- [ ] Verify "Manage Servers" button navigates to the MCP Ready page
- [ ] Verify MCP server selection/deselection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)