### PR TITLE
fix(workspaces): render actual terminal on details page

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -6,7 +6,6 @@ import { router } from 'tinro';
 import AgentWorkspaceDetailsFiles from '/@/lib/agent-workspaces/AgentWorkspaceDetailsFiles.svelte';
 import AgentWorkspaceDetailsOverview from '/@/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte';
 import AgentWorkspaceDetailsSettings from '/@/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte';
-import AgentWorkspaceDetailsTerminal from '/@/lib/agent-workspaces/AgentWorkspaceDetailsTerminal.svelte';
 import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
@@ -118,16 +117,13 @@ function handleRemove(): void {
       <AgentWorkspaceDetailsOverview {workspaceSummary} {configuration} />
     </Route>
     <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
-      <AgentWorkspaceDetailsTerminal />
+      <AgentWorkspaceTerminal workspaceId={workspaceId} />
     </Route>
     <Route path="/files" breadcrumb="Files" navigationHint="tab">
       <AgentWorkspaceDetailsFiles />
     </Route>
     <Route path="/settings" breadcrumb="Settings" navigationHint="tab">
       <AgentWorkspaceDetailsSettings />
-    </Route>
-    <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
-      <AgentWorkspaceTerminal workspaceId={workspaceId} />
     </Route>
   {/snippet}
 </DetailsPage>


### PR DESCRIPTION
## Summary
- Fixed workspace terminal tab showing a "not yet available" placeholder instead of the real xterm.js terminal
- Root cause: duplicate `<Route path="/terminal">` blocks — the first matched the placeholder component, preventing the real terminal from ever rendering
- Consolidated into a single route using `AgentWorkspaceTerminal`

## Test plan
- [ ] Open a workspace details page and click the Terminal tab
- [ ] Verify the xterm.js terminal renders and connects to the workspace shell
- [ ] Verify terminal works after stopping and restarting the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)