### PR TITLE
fix: rename RAG to Knowledges in Docling and Milvus extension labels

### DIFF
--- a/extensions/docling/package.json
+++ b/extensions/docling/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docling",
   "displayName": "Docling Chunk Provider",
-  "description": "Registers a Docling chunk provider for RAG",
+  "description": "Registers a Docling chunk provider for Knowledges",
   "version": "0.1.0-next",
   "publisher": "kaiden",
   "license": "Apache-2.0",

--- a/extensions/milvus/README.md
+++ b/extensions/milvus/README.md
@@ -1,6 +1,6 @@
 # Milvus Knowledges Provider Extension
 
-This extension provides Milvus vector database integration to create Knowledges environment in Kaiden using the RAG methodology (Retrieval-Augmented Generation).
+This extension provides Milvus vector database integration to create a Knowledges environment in Kaiden using the RAG methodology (Retrieval-Augmented Generation).
 
 ## Features
 

--- a/extensions/milvus/README.md
+++ b/extensions/milvus/README.md
@@ -1,6 +1,6 @@
 # Milvus Knowledges Provider Extension
 
-This extension provides Milvus vector database integration for Knowledges (Retrieval-Augmented Generation) functionality in Kaiden.
+This extension provides Milvus vector database integration to create Knowledges environment in Kaiden using the RAG methodology (Retrieval-Augmented Generation).
 
 ## Features
 

--- a/extensions/milvus/README.md
+++ b/extensions/milvus/README.md
@@ -1,17 +1,17 @@
-# Milvus RAG Provider Extension
+# Milvus Knowledges Provider Extension
 
-This extension provides Milvus vector database integration for RAG (Retrieval-Augmented Generation) functionality in Kaiden.
+This extension provides Milvus vector database integration for Knowledges (Retrieval-Augmented Generation) functionality in Kaiden.
 
 ## Features
 
-- **RAG Connection Factory**: Creates Milvus vector database instances
+- **Knowledges Connection Factory**: Creates Milvus vector database instances
 - **Container-based**: Runs Milvus in containers for easy management
 - **Persistent Storage**: Each Milvus instance uses a dedicated folder in extension storage
 - **Port Exposure**: Exposes Milvus API (19530)
 
 ## Usage
 
-1. Navigate to the RAG providers section in Kaiden
+1. Navigate to the Knowledges section in Kaiden
 2. Click "Create Milvus Connection"
 3. Provide a name for your connection
 4. The extension will:
@@ -20,13 +20,13 @@ This extension provides Milvus vector database integration for RAG (Retrieval-Au
    - Create and start a Milvus container with:
      - Volume mount to the storage folder at `/var/lib/milvus`
      - Port 19530 exposed for Milvus API
-   - Register the connection for use with RAG
+   - Register the connection for use with Knowledges
 
 ## Configuration
 
 The extension supports the following configuration parameter:
 
-- **name**: (Required) The name of the Milvus RAG connection
+- **name**: (Required) The name of the Milvus Knowledges connection
 
 ## License
 

--- a/extensions/milvus/package.json
+++ b/extensions/milvus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "milvus",
-  "displayName": "Milvus RAG Provider",
-  "description": "Provides Milvus vector database for RAG",
+  "displayName": "Milvus Knowledges Provider",
+  "description": "Provides Milvus vector database for Knowledges",
   "version": "0.1.0-next",
   "publisher": "kaiden",
   "license": "Apache-2.0",


### PR DESCRIPTION
The Docling and Milvus extension catalog entries still surfaced the legacy term "RAG" in their `displayName` / `description` fields and in the Milvus README. The navigation registry rebranded to "Knowledges" (see `packages/renderer/src/stores/navigation/navigation-registry-rag.svelte.ts` `name: 'Knowledges'` / `tooltip: 'Knowledges'`), and the workspace-create wizard's tools-and-secrets step uses "knowledges" alongside skills and MCP servers. The extension labels in the catalog were the last user-facing surface still saying "RAG".

## Changes

User-visible strings only:

- `extensions/docling/package.json` - `description`: "Registers a Docling chunk provider for **Knowledges**"
- `extensions/milvus/package.json` - `displayName`: "Milvus **Knowledges** Provider", `description`: "Provides Milvus vector database for **Knowledges**"
- `extensions/milvus/README.md` - header, the **Knowledges Connection Factory** feature bullet, "Navigate to the **Knowledges** section", "Register the connection for use with **Knowledges**", and the configuration parameter description.

The technical expansion in the README is preserved as "Knowledges (Retrieval-Augmented Generation)" so the doc still teaches readers what the brand maps to.

## Out of scope

- Internal API namespace `api.rag.*` and identifiers like `RagProviderConnectionFactory`, `ragConnection`, `ragEnvironments`. PR #1368 ("replace RAG by Knowledge Database(s)") established the same boundary - the rebrand has only touched user-facing copy and not the public API.
- Other extensions in the monorepo (none referenced "RAG" in their catalog labels).

Closes #1633