### PR TITLE
feat: add defaut model selection in create workspace wizard

### DIFF
--- a/packages/api/src/onboarding-settings-info.ts
+++ b/packages/api/src/onboarding-settings-info.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum OnboardingSettings {
-  SectionName = 'onboarding',
-  DefaultAgent = 'defaultAgent',
-  DefaultWorkspaceSettings = 'defaultWorkspaceSettings',
-  VertexProjectId = 'vertexProjectId',
-  VertexRegion = 'vertexRegion',
-  VertexCredentialsPath = 'vertexCredentialsPath',
+export interface DefaultWorkspaceModelSettings {
+  providerId: string;
+  connectionName: string;
+  label: string;
+}
+
+export interface DefaultWorkspaceSettings {
+  model?: DefaultWorkspaceModelSettings;
 }

--- a/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
@@ -49,3 +49,13 @@ test('registers onboarding configuration with hidden properties', () => {
     expect.objectContaining({ type: 'string', default: '', hidden: true }),
   );
 });
+
+test('registers defaultWorkspaceSettings as hidden object property', () => {
+  const init = new OnboardingInit(configurationRegistry);
+  init.init();
+
+  const config = registeredConfigs.at(0);
+  expect(config?.properties?.['onboarding.defaultWorkspaceSettings']).toEqual(
+    expect.objectContaining({ type: 'object', hidden: true }),
+  );
+});

--- a/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
@@ -56,6 +56,6 @@ test('registers defaultWorkspaceSettings as hidden object property', () => {
 
   const config = registeredConfigs.at(0);
   expect(config?.properties?.['onboarding.defaultWorkspaceSettings']).toEqual(
-    expect.objectContaining({ type: 'object', hidden: true }),
+    expect.objectContaining({ type: 'object', default: {}, hidden: true }),
   );
 });

--- a/packages/main/src/plugin/onboarding/onboarding-init.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.ts
@@ -38,6 +38,12 @@ export class OnboardingInit {
           default: '',
           hidden: true,
         },
+        [`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultWorkspaceSettings}`]: {
+          description: 'Default workspace settings selected during onboarding',
+          type: 'object',
+          default: {},
+          hidden: true,
+        },
         [`${OnboardingSettings.SectionName}.${OnboardingSettings.VertexProjectId}`]: {
           description: 'Google Cloud project ID for Claude on Vertex AI',
           type: 'string',

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -23,6 +23,7 @@ import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as mcpStore from '/@/stores/mcp-remote-servers';
+import * as modelCatalogStore from '/@/stores/model-catalog';
 import * as providerStore from '/@/stores/providers';
 import * as ragStore from '/@/stores/rag-environments';
 import * as secretVaultStore from '/@/stores/secret-vault';
@@ -41,6 +42,7 @@ vi.mock(import('/@/stores/mcp-remote-servers'));
 vi.mock(import('/@/stores/secret-vault'));
 vi.mock(import('/@/stores/providers'));
 vi.mock(import('/@/stores/rag-environments'));
+vi.mock(import('/@/stores/model-catalog'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -54,6 +56,13 @@ beforeEach(() => {
   vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
   vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([]);
   vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
+  vi.mocked(modelCatalogStore).disabledModels = writable<Set<string>>(new Set());
+  vi.mocked(modelCatalogStore.isModelEnabled).mockImplementation(
+    (disabled: Set<string>, providerId: string, label: string): boolean => !disabled.has(`${providerId}::${label}`),
+  );
+  vi.mocked(modelCatalogStore.modelKey).mockImplementation(
+    (providerId: string, label: string): string => `${providerId}::${label}`,
+  );
 });
 
 test('Expect page title displayed', () => {
@@ -672,6 +681,130 @@ test('Expect createAgentWorkspace called without network when agent_mode selecte
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
       network: undefined,
+    }));
+});
+
+const mockAnthropicProvider: ProviderInfo = {
+  id: 'claude',
+  name: 'Anthropic',
+  internalId: 'claude-internal',
+  status: 'started',
+  inferenceConnections: [
+    {
+      name: 'Anthropic Cloud',
+      type: 'cloud',
+      status: 'started',
+      llmMetadata: { name: 'anthropic' },
+      models: [{ label: 'claude-sonnet-4' }, { label: 'claude-opus-4' }],
+    },
+  ],
+  inferenceProviderConnectionCreation: false,
+} as unknown as ProviderInfo;
+
+const mockOllamaProvider: ProviderInfo = {
+  id: 'ollama',
+  name: 'Ollama',
+  internalId: 'ollama-internal',
+  status: 'started',
+  inferenceConnections: [
+    {
+      name: 'Ollama Local',
+      type: 'local',
+      status: 'started',
+      llmMetadata: { name: 'ollama' },
+      models: [{ label: 'llama3.2:3b' }],
+    },
+  ],
+  inferenceProviderConnectionCreation: false,
+} as unknown as ProviderInfo;
+
+test('Expect default model from onboarding.defaultWorkspaceSettings when valid', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+    if (key === 'onboarding.defaultAgent') return 'opencode';
+    if (key === 'onboarding.defaultWorkspaceSettings')
+      return { model: { providerId: 'claude', connectionName: 'Anthropic Cloud', label: 'claude-sonnet-4' } };
+    return undefined;
+  });
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.getConfigurationValue).toHaveBeenCalledWith('onboarding.defaultWorkspaceSettings');
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: 'claude::claude-sonnet-4',
+    }),
+  );
+});
+
+test('Expect first compatible model used when defaultWorkspaceSettings has no model and providers exist', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+    if (key === 'onboarding.defaultAgent') return 'opencode';
+    if (key === 'onboarding.defaultWorkspaceSettings') return {};
+    return undefined;
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider, mockOllamaProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: 'claude::claude-sonnet-4',
+    }),
+  );
+});
+
+test('Expect model undefined when no setting and no providers', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+    if (key === 'onboarding.defaultAgent') return 'opencode';
+    if (key === 'onboarding.defaultWorkspaceSettings') return {};
+    return undefined;
+  });
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: '',
+      agent: 'opencode',
+      name: 'my-repo',
+      skills: undefined,
+    }),
+  );
+});
+
+test('Expect first compatible model used when defaultWorkspaceSettings is undefined and providers exist', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+    if (key === 'onboarding.defaultAgent') return 'opencode';
+    if (key === 'onboarding.defaultWorkspaceSettings') return undefined;
+    return undefined;
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockOllamaProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: 'ollama::llama3.2:3b',
     }),
   );
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -681,7 +681,8 @@ test('Expect createAgentWorkspace called without network when agent_mode selecte
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
       network: undefined,
-    }));
+    }),
+  );
 });
 
 const mockAnthropicProvider: ProviderInfo = {
@@ -763,7 +764,7 @@ test('Expect first compatible model used when defaultWorkspaceSettings has no mo
   );
 });
 
