### PR TITLE
fix(workspaces): auto-select first compatible model in create workspace wizard

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
@@ -189,24 +189,48 @@ test('search filters model list', async () => {
   expect(screen.queryByText('claude-opus-4')).not.toBeInTheDocument();
 });
 
-test('selecting agent clears model selection', async () => {
+test('switching agent keeps model if still compatible', async () => {
   vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider]);
 
   render(AgentWorkspaceCreateStepAgentModel, {
     selectedAgent: 'opencode',
-    selectedModel: 'claude::claude-sonnet-4',
+    selectedModel: 'claude::claude-opus-4',
   });
 
-  const initiallySelected = screen.getByRole('radio', { name: 'Use claude-sonnet-4' });
+  const initiallySelected = screen.getByRole('radio', { name: 'Use claude-opus-4' });
   expect(initiallySelected).toBeChecked();
 
-  // Switching agent resets model selection — all radios unchecked
+  // Switching to Claude Code — claude-opus-4 is Anthropic, still compatible
   await fireEvent.click(screen.getByText('Claude Code'));
 
-  const radios = screen.queryAllByRole('radio');
-  for (const r of radios) {
-    expect(r).not.toBeChecked();
-  }
+  expect(screen.getByRole('radio', { name: 'Use claude-opus-4' })).toBeChecked();
+});
+
+test('auto-selects first model when no model pre-selected', async () => {
+  vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider]);
+
+  render(AgentWorkspaceCreateStepAgentModel, {
+    selectedAgent: 'opencode',
+    selectedModel: '',
+  });
+
+  const firstRadio = screen.getByRole('radio', { name: 'Use claude-sonnet-4' });
+  expect(firstRadio).toBeChecked();
+});
+
+test('auto-selects first model when agent filters remove current selection', async () => {
+  vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider, mockOllamaProvider]);
+
+  render(AgentWorkspaceCreateStepAgentModel, {
+    selectedAgent: 'opencode',
+    selectedModel: 'ollama::llama3.2:3b',
+  });
+
+  // Switching to Claude filters out Ollama models, should auto-select first Anthropic model
+  await fireEvent.click(screen.getByText('Claude Code'));
+
+  const firstRadio = screen.getByRole('radio', { name: 'Use claude-sonnet-4' });
+  expect(firstRadio).toBeChecked();
 });
 
 test('disabled models are hidden from selection list', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -2,6 +2,7 @@
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import { StatusIcon } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { untrack } from 'svelte';
 
 import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
 import { type CatalogModelInfo, getCatalogModels } from '/@/lib/models/models-utils';
@@ -90,13 +91,20 @@ function selectModel(model: CatalogModelInfo): void {
 function selectAgent(value: string): void {
   if (selectedAgent === value) return;
   selectedAgent = value;
-  selectedModel = '';
 }
 
 $effect(() => {
-  if (!selectedModel) return;
-  const stillEligible = agentFilteredModels.some(m => modelKey(m.providerId, m.label) === selectedModel);
-  if (!stillEligible) selectedModel = '';
+  const models = agentFilteredModels;
+  const current = untrack(() => selectedModel);
+  if (current) {
+    const stillEligible = models.some(m => modelKey(m.providerId, m.label) === current);
+    if (stillEligible) return;
+  }
+  if (models.length > 0) {
+    selectedModel = modelKey(models[0].providerId, models[0].label);
+  } else if (current) {
+    selectedModel = '';
+  }
 });
 
 function navigateToModels(): void {


### PR DESCRIPTION
When no model is selected or the current selection becomes ineligible
after switching agents, automatically select the first compatible model
instead of leaving the selection empty.

Right now, if you have both local and say anthropic models, the 1st local one is selected. Not sure it's an issue.

Fixes #1607