### PR TITLE
feat(workspace-networking): wire network config into workspace creation 

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -45,6 +45,12 @@ export type AgentWorkspaceConfiguration = configComponents['schemas']['Workspace
 export type CliInfo = cliComponents['schemas']['Info'];
 
 /**
+ * The schema for a workspace's network configuration
+ * Matches the contract in @openkaiden/workspace-configuration.
+ */
+export type NetworkConfiguration = configComponents['schemas']['NetworkConfiguration'];
+
+/**
  * Options for creating (initializing) a new workspace via `kdn init`.
  */
 export interface AgentWorkspaceCreateOptions {
@@ -54,4 +60,5 @@ export interface AgentWorkspaceCreateOptions {
   name?: string;
   project?: string;
   skills?: string[];
+  network?: NetworkConfiguration;
 }

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -274,6 +274,65 @@ describe('create', () => {
     expect(parsed.mcp).toEqual({ servers: [] });
     expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes']);
   });
+
+  test('writes workspace.json with network before calling kdn init', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      network: { mode: 'deny', hosts: ['registry.npmjs.org', 'pypi.org'] },
+    });
+
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/my-project', '.kaiden'), { recursive: true });
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.network).toEqual({ mode: 'deny', hosts: ['registry.npmjs.org', 'pypi.org'] });
+    expect(exec.exec).toHaveBeenCalled();
+  });
+
+  test('does not write workspace.json when no skills or network provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace(defaultOptions);
+
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('merges network into existing workspace.json', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ mcp: { servers: [] } }));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      network: { mode: 'allow' },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mcp).toEqual({ servers: [] });
+    expect(parsed.network).toEqual({ mode: 'allow' });
+  });
+
+  test('writes workspace.json with both skills and network', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/kubernetes'],
+      network: { mode: 'deny', hosts: ['registry.npmjs.org'] },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes']);
+    expect(parsed.network).toEqual({ mode: 'deny', hosts: ['registry.npmjs.org'] });
+  });
 });
 
 describe('list', () => {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -126,7 +126,7 @@ export class KdnCli {
   }
 
   async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
-    if (!options.skills?.length) {
+    if (!options.skills?.length && !options.network) {
       return;
     }
 
@@ -142,6 +142,7 @@ export class KdnCli {
     }
 
     existing.skills = options.skills;
+    existing.network = options.network;
 
     await mkdir(configDir, { recursive: true });
     await writeFile(configPath, JSON.stringify(existing, undefined, 2) + '\n', 'utf-8');

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -513,10 +513,10 @@ test('Expect all four network options rendered', async () => {
 
   await navigateToNetworkingStep();
 
-  expect(screen.getByRole('button', { name: 'Deny All' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Developer Preset' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Agent mode' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Unrestricted' })).toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: 'Use Deny All' })).toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: 'Use Agent mode' })).toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: 'Use Unrestricted' })).toBeInTheDocument();
 });
 
 test('Expect Developer Preset selected by default on networking step', async () => {
@@ -541,7 +541,7 @@ test('Expect selecting a different network option updates the radio', async () =
 
   await navigateToNetworkingStep();
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Unrestricted' }));
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Unrestricted' }));
 
   expect(screen.getByRole('radio', { name: 'Use Unrestricted' })).toBeChecked();
   expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).not.toBeChecked();
@@ -578,6 +578,10 @@ test('Expect default agent falls back to opencode when setting is empty', async 
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
       agent: 'opencode',
+      network: {
+        mode: 'deny',
+        hosts: ['registry.npmjs.org', 'pypi.python.org'],
+      },
     }),
   );
 });
@@ -595,6 +599,34 @@ test('Expect default agent falls back to opencode when setting is unknown value'
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
       agent: 'opencode',
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called with deny network when blocked selected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Deny All' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      network: { mode: 'deny' },
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called without network when agent_mode selected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Agent mode' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      network: undefined,
     }),
   );
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -22,6 +22,7 @@ import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
+import type { NetworkConfiguration } from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
 
 const agentOptions: CardSelectorOption[] = [
@@ -112,6 +113,21 @@ const networkOptions: NetworkAccessOption[] = [
     notes: 'Trusted setups',
   },
 ];
+
+const REGISTRY_HOSTS = ['registry.npmjs.org', 'pypi.python.org'];
+
+function mapNetworkSelection(value: string): NetworkConfiguration | undefined {
+  switch (value) {
+    case 'open':
+      return { mode: 'allow' };
+    case 'registries':
+      return { mode: 'deny', hosts: REGISTRY_HOSTS };
+    case 'blocked':
+      return { mode: 'deny' };
+    default:
+      return undefined;
+  }
+}
 
 const wizardSteps = [
   { id: 'workspace', title: 'Workspace' },
@@ -259,12 +275,14 @@ async function startWorkspace(): Promise<void> {
 
   try {
     const selectedSkillPaths = $skillInfos.filter(s => selectedSkillIds.includes(s.name)).map(s => s.path);
+    const network = mapNetworkSelection(selectedNetwork);
 
     await window.createAgentWorkspace({
       sourcePath,
       agent: selectedAgent,
       name: sessionName,
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
+      network,
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
@@ -17,10 +17,6 @@ interface Props {
 }
 
 let { networkOptions, selectedNetwork = $bindable() }: Props = $props();
-
-function selectOption(value: string): void {
-  selectedNetwork = value;
-}
 </script>
 
 <div class="flex items-center gap-3 mb-5">
@@ -38,12 +34,11 @@ function selectOption(value: string): void {
     {#if idx > 0}
       <div class="mx-3 border-t border-[var(--pd-content-card-border)] opacity-30"></div>
     {/if}
-    <button
+    <label
       class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
         {selectedNetwork === option.value
           ? 'bg-[var(--pd-content-card-hover-inset-bg)]'
           : 'hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
-      onclick={selectOption.bind(null, option.value)}
       aria-label={option.name}>
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2">
@@ -61,11 +56,11 @@ function selectOption(value: string): void {
           type="radio"
           name="networkAccess"
           value={option.value}
-          checked={selectedNetwork === option.value}
+          bind:group={selectedNetwork}
           aria-label="Use {option.name}"
-          class="accent-[var(--pd-button-primary-bg)] w-4 h-4 cursor-pointer pointer-events-none" />
+          class="accent-[var(--pd-button-primary-bg)] w-4 h-4 cursor-pointer" />
       </div>
-    </button>
+    </label>
   {/each}
 </div>
 


### PR DESCRIPTION
Wires up networking config with workspace creation

To try this 
Create new worksapce with every option 
Allow -> should have mode "allow"
Everything else should be "deny" + the registries should have specified hosts - registry.npmjs.org and pypi.pythin.org specified

Note if there is no mode the default mode is 'deny'

Closes https://github.com/openkaiden/kaiden/issues/1547