### PR TITLE
fix: navigate to skills list page when skill is deleted from details page

### DIFF
--- a/packages/renderer/src/lib/skills/SkillDetails.svelte
+++ b/packages/renderer/src/lib/skills/SkillDetails.svelte
@@ -24,11 +24,11 @@ let { name }: Props = $props();
 let skillInfo: SkillInfo | undefined = $derived($skillInfos.find(s => s.name === name));
 let skillContent: string | undefined = $state(undefined);
 let folderContents: SkillResourceEntry[] = $state([]);
+let detailsPage = $state<DetailsPage | undefined>();
 
 $effect(() => {
   if (!skillInfo) {
-    skillContent = undefined;
-    folderContents = [];
+    detailsPage?.close();
     return;
   }
   const currentName = name;
@@ -67,7 +67,7 @@ function onToggle(): void {
 }
 </script>
 
-<DetailsPage title={name}>
+<DetailsPage title={name} bind:this={detailsPage}>
   {#snippet subtitleSnippet()}
     <div class="flex items-center gap-3">
       <span


### PR DESCRIPTION

<img width="1052" height="702" alt="skill-delete" src="https://github.com/user-attachments/assets/6efe95f5-ae94-47f6-a0a3-466023a185af" />

Fixes #1530