### PR TITLE
feat(workspaces): wire secret vault entries into workspace creation

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -62,4 +62,5 @@ export interface AgentWorkspaceCreateOptions {
   project?: string;
   skills?: string[];
   network?: NetworkConfiguration;
+  secrets?: string[];
 }

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -250,15 +250,6 @@ describe('create', () => {
     expect(exec.exec).toHaveBeenCalled();
   });
 
-  test('does not write workspace.json when no skills provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
-
-    await kdnCli.createWorkspace(defaultOptions);
-
-    expect(writeFile).not.toHaveBeenCalled();
-  });
-
   test('merges skills into existing workspace.json', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(readFile).mockResolvedValue(JSON.stringify({ mcp: { servers: [] } }));
@@ -332,6 +323,65 @@ describe('create', () => {
     const parsed = JSON.parse(writtenContent);
     expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes']);
     expect(parsed.network).toEqual({ mode: 'deny', hosts: ['registry.npmjs.org'] });
+  });
+
+  test('writes workspace.json with secrets before calling kdn init', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      secrets: ['github-token', 'anthropic-key'],
+    });
+
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/my-project', '.kaiden'), { recursive: true });
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.secrets).toEqual(['github-token', 'anthropic-key']);
+    expect(exec.exec).toHaveBeenCalled();
+  });
+
+  test('does not write workspace.json when no skills or secrets provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace(defaultOptions);
+
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('merges secrets into existing workspace.json preserving other fields', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ mcp: { servers: [] } }));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      secrets: ['github-token'],
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mcp).toEqual({ servers: [] });
+    expect(parsed.secrets).toEqual(['github-token']);
+  });
+
+  test('writes workspace.json with both skills and secrets', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/kubernetes'],
+      secrets: ['github-token', 'anthropic-key'],
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes']);
+    expect(parsed.secrets).toEqual(['github-token', 'anthropic-key']);
   });
 });
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -129,7 +129,7 @@ export class KdnCli {
   }
 
   async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
-    if (!options.skills?.length && !options.network) {
+    if (!options.skills?.length && !options.secrets?.length && !options.network) {
       return;
     }
 
@@ -146,6 +146,7 @@ export class KdnCli {
 
     existing.skills = options.skills;
     existing.network = options.network;
+    existing.secrets = options.secrets;
 
     await mkdir(configDir, { recursive: true });
     await writeFile(configPath, JSON.stringify(existing, undefined, 2) + '\n', 'utf-8');

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -432,6 +432,51 @@ test('Expect createAgentWorkspace called without skills when none available', as
   );
 });
 
+test('Expect createAgentWorkspace called with secret ids when vault has entries', async () => {
+  vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([
+    {
+      id: 'github-token',
+      name: 'GitHub Token',
+      type: 'github',
+      description: 'Personal access token',
+    },
+    {
+      id: 'anthropic-key',
+      name: 'Anthropic Key',
+      type: 'anthropic',
+      description: 'API key',
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      secrets: ['github-token', 'anthropic-key'],
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called without secrets when vault is empty', async () => {
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      secrets: undefined,
+    }),
+  );
+});
+
 test('Expect Knowledges section visible after expanding customize', async () => {
   render(AgentWorkspaceCreate);
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -261,6 +261,7 @@ async function startWorkspace(): Promise<void> {
       name: sessionName,
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
       network,
+      secrets: selectedSecretIds.length > 0 ? [...selectedSecretIds] : undefined,
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);


### PR DESCRIPTION
Adds secrets field to AgentWorkspaceCreateOptions and passes secret ids from the vault store through the renderer and kdn-cli into workspace.json.

You can test this by having some secrets defined, select them when creating new workspace, you should be able to see them in workspace.json fil in the container

Closes https://github.com/openkaiden/kaiden/issues/1546