### PR TITLE
fix: fix feedback GitHub links

### DIFF
--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -50,7 +50,7 @@ export class FeedbackHandler {
     }
 
     const urlSearchParams = new URLSearchParams(this.toQueryParameters(issueProperties, additionalContent)).toString();
-    const link = `https://github.com/containers/podman-desktop/issues/new?${urlSearchParams}`;
+    const link = `https://github.com/openkaiden/kaiden/issues/new?${urlSearchParams}`;
     await shell.openExternal(link);
   }
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -172,7 +172,7 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
 
   await vi.waitFor(() => {
     expect(window.telemetryTrack).toHaveBeenCalledWith('feedback.openGitHub');
-    expect(window.openExternal).toHaveBeenCalledWith('https://github.com/containers/podman-desktop');
+    expect(window.openExternal).toHaveBeenCalledWith('https://github.com/openkaiden/kaiden');
   });
 });
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -72,7 +72,7 @@ async function sendFeedback(): Promise<void> {
 async function openGitHub(): Promise<void> {
   onCloseForm(false);
   await window.telemetryTrack('feedback.openGitHub');
-  await window.openExternal('https://github.com/containers/podman-desktop');
+  await window.openExternal('https://github.com/openkaiden/kaiden');
 }
 </script>
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -158,11 +158,11 @@ test.each([
 test.each([
   {
     category: 'bug',
-    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Fbug%20%F0%9F%90%9E%22',
+    link: 'https://github.com/openkaiden/kaiden/issues?q=label%3A%22bug%22',
   },
   {
     category: 'feature',
-    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Ffeature%20%F0%9F%92%A1%22',
+    link: 'https://github.com/openkaiden/kaiden/issues?q=label%3A%22enhancement%22',
   },
 ])('$category should have specific issues link', async ({ category, link }) => {
   const { getByLabelText } = renderGitHubIssueFeedback({

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -35,10 +35,12 @@ let issueValidationError = $derived.by(() => {
 
 let titlePlaceholder = $state(category === 'bug' ? 'Bug Report Title' : 'Feature name');
 let descriptionPlaceholder = $state(category === 'bug' ? 'Bug description' : 'Feature description');
+const KAIDEN_ISSUES_URL = 'https://github.com/openkaiden/kaiden/issues';
+
 let existingIssuesLink = $state(
   category === 'bug'
-    ? 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Fbug%20%F0%9F%90%9E%22'
-    : 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Ffeature%20%F0%9F%92%A1%22',
+    ? `${KAIDEN_ISSUES_URL}?q=label%3A%22bug%22`
+    : `${KAIDEN_ISSUES_URL}?q=label%3A%22enhancement%22`,
 );
 
 $effect(() => contentChange(Boolean(issueTitle || issueDescription)));
@@ -81,7 +83,7 @@ async function previewOnGitHub(): Promise<void> {
 
 <FeedbackForm>
   <svelte:fragment slot="content">
-    <div class="text-sm text-[var(--pd-state-warning)]">You can search existing {category} issues on <Link aria-label="GitHub issues" onclick={openGitHubIssues}>github.com/podman-desktop/podman-desktop/issues</Link></div>
+    <div class="text-sm text-[var(--pd-state-warning)]">You can search existing {category} issues on <Link aria-label="GitHub issues" onclick={openGitHubIssues}>github.com/openkaiden/kaiden/issues</Link></div>
     <!-- issue title -->
     <label for="issueTitle" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]">Title</label>
     <input


### PR DESCRIPTION
## Summary
- Updates the feedback GitHub/star link to point to `openkaiden/kaiden` instead of Podman Desktop.
- Updates existing bug/feature issue searches to use Kaiden issue labels.
- Updates the GitHub issue preview URL generated by the main feedback handler to create issues in Kaiden.

Fixes #1591
Fixes #1592
Fixes #1593

## Testing
- `pnpm run build:preload:types`
- `pnpm vitest --run --project=renderer packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts`
- `pnpm vitest --run --project=main packages/main/src/plugin/feedback-handler.spec.ts`

Note: the local environment is Node 22.16.0, while the repo currently declares Node >=24.0.0, so pnpm emitted engine warnings during validation.
