### PR TITLE
fix(theme): use solid border colors for nav item hover/selected states

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -381,6 +381,11 @@ export class ColorRegistry {
         .withLight(colorPaletteHelper(accent1[400]).withAlpha(0.14))
         .build(),
     );
+    // Pre-blended accent1[400] @ 14% over nav bg — alpha borders don't composite against the element background
+    this.registerColor(`${glNav}icon-hover-border`, {
+      dark: '#1a354e',
+      light: '#e6f7fe',
+    });
     this.registerColor(`${glNav}icon-inset-bg`, {
       dark: navy[800],
       light: navy[200],
@@ -395,6 +400,11 @@ export class ColorRegistry {
         .withLight(colorPaletteHelper(accent1[400]).withAlpha(0.12))
         .build(),
     );
+    // Pre-blended accent1[400] @ 12% over nav bg — see icon-hover-border comment
+    this.registerColor(`${glNav}icon-selected-border`, {
+      dark: '#18324b',
+      light: '#eaf8fe',
+    });
     this.registerColor(`${glNav}icon-selected-highlight`, {
       dark: accent1[400],
       light: accent1[500],

--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -51,7 +51,7 @@ test('Expect selection styling', async () => {
   expect(element.firstChild).toBeInTheDocument();
   expect(element.firstChild).toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
   expect(element.firstChild).not.toHaveClass('hover:bg-[var(--pd-global-nav-icon-hover-bg)]');
-  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-border)]');
 });
 
 test('Expect selection styling for encoded URLs', async () => {
@@ -85,7 +85,7 @@ test('Expect not to have selection styling', async () => {
   expect(element.firstChild).toBeInTheDocument();
   expect(element.firstChild).toHaveClass('border-l-[var(--pd-global-nav-bg)]');
   expect(element.firstChild).toHaveClass('hover:bg-[var(--pd-global-nav-icon-hover-bg)]');
-  expect(element.firstChild).toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-border)]');
   expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
   expect(element.firstChild).not.toHaveClass('px-2');
 });
@@ -102,12 +102,12 @@ test('Expect in-section styling', async () => {
   expect(element.firstChild).not.toHaveClass('border-[var(--pd-global-nav-bg)]');
   expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-bg)]');
   expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
-  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-border)]');
 });
 
 // class:hover:text-[color:var(--pd-global-nav-icon-hover)]="{!selected || inSection}"
 // class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]="{!selected || inSection}"
-// class:hover:border-[var(--pd-global-nav-icon-hover-bg)]="{!selected && !inSection}">
+// class:hover:border-[var(--pd-global-nav-icon-hover-border)]="{!selected && !inSection}">
 test('Expect in-section selection styling', async () => {
   const tooltip = 'Dashboard';
   render(NavItemTest);
@@ -120,7 +120,7 @@ test('Expect in-section selection styling', async () => {
   expect(element.firstChild).toHaveClass('hover:text-[color:var(--pd-global-nav-icon-hover)]');
   expect(element.firstChild).toHaveClass('hover:bg-[var(--pd-global-nav-icon-hover-bg)]');
   expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-bg)]');
-  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-border)]');
 });
 
 test('Expect that having an onClick handler overrides href and works', async () => {

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -48,11 +48,11 @@ onDestroy(() => {
     class:text-[color:var(--pd-global-nav-icon-selected)]={selected}
     class:border-l-[var(--pd-global-nav-icon-selected-highlight)]={selected && !inSection}
     class:bg-[var(--pd-global-nav-icon-selected-bg)]={selected && !inSection}
-    class:border-r-[var(--pd-global-nav-icon-selected-bg)]={selected && !inSection}
+    class:border-r-[var(--pd-global-nav-icon-selected-border)]={selected && !inSection}
     class:border-l-[var(--pd-global-nav-bg)]={!selected && !inSection}
     class:hover:text-[color:var(--pd-global-nav-icon-hover)]={!selected || inSection}
     class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]={!selected || inSection}
-    class:hover:border-[var(--pd-global-nav-icon-hover-bg)]={!selected && !inSection}>
+    class:hover:border-[var(--pd-global-nav-icon-hover-border)]={!selected && !inSection}>
     <Tooltip right tip={tooltipText} class="flex flex-col items-center">
       <slot />
     </Tooltip>


### PR DESCRIPTION
Alpha-transparent borders don't composite against the element's own
background, causing visible mismatched borders on hover. Use pre-blended
solid colors for nav item borders instead.


https://github.com/user-attachments/assets/b783dc41-b60a-421a-9a9e-47cd904b71e6

fixes https://github.com/openkaiden/kaiden/issues/1564