### PR TITLE
fix(ui): reduce custom nav icon size to match FontAwesome icons 

### DIFF
--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -25,7 +25,7 @@ let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps 
       <Fa icon={entry.icon.faIcon.definition} size={entry.icon.faIcon.size} />
     {:else if entry.icon.iconComponent}
       <!-- svelte-ignore svelte_component_deprecated -->
-      <svelte:component this={entry.icon.iconComponent} size="24" />
+      <svelte:component this={entry.icon.iconComponent} size="16" />
     {:else if entry.icon.iconImage && typeof entry.icon.iconImage === 'string'}
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
     {/if}


### PR DESCRIPTION
Custom SVG icons (like MCP) rendered at 24px while FontAwesome icons
use 'lg' (~21px with built-in whitespace). Reduce to 16px for visual
consistency.

<img width="220" height="438" alt="Screenshot 2026-05-05 at 11 47 39" src="https://github.com/user-attachments/assets/5c4c9ee0-4130-4da7-8389-310d010eddf2" />

However this as the effect of reducing the overall navbar size, since the extensions icon is also affected. New size on the left, old on the right:

<img width="170" height="405" alt="Screenshot 2026-05-05 at 11 53 43" src="https://github.com/user-attachments/assets/b63bd6b0-7a6c-4cef-a770-ffd5e1193f1f" />

Fixes #1567