### PR TITLE
feat(onboarding): add model selection step and persist workspace settings

### DIFF
--- a/packages/api/src/vertex-ai-info.ts
+++ b/packages/api/src/vertex-ai-info.ts
@@ -16,7 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum OnboardingSettings {
-  SectionName = 'onboarding',
-  DefaultWorkspaceSettings = 'defaultWorkspaceSettings',
+export interface VertexAiModelListRequest {
+  projectId: string;
+  region: string;
+  credentialsPath: string;
+}
+
+export interface VertexAiModelInfo {
+  name: string;
+  displayName: string;
 }

--- a/packages/api/src/vertex-ai-info.ts
+++ b/packages/api/src/vertex-ai-info.ts
@@ -19,7 +19,7 @@
 export interface VertexAiModelListRequest {
   projectId: string;
   region: string;
-  credentialsPath: string;
+  credentialsDir: string;
 }
 
 export interface VertexAiModelInfo {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -223,6 +223,7 @@ import { MessageBox } from './message-box.js';
 import { ModelCatalogInit } from './model-catalog-init.js';
 import { NavigationItemsInit } from './navigation-items-init.js';
 import { OnboardingInit } from './onboarding/onboarding-init.js';
+import { VertexAiDiscovery } from './onboarding/vertex-ai-discovery.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
 import { OpenDevToolsInit } from './open-devtools-init.js';
 import { ProviderRegistry } from './provider-registry.js';
@@ -594,6 +595,7 @@ export class PluginSystem {
     container.bind<CustomPickRegistry>(CustomPickRegistry).toSelf().inSingletonScope();
     container.bind<OnboardingRegistry>(OnboardingRegistry).toSelf().inSingletonScope();
     container.bind<OnboardingInit>(OnboardingInit).toSelf().inSingletonScope();
+    container.bind<VertexAiDiscovery>(VertexAiDiscovery).toSelf().inSingletonScope();
     container.bind<KubernetesClient>(KubernetesClient).toSelf().inSingletonScope();
     container.bind<ChatManager>(ChatManager).toSelf().inSingletonScope();
     container.bind<SchedulerRegistry>(SchedulerRegistry).toSelf().inSingletonScope();
@@ -675,6 +677,8 @@ export class PluginSystem {
     secretManager.init();
     const onboardingInit = container.get<OnboardingInit>(OnboardingInit);
     onboardingInit.init();
+    const vertexAiDiscovery = container.get<VertexAiDiscovery>(VertexAiDiscovery);
+    vertexAiDiscovery.init();
 
     const flowManager = container.get<FlowManager>(FlowManager);
     flowManager.init();

--- a/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
@@ -45,7 +45,7 @@ test('registers onboarding configuration with hidden properties', () => {
   const config = registeredConfigs.at(0);
   expect(config).toBeDefined();
   expect(config?.id).toBe('preferences.onboarding');
-  expect(config?.properties?.['onboarding.defaultAgent']).toEqual(
-    expect.objectContaining({ type: 'string', default: '', hidden: true }),
+  expect(config?.properties?.['onboarding.defaultWorkspaceSettings']).toEqual(
+    expect.objectContaining({ type: 'object', default: {}, hidden: true }),
   );
 });

--- a/packages/main/src/plugin/onboarding/onboarding-init.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.ts
@@ -32,28 +32,10 @@ export class OnboardingInit {
       title: 'Onboarding',
       type: 'object',
       properties: {
-        [`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultAgent}`]: {
-          description: 'Default coding agent selected during onboarding',
-          type: 'string',
-          default: '',
-          hidden: true,
-        },
-        [`${OnboardingSettings.SectionName}.${OnboardingSettings.VertexProjectId}`]: {
-          description: 'Google Cloud project ID for Claude on Vertex AI',
-          type: 'string',
-          default: '',
-          hidden: true,
-        },
-        [`${OnboardingSettings.SectionName}.${OnboardingSettings.VertexRegion}`]: {
-          description: 'Google Cloud region for Claude on Vertex AI',
-          type: 'string',
-          default: '',
-          hidden: true,
-        },
-        [`${OnboardingSettings.SectionName}.${OnboardingSettings.VertexCredentialsPath}`]: {
-          description: 'Path to Google Cloud credentials directory for Claude on Vertex AI',
-          type: 'string',
-          default: '',
+        [`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultWorkspaceSettings}`]: {
+          description: 'Default workspace settings assembled during onboarding',
+          type: 'object',
+          default: {},
           hidden: true,
         },
       },

--- a/packages/main/src/plugin/onboarding/vertex-ai-discovery.spec.ts
+++ b/packages/main/src/plugin/onboarding/vertex-ai-discovery.spec.ts
@@ -17,6 +17,8 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -25,6 +27,7 @@ import type { IPCHandle } from '/@/plugin/api.js';
 import { VertexAiDiscovery } from './vertex-ai-discovery.js';
 
 vi.mock(import('node:fs/promises'));
+vi.mock(import('node:os'));
 
 const ipcHandle: IPCHandle = vi.fn();
 
@@ -39,6 +42,7 @@ const validCredentials = JSON.stringify({
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(os.homedir).mockReturnValue('/home/testuser');
   discovery = new VertexAiDiscovery(ipcHandle);
 });
 
@@ -78,7 +82,10 @@ describe('listModels', () => {
       { name: 'claude-3-5-haiku-20241022', displayName: 'claude-3-5-haiku-20241022' },
     ]);
 
-    expect(fs.readFile).toHaveBeenCalledWith('/home/user/.config/gcloud/application_default_credentials.json', 'utf-8');
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.join('/home/user/.config/gcloud', 'application_default_credentials.json'),
+      'utf-8',
+    );
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://oauth2.googleapis.com/token',
@@ -97,6 +104,7 @@ describe('listModels', () => {
 
   test('expands tilde in credentials path', async () => {
     vi.mocked(fs.readFile).mockResolvedValue(validCredentials);
+    vi.mocked(os.homedir).mockReturnValue('/home/testuser');
 
     const fetchMock = vi.fn();
     fetchMock.mockResolvedValueOnce({
@@ -109,27 +117,16 @@ describe('listModels', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const origHome = process.env['HOME'];
-    process.env['HOME'] = '/home/testuser';
+    await discovery.listModels({
+      projectId: 'p',
+      region: 'r',
+      credentialsDir: '~/.config/gcloud',
+    });
 
-    try {
-      await discovery.listModels({
-        projectId: 'p',
-        region: 'r',
-        credentialsDir: '~/.config/gcloud',
-      });
-
-      expect(fs.readFile).toHaveBeenCalledWith(
-        '/home/testuser/.config/gcloud/application_default_credentials.json',
-        'utf-8',
-      );
-    } finally {
-      if (origHome === undefined) {
-        delete process.env['HOME'];
-      } else {
-        process.env['HOME'] = origHome;
-      }
-    }
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.join('/home/testuser/.config/gcloud', 'application_default_credentials.json'),
+      'utf-8',
+    );
   });
 
   test('throws on missing credential fields', async () => {

--- a/packages/main/src/plugin/onboarding/vertex-ai-discovery.spec.ts
+++ b/packages/main/src/plugin/onboarding/vertex-ai-discovery.spec.ts
@@ -70,7 +70,7 @@ describe('listModels', () => {
     const result = await discovery.listModels({
       projectId: 'my-project',
       region: 'us-east5',
-      credentialsPath: '/home/user/.config/gcloud',
+      credentialsDir: '/home/user/.config/gcloud',
     });
 
     expect(result).toEqual([
@@ -116,7 +116,7 @@ describe('listModels', () => {
       await discovery.listModels({
         projectId: 'p',
         region: 'r',
-        credentialsPath: '~/.config/gcloud',
+        credentialsDir: '~/.config/gcloud',
       });
 
       expect(fs.readFile).toHaveBeenCalledWith(
@@ -124,14 +124,18 @@ describe('listModels', () => {
         'utf-8',
       );
     } finally {
-      process.env['HOME'] = origHome;
+      if (origHome === undefined) {
+        delete process.env['HOME'];
+      } else {
+        process.env['HOME'] = origHome;
+      }
     }
   });
 
   test('throws on missing credential fields', async () => {
     vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ client_id: 'only-id' }));
 
-    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' })).rejects.toThrow(
+    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsDir: '/path' })).rejects.toThrow(
       /missing required fields/,
     );
   });
@@ -146,7 +150,7 @@ describe('listModels', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' })).rejects.toThrow(
+    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsDir: '/path' })).rejects.toThrow(
       /Failed to exchange token: 401/,
     );
   });
@@ -166,7 +170,7 @@ describe('listModels', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' })).rejects.toThrow(
+    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsDir: '/path' })).rejects.toThrow(
       /Failed to list Vertex AI models: 403/,
     );
   });
@@ -185,7 +189,7 @@ describe('listModels', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const result = await discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' });
+    const result = await discovery.listModels({ projectId: 'p', region: 'r', credentialsDir: '/path' });
     expect(result).toEqual([]);
   });
 });

