### PR TITLE
feat(guided-setup): add Claude on Vertex AI agent type

### DIFF
--- a/packages/main/src/plugin/onboarding/onboarding-init.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.ts
@@ -38,6 +38,24 @@ export class OnboardingInit {
           default: '',
           hidden: true,
         },
+        [`${OnboardingSettings.SectionName}.${OnboardingSettings.VertexProjectId}`]: {
+          description: 'Google Cloud project ID for Claude on Vertex AI',
+          type: 'string',
+          default: '',
+          hidden: true,
+        },
+        [`${OnboardingSettings.SectionName}.${OnboardingSettings.VertexRegion}`]: {
+          description: 'Google Cloud region for Claude on Vertex AI',
+          type: 'string',
+          default: '',
+          hidden: true,
+        },
+        [`${OnboardingSettings.SectionName}.${OnboardingSettings.VertexCredentialsPath}`]: {
+          description: 'Path to Google Cloud credentials directory for Claude on Vertex AI',
+          type: 'string',
+          default: '',
+          hidden: true,
+        },
       },
     };
 

--- a/packages/main/src/plugin/onboarding/onboarding-settings.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-settings.ts
@@ -19,4 +19,7 @@
 export enum OnboardingSettings {
   SectionName = 'onboarding',
   DefaultAgent = 'defaultAgent',
+  VertexProjectId = 'vertexProjectId',
+  VertexRegion = 'vertexRegion',
+  VertexCredentialsPath = 'vertexCredentialsPath',
 }

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -228,6 +228,65 @@ describe('Claude agent tile', () => {
   });
 });
 
