### PR TITLE
fix(models): show single provider card per provider

### DIFF
--- a/packages/renderer/src/lib/models/ModelsCatalog.svelte
+++ b/packages/renderer/src/lib/models/ModelsCatalog.svelte
@@ -96,7 +96,7 @@ function filterBySearch(models: CatalogModelInfo[], term: string): CatalogModelI
       m.label.toLowerCase().includes(q) ||
       m.providerId.toLowerCase().includes(q) ||
       m.providerName.toLowerCase().includes(q) ||
-      m.connectionName.toLowerCase().includes(q),
+      (m.connectionName?.toLowerCase().includes(q) ?? false),
   );
 }
 
@@ -106,7 +106,7 @@ function filterConnectionsBySearch(conns: InferenceConnectionSummary[], term: st
   return conns.filter(
     c =>
       c.providerName.toLowerCase().includes(q) ||
-      c.connectionName.toLowerCase().includes(q) ||
+      (c.connectionName?.toLowerCase().includes(q) ?? false) ||
       (c.connectionType?.toLowerCase().includes(q) ?? false),
   );
 }

--- a/packages/renderer/src/lib/models/models-utils.spec.ts
+++ b/packages/renderer/src/lib/models/models-utils.spec.ts
@@ -73,7 +73,7 @@ test('getCatalogModels handles connections with no models', () => {
   expect(getCatalogModels([provider])).toEqual([]);
 });
 
-test('getInferenceConnectionSummaries returns summaries for each connection', () => {
+test('getInferenceConnectionSummaries returns one summary per provider with aggregated model count', () => {
   const provider = {
     id: 'openai',
     name: 'OpenAI',
@@ -85,7 +85,7 @@ test('getInferenceConnectionSummaries returns summaries for each connection', ()
   } as unknown as ProviderInfo;
 
   const result = getInferenceConnectionSummaries([provider]);
-  expect(result).toHaveLength(2);
+  expect(result).toHaveLength(1);
   expect(result[0]).toEqual({
     providerName: 'OpenAI',
     providerId: 'openai',
@@ -93,17 +93,7 @@ test('getInferenceConnectionSummaries returns summaries for each connection', ()
     connectionName: 'conn-1',
     connectionType: 'cloud',
     status: 'started',
-    modelCount: 2,
-    creationDisplayName: 'OpenAI',
-  });
-  expect(result[1]).toEqual({
-    providerName: 'OpenAI',
-    providerId: 'openai',
-    providerInternalId: 'internal-1',
-    connectionName: 'conn-2',
-    connectionType: 'self-hosted',
-    status: 'stopped',
-    modelCount: 1,
+    modelCount: 3,
     creationDisplayName: 'OpenAI',
   });
 });

--- a/packages/renderer/src/lib/models/models-utils.ts
+++ b/packages/renderer/src/lib/models/models-utils.ts
@@ -66,18 +66,19 @@ export function getInferenceConnectionSummaries(providerInfos: ProviderInfo[]): 
   const result: InferenceConnectionSummary[] = [];
   for (const provider of providerInfos) {
     if (provider.inferenceConnections.length > 0) {
-      for (const connection of provider.inferenceConnections) {
-        result.push({
-          providerName: provider.name,
-          providerId: provider.id,
-          providerInternalId: provider.internalId,
-          connectionName: connection.name,
-          connectionType: connection.type,
-          status: connection.status,
-          modelCount: connection.models.length,
-          creationDisplayName: provider.inferenceProviderConnectionCreationDisplayName ?? provider.name,
-        });
-      }
+      const started = provider.inferenceConnections.find(c => c.status === 'started');
+      const representative = started ?? provider.inferenceConnections[0];
+      const totalModels = provider.inferenceConnections.reduce((sum, c) => sum + c.models.length, 0);
+      result.push({
+        providerName: provider.name,
+        providerId: provider.id,
+        providerInternalId: provider.internalId,
+        connectionName: representative.name,
+        connectionType: representative.type,
+        status: representative.status,
+        modelCount: totalModels,
+        creationDisplayName: provider.inferenceProviderConnectionCreationDisplayName ?? provider.name,
+      });
     } else if (provider.inferenceProviderConnectionCreation) {
       result.push({
         providerName: provider.name,


### PR DESCRIPTION
## Summary
- Providers like RamaLama that register multiple inference connections (one per model/port) caused the Models dashboard to display duplicate provider cards
- Fixed `getInferenceConnectionSummaries` in the renderer to group connections by provider, producing one card per provider with an aggregated model count
- Picks a "started" connection as the representative status when available

Fixes: https://github.com/openkaiden/kaiden/issues/1602

https://github.com/openkaiden/kaiden/pull/1610 is related

## Test plan
- [x] Unit tests updated and passing
- [ ] Verify Models dashboard shows one RamaLama card regardless of how many models are served

🤖 Generated with [Claude Code](https://claude.com/claude-code)