--- a/packages/main/src/plugin/onboarding/vertex-ai-discovery.spec.ts
+++ b/packages/main/src/plugin/onboarding/vertex-ai-discovery.spec.ts
@@ -1,0 +1,191 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs/promises';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { IPCHandle } from '/@/plugin/api.js';
+
+import { VertexAiDiscovery } from './vertex-ai-discovery.js';
+
+vi.mock(import('node:fs/promises'));
+
+const ipcHandle: IPCHandle = vi.fn();
+
+let discovery: VertexAiDiscovery;
+
+const validCredentials = JSON.stringify({
+  client_id: 'test-client-id',
+  client_secret: 'test-client-secret',
+  refresh_token: 'test-refresh-token',
+  type: 'authorized_user',
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  discovery = new VertexAiDiscovery(ipcHandle);
+});
+
+describe('init', () => {
+  test('registers vertex-ai:list-models IPC handler', () => {
+    discovery.init();
+
+    expect(ipcHandle).toHaveBeenCalledWith('vertex-ai:list-models', expect.any(Function));
+  });
+});
+
+describe('listModels', () => {
+  test('reads credentials, exchanges token, and fetches models', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(validCredentials);
+
+    const tokenResponse = { access_token: 'test-access-token', expires_in: 3600, token_type: 'Bearer' };
+    const modelsResponse = {
+      publisherModels: [
+        { name: 'publishers/anthropic/models/claude-sonnet-4-20250514' },
+        { name: 'publishers/anthropic/models/claude-3-5-haiku-20241022' },
+      ],
+    };
+
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(tokenResponse) });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(modelsResponse) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await discovery.listModels({
+      projectId: 'my-project',
+      region: 'us-east5',
+      credentialsPath: '/home/user/.config/gcloud',
+    });
+
+    expect(result).toEqual([
+      { name: 'claude-sonnet-4-20250514', displayName: 'claude-sonnet-4-20250514' },
+      { name: 'claude-3-5-haiku-20241022', displayName: 'claude-3-5-haiku-20241022' },
+    ]);
+
+    expect(fs.readFile).toHaveBeenCalledWith('/home/user/.config/gcloud/application_default_credentials.json', 'utf-8');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://oauth2.googleapis.com/token',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://us-east5-aiplatform.googleapis.com/v1beta1/publishers/anthropic/models',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer test-access-token', 'x-goog-user-project': 'my-project' },
+      }),
+    );
+  });
+
+  test('expands tilde in credentials path', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(validCredentials);
+
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'tok', expires_in: 3600, token_type: 'Bearer' }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ publisherModels: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const origHome = process.env['HOME'];
+    process.env['HOME'] = '/home/testuser';
+
+    try {
+      await discovery.listModels({
+        projectId: 'p',
+        region: 'r',
+        credentialsPath: '~/.config/gcloud',
+      });
+
+      expect(fs.readFile).toHaveBeenCalledWith(
+        '/home/testuser/.config/gcloud/application_default_credentials.json',
+        'utf-8',
+      );
+    } finally {
+      process.env['HOME'] = origHome;
+    }
+  });
+
+  test('throws on missing credential fields', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ client_id: 'only-id' }));
+
+    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' })).rejects.toThrow(
+      /missing required fields/,
+    );
+  });
+
+  test('throws on token exchange failure', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(validCredentials);
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve('invalid_grant'),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' })).rejects.toThrow(
+      /Failed to exchange token: 401/,
+    );
+  });
+
+  test('throws on model listing failure', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(validCredentials);
+
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'tok', expires_in: 3600, token_type: 'Bearer' }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve('permission denied'),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' })).rejects.toThrow(
+      /Failed to list Vertex AI models: 403/,
+    );
+  });
+
+  test('returns empty array when no publisherModels in response', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(validCredentials);
+
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'tok', expires_in: 3600, token_type: 'Bearer' }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await discovery.listModels({ projectId: 'p', region: 'r', credentialsPath: '/path' });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/main/src/plugin/onboarding/vertex-ai-discovery.ts
+++ b/packages/main/src/plugin/onboarding/vertex-ai-discovery.ts
@@ -1,0 +1,140 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { inject, injectable } from 'inversify';
+
+import { IPCHandle } from '/@/plugin/api.js';
+import type { VertexAiModelInfo, VertexAiModelListRequest } from '/@api/vertex-ai-info.js';
+
+interface ApplicationDefaultCredentials {
+  client_id: string;
+  client_secret: string;
+  refresh_token: string;
+  type: string;
+}
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+interface VertexModelResponse {
+  publisherModels?: Array<{
+    name: string;
+    versionId?: string;
+  }>;
+}
+
+@injectable()
+export class VertexAiDiscovery {
+  constructor(
+    @inject(IPCHandle)
+    private readonly ipcHandle: IPCHandle,
+  ) {}
+
+  async listModels(request: VertexAiModelListRequest): Promise<VertexAiModelInfo[]> {
+    const credentials = await this.readCredentials(request.credentialsPath);
+    const accessToken = await this.exchangeToken(credentials);
+    return this.fetchModels(request.projectId, request.region, accessToken);
+  }
+
+  private async readCredentials(credentialsDir: string): Promise<ApplicationDefaultCredentials> {
+    const resolvedDir = credentialsDir.replace(/^~/, process.env['HOME'] ?? '');
+    const credFile = path.join(resolvedDir, 'application_default_credentials.json');
+    const raw = await fs.readFile(credFile, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('Invalid credentials file format');
+    }
+
+    const creds = parsed as Record<string, unknown>;
+    if (!creds['client_id'] || !creds['client_secret'] || !creds['refresh_token']) {
+      throw new Error(
+        'Credentials file is missing required fields. Run "gcloud auth application-default login" first.',
+      );
+    }
+
+    return parsed as ApplicationDefaultCredentials;
+  }
+
+  private async exchangeToken(credentials: ApplicationDefaultCredentials): Promise<string> {
+    const body = new URLSearchParams({
+      client_id: credentials.client_id,
+      client_secret: credentials.client_secret,
+      refresh_token: credentials.refresh_token,
+      grant_type: 'refresh_token',
+    });
+
+    const response = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to exchange token: ${response.status} ${text}`);
+    }
+
+    const data = (await response.json()) as TokenResponse;
+    return data.access_token;
+  }
+
+  private async fetchModels(projectId: string, region: string, accessToken: string): Promise<VertexAiModelInfo[]> {
+    const url = `https://${region}-aiplatform.googleapis.com/v1beta1/publishers/anthropic/models`;
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'x-goog-user-project': projectId,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to list Vertex AI models: ${response.status} ${text}`);
+    }
+
+    const data = (await response.json()) as VertexModelResponse;
+    if (!data.publisherModels || !Array.isArray(data.publisherModels)) {
+      return [];
+    }
+
+    return data.publisherModels.map(m => {
+      const modelId = m.name.split('/').pop() ?? m.name;
+      return {
+        name: modelId,
+        displayName: modelId,
+      };
+    });
+  }
+
+  init(): void {
+    this.ipcHandle(
+      'vertex-ai:list-models',
+      async (_listener: unknown, request: VertexAiModelListRequest): Promise<VertexAiModelInfo[]> => {
+        return this.listModels(request);
+      },
+    );
+  }
+}

--- a/packages/main/src/plugin/onboarding/vertex-ai-discovery.ts
+++ b/packages/main/src/plugin/onboarding/vertex-ai-discovery.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { inject, injectable } from 'inversify';
@@ -52,13 +53,13 @@ export class VertexAiDiscovery {
   ) {}
 
   async listModels(request: VertexAiModelListRequest): Promise<VertexAiModelInfo[]> {
-    const credentials = await this.readCredentials(request.credentialsPath);
+    const credentials = await this.readCredentials(request.credentialsDir);
     const accessToken = await this.exchangeToken(credentials);
     return this.fetchModels(request.projectId, request.region, accessToken);
   }
 
   private async readCredentials(credentialsDir: string): Promise<ApplicationDefaultCredentials> {
-    const resolvedDir = credentialsDir.replace(/^~/, process.env['HOME'] ?? '');
+    const resolvedDir = credentialsDir.replace(/^~/, os.homedir());
     const credFile = path.join(resolvedDir, 'application_default_credentials.json');
     const raw = await fs.readFile(credFile, 'utf-8');
     const parsed: unknown = JSON.parse(raw);
@@ -89,6 +90,7 @@ export class VertexAiDiscovery {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: body.toString(),
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (!response.ok) {
@@ -108,6 +110,7 @@ export class VertexAiDiscovery {
         Authorization: `Bearer ${accessToken}`,
         'x-goog-user-project': projectId,
       },
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (!response.ok) {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -148,6 +148,7 @@ import type { SkillFileContent, SkillFolderInfo, SkillInfo, SkillResourceEntry }
 import type { StatusBarEntryDescriptor } from '/@api/status-bar';
 import type { PinOption } from '/@api/status-bar/pin-option';
 import type { TelemetryMessages } from '/@api/telemetry';
+import type { VertexAiModelInfo, VertexAiModelListRequest } from '/@api/vertex-ai-info';
 import type { ViewInfoUI } from '/@api/view-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info';
 import type { WebviewInfo } from '/@api/webview-info';
@@ -439,6 +440,13 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('listSecretServices', async (): Promise<SecretService[]> => {
     return ipcInvoke('secret-manager:list-services');
   });
+
+  contextBridge.exposeInMainWorld(
+    'listVertexAiModels',
+    async (request: VertexAiModelListRequest): Promise<VertexAiModelInfo[]> => {
+      return ipcInvoke('vertex-ai:list-models', request);
+    },
+  );
 
   contextBridge.exposeInMainWorld('listFlows', async (): Promise<Array<FlowInfo>> => {
     return ipcInvoke('flows:list');

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
-import { StatusIcon } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
 import { type CatalogModelInfo, getCatalogModels } from '/@/lib/models/models-utils';
+import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
 import { handleNavigation } from '/@/navigation';
 import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
 import { providerInfos } from '/@/stores/providers';
@@ -23,15 +23,6 @@ const categoryLabels: Record<ModelCategory, string> = {
   cloud: 'Cloud · LLM providers',
   corporate: 'In-house · OpenShift AI',
   local: 'Local · Ollama & Ramalama',
-};
-
-const statusMap: Record<string, string> = {
-  started: 'RUNNING',
-  starting: 'STARTING',
-  stopped: 'CREATED',
-  stopping: 'DELETING',
-  failed: 'DEGRADED',
-  unknown: 'RUNNING',
 };
 
 let searchTerm = $state('');
@@ -79,8 +70,8 @@ function filterBySearch(models: CatalogModelInfo[], term: string): CatalogModelI
   );
 }
 
-function getModelStatus(model: CatalogModelInfo): string {
-  return statusMap[model.connectionStatus] ?? 'RUNNING';
+function getKey(model: CatalogModelInfo): string {
+  return modelKey(model.providerId, model.label);
 }
 
 function selectModel(model: CatalogModelInfo): void {
@@ -188,58 +179,13 @@ function navigateToModels(): void {
                 <h4 class="text-xs font-semibold text-[var(--pd-content-card-text)] opacity-60 uppercase tracking-wide mb-2">
                   {categoryLabels[category]}
                 </h4>
-                <div class="rounded-md border border-[var(--pd-content-card-border)] overflow-hidden">
-                  <table class="w-full text-sm" aria-label="{categoryLabels[category]} models">
-                    <thead>
-                      <tr class="border-b border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)]">
-                        <th class="w-10 px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Status</th>
-                        <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Name</th>
-                        <th class="w-20 px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Size</th>
-                        <th class="w-28 px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Runtime</th>
-                        <th class="w-12 px-3 py-2 text-center text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Use</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {#each models as model (modelKey(model.providerId, model.label))}
-                        {@const key = modelKey(model.providerId, model.label)}
-                        {@const isSelected = selectedModel === key}
-                        <tr
-                          role="button"
-                          tabindex="0"
-                          class="border-b border-[var(--pd-content-card-border)] last:border-b-0 transition-colors
-                            cursor-pointer hover:bg-[var(--pd-content-card-hover-inset-bg)]
-                            {isSelected ? 'bg-[var(--pd-content-card-hover-inset-bg)]' : ''}"
-                          onclick={(): void => selectModel(model)}
-                          onkeydown={(e: KeyboardEvent): void => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault();
-                              selectModel(model);
-                            }
-                          }}>
-                          <td class="px-3 py-2">
-                            <StatusIcon status={getModelStatus(model)} />
-                          </td>
-                          <td class="px-3 py-2">
-                            <div class="font-medium text-[var(--pd-table-body-text-highlight)]">{model.label}</div>
-                            <div class="text-[11px] text-[var(--pd-content-card-text)] opacity-60">{model.connectionName}</div>
-                          </td>
-                          <td class="px-3 py-2 text-[var(--pd-table-body-text)]">—</td>
-                          <td class="px-3 py-2 text-[var(--pd-table-body-text)]">{model.providerName}</td>
-                          <td class="px-3 py-2 text-center">
-                            <input
-                              type="radio"
-                              name="workspaceModel"
-                              value={key}
-                              checked={isSelected}
-                              aria-label="Use {model.label}"
-                              onclick={(e: MouseEvent): void => e.stopPropagation()}
-                              onchange={(): void => selectModel(model)} />
-                          </td>
-                        </tr>
-                      {/each}
-                    </tbody>
-                  </table>
-                </div>
+                <ModelSelectionTable
+                  {models}
+                  selectedKey={selectedModel}
+                  radioName="workspaceModel"
+                  heading={categoryLabels[category]}
+                  onselect={selectModel}
+                  modelKey={getKey} />
               </div>
             {/if}
           {/each}

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
@@ -23,9 +23,10 @@ onMount(async () => {
 });
 
 let filteredDefinitions = $derived.by(() => {
-  if (!cliAgents) return agentDefinitions;
-  const filtered = agentDefinitions.filter(d => cliAgents!.includes(d.cliAgent ?? d.cliName));
-  return filtered.length > 0 ? filtered : agentDefinitions;
+  const withPanel = agentDefinitions.filter(d => d.panel);
+  if (!cliAgents) return withPanel;
+  const filtered = withPanel.filter(d => cliAgents!.includes(d.cliAgent ?? d.cliName));
+  return filtered.length > 0 ? filtered : withPanel;
 });
 
 const definitionsByAgent = $derived(new Map<string, AgentDefinition>(filteredDefinitions.map(d => [d.cliName, d])));

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -60,6 +60,7 @@ vi.mock(import('./guided-setup-steps'), async importOriginal => {
     ] satisfies GuidedSetupStep[],
     createDefaultOnboardingState: (): OnboardingState => ({
       agent: 'opencode',
+      model: undefined,
     }),
   };
 });
@@ -103,14 +104,14 @@ test('"Continue" advances to next step', async () => {
   expect(secondStepButton).toHaveAttribute('aria-current', 'step');
 });
 
-test('"Skip" advances to next step', async () => {
+test('"Skip" closes the wizard without saving', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
   const skipButton = screen.getByRole('button', { name: 'Skip' });
   await fireEvent.click(skipButton);
 
-  const secondStepButton = screen.getByRole('button', { name: 'Step B step' });
-  expect(secondStepButton).toHaveAttribute('aria-current', 'step');
+  expect(closeMock).toHaveBeenCalled();
+  expect(window.updateConfigurationValue).not.toHaveBeenCalled();
 });
 
 test('completed steps are tracked after Continue', async () => {
@@ -124,14 +125,16 @@ test('completed steps are tracked after Continue', async () => {
   expect(firstStepButton).toBeEnabled();
 });
 
-test('skipped steps are not marked completed', async () => {
+test('"Skip" is always visible regardless of step', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
-  const skipButton = screen.getByRole('button', { name: 'Skip' });
-  await fireEvent.click(skipButton);
+  expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument();
 
-  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
-  expect(firstStepButton).toBeDisabled();
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument();
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument();
 });
 
 test('last step shows "Go to Dashboard" instead of "Continue"', async () => {
@@ -187,16 +190,35 @@ test('stepper progress bar has correct number of connector lines', () => {
   expect(connectors.length).toBe(2);
 });
 
-test('Skip button is not shown for non-skippable steps', async () => {
+test('"Back" button is not shown on the first step', () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+});
+
+test('"Back" button appears on the second step', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
   await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
-  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
 
-  expect(screen.queryByRole('button', { name: 'Skip' })).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
 });
 
-test('persists default agent to settings.json when wizard completes', async () => {
+test('"Back" navigates to the previous step', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+
+  const secondStepButton = screen.getByRole('button', { name: 'Step B step' });
+  expect(secondStepButton).toHaveAttribute('aria-current', 'step');
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
+  expect(firstStepButton).toHaveAttribute('aria-current', 'step');
+});
+
+test('persists defaultWorkspaceSettings as object when wizard completes', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
   await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
@@ -204,20 +226,24 @@ test('persists default agent to settings.json when wizard completes', async () =
   await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
 
   await waitFor(() => {
-    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
+    expect(window.updateConfigurationValue).toHaveBeenCalledWith(
+      'onboarding.defaultWorkspaceSettings',
+      expect.objectContaining({
+        agent: 'opencode',
+        workspaceConfig: { environment: [], mounts: [] },
+      }),
+    );
   });
 });
 
-test('persists defaults when skipping to the end', async () => {
+test('"Skip" does not persist any defaults', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
   await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
-  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
 
-  await waitFor(() => {
-    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
-  });
+  expect(closeMock).toHaveBeenCalled();
+  expect(window.updateConfigurationValue).not.toHaveBeenCalled();
 });
 
 test('closes wizard even when persistence fails', async () => {

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -52,8 +52,8 @@ function buildWorkspaceConfig(): { environment: WorkspaceEnvVar[]; mounts: Works
   }
 
   if (agent === 'claude-vertex' && onboardingState.vertexConfig) {
-    const { projectId, region, credentialsPath, mountClaudeConfig } = onboardingState.vertexConfig;
-    const mounts: WorkspaceMount[] = [{ host: credentialsPath, target: '$HOME/.config/gcloud', ro: true }];
+    const { projectId, region, credentialsDir, mountClaudeConfig } = onboardingState.vertexConfig;
+    const mounts: WorkspaceMount[] = [{ host: credentialsDir, target: '$HOME/.config/gcloud', ro: true }];
     if (mountClaudeConfig) {
       mounts.push({ host: '$HOME/.claude', target: '$HOME/.claude', ro: true });
       mounts.push({ host: '$HOME/.claude.json', target: '$HOME/.claude.json', ro: true });

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -4,6 +4,7 @@ import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { SvelteSet } from 'svelte/reactivity';
 
+import { getAgentDefinition } from './agent-registry';
 import { createDefaultOnboardingState, guidedSetupSteps } from './guided-setup-steps';
 
 interface Props {
@@ -28,17 +29,60 @@ function getStepState(index: number): 'completed' | 'active' | 'upcoming' {
   return 'upcoming';
 }
 
-async function persistOnboardingDefaults(): Promise<void> {
-  await window.updateConfigurationValue('onboarding.defaultAgent', onboardingState.agent);
+interface WorkspaceEnvVar {
+  name: string;
+  value?: string;
+  secret?: string;
+}
 
-  if (onboardingState.agent === 'claude-vertex' && onboardingState.vertexConfig) {
-    await window.updateConfigurationValue('onboarding.vertexProjectId', onboardingState.vertexConfig.projectId);
-    await window.updateConfigurationValue('onboarding.vertexRegion', onboardingState.vertexConfig.region);
-    await window.updateConfigurationValue(
-      'onboarding.vertexCredentialsPath',
-      onboardingState.vertexConfig.credentialsPath,
-    );
+interface WorkspaceMount {
+  host: string;
+  target: string;
+  ro: boolean;
+}
+
+function buildWorkspaceConfig(): { environment: WorkspaceEnvVar[]; mounts: WorkspaceMount[] } {
+  const agent = onboardingState.agent;
+
+  if (agent === 'claude' && onboardingState.secretName) {
+    return {
+      environment: [{ name: 'ANTHROPIC_API_KEY', secret: onboardingState.secretName }],
+      mounts: [],
+    };
   }
+
+  if (agent === 'claude-vertex' && onboardingState.vertexConfig) {
+    const { projectId, region, credentialsPath, mountClaudeConfig } = onboardingState.vertexConfig;
+    const mounts: WorkspaceMount[] = [{ host: credentialsPath, target: '$HOME/.config/gcloud', ro: true }];
+    if (mountClaudeConfig) {
+      mounts.push({ host: '$HOME/.claude', target: '$HOME/.claude', ro: true });
+      mounts.push({ host: '$HOME/.claude.json', target: '$HOME/.claude.json', ro: true });
+    }
+    return {
+      environment: [
+        { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+        { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: projectId },
+        { name: 'CLOUD_ML_REGION', value: region },
+      ],
+      mounts,
+    };
+  }
+
+  return { environment: [], mounts: [] };
+}
+
+async function persistOnboardingDefaults(): Promise<void> {
+  const resolvedAgent = getAgentDefinition(onboardingState.agent).cliAgent ?? onboardingState.agent;
+
+  const settings = {
+    agent: resolvedAgent,
+    model: onboardingState.model ?? undefined,
+    workspaceConfig: buildWorkspaceConfig(),
+  };
+
+  // Strip Svelte reactive proxies so the value is safe for structured-clone over IPC
+  const plain = JSON.parse(JSON.stringify(settings));
+  await window.updateConfigurationValue('onboarding.defaultWorkspaceSettings', plain);
 }
 
 async function advance(): Promise<void> {
@@ -73,16 +117,15 @@ async function handleContinue(): Promise<void> {
   }
 }
 
-async function handleSkip(): Promise<void> {
-  if (advancing) return;
-  advancing = true;
-  try {
-    await advance();
-  } catch (err: unknown) {
-    console.error('advance failed', err);
-  } finally {
-    advancing = false;
-  }
+function handleSkip(): void {
+  onclose();
+}
+
+let isFirstStep = $derived(currentStepIndex === 0);
+
+function handleBack(): void {
+  if (advancing || isFirstStep) return;
+  currentStepIndex--;
 }
 
 function handleStepClick(index: number): void {
@@ -147,10 +190,15 @@ function handleStepClick(index: number): void {
   </div>
 
   <!-- Footer -->
-  <footer class="flex justify-end gap-3 px-8 py-6 bg-(--pd-content-bg)">
-    {#if currentStep?.isSkippable}
+  <footer class="flex items-center justify-between px-8 py-6 bg-(--pd-content-bg)">
+    <div>
+      {#if !isFirstStep}
+        <Button type="secondary" aria-label="Back" onclick={handleBack} disabled={advancing}>&lsaquo; Back</Button>
+      {/if}
+    </div>
+    <div class="flex gap-3">
       <Button type="secondary" aria-label="Skip" onclick={handleSkip} disabled={advancing}>Skip</Button>
-    {/if}
-    <Button type="primary" aria-label={continueLabel} onclick={handleContinue} disabled={advancing}>{continueLabel} &rsaquo;</Button>
+      <Button type="primary" aria-label={continueLabel} onclick={handleContinue} disabled={advancing}>{continueLabel} &rsaquo;</Button>
+    </div>
   </footer>
 </div>

--- a/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
@@ -192,7 +192,7 @@ describe('model selection', () => {
 
     renderStep();
 
-    const row = screen.getByTestId('model-row-llama3.2:3b');
+    const row = screen.getByTestId('model-row-ollama/llama3.2:3b');
     await fireEvent.click(row);
 
     await waitFor(() => {
@@ -205,7 +205,7 @@ describe('model selection', () => {
 
     renderStep();
 
-    const row = screen.getByTestId('model-row-llama3.2:3b');
+    const row = screen.getByTestId('model-row-ollama/llama3.2:3b');
     await fireEvent.click(row);
 
     await waitFor(() => {
@@ -261,7 +261,7 @@ describe('self-hosted models', () => {
 
     renderStep();
 
-    const row = screen.getByTestId('model-row-granite-model');
+    const row = screen.getByTestId('model-row-openshiftai/granite-model');
     await fireEvent.click(row);
 
     await waitFor(() => {

--- a/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
@@ -1,0 +1,438 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { Writable } from 'svelte/store';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { providerInfos } from '/@/stores/providers';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import type { OnboardingState } from './guided-setup-steps';
+import ModelStep from './ModelStep.svelte';
+
+vi.mock(import('/@/stores/providers'), async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    providerInfos: writable<ProviderInfo[]>([]),
+    fetchProviders: vi.fn().mockResolvedValue([]),
+  };
+});
+
+let onboarding: OnboardingState;
+
+function setProviders(providers: Partial<ProviderInfo>[]): void {
+  (providerInfos as Writable<ProviderInfo[]>).set(providers as ProviderInfo[]);
+}
+
+function ollamaProvider(...modelLabels: string[]): Partial<ProviderInfo> {
+  return {
+    id: 'ollama',
+    name: 'Ollama',
+    inferenceConnections: [
+      {
+        connectionType: 'inference',
+        name: 'ollama',
+        type: 'local',
+        status: 'started',
+        models: modelLabels.map(label => ({ label })),
+      },
+    ],
+  };
+}
+
+function ramalamaProvider(...modelLabels: string[]): Partial<ProviderInfo> {
+  return {
+    id: 'ramalama',
+    name: 'Ramalama',
+    inferenceConnections: [
+      {
+        connectionType: 'inference',
+        name: 'ramalama',
+        type: 'local',
+        status: 'started',
+        models: modelLabels.map(label => ({ label })),
+      },
+    ],
+  };
+}
+
+function openshiftAiProvider(...modelLabels: string[]): Partial<ProviderInfo> {
+  return {
+    id: 'openshiftai',
+    name: 'OpenShift AI',
+    inferenceConnections: [
+      {
+        connectionType: 'inference',
+        name: 'https://my-cluster/v1',
+        type: 'self-hosted',
+        status: 'unknown',
+        models: modelLabels.map(label => ({ label })),
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+  onboarding = { agent: 'opencode', model: undefined };
+  setProviders([]);
+  vi.stubGlobal('listVertexAiModels', vi.fn().mockResolvedValue([]));
+});
+
+function renderStep(overrides: Partial<OnboardingState> = {}): void {
+  Object.assign(onboarding, overrides);
+  render(ModelStep, {
+    stepId: 'model',
+    title: 'Model',
+    description: 'Select the default model.',
+    onboarding,
+  });
+}
+
+describe('rendering', () => {
+  test('renders the step title and description', () => {
+    renderStep();
+
+    expect(screen.getByText('Default model for the agent')).toBeInTheDocument();
+    expect(screen.getByText(/will use by default in new workspaces/)).toBeInTheDocument();
+  });
+
+  test('renders the model card container', () => {
+    renderStep();
+
+    expect(screen.getByTestId('model-step-card')).toBeInTheDocument();
+  });
+
+  test('includes agent name in description', () => {
+    renderStep();
+
+    expect(screen.getByText(/OpenCode/)).toBeInTheDocument();
+  });
+
+  test('shows empty state when no models are available', () => {
+    renderStep();
+
+    expect(screen.getByTestId('model-step-empty')).toBeInTheDocument();
+    expect(screen.getByText('No models found')).toBeInTheDocument();
+  });
+});
+
+describe('local models', () => {
+  test('shows local models section when Ollama models are available', () => {
+    setProviders([ollamaProvider('qwen3-code', 'llama3.2:3b')]);
+
+    renderStep();
+
+    expect(screen.getByTestId('local-models-section')).toBeInTheDocument();
+    expect(screen.getByText('qwen3-code')).toBeInTheDocument();
+    expect(screen.getByText('llama3.2:3b')).toBeInTheDocument();
+  });
+
+  test('shows combined provider names in section header', () => {
+    setProviders([ollamaProvider('model-a'), ramalamaProvider('model-b')]);
+
+    renderStep();
+
+    expect(screen.getByText(/Local · Ollama & Ramalama/)).toBeInTheDocument();
+  });
+
+  test('shows provider name and status in model subtitle', () => {
+    setProviders([ollamaProvider('qwen3-code')]);
+
+    renderStep();
+
+    expect(screen.getByText(/Ollama · loaded in memory/)).toBeInTheDocument();
+  });
+
+  test('auto-selects the first model', async () => {
+    setProviders([ollamaProvider('qwen3-code', 'llama3.2:3b')]);
+
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('Selected: qwen3-code');
+    });
+  });
+
+  test('updates onboarding.model when auto-selecting', async () => {
+    setProviders([ollamaProvider('qwen3-code')]);
+
+    renderStep();
+
+    await waitFor(() => {
+      expect(onboarding.model).toEqual(expect.objectContaining({ providerId: 'ollama', label: 'qwen3-code' }));
+    });
+  });
+});
+
+describe('model selection', () => {
+  test('clicking a model row selects it', async () => {
+    setProviders([ollamaProvider('qwen3-code', 'llama3.2:3b')]);
+
+    renderStep();
+
+    const row = screen.getByTestId('model-row-llama3.2:3b');
+    await fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('Selected: llama3.2:3b');
+    });
+  });
+
+  test('updates onboarding.model when a model is clicked', async () => {
+    setProviders([ollamaProvider('qwen3-code', 'llama3.2:3b')]);
+
+    renderStep();
+
+    const row = screen.getByTestId('model-row-llama3.2:3b');
+    await fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(onboarding.model).toEqual(expect.objectContaining({ providerId: 'ollama', label: 'llama3.2:3b' }));
+    });
+  });
+
+  test('radio input is checked for selected model', async () => {
+    setProviders([ollamaProvider('qwen3-code', 'llama3.2:3b')]);
+
+    renderStep();
+
+    await waitFor(() => {
+      const selectedRadio = screen.getByRole('radio', { name: 'Use qwen3-code' });
+      expect(selectedRadio).toBeChecked();
+    });
+
+    const unselectedRadio = screen.getByRole('radio', { name: 'Use llama3.2:3b' });
+    expect(unselectedRadio).not.toBeChecked();
+  });
+
+  test('restores previous selection when re-mounting', async () => {
+    setProviders([ollamaProvider('qwen3-code', 'llama3.2:3b')]);
+
+    renderStep({ model: { providerId: 'ollama', label: 'llama3.2:3b' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('Selected: llama3.2:3b');
+    });
+  });
+});
+
+describe('self-hosted models', () => {
+  test('shows In-house section when OpenShift AI models are available', () => {
+    setProviders([openshiftAiProvider('ibm-granite-3.3-8b-instruct')]);
+
+    renderStep();
+
+    expect(screen.getByTestId('self-hosted-models-section')).toBeInTheDocument();
+    expect(screen.getByText('ibm-granite-3.3-8b-instruct')).toBeInTheDocument();
+  });
+
+  test('shows OpenShift AI in section header', () => {
+    setProviders([openshiftAiProvider('my-model')]);
+
+    renderStep();
+
+    expect(screen.getByText(/In-house · OpenShift AI/)).toBeInTheDocument();
+  });
+
+  test('can select self-hosted models', async () => {
+    setProviders([ollamaProvider('qwen3-code'), openshiftAiProvider('granite-model')]);
+
+    renderStep();
+
+    const row = screen.getByTestId('model-row-granite-model');
+    await fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(onboarding.model).toEqual(expect.objectContaining({ providerId: 'openshiftai', label: 'granite-model' }));
+    });
+  });
+});
+
+describe('mixed providers', () => {
+  test('shows both local and self-hosted sections', () => {
+    setProviders([ollamaProvider('qwen3-code'), openshiftAiProvider('granite-model')]);
+
+    renderStep();
+
+    expect(screen.getByTestId('local-models-section')).toBeInTheDocument();
+    expect(screen.getByTestId('self-hosted-models-section')).toBeInTheDocument();
+  });
+
+  test('does not show empty state when models exist', () => {
+    setProviders([ollamaProvider('qwen3-code')]);
+
+    renderStep();
+
+    expect(screen.queryByTestId('model-step-empty')).not.toBeInTheDocument();
+  });
+});
+
+describe('agent filtering', () => {
+  test('filters models by agent provider mapping', () => {
+    setProviders([
+      ollamaProvider('local-model'),
+      {
+        id: 'claude',
+        name: 'Claude',
+        inferenceConnections: [
+          {
+            connectionType: 'inference',
+            name: 'claude',
+            type: 'cloud',
+            status: 'started',
+            models: [{ label: 'claude-sonnet-4-20250514' }],
+          },
+        ],
+      } as unknown as ProviderInfo,
+    ]);
+
+    renderStep({ agent: 'opencode' });
+
+    expect(screen.getByText('local-model')).toBeInTheDocument();
+    expect(screen.queryByText('claude-sonnet-4-20250514')).not.toBeInTheDocument();
+  });
+
+  test('shows claude models when agent is claude', () => {
+    setProviders([
+      ollamaProvider('local-model'),
+      {
+        id: 'claude',
+        name: 'Claude',
+        inferenceConnections: [
+          {
+            connectionType: 'inference',
+            name: 'claude',
+            type: 'cloud',
+            status: 'started',
+            models: [{ label: 'claude-sonnet-4-20250514' }],
+          },
+        ],
+      } as unknown as ProviderInfo,
+    ]);
+
+    renderStep({ agent: 'claude' });
+
+    expect(screen.queryByText('local-model')).not.toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-4-20250514')).toBeInTheDocument();
+  });
+});
+
+describe('vertex AI models', () => {
+  test('fetches models from Vertex AI when agent is claude-vertex', async () => {
+    vi.mocked(window.listVertexAiModels).mockResolvedValue([
+      { name: 'claude-sonnet-4-20250514', displayName: 'claude-sonnet-4-20250514' },
+      { name: 'claude-3-5-haiku-20241022', displayName: 'claude-3-5-haiku-20241022' },
+    ]);
+
+    renderStep({
+      agent: 'claude-vertex',
+      vertexConfig: { projectId: 'my-proj', region: 'us-east5', credentialsPath: '/gcloud' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('claude-sonnet-4-20250514')).toBeInTheDocument();
+      expect(screen.getByText('claude-3-5-haiku-20241022')).toBeInTheDocument();
+    });
+
+    expect(window.listVertexAiModels).toHaveBeenCalledWith({
+      projectId: 'my-proj',
+      region: 'us-east5',
+      credentialsPath: '/gcloud',
+    });
+  });
+
+  test('shows loading state while fetching vertex models', async () => {
+    let resolveModels: (v: unknown) => void;
+    const pending = new Promise(resolve => {
+      resolveModels = resolve;
+    });
+    vi.mocked(window.listVertexAiModels).mockReturnValue(pending as ReturnType<typeof window.listVertexAiModels>);
+
+    renderStep({
+      agent: 'claude-vertex',
+      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('vertex-loading')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Fetching models from Vertex AI/)).toBeInTheDocument();
+
+    resolveModels!([]);
+  });
+
+  test('shows error state when vertex fetch fails', async () => {
+    vi.mocked(window.listVertexAiModels).mockRejectedValue(new Error('permission denied'));
+
+    renderStep({
+      agent: 'claude-vertex',
+      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('vertex-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Failed to fetch Vertex AI models')).toBeInTheDocument();
+    expect(screen.getByText('permission denied')).toBeInTheDocument();
+  });
+
+  test('shows empty state when vertex returns no models', async () => {
+    vi.mocked(window.listVertexAiModels).mockResolvedValue([]);
+
+    renderStep({
+      agent: 'claude-vertex',
+      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-step-empty')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/valid credentials/)).toBeInTheDocument();
+  });
+
+  test('does not fetch vertex models when config is incomplete', () => {
+    renderStep({
+      agent: 'claude-vertex',
+      vertexConfig: { projectId: '', region: 'us-east5', credentialsPath: '/c' },
+    });
+
+    expect(window.listVertexAiModels).not.toHaveBeenCalled();
+  });
+
+  test('auto-selects first vertex model', async () => {
+    vi.mocked(window.listVertexAiModels).mockResolvedValue([
+      { name: 'claude-sonnet-4-20250514', displayName: 'claude-sonnet-4-20250514' },
+    ]);
+
+    renderStep({
+      agent: 'claude-vertex',
+      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+    });
+
+    await waitFor(() => {
+      expect(onboarding.model).toEqual(
+        expect.objectContaining({ providerId: 'claude', label: 'claude-sonnet-4-20250514' }),
+      );
+    });
+  });
+});

--- a/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
@@ -155,12 +155,14 @@ describe('local models', () => {
     expect(screen.getByText(/Local · Ollama & Ramalama/)).toBeInTheDocument();
   });
 
-  test('shows provider name and status in model subtitle', () => {
+  test('shows status label in subtitle and provider in Runtime column', () => {
     setProviders([ollamaProvider('qwen3-code')]);
 
     renderStep();
 
-    expect(screen.getByText(/Ollama · loaded in memory/)).toBeInTheDocument();
+    expect(screen.getByText(/loaded in memory/)).toBeInTheDocument();
+    const runtimeCells = screen.getAllByText('Ollama');
+    expect(runtimeCells.length).toBeGreaterThanOrEqual(1);
   });
 
   test('auto-selects the first model', async () => {
@@ -346,7 +348,7 @@ describe('vertex AI models', () => {
 
     renderStep({
       agent: 'claude-vertex',
-      vertexConfig: { projectId: 'my-proj', region: 'us-east5', credentialsPath: '/gcloud' },
+      vertexConfig: { projectId: 'my-proj', region: 'us-east5', credentialsDir: '/gcloud' },
     });
 
     await waitFor(() => {
@@ -357,7 +359,7 @@ describe('vertex AI models', () => {
     expect(window.listVertexAiModels).toHaveBeenCalledWith({
       projectId: 'my-proj',
       region: 'us-east5',
-      credentialsPath: '/gcloud',
+      credentialsDir: '/gcloud',
     });
   });
 
@@ -370,7 +372,7 @@ describe('vertex AI models', () => {
 
     renderStep({
       agent: 'claude-vertex',
-      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+      vertexConfig: { projectId: 'p', region: 'r', credentialsDir: '/c' },
     });
 
     await waitFor(() => {
@@ -386,7 +388,7 @@ describe('vertex AI models', () => {
 
     renderStep({
       agent: 'claude-vertex',
-      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+      vertexConfig: { projectId: 'p', region: 'r', credentialsDir: '/c' },
     });
 
     await waitFor(() => {
@@ -401,7 +403,7 @@ describe('vertex AI models', () => {
 
     renderStep({
       agent: 'claude-vertex',
-      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+      vertexConfig: { projectId: 'p', region: 'r', credentialsDir: '/c' },
     });
 
     await waitFor(() => {
@@ -413,7 +415,7 @@ describe('vertex AI models', () => {
   test('does not fetch vertex models when config is incomplete', () => {
     renderStep({
       agent: 'claude-vertex',
-      vertexConfig: { projectId: '', region: 'us-east5', credentialsPath: '/c' },
+      vertexConfig: { projectId: '', region: 'us-east5', credentialsDir: '/c' },
     });
 
     expect(window.listVertexAiModels).not.toHaveBeenCalled();
@@ -426,7 +428,7 @@ describe('vertex AI models', () => {
 
     renderStep({
       agent: 'claude-vertex',
-      vertexConfig: { projectId: 'p', region: 'r', credentialsPath: '/c' },
+      vertexConfig: { projectId: 'p', region: 'r', credentialsDir: '/c' },
     });
 
     await waitFor(() => {

--- a/packages/renderer/src/lib/guided-setup/ModelStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-import { Spinner, StatusIcon } from '@podman-desktop/ui-svelte';
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { untrack } from 'svelte';
 
 import { type CatalogModelInfo, getCatalogModels } from '/@/lib/models/models-utils';
+import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
 import { providerInfos } from '/@/stores/providers';
 
 import { getAgentDefinition } from './agent-registry';
@@ -16,15 +17,6 @@ const agentToProviders: Record<CliAgent, string[]> = {
   'claude-vertex': ['claude'],
   cursor: [],
   goose: [],
-};
-
-const statusMap: Record<string, string> = {
-  started: 'RUNNING',
-  starting: 'STARTING',
-  stopped: 'CREATED',
-  stopping: 'DELETING',
-  failed: 'DEGRADED',
-  unknown: 'RUNNING',
 };
 
 let agentTitle = $derived(getAgentDefinition(onboarding.agent).title);
@@ -41,18 +33,18 @@ let allModels: CatalogModelInfo[] = $derived(onboarding.agent === 'claude-vertex
 
 $effect(() => {
   if (onboarding.agent === 'claude-vertex' && onboarding.vertexConfig) {
-    const { projectId, region, credentialsPath } = onboarding.vertexConfig;
-    if (projectId && region && credentialsPath) {
-      fetchVertexModels(projectId, region, credentialsPath).catch((e: unknown) => console.error(e));
+    const { projectId, region, credentialsDir } = onboarding.vertexConfig;
+    if (projectId && region && credentialsDir) {
+      fetchVertexModels(projectId, region, credentialsDir).catch((e: unknown) => console.error(e));
     }
   }
 });
 
-async function fetchVertexModels(projectId: string, region: string, credentialsPath: string): Promise<void> {
+async function fetchVertexModels(projectId: string, region: string, credentialsDir: string): Promise<void> {
   vertexLoading = true;
   vertexError = '';
   try {
-    const models = await window.listVertexAiModels({ projectId, region, credentialsPath });
+    const models = await window.listVertexAiModels({ projectId, region, credentialsDir });
     vertexModels = models.map(m => ({
       providerId: 'claude',
       providerName: 'Anthropic (Vertex AI)',
@@ -95,19 +87,20 @@ $effect(() => {
   }
 });
 
-function selectModel(label: string): void {
-  userSelectionLabel = label;
+function selectModel(model: CatalogModelInfo): void {
+  userSelectionLabel = model.label;
 }
 
 function uniqueProviderNames(models: CatalogModelInfo[]): string {
   return [...new Set(models.map(m => m.providerName))].join(' & ');
 }
 
-function mapStatus(connectionStatus: string): string {
-  return statusMap[connectionStatus] ?? 'RUNNING';
+function getModelKey(model: CatalogModelInfo): string {
+  return model.providerId + '/' + model.label;
 }
 
-function statusLabel(connectionStatus: string, type: string): string {
+function statusLabel(model: CatalogModelInfo): string {
+  const { connectionStatus, type } = model;
   if (connectionStatus === 'started') return type === 'local' ? 'loaded in memory' : 'deployed';
   if (connectionStatus === 'stopped') return type === 'local' ? 'not loaded' : 'not deployed';
   if (connectionStatus === 'starting') return 'starting…';
@@ -156,128 +149,23 @@ function statusLabel(connectionStatus: string, type: string): string {
       </div>
     {/if}
 
-    {#if localModels.length > 0}
-      <div class="mb-6" data-testid="local-models-section">
-        <h4 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
-          Local · {uniqueProviderNames(localModels)}
-        </h4>
-        <div class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-bg) overflow-hidden">
-          {#each localModels as model, idx (model.providerId + '/' + model.label)}
-            {#if idx > 0}
-              <div class="mx-3 border-t border-(--pd-content-divider) opacity-30"></div>
-            {/if}
-            <button
-              class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
-                {effectiveModel?.label === model.label
-                  ? 'bg-(--pd-content-card-hover-inset-bg)'
-                  : 'hover:bg-(--pd-content-card-hover-inset-bg)'}"
-              onclick={selectModel.bind(undefined, model.label)}
-              aria-label={model.label}
-              data-testid="model-row-{model.label}">
-              <StatusIcon status={mapStatus(model.connectionStatus)} />
-              <div class="min-w-0 flex-1">
-                <span class="text-[13px] font-medium text-(--pd-table-body-text-highlight)">{model.label}</span>
-                <div class="text-[11px] text-(--pd-table-body-text) mt-0.5">
-                  {model.providerName} · {statusLabel(model.connectionStatus, model.type)}
-                </div>
-              </div>
-              <div class="flex items-center gap-4 shrink-0 text-xs text-(--pd-table-body-text)">
-                <span class="w-20">{model.providerName}</span>
-                <input
-                  type="radio"
-                  name="model-selection"
-                  value={model.label}
-                  checked={effectiveModel?.label === model.label}
-                  aria-label="Use {model.label}"
-                  class="accent-(--pd-button-primary-bg) w-4 h-4 cursor-pointer pointer-events-none" />
-              </div>
-            </button>
-          {/each}
+    {#each [['local', localModels, 'Local · ' + uniqueProviderNames(localModels)] as const, ['self-hosted', selfHostedModels, 'In-house · ' + uniqueProviderNames(selfHostedModels)] as const, ['cloud', cloudModels, 'Cloud · ' + uniqueProviderNames(cloudModels)] as const] as [category, models, heading] (category)}
+      {#if models.length > 0}
+        <div class={category !== 'cloud' ? 'mb-6' : ''} data-testid="{category}-models-section">
+          <h4 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+            {heading}
+          </h4>
+          <ModelSelectionTable
+            {models}
+            selectedKey={effectiveModel ? getModelKey(effectiveModel) : ''}
+            radioName="model-selection"
+            {heading}
+            onselect={selectModel}
+            modelKey={getModelKey}
+            subtitle={statusLabel} />
         </div>
-      </div>
-    {/if}
-
-    {#if selfHostedModels.length > 0}
-      <div class="mb-6" data-testid="self-hosted-models-section">
-        <h4 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
-          In-house · {uniqueProviderNames(selfHostedModels)}
-        </h4>
-        <div class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-bg) overflow-hidden">
-          {#each selfHostedModels as model, idx (model.providerId + '/' + model.label)}
-            {#if idx > 0}
-              <div class="mx-3 border-t border-(--pd-content-divider) opacity-30"></div>
-            {/if}
-            <button
-              class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
-                {effectiveModel?.label === model.label
-                  ? 'bg-(--pd-content-card-hover-inset-bg)'
-                  : 'hover:bg-(--pd-content-card-hover-inset-bg)'}"
-              onclick={selectModel.bind(undefined, model.label)}
-              aria-label={model.label}
-              data-testid="model-row-{model.label}">
-              <StatusIcon status={mapStatus(model.connectionStatus)} />
-              <div class="min-w-0 flex-1">
-                <span class="text-[13px] font-medium text-(--pd-table-body-text-highlight)">{model.label}</span>
-                <div class="text-[11px] text-(--pd-table-body-text) mt-0.5">
-                  {model.providerName} · {statusLabel(model.connectionStatus, model.type)}
-                </div>
-              </div>
-              <div class="flex items-center gap-4 shrink-0 text-xs text-(--pd-table-body-text)">
-                <span class="w-20">{model.providerName}</span>
-                <input
-                  type="radio"
-                  name="model-selection"
-                  value={model.label}
-                  checked={effectiveModel?.label === model.label}
-                  aria-label="Use {model.label}"
-                  class="accent-(--pd-button-primary-bg) w-4 h-4 cursor-pointer pointer-events-none" />
-              </div>
-            </button>
-          {/each}
-        </div>
-      </div>
-    {/if}
-
-    {#if cloudModels.length > 0}
-      <div data-testid="cloud-models-section">
-        <h4 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
-          Cloud · {uniqueProviderNames(cloudModels)}
-        </h4>
-        <div class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-bg) overflow-hidden">
-          {#each cloudModels as model, idx (model.providerId + '/' + model.label)}
-            {#if idx > 0}
-              <div class="mx-3 border-t border-(--pd-content-divider) opacity-30"></div>
-            {/if}
-            <button
-              class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
-                {effectiveModel?.label === model.label
-                  ? 'bg-(--pd-content-card-hover-inset-bg)'
-                  : 'hover:bg-(--pd-content-card-hover-inset-bg)'}"
-              onclick={selectModel.bind(undefined, model.label)}
-              aria-label={model.label}
-              data-testid="model-row-{model.label}">
-              <StatusIcon status={mapStatus(model.connectionStatus)} />
-              <div class="min-w-0 flex-1">
-                <span class="text-[13px] font-medium text-(--pd-table-body-text-highlight)">{model.label}</span>
-                <div class="text-[11px] text-(--pd-table-body-text) mt-0.5">
-                  {model.providerName}
-                </div>
-              </div>
-              <div class="flex items-center gap-4 shrink-0 text-xs text-(--pd-table-body-text)">
-                <span class="w-20">{model.providerName}</span>
-                <input
-                  type="radio"
-                  name="model-selection"
-                  value={model.label}
-                  checked={effectiveModel?.label === model.label}
-                  aria-label="Use {model.label}"
-                  class="accent-(--pd-button-primary-bg) w-4 h-4 cursor-pointer pointer-events-none" />
-              </div>
-            </button>
-          {/each}
-        </div>
-      </div>
-    {/if}
+      {/if}
+    {/each}
   </div>
 
   {#if effectiveModel}

--- a/packages/renderer/src/lib/guided-setup/ModelStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.svelte
@@ -65,11 +65,13 @@ let localModels = $derived(allModels.filter(m => m.type === 'local'));
 let selfHostedModels = $derived(allModels.filter(m => m.type === 'self-hosted'));
 let cloudModels = $derived(allModels.filter(m => m.type === 'cloud'));
 
-let userSelectionLabel = $state(untrack(() => onboarding.model?.label ?? ''));
+let userSelectionKey = $state(
+  untrack(() => (onboarding.model ? getModelKey(onboarding.model as CatalogModelInfo) : '')),
+);
 
 let effectiveModel: CatalogModelInfo | undefined = $derived.by(() => {
-  if (userSelectionLabel) {
-    const match = allModels.find(m => m.label === userSelectionLabel);
+  if (userSelectionKey) {
+    const match = allModels.find(m => getModelKey(m) === userSelectionKey);
     if (match) return match;
   }
   return allModels.length > 0 ? allModels[0] : undefined;
@@ -88,7 +90,7 @@ $effect(() => {
 });
 
 function selectModel(model: CatalogModelInfo): void {
-  userSelectionLabel = model.label;
+  userSelectionKey = getModelKey(model);
 }
 
 function uniqueProviderNames(models: CatalogModelInfo[]): string {

--- a/packages/renderer/src/lib/guided-setup/ModelStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.svelte
@@ -28,6 +28,7 @@ let providerModels: CatalogModelInfo[] = $derived(
 let vertexModels: CatalogModelInfo[] = $state([]);
 let vertexLoading = $state(false);
 let vertexError = $state('');
+let fetchSeq = 0;
 
 let allModels: CatalogModelInfo[] = $derived(onboarding.agent === 'claude-vertex' ? vertexModels : providerModels);
 
@@ -41,10 +42,13 @@ $effect(() => {
 });
 
 async function fetchVertexModels(projectId: string, region: string, credentialsDir: string): Promise<void> {
+  const seq = ++fetchSeq;
   vertexLoading = true;
   vertexError = '';
+  vertexModels = [];
   try {
     const models = await window.listVertexAiModels({ projectId, region, credentialsDir });
+    if (seq !== fetchSeq) return;
     vertexModels = models.map(m => ({
       providerId: 'claude',
       providerName: 'Anthropic (Vertex AI)',
@@ -54,10 +58,11 @@ async function fetchVertexModels(projectId: string, region: string, credentialsD
       connectionStatus: 'started' as const,
     }));
   } catch (err: unknown) {
+    if (seq !== fetchSeq) return;
     vertexError = err instanceof Error ? err.message : String(err);
     vertexModels = [];
   } finally {
-    vertexLoading = false;
+    if (seq === fetchSeq) vertexLoading = false;
   }
 }
 

--- a/packages/renderer/src/lib/guided-setup/ModelStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+import { Spinner, StatusIcon } from '@podman-desktop/ui-svelte';
+import { untrack } from 'svelte';
+
+import { type CatalogModelInfo, getCatalogModels } from '/@/lib/models/models-utils';
+import { providerInfos } from '/@/stores/providers';
+
+import { getAgentDefinition } from './agent-registry';
+import type { CliAgent, GuidedSetupStepProps, OnboardingModelSelection } from './guided-setup-steps';
+
+let { onboarding }: GuidedSetupStepProps = $props();
+
+const agentToProviders: Record<CliAgent, string[]> = {
+  opencode: ['ollama', 'ramalama', 'openshiftai'],
+  claude: ['claude'],
+  'claude-vertex': ['claude'],
+  cursor: [],
+  goose: [],
+};
+
+const statusMap: Record<string, string> = {
+  started: 'RUNNING',
+  starting: 'STARTING',
+  stopped: 'CREATED',
+  stopping: 'DELETING',
+  failed: 'DEGRADED',
+  unknown: 'RUNNING',
+};
+
+let agentTitle = $derived(getAgentDefinition(onboarding.agent).title);
+
+let providerModels: CatalogModelInfo[] = $derived(
+  getCatalogModels($providerInfos).filter(m => agentToProviders[onboarding.agent]?.includes(m.providerId)),
+);
+
+let vertexModels: CatalogModelInfo[] = $state([]);
+let vertexLoading = $state(false);
+let vertexError = $state('');
+
+let allModels: CatalogModelInfo[] = $derived(onboarding.agent === 'claude-vertex' ? vertexModels : providerModels);
+
+$effect(() => {
+  if (onboarding.agent === 'claude-vertex' && onboarding.vertexConfig) {
+    const { projectId, region, credentialsPath } = onboarding.vertexConfig;
+    if (projectId && region && credentialsPath) {
+      fetchVertexModels(projectId, region, credentialsPath).catch((e: unknown) => console.error(e));
+    }
+  }
+});
+
+async function fetchVertexModels(projectId: string, region: string, credentialsPath: string): Promise<void> {
+  vertexLoading = true;
+  vertexError = '';
+  try {
+    const models = await window.listVertexAiModels({ projectId, region, credentialsPath });
+    vertexModels = models.map(m => ({
+      providerId: 'claude',
+      providerName: 'Anthropic (Vertex AI)',
+      connectionName: 'vertex-ai',
+      type: 'cloud' as const,
+      label: m.name,
+      connectionStatus: 'started' as const,
+    }));
+  } catch (err: unknown) {
+    vertexError = err instanceof Error ? err.message : String(err);
+    vertexModels = [];
+  } finally {
+    vertexLoading = false;
+  }
+}
+
+let localModels = $derived(allModels.filter(m => m.type === 'local'));
+let selfHostedModels = $derived(allModels.filter(m => m.type === 'self-hosted'));
+let cloudModels = $derived(allModels.filter(m => m.type === 'cloud'));
+
+let userSelectionLabel = $state(untrack(() => onboarding.model?.label ?? ''));
+
+let effectiveModel: CatalogModelInfo | undefined = $derived.by(() => {
+  if (userSelectionLabel) {
+    const match = allModels.find(m => m.label === userSelectionLabel);
+    if (match) return match;
+  }
+  return allModels.length > 0 ? allModels[0] : undefined;
+});
+
+$effect(() => {
+  if (effectiveModel) {
+    const selection: OnboardingModelSelection = {
+      providerId: effectiveModel.providerId,
+      label: effectiveModel.label,
+    };
+    onboarding.model = selection;
+  } else {
+    onboarding.model = undefined;
+  }
+});
+
+function selectModel(label: string): void {
+  userSelectionLabel = label;
+}
+
+function uniqueProviderNames(models: CatalogModelInfo[]): string {
+  return [...new Set(models.map(m => m.providerName))].join(' & ');
+}
+
+function mapStatus(connectionStatus: string): string {
+  return statusMap[connectionStatus] ?? 'RUNNING';
+}
+
+function statusLabel(connectionStatus: string, type: string): string {
+  if (connectionStatus === 'started') return type === 'local' ? 'loaded in memory' : 'deployed';
+  if (connectionStatus === 'stopped') return type === 'local' ? 'not loaded' : 'not deployed';
+  if (connectionStatus === 'starting') return 'starting…';
+  return connectionStatus;
+}
+</script>
+
+<div class="mx-auto max-w-3xl py-4">
+  <h2 class="text-xl font-semibold text-(--pd-content-card-text) mb-1">Default model for the agent</h2>
+  <p class="text-sm text-(--pd-content-card-text) opacity-60 mb-6">
+    This is the model {agentTitle} will use by default in new workspaces.
+    Names match the <strong>Models</strong> catalog; enable or disable rows there.
+    You can override per session later.
+  </p>
+
+  <div
+    class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
+    data-testid="model-step-card">
+    <p class="text-sm text-(--pd-content-card-text) opacity-70 mb-5">
+      Same rows as <strong>Models</strong>. Click a line or use the <strong>Use</strong> control
+      to pick your default for <strong>{onboarding.agent === 'opencode' ? 'local' : 'cloud'}</strong> models.
+    </p>
+
+    {#if vertexLoading}
+      <div class="flex items-center justify-center py-12 text-center gap-3" data-testid="vertex-loading">
+        <Spinner size="1.25em" />
+        <p class="text-sm text-(--pd-content-card-text) opacity-60">Fetching models from Vertex AI…</p>
+      </div>
+    {:else if vertexError}
+      <div class="py-6 text-center" data-testid="vertex-error">
+        <p class="text-sm text-(--pd-state-error) mb-1">Failed to fetch Vertex AI models</p>
+        <p class="text-xs text-(--pd-content-card-text) opacity-50">{vertexError}</p>
+      </div>
+    {:else if allModels.length === 0}
+      <div class="flex items-center justify-center py-12 text-center" data-testid="model-step-empty">
+        <div>
+          <p class="text-sm text-(--pd-content-card-text) opacity-60">No models found</p>
+          <p class="text-xs text-(--pd-content-card-text) opacity-40 mt-1">
+            {#if onboarding.agent === 'claude-vertex'}
+              Make sure you provided valid credentials and the Vertex AI API is enabled in your project.
+            {:else}
+              Make sure a compatible runtime is running with at least one model available.
+            {/if}
+          </p>
+        </div>
+      </div>
+    {/if}
+
+    {#if localModels.length > 0}
+      <div class="mb-6" data-testid="local-models-section">
+        <h4 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+          Local · {uniqueProviderNames(localModels)}
+        </h4>
+        <div class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-bg) overflow-hidden">
+          {#each localModels as model, idx (model.providerId + '/' + model.label)}
+            {#if idx > 0}
+              <div class="mx-3 border-t border-(--pd-content-divider) opacity-30"></div>
+            {/if}
+            <button
+              class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
+                {effectiveModel?.label === model.label
+                  ? 'bg-(--pd-content-card-hover-inset-bg)'
+                  : 'hover:bg-(--pd-content-card-hover-inset-bg)'}"
+              onclick={selectModel.bind(undefined, model.label)}
+              aria-label={model.label}
+              data-testid="model-row-{model.label}">
+              <StatusIcon status={mapStatus(model.connectionStatus)} />
+              <div class="min-w-0 flex-1">
+                <span class="text-[13px] font-medium text-(--pd-table-body-text-highlight)">{model.label}</span>
+                <div class="text-[11px] text-(--pd-table-body-text) mt-0.5">
+                  {model.providerName} · {statusLabel(model.connectionStatus, model.type)}
+                </div>
+              </div>
+              <div class="flex items-center gap-4 shrink-0 text-xs text-(--pd-table-body-text)">
+                <span class="w-20">{model.providerName}</span>
+                <input
+                  type="radio"
+                  name="model-selection"
+                  value={model.label}
+                  checked={effectiveModel?.label === model.label}
+                  aria-label="Use {model.label}"
+                  class="accent-(--pd-button-primary-bg) w-4 h-4 cursor-pointer pointer-events-none" />
+              </div>
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if selfHostedModels.length > 0}
+      <div class="mb-6" data-testid="self-hosted-models-section">
+        <h4 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+          In-house · {uniqueProviderNames(selfHostedModels)}
+        </h4>
+        <div class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-bg) overflow-hidden">
+          {#each selfHostedModels as model, idx (model.providerId + '/' + model.label)}
+            {#if idx > 0}
+              <div class="mx-3 border-t border-(--pd-content-divider) opacity-30"></div>
+            {/if}
+            <button
+              class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
+                {effectiveModel?.label === model.label
+                  ? 'bg-(--pd-content-card-hover-inset-bg)'
+                  : 'hover:bg-(--pd-content-card-hover-inset-bg)'}"
+              onclick={selectModel.bind(undefined, model.label)}
+              aria-label={model.label}
+              data-testid="model-row-{model.label}">
+              <StatusIcon status={mapStatus(model.connectionStatus)} />
+              <div class="min-w-0 flex-1">
+                <span class="text-[13px] font-medium text-(--pd-table-body-text-highlight)">{model.label}</span>
+                <div class="text-[11px] text-(--pd-table-body-text) mt-0.5">
+                  {model.providerName} · {statusLabel(model.connectionStatus, model.type)}
+                </div>
+              </div>
+              <div class="flex items-center gap-4 shrink-0 text-xs text-(--pd-table-body-text)">
+                <span class="w-20">{model.providerName}</span>
+                <input
+                  type="radio"
+                  name="model-selection"
+                  value={model.label}
+                  checked={effectiveModel?.label === model.label}
+                  aria-label="Use {model.label}"
+                  class="accent-(--pd-button-primary-bg) w-4 h-4 cursor-pointer pointer-events-none" />
+              </div>
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if cloudModels.length > 0}
+      <div data-testid="cloud-models-section">
+        <h4 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+          Cloud · {uniqueProviderNames(cloudModels)}
+        </h4>
+        <div class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-bg) overflow-hidden">
+          {#each cloudModels as model, idx (model.providerId + '/' + model.label)}
+            {#if idx > 0}
+              <div class="mx-3 border-t border-(--pd-content-divider) opacity-30"></div>
+            {/if}
+            <button
+              class="w-full flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors text-left
+                {effectiveModel?.label === model.label
+                  ? 'bg-(--pd-content-card-hover-inset-bg)'
+                  : 'hover:bg-(--pd-content-card-hover-inset-bg)'}"
+              onclick={selectModel.bind(undefined, model.label)}
+              aria-label={model.label}
+              data-testid="model-row-{model.label}">
+              <StatusIcon status={mapStatus(model.connectionStatus)} />
+              <div class="min-w-0 flex-1">
+                <span class="text-[13px] font-medium text-(--pd-table-body-text-highlight)">{model.label}</span>
+                <div class="text-[11px] text-(--pd-table-body-text) mt-0.5">
+                  {model.providerName}
+                </div>
+              </div>
+              <div class="flex items-center gap-4 shrink-0 text-xs text-(--pd-table-body-text)">
+                <span class="w-20">{model.providerName}</span>
+                <input
+                  type="radio"
+                  name="model-selection"
+                  value={model.label}
+                  checked={effectiveModel?.label === model.label}
+                  aria-label="Use {model.label}"
+                  class="accent-(--pd-button-primary-bg) w-4 h-4 cursor-pointer pointer-events-none" />
+              </div>
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  </div>
+
+  {#if effectiveModel}
+    <p class="text-sm text-(--pd-button-primary-bg) mt-4" data-testid="selected-model">
+      Selected: {effectiveModel.label}
+    </p>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
+++ b/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
@@ -21,6 +21,7 @@ import { faRobot } from '@fortawesome/free-solid-svg-icons';
 import type { Component } from 'svelte';
 
 import CodingAgentStep from './CodingAgentStep.svelte';
+import ModelStep from './ModelStep.svelte';
 
 export type CliAgent = 'opencode' | 'claude' | 'claude-vertex' | 'cursor' | 'goose';
 
@@ -28,11 +29,20 @@ export interface VertexConfig {
   projectId: string;
   region: string;
   credentialsPath: string;
+  mountClaudeConfig?: boolean;
+}
+
+export interface OnboardingModelSelection {
+  providerId: string;
+  label: string;
 }
 
 export interface OnboardingState {
   agent: CliAgent;
+  model: OnboardingModelSelection | undefined;
   vertexConfig?: VertexConfig;
+  /** Secret name created during Claude API key setup (e.g. 'anthropic'). */
+  secretName?: string;
   beforeAdvance?: () => Promise<boolean>;
 }
 
@@ -56,17 +66,27 @@ export interface GuidedSetupStep {
 export function createDefaultOnboardingState(): OnboardingState {
   return {
     agent: 'opencode',
+    model: undefined,
   };
 }
 
 export const guidedSetupSteps: GuidedSetupStep[] = [
   {
     id: 'coding-agent',
-    title: 'Choose your coding agent',
+    title: 'Coding agent',
     description:
       'Pick the default coding agent runtime. The API notes below update for your choice. You can change this later in settings.',
     icon: faRobot,
     component: CodingAgentStep,
+    isComplete: (): boolean => false,
+    isSkippable: true,
+  },
+  {
+    id: 'model',
+    title: 'Model',
+    description: 'Select the default model for the chosen agent.',
+    icon: faRobot,
+    component: ModelStep,
     isComplete: (): boolean => false,
     isSkippable: true,
   },

--- a/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
+++ b/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
@@ -28,7 +28,7 @@ export type CliAgent = 'opencode' | 'claude' | 'claude-vertex' | 'cursor' | 'goo
 export interface VertexConfig {
   projectId: string;
   region: string;
-  credentialsPath: string;
+  credentialsDir: string;
   mountClaudeConfig?: boolean;
 }
 

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -71,7 +71,7 @@ let onboarding: OnboardingState;
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
-  onboarding = { agent: 'claude' };
+  onboarding = { agent: 'claude', model: undefined };
   vi.stubGlobal('createSecret', vi.fn().mockResolvedValue({ name: 'anthropic' }));
   vi.stubGlobal('createInferenceProviderConnection', vi.fn().mockResolvedValue(undefined));
   stubClaudeProvider();
@@ -101,13 +101,29 @@ describe('rendering', () => {
     renderPanel();
 
     expect(screen.getByTestId('claude-provider-missing')).toBeInTheDocument();
-    expect(screen.getByLabelText('Anthropic API key')).toBeDisabled();
+    expect(screen.queryByLabelText('Anthropic API key')).not.toBeInTheDocument();
   });
 
   test('does not show error message initially', () => {
     renderPanel();
 
     expect(screen.queryByText(/Please enter your Anthropic API key/)).not.toBeInTheDocument();
+  });
+
+  test('shows connected state when inference connection already exists', () => {
+    stubClaudeProvider({ withModels: true });
+    renderPanel();
+
+    expect(screen.getByTestId('claude-already-connected')).toBeInTheDocument();
+    expect(screen.getByText('Connection configured')).toBeInTheDocument();
+    expect(screen.getByLabelText('Anthropic API key')).toBeDisabled();
+  });
+
+  test('does not show connected state when no connection exists', () => {
+    stubClaudeProvider();
+    renderPanel();
+
+    expect(screen.queryByTestId('claude-already-connected')).not.toBeInTheDocument();
   });
 });
 
@@ -117,6 +133,17 @@ describe('beforeAdvance callback', () => {
 
     expect(onboarding.beforeAdvance).toBeDefined();
     expect(typeof onboarding.beforeAdvance).toBe('function');
+  });
+
+  test('returns true immediately when connection already exists', async () => {
+    stubClaudeProvider({ withModels: true });
+    renderPanel();
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(true);
+    expect(window.createSecret).not.toHaveBeenCalled();
+    expect(window.createInferenceProviderConnection).not.toHaveBeenCalled();
   });
 
   test('returns false and shows error when API key is empty', async () => {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCircleCheck, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
@@ -27,9 +27,17 @@ let apiKey = $state('');
 let errorMessage = $state('');
 
 let claudeProvider = $derived($providerInfos.find(p => p.id === providerId));
+let alreadyConnected = $derived(claudeProvider !== undefined && claudeProvider.inferenceConnections.length > 0);
 
 async function validate(): Promise<boolean> {
   errorMessage = '';
+
+  if (alreadyConnected) {
+    if (onboarding) {
+      onboarding.secretName = secretType;
+    }
+    return true;
+  }
 
   if (!claudeProvider) {
     errorMessage = 'Claude provider extension is not available. Make sure the Claude extension is enabled.';
@@ -42,14 +50,21 @@ async function validate(): Promise<boolean> {
   }
 
   try {
-    await window.createSecret({
+    const result = await window.createSecret({
       name: secretType,
       type: secretType,
       value: apiKey.trim(),
     });
+    if (onboarding) {
+      onboarding.secretName = result.name;
+    }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes('already exists')) {
+    if (msg.includes('already exists')) {
+      if (onboarding) {
+        onboarding.secretName = secretType;
+      }
+    } else {
       errorMessage = `Failed to store secret: ${msg}`;
       return false;
     }
@@ -98,7 +113,25 @@ $effect(() => {
   </p>
 
   <div class="flex flex-col gap-3" data-testid="claude-form">
-    {#if !claudeProvider}
+    {#if alreadyConnected}
+      <div
+        class="flex items-center gap-3 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-success) p-4"
+        role="status"
+        data-testid="claude-already-connected">
+        <Icon icon={faCircleCheck} size="lg" class="text-(--pd-state-success)" />
+        <div>
+          <strong class="text-sm text-(--pd-state-success)">Connection configured</strong>
+          <p class="text-xs text-(--pd-content-card-text) opacity-70 mt-0.5">
+            An Anthropic API key is already stored. You can continue to the next step.
+          </p>
+        </div>
+      </div>
+      <Input
+        type="password"
+        value="••••••••••••••••"
+        aria-label="Anthropic API key"
+        disabled />
+    {:else if !claudeProvider}
       <div
         class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-warning) p-3"
         role="alert"
@@ -106,14 +139,13 @@ $effect(() => {
         <Icon icon={faTriangleExclamation} size="sm" class="text-(--pd-state-warning) shrink-0" />
         <span class="text-xs text-(--pd-state-warning)">Claude provider extension not detected.</span>
       </div>
+    {:else}
+      <Input
+        type="password"
+        placeholder="sk-ant-..."
+        bind:value={apiKey}
+        aria-label="Anthropic API key" />
     {/if}
-
-    <Input
-      type="password"
-      placeholder="sk-ant-..."
-      bind:value={apiKey}
-      aria-label="Anthropic API key"
-      disabled={!claudeProvider} />
 
     {#if errorMessage}
       <ErrorMessage error={errorMessage} />

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
@@ -160,7 +160,7 @@ describe('beforeAdvance callback', () => {
     expect(onboarding.vertexConfig).toEqual({
       projectId: 'my-gcp-project',
       region: 'us-east5',
-      credentialsPath: '/home/user/.config/gcloud',
+      credentialsDir: '/home/user/.config/gcloud',
       mountClaudeConfig: false,
     });
   });
@@ -181,7 +181,7 @@ describe('beforeAdvance callback', () => {
     expect(onboarding.vertexConfig).toEqual({
       projectId: 'my-project',
       region: 'europe-west1',
-      credentialsPath: '/home/user/.config/gcloud',
+      credentialsDir: '/home/user/.config/gcloud',
       mountClaudeConfig: false,
     });
   });
@@ -202,7 +202,7 @@ describe('beforeAdvance callback', () => {
     expect(onboarding.vertexConfig).toEqual({
       projectId: 'my-project',
       region: 'europe-west1',
-      credentialsPath: '/home/user/.config/gcloud',
+      credentialsDir: '/home/user/.config/gcloud',
       mountClaudeConfig: false,
     });
   });

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
@@ -30,7 +30,7 @@ let onboarding: OnboardingState;
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
-  onboarding = { agent: 'claude-vertex' };
+  onboarding = { agent: 'claude-vertex', model: undefined };
   vi.stubGlobal('openExternal', vi.fn().mockResolvedValue(undefined));
   vi.stubGlobal('openDialog', vi.fn().mockResolvedValue(undefined));
 });
@@ -61,11 +61,11 @@ describe('rendering', () => {
     expect(screen.queryByLabelText('CLAUDE_CODE_USE_VERTEX')).not.toBeInTheDocument();
   });
 
-  test('region input defaults to global', () => {
+  test('region input defaults to us-east5', () => {
     renderPanel();
 
     const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
-    expect(regionInput.value).toBe('global');
+    expect(regionInput.value).toBe('us-east5');
   });
 
   test('shows informational text about workspace.json mapping', () => {
@@ -159,8 +159,9 @@ describe('beforeAdvance callback', () => {
     expect(result).toBe(true);
     expect(onboarding.vertexConfig).toEqual({
       projectId: 'my-gcp-project',
-      region: 'global',
+      region: 'us-east5',
       credentialsPath: '/home/user/.config/gcloud',
+      mountClaudeConfig: false,
     });
   });
 
@@ -181,6 +182,7 @@ describe('beforeAdvance callback', () => {
       projectId: 'my-project',
       region: 'europe-west1',
       credentialsPath: '/home/user/.config/gcloud',
+      mountClaudeConfig: false,
     });
   });
 
@@ -201,6 +203,7 @@ describe('beforeAdvance callback', () => {
       projectId: 'my-project',
       region: 'europe-west1',
       credentialsPath: '/home/user/.config/gcloud',
+      mountClaudeConfig: false,
     });
   });
 });

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
@@ -63,7 +63,7 @@ async function validate(): Promise<boolean> {
     onboarding.vertexConfig = {
       projectId: projectId.trim(),
       region: region.trim(),
-      credentialsPath: credentialsPath.trim(),
+      credentialsDir: credentialsPath.trim(),
       mountClaudeConfig,
     };
   }

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
@@ -12,7 +12,7 @@ interface Props {
 let { onboarding }: Props = $props();
 
 let projectId = $state('');
-let region = $state('global');
+let region = $state('us-east5');
 let credentialsPath = $state('');
 let mountClaudeConfig = $state(false);
 let errorMessage = $state('');
@@ -64,6 +64,7 @@ async function validate(): Promise<boolean> {
       projectId: projectId.trim(),
       region: region.trim(),
       credentialsPath: credentialsPath.trim(),
+      mountClaudeConfig,
     };
   }
 

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -58,8 +58,8 @@ function handleKeydown(e: KeyboardEvent, model: CatalogModelInfo): void {
         {@const key = getKey(model)}
         {@const isSelected = selectedKey === key}
         <tr
-          role="button"
           tabindex="0"
+          aria-selected={isSelected}
           class="border-b border-(--pd-content-divider) last:border-b-0 transition-colors
             cursor-pointer hover:bg-(--pd-content-card-hover-inset-bg)
             {isSelected ? 'bg-(--pd-content-card-hover-inset-bg)' : ''}"

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -20,7 +20,7 @@ const defaultStatusMap: Record<string, string> = {
   stopped: 'CREATED',
   stopping: 'DELETING',
   failed: 'DEGRADED',
-  unknown: 'RUNNING',
+  unknown: 'DEGRADED',
 };
 
 let {
@@ -43,7 +43,7 @@ function handleKeydown(e: KeyboardEvent, model: CatalogModelInfo): void {
 </script>
 
 <div class="rounded-md border border-(--pd-content-divider) overflow-hidden">
-  <table class="w-full text-sm" aria-label="{heading} models">
+  <table role="grid" class="w-full text-sm" aria-label="{heading} models">
     <thead>
       <tr class="border-b border-(--pd-content-divider) bg-(--pd-content-card-inset-bg)">
         <th class="w-10 px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Status</th>
@@ -65,7 +65,7 @@ function handleKeydown(e: KeyboardEvent, model: CatalogModelInfo): void {
             {isSelected ? 'bg-(--pd-content-card-hover-inset-bg)' : ''}"
           onclick={onselect.bind(undefined, model)}
           onkeydown={(e: KeyboardEvent): void => handleKeydown(e, model)}
-          data-testid="model-row-{model.label}">
+          data-testid="model-row-{getKey(model)}">
           <td class="px-3 py-2">
             <StatusIcon status={statusMapper(model.connectionStatus)} />
           </td>

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+import { StatusIcon } from '@podman-desktop/ui-svelte';
+
+import type { CatalogModelInfo } from './models-utils';
+
+interface Props {
+  models: CatalogModelInfo[];
+  selectedKey: string;
+  radioName: string;
+  heading: string;
+  onselect: (model: CatalogModelInfo) => void;
+  modelKey: (model: CatalogModelInfo) => string;
+  subtitle?: (model: CatalogModelInfo) => string;
+  statusMapper?: (connectionStatus: string) => string;
+}
+
+const defaultStatusMap: Record<string, string> = {
+  started: 'RUNNING',
+  starting: 'STARTING',
+  stopped: 'CREATED',
+  stopping: 'DELETING',
+  failed: 'DEGRADED',
+  unknown: 'RUNNING',
+};
+
+let {
+  models,
+  selectedKey,
+  radioName,
+  heading,
+  onselect,
+  modelKey: getKey,
+  subtitle = (m: CatalogModelInfo): string => m.connectionName,
+  statusMapper = (s: string): string => defaultStatusMap[s] ?? 'RUNNING',
+}: Props = $props();
+
+function handleKeydown(e: KeyboardEvent, model: CatalogModelInfo): void {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    onselect(model);
+  }
+}
+</script>
+
+<div class="rounded-md border border-(--pd-content-divider) overflow-hidden">
+  <table class="w-full text-sm" aria-label="{heading} models">
+    <thead>
+      <tr class="border-b border-(--pd-content-divider) bg-(--pd-content-card-inset-bg)">
+        <th class="w-10 px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Status</th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Name</th>
+        <th class="w-20 px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Size</th>
+        <th class="w-28 px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Runtime</th>
+        <th class="w-12 px-3 py-2 text-center text-xs font-medium text-(--pd-content-card-text) opacity-60">Use</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each models as model (getKey(model))}
+        {@const key = getKey(model)}
+        {@const isSelected = selectedKey === key}
+        <tr
+          role="button"
+          tabindex="0"
+          class="border-b border-(--pd-content-divider) last:border-b-0 transition-colors
+            cursor-pointer hover:bg-(--pd-content-card-hover-inset-bg)
+            {isSelected ? 'bg-(--pd-content-card-hover-inset-bg)' : ''}"
+          onclick={onselect.bind(undefined, model)}
+          onkeydown={(e: KeyboardEvent): void => handleKeydown(e, model)}
+          data-testid="model-row-{model.label}">
+          <td class="px-3 py-2">
+            <StatusIcon status={statusMapper(model.connectionStatus)} />
+          </td>
+          <td class="px-3 py-2">
+            <div class="font-medium text-(--pd-table-body-text-highlight)">{model.label}</div>
+            <div class="text-[11px] text-(--pd-content-card-text) opacity-60">{subtitle(model)}</div>
+          </td>
+          <td class="px-3 py-2 text-(--pd-table-body-text)">—</td>
+          <td class="px-3 py-2 text-(--pd-table-body-text)">{model.providerName}</td>
+          <td class="px-3 py-2 text-center">
+            <input
+              type="radio"
+              name={radioName}
+              value={key}
+              checked={isSelected}
+              aria-label="Use {model.label}"
+              class="accent-(--pd-button-primary-bg) w-4 h-4 cursor-pointer pointer-events-none" />
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
Implement Step 2 of the guided setup wizard where users pick a default model for their chosen agent. Models are fetched from provider extensions and grouped into Local, In-house, and Cloud sections. For Claude on Vertex AI, a new discovery service exchanges ADC credentials for an access token and queries the Vertex AI API. All onboarding choices (agent, model, environment variables, mounts) are persisted as a single object under onboarding.defaultWorkspaceSettings for later consumption by workspace creation.

https://github.com/user-attachments/assets/be6f1aa0-0e2d-411b-ba73-623660031bb8

Closes #1501