+describe('Claude on Vertex AI tile', () => {
+  test('renders the Vertex AI tile when CLI includes claude', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Claude on Vertex AI' })).toBeInTheDocument();
+    });
+  });
+
+  test('shows Vertex AI badge on the tile', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByText('Vertex AI')).toBeInTheDocument();
+    });
+  });
+
+  test('shows Vertex panel when Claude on Vertex AI is selected', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Claude on Vertex AI' })).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Claude on Vertex AI' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('claude-vertex-panel')).toBeInTheDocument();
+      expect(screen.getByText('Google Cloud Vertex AI')).toBeInTheDocument();
+    });
+  });
+
+  test('updates onboarding.agent when Claude on Vertex AI is selected', async () => {
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Claude on Vertex AI' })).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Claude on Vertex AI' }));
+
+    await waitFor(() => {
+      expect(onboarding.agent).toBe('claude-vertex');
+    });
+  });
+
+  test('does not show Vertex tile when CLI does not include claude', async () => {
+    vi.mocked(window.getCliInfo).mockResolvedValue({ version: '0.1.0', agents: ['opencode'], runtimes: ['podman'] });
+
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Claude on Vertex AI' })).not.toBeInTheDocument();
+  });
+});
+
 describe('CLI fallback', () => {
   test('falls back to all registry entries when CLI returns empty agents', async () => {
     vi.mocked(window.getCliInfo).mockResolvedValue({ version: '0.1.0', agents: [], runtimes: [] });

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
@@ -24,7 +24,7 @@ onMount(async () => {
 
 let filteredDefinitions = $derived.by(() => {
   if (!cliAgents) return agentDefinitions;
-  const filtered = agentDefinitions.filter(d => cliAgents!.includes(d.cliName));
+  const filtered = agentDefinitions.filter(d => cliAgents!.includes(d.cliAgent ?? d.cliName));
   return filtered.length > 0 ? filtered : agentDefinitions;
 });
 

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -30,6 +30,15 @@ function getStepState(index: number): 'completed' | 'active' | 'upcoming' {
 
 async function persistOnboardingDefaults(): Promise<void> {
   await window.updateConfigurationValue('onboarding.defaultAgent', onboardingState.agent);
+
+  if (onboardingState.agent === 'claude-vertex' && onboardingState.vertexConfig) {
+    await window.updateConfigurationValue('onboarding.vertexProjectId', onboardingState.vertexConfig.projectId);
+    await window.updateConfigurationValue('onboarding.vertexRegion', onboardingState.vertexConfig.region);
+    await window.updateConfigurationValue(
+      'onboarding.vertexCredentialsPath',
+      onboardingState.vertexConfig.credentialsPath,
+    );
+  }
 }
 
 async function advance(): Promise<void> {

--- a/packages/renderer/src/lib/guided-setup/agent-registry.ts
+++ b/packages/renderer/src/lib/guided-setup/agent-registry.ts
@@ -17,16 +17,23 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
-import { faClaude } from '@fortawesome/free-brands-svg-icons';
+import { faClaude, faGoogle } from '@fortawesome/free-brands-svg-icons';
 import { faDesktop } from '@fortawesome/free-solid-svg-icons';
 import type { Component } from 'svelte';
 
 import type { CliAgent } from './guided-setup-steps';
 import ClaudePanel from './panels/ClaudePanel.svelte';
+import ClaudeVertexPanel from './panels/ClaudeVertexPanel.svelte';
 import OpenCodePanel from './panels/OpenCodePanel.svelte';
 
 export interface AgentDefinition {
   cliName: CliAgent;
+  /**
+   * The CLI agent name used for filtering against `kdn info` output.
+   * Allows UI variants (e.g. `claude-vertex`) to match their parent CLI agent (`claude`).
+   * Falls back to {@link cliName} when omitted.
+   */
+  cliAgent?: string;
   title: string;
   description: string;
   badge: string;
@@ -56,5 +63,14 @@ export const agentDefinitions: AgentDefinition[] = [
     panel: ClaudePanel,
     providerSelector: 'kaiden.claude:claude',
     secretType: 'anthropic',
+  },
+  {
+    cliName: 'claude-vertex',
+    cliAgent: 'claude',
+    title: 'Claude on Vertex AI',
+    description: 'Run Claude Code through Google Cloud Vertex AI using your GCP project credentials.',
+    badge: 'Vertex AI',
+    icon: faGoogle,
+    panel: ClaudeVertexPanel,
   },
 ];

--- a/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
+++ b/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
@@ -22,10 +22,17 @@ import type { Component } from 'svelte';
 
 import CodingAgentStep from './CodingAgentStep.svelte';
 
-export type CliAgent = 'opencode' | 'claude';
+export type CliAgent = 'opencode' | 'claude' | 'claude-vertex';
+
+export interface VertexConfig {
+  projectId: string;
+  region: string;
+  credentialsPath: string;
+}
 
 export interface OnboardingState {
   agent: CliAgent;
+  vertexConfig?: VertexConfig;
   beforeAdvance?: () => Promise<boolean>;
 }
 

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
@@ -1,0 +1,252 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { OnboardingState } from '../guided-setup-steps';
+import ClaudeVertexPanel from './ClaudeVertexPanel.svelte';
+
+let onboarding: OnboardingState;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+  onboarding = { agent: 'claude-vertex' };
+  vi.stubGlobal('openExternal', vi.fn().mockResolvedValue(undefined));
+  vi.stubGlobal('openDialog', vi.fn().mockResolvedValue(undefined));
+});
+
+function renderPanel(): void {
+  render(ClaudeVertexPanel, { onboarding });
+}
+
+describe('rendering', () => {
+  test('renders the Vertex AI panel', () => {
+    renderPanel();
+
+    expect(screen.getByTestId('claude-vertex-panel')).toBeInTheDocument();
+    expect(screen.getByText('Google Cloud Vertex AI')).toBeInTheDocument();
+  });
+
+  test('shows the form with environment variable inputs', () => {
+    renderPanel();
+
+    expect(screen.getByTestId('claude-vertex-form')).toBeInTheDocument();
+    expect(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('CLOUD_ML_REGION')).toBeInTheDocument();
+  });
+
+  test('does not expose CLAUDE_CODE_USE_VERTEX field', () => {
+    renderPanel();
+
+    expect(screen.queryByLabelText('CLAUDE_CODE_USE_VERTEX')).not.toBeInTheDocument();
+  });
+
+  test('region input defaults to global', () => {
+    renderPanel();
+
+    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
+    expect(regionInput.value).toBe('global');
+  });
+
+  test('shows informational text about workspace.json mapping', () => {
+    renderPanel();
+
+    expect(screen.getByText(/workspace\.json/)).toBeInTheDocument();
+  });
+
+  test('shows note about gcloud auth', () => {
+    renderPanel();
+
+    expect(screen.getByText(/gcloud auth application-default login/)).toBeInTheDocument();
+  });
+
+  test('shows note about ANTHROPIC_API_KEY not being required', () => {
+    renderPanel();
+
+    expect(screen.getByText(/ANTHROPIC_API_KEY/)).toBeInTheDocument();
+  });
+
+  test('shows credentials directory input with browse button', () => {
+    renderPanel();
+
+    expect(screen.getByLabelText('Google Cloud credentials path')).toBeInTheDocument();
+    expect(screen.getByLabelText('Browse credentials')).toBeInTheDocument();
+  });
+
+  test('shows kdn README link', () => {
+    renderPanel();
+
+    expect(screen.getByText(/kdn README/)).toBeInTheDocument();
+  });
+
+  test('does not show error message initially', () => {
+    renderPanel();
+
+    expect(screen.queryByText(/Please enter your Google Cloud project ID/)).not.toBeInTheDocument();
+  });
+});
+
+describe('beforeAdvance callback', () => {
+  test('registers beforeAdvance on onboarding state', () => {
+    renderPanel();
+
+    expect(onboarding.beforeAdvance).toBeDefined();
+    expect(typeof onboarding.beforeAdvance).toBe('function');
+  });
+
+  test('returns false and shows error when project ID is empty', async () => {
+    renderPanel();
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+    expect(screen.getByText(/Please enter your Google Cloud project ID/)).toBeInTheDocument();
+  });
+
+  test('returns false and shows error when region is empty', async () => {
+    renderPanel();
+
+    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-project');
+
+    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
+    await userEvent.clear(regionInput);
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+    expect(screen.getByText(/Please enter a region/)).toBeInTheDocument();
+  });
+
+  test('returns false and shows error when credentials path is empty', async () => {
+    renderPanel();
+
+    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-project');
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+    expect(screen.getByText(/Please provide the path to your Google Cloud credentials directory/)).toBeInTheDocument();
+  });
+
+  test('returns true and stores vertexConfig when all inputs are valid', async () => {
+    renderPanel();
+
+    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-gcp-project');
+    await userEvent.type(screen.getByLabelText('Google Cloud credentials path'), '/home/user/.config/gcloud');
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(true);
+    expect(onboarding.vertexConfig).toEqual({
+      projectId: 'my-gcp-project',
+      region: 'global',
+      credentialsPath: '/home/user/.config/gcloud',
+    });
+  });
+
+  test('stores custom region in vertexConfig', async () => {
+    renderPanel();
+
+    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-project');
+    await userEvent.type(screen.getByLabelText('Google Cloud credentials path'), '/home/user/.config/gcloud');
+
+    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
+    await userEvent.clear(regionInput);
+    await userEvent.type(regionInput, 'europe-west1');
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(true);
+    expect(onboarding.vertexConfig).toEqual({
+      projectId: 'my-project',
+      region: 'europe-west1',
+      credentialsPath: '/home/user/.config/gcloud',
+    });
+  });
+
+  test('trims whitespace from inputs', async () => {
+    renderPanel();
+
+    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), '  my-project  ');
+    await userEvent.type(screen.getByLabelText('Google Cloud credentials path'), '  /home/user/.config/gcloud  ');
+
+    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
+    await userEvent.clear(regionInput);
+    await userEvent.type(regionInput, '  europe-west1  ');
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(true);
+    expect(onboarding.vertexConfig).toEqual({
+      projectId: 'my-project',
+      region: 'europe-west1',
+      credentialsPath: '/home/user/.config/gcloud',
+    });
+  });
+});
+
+describe('credentials browse', () => {
+  test('opens file dialog when browse button is clicked', async () => {
+    vi.mocked(window.openDialog).mockResolvedValue(['/home/user/.config/gcloud']);
+    renderPanel();
+
+    await fireEvent.click(screen.getByLabelText('Browse credentials'));
+
+    expect(window.openDialog).toHaveBeenCalledWith({
+      title: 'Select Google Cloud credentials directory',
+      selectors: ['openDirectory'],
+    });
+  });
+
+  test('sets credentials path from dialog result', async () => {
+    vi.mocked(window.openDialog).mockResolvedValue(['/home/user/.config/gcloud']);
+    renderPanel();
+
+    await fireEvent.click(screen.getByLabelText('Browse credentials'));
+
+    const credInput = screen.getByLabelText('Google Cloud credentials path') as HTMLInputElement;
+    expect(credInput.value).toBe('/home/user/.config/gcloud');
+  });
+
+  test('does not update credentials path when dialog is cancelled', async () => {
+    vi.mocked(window.openDialog).mockResolvedValue(undefined as unknown as string[]);
+    renderPanel();
+
+    await fireEvent.click(screen.getByLabelText('Browse credentials'));
+
+    const credInput = screen.getByLabelText('Google Cloud credentials path') as HTMLInputElement;
+    expect(credInput.value).toBe('');
+  });
+});
+
+describe('cleanup', () => {
+  test('clears beforeAdvance when component is destroyed', () => {
+    const { unmount } = render(ClaudeVertexPanel, { onboarding });
+
+    expect(onboarding.beforeAdvance).toBeDefined();
+
+    unmount();
+
+    expect(onboarding.beforeAdvance).toBeUndefined();
+  });
+});

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+import { faArrowUpRightFromSquare, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { Button, Checkbox, ErrorMessage, Input, Link } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import type { OnboardingState } from '../guided-setup-steps';
+
+interface Props {
+  onboarding?: OnboardingState;
+}
+
+let { onboarding }: Props = $props();
+
+let projectId = $state('');
+let region = $state('global');
+let credentialsPath = $state('');
+let mountClaudeConfig = $state(false);
+let errorMessage = $state('');
+let defaultGcloudPath = $state('~/.config/gcloud');
+
+async function detectDefaultGcloudPath(): Promise<void> {
+  const platform = await window.getOsPlatform();
+  defaultGcloudPath = platform === 'win32' ? '%APPDATA%\\gcloud' : '~/.config/gcloud';
+}
+
+detectDefaultGcloudPath().catch(() => {});
+
+const KDN_VERTEX_README = 'https://github.com/openkaiden/kdn/blob/main/README.md#claude-with-a-model-from-vertex-ai';
+
+function openReadmeLink(): void {
+  window.openExternal(KDN_VERTEX_README).catch(() => {});
+}
+
+async function browseCredentials(): Promise<void> {
+  const result = await window.openDialog({
+    title: 'Select Google Cloud credentials directory',
+    selectors: ['openDirectory'],
+  });
+  if (result?.[0]) {
+    credentialsPath = result[0];
+  }
+}
+
+async function validate(): Promise<boolean> {
+  errorMessage = '';
+
+  if (!projectId.trim()) {
+    errorMessage = 'Please enter your Google Cloud project ID.';
+    return false;
+  }
+
+  if (!region.trim()) {
+    errorMessage = 'Please enter a region (e.g. us-east5, europe-west1).';
+    return false;
+  }
+
+  if (!credentialsPath.trim()) {
+    errorMessage = 'Please provide the path to your Google Cloud credentials directory.';
+    return false;
+  }
+
+  if (onboarding) {
+    onboarding.vertexConfig = {
+      projectId: projectId.trim(),
+      region: region.trim(),
+      credentialsPath: credentialsPath.trim(),
+    };
+  }
+
+  return true;
+}
+
+$effect(() => {
+  if (onboarding) {
+    onboarding.beforeAdvance = validate;
+  }
+  return (): void => {
+    if (onboarding?.beforeAdvance === validate) {
+      onboarding.beforeAdvance = undefined;
+    }
+  };
+});
+</script>
+
+<div
+  class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
+  data-testid="claude-vertex-panel">
+  <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+    Google Cloud Vertex AI
+  </h3>
+  <p class="text-xs text-(--pd-content-card-text) opacity-50 mb-4 leading-relaxed">
+    These values map to <code class="font-mono">environment</code> entries for the Claude agent
+    in <code class="font-mono">$PROJECT_DIR/.kaiden/workspace.json</code>.
+    Run <code class="font-mono">gcloud auth application-default login</code> on the host before starting the workspace.
+  </p>
+
+  <div class="flex flex-col gap-4" data-testid="claude-vertex-form">
+    <div class="flex flex-col gap-1.5">
+      <label for="vertex-project-id" class="text-xs font-medium text-(--pd-content-card-text) font-mono">
+        ANTHROPIC_VERTEX_PROJECT_ID
+      </label>
+      <Input
+        id="vertex-project-id"
+        placeholder="my-gcp-project-id"
+        bind:value={projectId}
+        aria-label="ANTHROPIC_VERTEX_PROJECT_ID" />
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label for="vertex-region" class="text-xs font-medium text-(--pd-content-card-text) font-mono">
+        CLOUD_ML_REGION
+      </label>
+      <Input
+        id="vertex-region"
+        placeholder="us-east5"
+        bind:value={region}
+        aria-label="CLOUD_ML_REGION" />
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label for="vertex-credentials" class="text-xs font-medium text-(--pd-content-card-text)">
+        Google Cloud credentials directory
+      </label>
+      <div class="flex flex-row grow space-x-1.5">
+        <Input
+          id="vertex-credentials"
+          placeholder={defaultGcloudPath}
+          bind:value={credentialsPath}
+          aria-label="Google Cloud credentials path" />
+        <Button type="secondary" aria-label="Browse credentials" icon={faFolderOpen} onclick={browseCredentials} />
+      </div>
+      <span class="text-[10px] text-(--pd-content-card-text) opacity-40">
+        This directory will be mounted read-only into the workspace so Claude Code can
+        authenticate with Vertex AI via application default credentials.
+      </span>
+    </div>
+
+    <Checkbox
+      bind:checked={mountClaudeConfig}
+      title="Mount Claude config">Also mount ~/.claude and ~/.claude.json (optional; reuse host Claude Code settings)</Checkbox>
+
+    <p class="text-[10px] text-(--pd-content-card-text) opacity-40 leading-relaxed">
+      No <code class="font-mono">ANTHROPIC_API_KEY</code> is required when using Vertex;
+      credentials come from your gcloud application default credentials.
+    </p>
+
+    {#if errorMessage}
+      <ErrorMessage error={errorMessage} />
+    {/if}
+
+    <div class="pt-1">
+    <Link class="flex flex-row w-fit items-center" on:click={openReadmeLink}>  <Icon class="ml-1 self-center" icon={faArrowUpRightFromSquare} />&nbsp;kdn README: Claude Code with a model from Vertex AI </Link>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Allow users to select Claude Code with Vertex AI in the onboarding wizard, collecting GCP project ID, region, and credentials directory path needed for workspace creation.
<img width="1045" height="948" alt="Captura de pantalla 2026-05-01 a las 11 18 20" src="https://github.com/user-attachments/assets/0db5ddca-225e-4db6-936d-a128dd7a1e55" />

Closes #1503