-test('Expect model undefined when no setting and no providers', async () => {
+test('Expect model empty when no setting and no providers', async () => {
   vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
     if (key === 'onboarding.defaultAgent') return 'opencode';
     if (key === 'onboarding.defaultWorkspaceSettings') return {};

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -13,17 +13,20 @@ import AgentWorkspaceCreateStepNetworking from '/@/lib/agent-workspaces/AgentWor
 import AgentWorkspaceCreateStepToolsSecrets from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte';
 import AgentWorkspaceCreateStepWorkspace from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte';
 import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
+import { getCatalogModels } from '/@/lib/models/models-utils';
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
+import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
 import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
 import type { NetworkConfiguration } from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
+import type { DefaultWorkspaceSettings } from '/@api/onboarding-settings-info';
 
 const fileAccessOptions: FileAccessOption[] = [
   {
@@ -151,6 +154,19 @@ onMount(async () => {
   if (defaultAgent && agentDefinitions.some(d => d.cliName === defaultAgent)) {
     selectedAgent = defaultAgent;
   }
+
+  const defaultSettings = await window.getConfigurationValue<DefaultWorkspaceSettings>(
+    'onboarding.defaultWorkspaceSettings',
+  );
+  if (defaultSettings?.model?.providerId && defaultSettings.model.label) {
+    selectedModel = `${defaultSettings.model.providerId}::${defaultSettings.model.label}`;
+  }
+  if (!selectedModel) {
+    const firstModel = getFirstCompatibleModelKey();
+    if (firstModel) {
+      selectedModel = firstModel;
+    }
+  }
 });
 let selectedFileAccess = $state('workspace');
 let selectedNetwork = $state('registries');
@@ -244,6 +260,22 @@ function cancel(): void {
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 }
 
+function getFirstCompatibleModelKey(): string {
+  const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
+  const enabled = getCatalogModels($providerInfos).filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const seen = new Set<string>();
+  const unique = enabled.filter(m => {
+    const key = modelKey(m.providerId, m.label);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  const compatible = agentDef?.modelFilter ? unique.filter(m => m.llmMetadata?.name === agentDef.modelFilter) : unique;
+  const first = compatible[0];
+  return first ? modelKey(first.providerId, first.label) : '';
+}
+
 async function startWorkspace(): Promise<void> {
   if (!sessionName.trim() || !sourcePath.trim()) return;
 
@@ -257,7 +289,7 @@ async function startWorkspace(): Promise<void> {
     await window.createAgentWorkspace({
       sourcePath,
       agent: agentDef?.cliAgent ?? selectedAgent,
-      model: selectedModel || undefined,
+      model: selectedModel,
       name: sessionName,
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
       network,

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -159,7 +159,7 @@ onMount(async () => {
     'onboarding.defaultWorkspaceSettings',
   );
   if (defaultSettings?.model?.providerId && defaultSettings.model.label) {
-    selectedModel = `${defaultSettings.model.providerId}::${defaultSettings.model.label}`;
+    selectedModel = modelKey(defaultSettings.model.providerId, defaultSettings.model.label);
   }
   if (!selectedModel) {
     const firstModel = getFirstCompatibleModelKey();


### PR DESCRIPTION
To test:

add the following snippet in your settings.json:

```
"onboarding.defaultWorkspaceSettings": {
          "model": {
                  "providerId": "claude",
                  "label": "claude-opus-4-6"
          }
  },
```

Go create a workspace and if you have claude as the default agent you should see the claude opus 4.6 model selected

Fixes #1553