### PR TITLE
feat(onboarding): add model selection step and extract shared ModelSelectionTable

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
@@ -122,7 +122,7 @@ test('OpenCode tile has Recommended badge', () => {
 test('model catalog hidden when no agent selected', () => {
   render(AgentWorkspaceCreateStepAgentModel);
 
-  expect(screen.queryByText('Model for this workspace')).not.toBeInTheDocument();
+  expect(screen.queryByText('Model for workspace')).not.toBeInTheDocument();
 });
 
 test('model catalog shown after agent selection', async () => {
@@ -130,7 +130,7 @@ test('model catalog shown after agent selection', async () => {
 
   await fireEvent.click(screen.getByText('OpenCode'));
 
-  expect(screen.getByText('Model for this workspace')).toBeInTheDocument();
+  expect(screen.getByText('Model for workspace')).toBeInTheDocument();
 });
 
 test('shows empty state when no providers configured', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
-import { StatusIcon } from '@podman-desktop/ui-svelte';
-import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { untrack } from 'svelte';
 
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
 import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
-import { type CatalogModelInfo, getCatalogModels } from '/@/lib/models/models-utils';
-import { handleNavigation } from '/@/navigation';
+import type { CatalogModelInfo } from '/@/lib/models/models-utils';
+import { getCatalogModels } from '/@/lib/models/models-utils';
+import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
 import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
 import { providerInfos } from '/@/stores/providers';
-import { NavigationPage } from '/@api/navigation-page';
 
 interface Props {
   selectedAgent?: string;
@@ -18,25 +15,6 @@ interface Props {
 }
 
 let { selectedAgent = $bindable(''), selectedModel = $bindable() }: Props = $props();
-
-type ModelCategory = 'cloud' | 'corporate' | 'local';
-
-const categoryLabels: Record<ModelCategory, string> = {
-  cloud: 'Cloud · LLM providers',
-  corporate: 'In-house · OpenShift AI',
-  local: 'Local · Ollama & Ramalama',
-};
-
-const statusMap: Record<string, string> = {
-  started: 'RUNNING',
-  starting: 'STARTING',
-  stopped: 'CREATED',
-  stopping: 'DELETING',
-  failed: 'DEGRADED',
-  unknown: 'RUNNING',
-};
-
-let searchTerm = $state('');
 
 let allModels: CatalogModelInfo[] = $derived.by(() => {
   const enabled = getCatalogModels($providerInfos).filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
@@ -51,17 +29,13 @@ let allModels: CatalogModelInfo[] = $derived.by(() => {
 
 let agentFilteredModels: CatalogModelInfo[] = $derived(filterByAgent(allModels, selectedAgent));
 
-let displayedModels: CatalogModelInfo[] = $derived(filterBySearch(agentFilteredModels, searchTerm));
-
 let selectedAgentLabel: string = $derived(
   agentDefinitions.find(a => a.cliName === selectedAgent)?.title ?? 'the selected agent',
 );
 
-let cloudModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m.type === 'cloud'));
-let corporateModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m.type === 'self-hosted'));
-let localModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m.type === 'local'));
-
-let hasAnyModels: boolean = $derived(cloudModels.length > 0 || corporateModels.length > 0 || localModels.length > 0);
+let selectedKey: string = $derived(
+  selectedModel ? modelKey(selectedModel.providerId, selectedModel.label) : '',
+);
 
 function filterByAgent(models: CatalogModelInfo[], agent: string): CatalogModelInfo[] {
   if (!agent) return models;
@@ -70,22 +44,7 @@ function filterByAgent(models: CatalogModelInfo[], agent: string): CatalogModelI
   return models.filter(m => m.llmMetadata?.name === def.modelFilter);
 }
 
-function filterBySearch(models: CatalogModelInfo[], term: string): CatalogModelInfo[] {
-  if (!term.trim()) return models;
-  const q = term.trim().toLowerCase();
-  return models.filter(
-    m =>
-      m.label.toLowerCase().includes(q) ||
-      m.providerName.toLowerCase().includes(q) ||
-      m.connectionName.toLowerCase().includes(q),
-  );
-}
-
-function getModelStatus(model: CatalogModelInfo): string {
-  return statusMap[model.connectionStatus] ?? 'RUNNING';
-}
-
-function selectModel(model: CatalogModelInfo): void {
+function handleModelSelect(model: CatalogModelInfo): void {
   selectedModel = model;
 }
 
@@ -109,10 +68,6 @@ $effect(() => {
     selectedModel = undefined;
   }
 });
-
-function navigateToModels(): void {
-  handleNavigation({ page: NavigationPage.MODELS });
-}
 </script>
 
 <div class="flex flex-col gap-6">
@@ -157,105 +112,16 @@ function navigateToModels(): void {
   <!-- Model catalog -->
   {#if selectedAgent}
     <div>
-      <h3 class="text-base font-semibold text-[var(--pd-modal-text)] mb-1">Model for this workspace</h3>
+      <h3 class="text-base font-semibold text-[var(--pd-modal-text)] mb-1">Model for workspace</h3>
       <p class="text-xs text-[var(--pd-content-card-text)] opacity-70 mb-3">
         Choose the default model <strong class="text-[var(--pd-modal-text)]">{selectedAgentLabel}</strong> will use
         here. Disabled rows cannot be selected; the table is filtered to models that fit the agent you picked above.
       </p>
 
-      <!-- Toolbar -->
-      <div class="flex items-center justify-between mb-3 gap-3">
-        <div
-          class="flex items-center gap-2 px-3 py-1.5 rounded-md border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)] flex-1 max-w-xs">
-          <Icon icon={faSearch} size="sm" class="text-[var(--pd-content-card-text)] opacity-50" />
-          <input
-            type="search"
-            bind:value={searchTerm}
-            placeholder="Filter models…"
-            autocomplete="off"
-            aria-label="Filter catalog models"
-            class="bg-transparent border-none outline-none text-sm text-[var(--pd-content-card-text)] placeholder:opacity-50 w-full" />
-        </div>
-        <button
-          type="button"
-          class="text-xs text-[var(--pd-link)] hover:underline whitespace-nowrap"
-          onclick={navigateToModels}>
-          Open Models catalog
-        </button>
-      </div>
-
-      {#if !hasAnyModels}
-        <div class="text-sm text-[var(--pd-content-card-text)] opacity-70 py-4 text-center">
-          No model sources match your settings.
-          <button type="button" class="text-[var(--pd-link)] hover:underline" onclick={navigateToModels}>
-            Enable a provider in Models
-          </button>, then return here.
-        </div>
-      {:else}
-        <div class="flex flex-col gap-4">
-          {#each ([['cloud', cloudModels], ['corporate', corporateModels], ['local', localModels]] as const) as [category, models] (category)}
-            {#if models.length > 0}
-              <div>
-                <h4 class="text-xs font-semibold text-[var(--pd-content-card-text)] opacity-60 uppercase tracking-wide mb-2">
-                  {categoryLabels[category]}
-                </h4>
-                <div class="rounded-md border border-[var(--pd-content-card-border)] overflow-hidden">
-                  <table class="w-full text-sm" aria-label="{categoryLabels[category]} models">
-                    <thead>
-                      <tr class="border-b border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)]">
-                        <th class="w-10 px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Status</th>
-                        <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Name</th>
-                        <th class="w-20 px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Size</th>
-                        <th class="w-28 px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Runtime</th>
-                        <th class="w-12 px-3 py-2 text-center text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Use</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {#each models as model (modelKey(model.providerId, model.label))}
-                        {@const key = modelKey(model.providerId, model.label)}
-                        {@const isSelected = selectedModel ? modelKey(selectedModel.providerId, selectedModel.label) === key : false}
-                        <tr
-                          role="button"
-                          tabindex="0"
-                          class="border-b border-[var(--pd-content-card-border)] last:border-b-0 transition-colors
-                            cursor-pointer hover:bg-[var(--pd-content-card-hover-inset-bg)]
-                            {isSelected ? 'bg-[var(--pd-content-card-hover-inset-bg)]' : ''}"
-                          onclick={(): void => selectModel(model)}
-                          onkeydown={(e: KeyboardEvent): void => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault();
-                              selectModel(model);
-                            }
-                          }}>
-                          <td class="px-3 py-2">
-                            <StatusIcon status={getModelStatus(model)} />
-                          </td>
-                          <td class="px-3 py-2">
-                            <div class="font-medium text-[var(--pd-table-body-text-highlight)]">{model.label}</div>
-                            <div class="text-[11px] text-[var(--pd-content-card-text)] opacity-60">{model.connectionName}</div>
-                          </td>
-                          <td class="px-3 py-2 text-[var(--pd-table-body-text)]">—</td>
-                          <td class="px-3 py-2 text-[var(--pd-table-body-text)]">{model.providerName}</td>
-                          <td class="px-3 py-2 text-center">
-                            <input
-                              type="radio"
-                              name="workspaceModel"
-                              value={key}
-                              checked={isSelected}
-                              aria-label="Use {model.label}"
-                              onclick={(e: MouseEvent): void => e.stopPropagation()}
-                              onchange={(): void => selectModel(model)} />
-                          </td>
-                        </tr>
-                      {/each}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            {/if}
-          {/each}
-        </div>
-      {/if}
+      <ModelSelectionTable
+        models={agentFilteredModels}
+        selectedKey={selectedKey}
+        onselect={handleModelSelect} />
     </div>
   {/if}
 </div>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -33,9 +33,7 @@ let selectedAgentLabel: string = $derived(
   agentDefinitions.find(a => a.cliName === selectedAgent)?.title ?? 'the selected agent',
 );
 
-let selectedKey: string = $derived(
-  selectedModel ? modelKey(selectedModel.providerId, selectedModel.label) : '',
-);
+let selectedKey: string = $derived(selectedModel ? modelKey(selectedModel.providerId, selectedModel.label) : '');
 
 function filterByAgent(models: CatalogModelInfo[], agent: string): CatalogModelInfo[] {
   if (!agent) return models;

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.spec.ts
@@ -64,7 +64,7 @@ function renderStep(overrides: Partial<OnboardingState> = {}): void {
   Object.assign(onboarding, overrides);
   render(CodingAgentStep, {
     stepId: 'coding-agent',
-    title: 'Choose your coding agent',
+    title: 'Coding agent',
     description: 'Pick one runtime for kdn.',
     onboarding,
   });
@@ -100,7 +100,7 @@ describe('rendering', () => {
   test('step title and description are rendered', () => {
     renderStep();
 
-    expect(screen.getByText('Choose your coding agent')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Coding agent' })).toBeInTheDocument();
     expect(screen.getByText('Pick one runtime for kdn.')).toBeInTheDocument();
   });
 
@@ -228,54 +228,13 @@ describe('Claude agent tile', () => {
   });
 });
 
-describe('Claude on Vertex AI tile', () => {
-  test('renders the Vertex AI tile when CLI includes claude', async () => {
-    renderStep();
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Claude on Vertex AI' })).toBeInTheDocument();
+describe('agents without panels', () => {
+  test('does not show Cursor tile (no panel configured)', async () => {
+    vi.mocked(window.getCliInfo).mockResolvedValue({
+      version: '0.1.0',
+      agents: ['opencode', 'claude', 'cursor'],
+      runtimes: ['podman'],
     });
-  });
-
-  test('shows Vertex AI badge on the tile', async () => {
-    renderStep();
-
-    await waitFor(() => {
-      expect(screen.getByText('Vertex AI')).toBeInTheDocument();
-    });
-  });
-
-  test('shows Vertex panel when Claude on Vertex AI is selected', async () => {
-    renderStep();
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Claude on Vertex AI' })).toBeInTheDocument();
-    });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Claude on Vertex AI' }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('claude-vertex-panel')).toBeInTheDocument();
-      expect(screen.getByText('Google Cloud Vertex AI')).toBeInTheDocument();
-    });
-  });
-
-  test('updates onboarding.agent when Claude on Vertex AI is selected', async () => {
-    renderStep();
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Claude on Vertex AI' })).toBeInTheDocument();
-    });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Claude on Vertex AI' }));
-
-    await waitFor(() => {
-      expect(onboarding.agent).toBe('claude-vertex');
-    });
-  });
-
-  test('does not show Vertex tile when CLI does not include claude', async () => {
-    vi.mocked(window.getCliInfo).mockResolvedValue({ version: '0.1.0', agents: ['opencode'], runtimes: ['podman'] });
 
     renderStep();
 
@@ -283,7 +242,23 @@ describe('Claude on Vertex AI tile', () => {
       expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole('button', { name: 'Claude on Vertex AI' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cursor' })).not.toBeInTheDocument();
+  });
+
+  test('does not show Goose tile (no panel configured)', async () => {
+    vi.mocked(window.getCliInfo).mockResolvedValue({
+      version: '0.1.0',
+      agents: ['opencode', 'claude', 'goose'],
+      runtimes: ['podman'],
+    });
+
+    renderStep();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'OpenCode' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Goose' })).not.toBeInTheDocument();
   });
 });
 

--- a/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/CodingAgentStep.svelte
@@ -23,9 +23,10 @@ onMount(async () => {
 });
 
 let filteredDefinitions = $derived.by(() => {
-  if (!cliAgents) return agentDefinitions;
-  const filtered = agentDefinitions.filter(d => cliAgents!.includes(d.cliAgent ?? d.cliName));
-  return filtered.length > 0 ? filtered : agentDefinitions;
+  const withPanel = agentDefinitions.filter(d => d.panel);
+  if (!cliAgents) return withPanel;
+  const filtered = withPanel.filter(d => cliAgents!.includes(d.cliAgent ?? d.cliName));
+  return filtered.length > 0 ? filtered : withPanel;
 });
 
 const definitionsByAgent = $derived(new Map<string, AgentDefinition>(filteredDefinitions.map(d => [d.cliName, d])));

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -22,8 +22,11 @@ import { faBrain, faCheckCircle, faRobot } from '@fortawesome/free-solid-svg-ico
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { getAgentDefinition } from './agent-registry';
 import type { GuidedSetupStep, OnboardingState } from './guided-setup-steps';
 import GuidedSetup from './GuidedSetup.svelte';
+
+vi.mock(import('./agent-registry'));
 
 vi.mock(import('./guided-setup-steps'), async importOriginal => {
   const orig = await importOriginal();
@@ -69,6 +72,9 @@ const closeMock = vi.fn();
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
+  vi.mocked(getAgentDefinition).mockReturnValue({ cliName: 'opencode', title: 'OpenCode' } as ReturnType<
+    typeof getAgentDefinition
+  >);
   vi.stubGlobal('updateConfigurationValue', vi.fn().mockResolvedValue(undefined));
 });
 
@@ -103,14 +109,14 @@ test('"Continue" advances to next step', async () => {
   expect(secondStepButton).toHaveAttribute('aria-current', 'step');
 });
 
-test('"Skip" advances to next step', async () => {
+test('"Skip" closes the wizard without persisting', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
   const skipButton = screen.getByRole('button', { name: 'Skip' });
   await fireEvent.click(skipButton);
 
-  const secondStepButton = screen.getByRole('button', { name: 'Step B step' });
-  expect(secondStepButton).toHaveAttribute('aria-current', 'step');
+  expect(closeMock).toHaveBeenCalled();
+  expect(window.updateConfigurationValue).not.toHaveBeenCalled();
 });
 
 test('completed steps are tracked after Continue', async () => {
@@ -124,14 +130,13 @@ test('completed steps are tracked after Continue', async () => {
   expect(firstStepButton).toBeEnabled();
 });
 
-test('skipped steps are not marked completed', async () => {
+test('skipped steps close immediately without changing stepper state', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
   const skipButton = screen.getByRole('button', { name: 'Skip' });
   await fireEvent.click(skipButton);
 
-  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
-  expect(firstStepButton).toBeDisabled();
+  expect(closeMock).toHaveBeenCalled();
 });
 
 test('last step shows "Go to Dashboard" instead of "Continue"', async () => {
@@ -208,16 +213,13 @@ test('persists default agent to settings.json when wizard completes', async () =
   });
 });
 
-test('persists defaults when skipping to the end', async () => {
+test('Skip closes without persisting any settings', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
   await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
-  await fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
-  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
 
-  await waitFor(() => {
-    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
-  });
+  expect(closeMock).toHaveBeenCalled();
+  expect(window.updateConfigurationValue).not.toHaveBeenCalled();
 });
 
 test('closes wizard even when persistence fails', async () => {
@@ -243,4 +245,56 @@ test('does not persist defaults when advancing to intermediate steps', async () 
   await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
 
   expect(window.updateConfigurationValue).not.toHaveBeenCalled();
+});
+
+test('Back button is not shown on the first step', () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+});
+
+test('Back button appears after advancing to step 2', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+
+  expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+});
+
+test('Back button navigates to the previous step', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+
+  const secondStepButton = screen.getByRole('button', { name: 'Step B step' });
+  expect(secondStepButton).toHaveAttribute('aria-current', 'step');
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+  const firstStepButton = screen.getByRole('button', { name: 'Step A step' });
+  expect(firstStepButton).toHaveAttribute('aria-current', 'step');
+});
+
+test('Back button is hidden again after going back to the first step', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+  expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+});
+
+test('persists defaultWorkspaceSettings with workspaceConfig when wizard completes', async () => {
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
+
+  await waitFor(() => {
+    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultWorkspaceSettings', {
+      workspaceConfig: { environment: [] },
+    });
+  });
 });

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -130,7 +130,7 @@ test('completed steps are tracked after Continue', async () => {
   expect(firstStepButton).toBeEnabled();
 });
 
-test('skipped steps close immediately without changing stepper state', async () => {
+test('Skip closes the wizard immediately', async () => {
   render(GuidedSetup, { onclose: closeMock });
 
   const skipButton = screen.getByRole('button', { name: 'Skip' });

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -4,6 +4,7 @@ import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { SvelteSet } from 'svelte/reactivity';
 
+import { getAgentDefinition } from './agent-registry';
 import { createDefaultOnboardingState, guidedSetupSteps } from './guided-setup-steps';
 
 interface Props {
@@ -18,6 +19,7 @@ let onboardingState = $state(createDefaultOnboardingState());
 
 let hasSteps = $derived(guidedSetupSteps.length > 0);
 let currentStep = $derived(guidedSetupSteps[currentStepIndex]);
+let isFirstStep = $derived(currentStepIndex === 0);
 let isLastStep = $derived(currentStepIndex === guidedSetupSteps.length - 1);
 let continueLabel = $derived(isLastStep ? 'Go to Dashboard' : 'Continue');
 
@@ -28,17 +30,35 @@ function getStepState(index: number): 'completed' | 'active' | 'upcoming' {
   return 'upcoming';
 }
 
-async function persistOnboardingDefaults(): Promise<void> {
-  await window.updateConfigurationValue('onboarding.defaultAgent', onboardingState.agent);
+interface WorkspaceEnvVar {
+  name: string;
+  value?: string;
+  secret?: string;
+}
 
-  if (onboardingState.agent === 'claude-vertex' && onboardingState.vertexConfig) {
-    await window.updateConfigurationValue('onboarding.vertexProjectId', onboardingState.vertexConfig.projectId);
-    await window.updateConfigurationValue('onboarding.vertexRegion', onboardingState.vertexConfig.region);
-    await window.updateConfigurationValue(
-      'onboarding.vertexCredentialsPath',
-      onboardingState.vertexConfig.credentialsPath,
-    );
+function buildWorkspaceConfig(): { environment: WorkspaceEnvVar[] } {
+  const agent = onboardingState.agent;
+
+  if (agent === 'claude' && onboardingState.secretName) {
+    return {
+      environment: [{ name: 'ANTHROPIC_API_KEY', secret: onboardingState.secretName }],
+    };
   }
+
+  return { environment: [] };
+}
+
+async function persistOnboardingDefaults(): Promise<void> {
+  const resolvedAgent = getAgentDefinition(onboardingState.agent).cliAgent ?? onboardingState.agent;
+  await window.updateConfigurationValue('onboarding.defaultAgent', resolvedAgent);
+
+  const settings = {
+    model: onboardingState.model ?? undefined,
+    workspaceConfig: buildWorkspaceConfig(),
+  };
+
+  const plain = JSON.parse(JSON.stringify(settings));
+  await window.updateConfigurationValue('onboarding.defaultWorkspaceSettings', plain);
 }
 
 async function advance(): Promise<void> {
@@ -73,16 +93,13 @@ async function handleContinue(): Promise<void> {
   }
 }
 
-async function handleSkip(): Promise<void> {
-  if (advancing) return;
-  advancing = true;
-  try {
-    await advance();
-  } catch (err: unknown) {
-    console.error('advance failed', err);
-  } finally {
-    advancing = false;
-  }
+function handleSkip(): void {
+  onclose();
+}
+
+function goBack(): void {
+  if (advancing || isFirstStep) return;
+  currentStepIndex--;
 }
 
 function handleStepClick(index: number): void {
@@ -147,10 +164,17 @@ function handleStepClick(index: number): void {
   </div>
 
   <!-- Footer -->
-  <footer class="flex justify-end gap-3 px-8 py-6 bg-(--pd-content-bg)">
-    {#if currentStep?.isSkippable}
-      <Button type="secondary" aria-label="Skip" onclick={handleSkip} disabled={advancing}>Skip</Button>
-    {/if}
-    <Button type="primary" aria-label={continueLabel} onclick={handleContinue} disabled={advancing}>{continueLabel} &rsaquo;</Button>
+  <footer class="flex justify-between px-8 py-6 bg-(--pd-content-bg)">
+    <div>
+      {#if !isFirstStep}
+        <Button type="secondary" aria-label="Back" onclick={goBack} disabled={advancing}>&lsaquo; Back</Button>
+      {/if}
+    </div>
+    <div class="flex gap-3">
+      {#if currentStep?.isSkippable}
+        <Button type="secondary" aria-label="Skip" onclick={handleSkip} disabled={advancing}>Skip</Button>
+      {/if}
+      <Button type="primary" aria-label={continueLabel} onclick={handleContinue} disabled={advancing}>{continueLabel} &rsaquo;</Button>
+    </div>
   </footer>
 </div>

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -37,9 +37,9 @@ interface WorkspaceEnvVar {
 }
 
 function buildWorkspaceConfig(): { environment: WorkspaceEnvVar[] } {
-  const agent = onboardingState.agent;
+  const resolved = getAgentDefinition(onboardingState.agent).cliAgent ?? onboardingState.agent;
 
-  if (agent === 'claude' && onboardingState.secretName) {
+  if (resolved === 'claude' && onboardingState.secretName) {
     return {
       environment: [{ name: 'ANTHROPIC_API_KEY', secret: onboardingState.secretName }],
     };

--- a/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
@@ -149,7 +149,7 @@ describe('opencode agent models', () => {
     });
   });
 
-  test('does not show claude models for opencode agent', () => {
+  test('shows all available models for opencode agent', () => {
     stubProviders(MIXED_PROVIDERS);
     renderStep({ agent: 'opencode' });
 

--- a/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
@@ -1,0 +1,245 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { Writable } from 'svelte/store';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { providerInfos } from '/@/stores/providers';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import type { OnboardingState } from './guided-setup-steps';
+import { createDefaultOnboardingState } from './guided-setup-steps';
+import ModelStep from './ModelStep.svelte';
+
+vi.mock(import('/@/navigation'));
+
+vi.mock(import('/@/stores/providers'), async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    providerInfos: writable<ProviderInfo[]>([]),
+    fetchProviders: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock(import('/@/stores/model-catalog'), async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    disabledModels: writable<Set<string>>(new Set()),
+    modelKey: (providerId: string, label: string): string => `${providerId}::${label}`,
+    isModelEnabled: (): boolean => true,
+    toggleModel: vi.fn(),
+  };
+});
+
+let onboarding: OnboardingState;
+
+function stubProviders(providers: Partial<ProviderInfo>[]): void {
+  (providerInfos as Writable<ProviderInfo[]>).set(providers as unknown as ProviderInfo[]);
+}
+
+const OPENCODE_PROVIDERS: Partial<ProviderInfo>[] = [
+  {
+    id: 'ollama',
+    name: 'Ollama',
+    inferenceConnections: [
+      {
+        name: 'default',
+        type: 'local',
+        status: 'started',
+        models: [{ label: 'llama3.2:3b' }, { label: 'codellama:7b' }],
+        llmMetadata: { name: 'ollama' },
+      },
+    ],
+  } as unknown as ProviderInfo,
+];
+
+const CLAUDE_PROVIDERS: Partial<ProviderInfo>[] = [
+  {
+    id: 'claude',
+    name: 'Claude',
+    inferenceConnections: [
+      {
+        name: 'api-key',
+        type: 'cloud',
+        status: 'started',
+        models: [{ label: 'claude-sonnet-4-20250514' }, { label: 'claude-3-5-haiku-20241022' }],
+        llmMetadata: { name: 'anthropic' },
+      },
+    ],
+  } as unknown as ProviderInfo,
+];
+
+const MIXED_PROVIDERS: Partial<ProviderInfo>[] = [...OPENCODE_PROVIDERS, ...CLAUDE_PROVIDERS];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+  onboarding = createDefaultOnboardingState();
+  stubProviders([]);
+});
+
+function renderStep(overrides: Partial<OnboardingState> = {}): void {
+  Object.assign(onboarding, overrides);
+  render(ModelStep, {
+    stepId: 'model-selection',
+    title: 'Model',
+    description: 'Select the default model for your coding agent.',
+    onboarding,
+  });
+}
+
+describe('rendering', () => {
+  test('renders title and description', () => {
+    renderStep();
+
+    expect(screen.getByText('Default model for the agent')).toBeInTheDocument();
+    expect(screen.getByText(/used by default in new workspaces/)).toBeInTheDocument();
+  });
+
+  test('shows no-models message when no providers exist', () => {
+    renderStep();
+
+    expect(screen.getByTestId('no-models')).toBeInTheDocument();
+  });
+
+  test('shows agent-specific inner text for claude agent', () => {
+    stubProviders(CLAUDE_PROVIDERS);
+    renderStep({ agent: 'claude' });
+
+    expect(screen.getByText(/Claude Code rows/)).toBeInTheDocument();
+  });
+});
+
+describe('opencode agent models', () => {
+  test('displays local models for opencode agent', () => {
+    stubProviders(OPENCODE_PROVIDERS);
+    renderStep({ agent: 'opencode' });
+
+    expect(screen.getByText('llama3.2:3b')).toBeInTheDocument();
+    expect(screen.getByText('codellama:7b')).toBeInTheDocument();
+  });
+
+  test('auto-selects first model when none is pre-selected', async () => {
+    stubProviders(OPENCODE_PROVIDERS);
+    renderStep({ agent: 'opencode' });
+
+    await waitFor(() => {
+      expect(onboarding.model).toEqual({
+        providerId: 'ollama',
+        label: 'llama3.2:3b',
+      });
+    });
+  });
+
+  test('does not show claude models for opencode agent', () => {
+    stubProviders(MIXED_PROVIDERS);
+    renderStep({ agent: 'opencode' });
+
+    expect(screen.getByText('llama3.2:3b')).toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-4-20250514')).toBeInTheDocument();
+  });
+});
+
+describe('claude agent models', () => {
+  test('filters to anthropic models only for claude agent', () => {
+    stubProviders(MIXED_PROVIDERS);
+    renderStep({ agent: 'claude' });
+
+    expect(screen.getByText('claude-sonnet-4-20250514')).toBeInTheDocument();
+    expect(screen.getByText('claude-3-5-haiku-20241022')).toBeInTheDocument();
+    expect(screen.queryByText('llama3.2:3b')).not.toBeInTheDocument();
+  });
+
+  test('auto-selects first claude model', async () => {
+    stubProviders(CLAUDE_PROVIDERS);
+    renderStep({ agent: 'claude' });
+
+    await waitFor(() => {
+      expect(onboarding.model).toEqual({
+        providerId: 'claude',
+        label: 'claude-sonnet-4-20250514',
+      });
+    });
+  });
+});
+
+describe('model selection', () => {
+  test('updates onboarding.model when a model row is clicked', async () => {
+    stubProviders(OPENCODE_PROVIDERS);
+    renderStep({ agent: 'opencode' });
+
+    const row = screen.getByTestId('model-row-codellama:7b');
+    await fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(onboarding.model).toEqual({
+        providerId: 'ollama',
+        label: 'codellama:7b',
+      });
+    });
+  });
+
+  test('preserves pre-selected model from onboarding state', async () => {
+    stubProviders(OPENCODE_PROVIDERS);
+    renderStep({
+      agent: 'opencode',
+      model: { providerId: 'ollama', label: 'codellama:7b' },
+    });
+
+    await waitFor(() => {
+      expect(onboarding.model?.label).toBe('codellama:7b');
+    });
+
+    const radio = screen.getByRole('radio', { name: 'Use codellama:7b' });
+    expect(radio).toBeChecked();
+  });
+
+  test('clears model when no compatible models exist', async () => {
+    stubProviders([]);
+    renderStep({ agent: 'claude' });
+
+    await waitFor(() => {
+      expect(onboarding.model).toBeUndefined();
+    });
+  });
+});
+
+describe('model radio selection', () => {
+  test('auto-selected model has its radio checked', async () => {
+    stubProviders(OPENCODE_PROVIDERS);
+    renderStep({ agent: 'opencode' });
+
+    await waitFor(() => {
+      const radio = screen.getByRole('radio', { name: 'Use llama3.2:3b' });
+      expect(radio).toBeChecked();
+    });
+  });
+
+  test('shows selected model label below the table', async () => {
+    stubProviders(OPENCODE_PROVIDERS);
+    renderStep({ agent: 'opencode' });
+
+    await waitFor(() => {
+      const indicator = screen.getByTestId('selected-model');
+      expect(indicator).toHaveTextContent('Selected: llama3.2:3b');
+    });
+  });
+});

--- a/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.spec.ts
@@ -212,12 +212,13 @@ describe('model selection', () => {
     expect(radio).toBeChecked();
   });
 
-  test('clears model when no compatible models exist', async () => {
+  test('preserves model when catalog is empty (loading)', async () => {
+    const seeded = { providerId: 'claude', label: 'claude-sonnet-4-20250514' };
     stubProviders([]);
-    renderStep({ agent: 'claude' });
+    renderStep({ agent: 'claude', model: seeded });
 
     await waitFor(() => {
-      expect(onboarding.model).toBeUndefined();
+      expect(onboarding.model).toEqual(seeded);
     });
   });
 });

--- a/packages/renderer/src/lib/guided-setup/ModelStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import { untrack } from 'svelte';
+import { SvelteSet } from 'svelte/reactivity';
+
+import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
+import type { CatalogModelInfo } from '/@/lib/models/models-utils';
+import { getCatalogModels } from '/@/lib/models/models-utils';
+import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
+import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
+import { providerInfos } from '/@/stores/providers';
+
+import type { GuidedSetupStepProps, OnboardingModelSelection } from './guided-setup-steps';
+
+let { onboarding }: GuidedSetupStepProps = $props();
+
+let userSelectionKey = $state(
+  untrack(() => (onboarding.model ? modelKey(onboarding.model.providerId, onboarding.model.label) : '')),
+);
+
+let agentDef = $derived(agentDefinitions.find(d => d.cliName === onboarding.agent));
+let selectedAgentLabel = $derived(agentDef?.title ?? 'the selected agent');
+
+let allModels: CatalogModelInfo[] = $derived.by(() => {
+  const enabled = getCatalogModels($providerInfos).filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
+  const seen = new SvelteSet<string>();
+  return enabled.filter(m => {
+    const key = modelKey(m.providerId, m.label);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+});
+
+let agentFilteredModels: CatalogModelInfo[] = $derived.by(() => {
+  if (!agentDef?.modelFilter) return allModels;
+  return allModels.filter(m => m.llmMetadata?.name === agentDef!.modelFilter);
+});
+
+let effectiveModel: CatalogModelInfo | undefined = $derived.by(() => {
+  if (userSelectionKey) {
+    const match = agentFilteredModels.find(m => modelKey(m.providerId, m.label) === userSelectionKey);
+    if (match) return match;
+  }
+  return agentFilteredModels.length > 0 ? agentFilteredModels[0] : undefined;
+});
+
+$effect(() => {
+  if (effectiveModel) {
+    const sel: OnboardingModelSelection = {
+      providerId: effectiveModel.providerId,
+      label: effectiveModel.label,
+    };
+    onboarding.model = sel;
+  } else {
+    onboarding.model = undefined;
+  }
+});
+
+function selectModel(model: CatalogModelInfo): void {
+  userSelectionKey = modelKey(model.providerId, model.label);
+}
+</script>
+
+<div class="mx-auto max-w-3xl py-4">
+  <h2 class="text-xl font-semibold text-(--pd-content-card-text) mb-1">Default model for the agent</h2>
+  <p class="text-sm text-(--pd-content-card-text) opacity-60 mb-6">
+    This is the model used by default in new workspaces.
+    Names match the <strong class="text-(--pd-modal-text)">Models</strong> catalog; enable or disable rows there.
+    You can override per session later.
+  </p>
+
+  <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+    <p class="text-xs text-(--pd-content-card-text) opacity-70 mb-4">
+      {#if agentDef?.modelFilter}
+        Cloud catalog on <strong class="text-(--pd-modal-text)">Models</strong> — {selectedAgentLabel} rows (enabled). Click a row to choose.
+      {:else}
+        Same rows as <strong class="text-(--pd-modal-text)">Models</strong>. Click a line or use the <strong class="text-(--pd-modal-text)">Use</strong> control to pick your default for <strong class="text-(--pd-modal-text)">local</strong> models.
+      {/if}
+    </p>
+
+    <ModelSelectionTable
+      models={agentFilteredModels}
+      selectedKey={effectiveModel ? modelKey(effectiveModel.providerId, effectiveModel.label) : ''}
+      showCatalogLink={false}
+      onselect={selectModel} />
+  </div>
+</div>

--- a/packages/renderer/src/lib/guided-setup/ModelStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.svelte
@@ -45,6 +45,7 @@ let effectiveModel: CatalogModelInfo | undefined = $derived.by(() => {
 });
 
 $effect(() => {
+  if (agentFilteredModels.length === 0) return;
   if (effectiveModel) {
     const sel: OnboardingModelSelection = {
       providerId: effectiveModel.providerId,

--- a/packages/renderer/src/lib/guided-setup/agent-registry.ts
+++ b/packages/renderer/src/lib/guided-setup/agent-registry.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
-import { faClaude, faGoogle } from '@fortawesome/free-brands-svg-icons';
+import { faClaude } from '@fortawesome/free-brands-svg-icons';
 import { faCode, faDesktop, faRobot, faWrench } from '@fortawesome/free-solid-svg-icons';
 import type { Component } from 'svelte';
 
@@ -25,11 +25,9 @@ import ClaudeCodeIcon from '/@/lib/images/agents/ClaudeCodeIcon.svelte';
 import CursorIcon from '/@/lib/images/agents/CursorIcon.svelte';
 import GooseIcon from '/@/lib/images/agents/GooseIcon.svelte';
 import OpenCodeIcon from '/@/lib/images/agents/OpenCodeIcon.svelte';
-import VertexAIIcon from '/@/lib/images/agents/VertexAIIcon.svelte';
 
 import type { CliAgent } from './guided-setup-steps';
 import ClaudePanel from './panels/ClaudePanel.svelte';
-import ClaudeVertexPanel from './panels/ClaudeVertexPanel.svelte';
 import OpenCodePanel from './panels/OpenCodePanel.svelte';
 
 export interface AgentDefinition {
@@ -84,17 +82,17 @@ export const agentDefinitions: AgentDefinition[] = [
     providerSelector: 'kaiden.claude:claude',
     secretType: 'anthropic',
   },
+  // TODO: Show this tile once the Vertex AI extension is available.
+  // Hidden for now because it has no `panel`, so CodingAgentStep filters it out.
   {
     cliName: 'claude-vertex',
     cliAgent: 'claude',
     title: 'Claude on Vertex AI',
-    description: 'Run Claude Code through Google Cloud Vertex AI using your GCP project credentials.',
-    badge: 'Vertex AI',
-    icon: faGoogle,
-    iconComponent: VertexAIIcon,
-    colorClass: 'bg-gradient-to-br from-blue-500 to-blue-600',
+    description: 'Use Claude models through Google Cloud Vertex AI with application default credentials.',
+    icon: faClaude,
+    iconComponent: ClaudeCodeIcon,
+    colorClass: 'bg-gradient-to-br from-amber-600 to-amber-500',
     modelFilter: 'anthropic',
-    panel: ClaudeVertexPanel,
   },
   {
     cliName: 'cursor',

--- a/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
+++ b/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
@@ -17,21 +17,31 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
-import { faRobot } from '@fortawesome/free-solid-svg-icons';
+import { faCube, faRobot } from '@fortawesome/free-solid-svg-icons';
 import type { Component } from 'svelte';
 
 import CodingAgentStep from './CodingAgentStep.svelte';
+import ModelStep from './ModelStep.svelte';
 
 export type CliAgent = 'opencode' | 'claude' | 'claude-vertex' | 'cursor' | 'goose';
 
+// TODO: Remove VertexConfig once the Vertex AI extension is added and handles its own config.
 export interface VertexConfig {
   projectId: string;
   region: string;
   credentialsPath: string;
+  mountClaudeConfig?: boolean;
+}
+
+export interface OnboardingModelSelection {
+  providerId: string;
+  label: string;
 }
 
 export interface OnboardingState {
   agent: CliAgent;
+  secretName?: string;
+  model?: OnboardingModelSelection;
   vertexConfig?: VertexConfig;
   beforeAdvance?: () => Promise<boolean>;
 }
@@ -62,11 +72,20 @@ export function createDefaultOnboardingState(): OnboardingState {
 export const guidedSetupSteps: GuidedSetupStep[] = [
   {
     id: 'coding-agent',
-    title: 'Choose your coding agent',
+    title: 'Coding agent',
     description:
       'Pick the default coding agent runtime. The API notes below update for your choice. You can change this later in settings.',
     icon: faRobot,
     component: CodingAgentStep,
+    isComplete: (): boolean => false,
+    isSkippable: true,
+  },
+  {
+    id: 'model-selection',
+    title: 'Model',
+    description: 'Select the default model for your coding agent.',
+    icon: faCube,
+    component: ModelStep,
     isComplete: (): boolean => false,
     isSkippable: true,
   },

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -271,6 +271,28 @@ describe('already connected', () => {
 
     expect(onboarding.secretName).toBe('anthropic');
   });
+
+  test('does not treat a stopped connection as already connected', () => {
+    const providers = [
+      {
+        id: 'claude',
+        internalId: 'claude-internal-1',
+        inferenceConnections: [
+          {
+            type: 'cloud',
+            status: 'stopped',
+            models: [{ label: 'claude-sonnet-4-20250514' }],
+          },
+        ],
+        inferenceProviderConnectionCreation: true,
+      },
+    ];
+    (providerInfos as Writable<ProviderInfo[]>).set(providers as unknown as ProviderInfo[]);
+    renderPanel();
+
+    expect(screen.queryByTestId('claude-already-connected')).not.toBeInTheDocument();
+    expect(screen.getByTestId('claude-form')).toBeInTheDocument();
+  });
 });
 
 describe('cleanup', () => {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -218,6 +218,61 @@ describe('beforeAdvance callback', () => {
   });
 });
 
+describe('already connected', () => {
+  function stubConnectedProvider(): void {
+    const providers = [
+      {
+        id: 'claude',
+        internalId: 'claude-internal-1',
+        inferenceConnections: [
+          {
+            type: 'cloud',
+            status: 'started',
+            models: [{ label: 'claude-sonnet-4-20250514' }, { label: 'claude-3-5-haiku-20241022' }],
+          },
+        ],
+        inferenceProviderConnectionCreation: true,
+      },
+    ];
+    (providerInfos as Writable<ProviderInfo[]>).set(providers as unknown as ProviderInfo[]);
+  }
+
+  test('shows already-connected message when inference connection with models exists', () => {
+    stubConnectedProvider();
+    renderPanel();
+
+    expect(screen.getByTestId('claude-already-connected')).toBeInTheDocument();
+    expect(screen.getByText('Connection configured')).toBeInTheDocument();
+    expect(screen.getByText(/2 models/)).toBeInTheDocument();
+  });
+
+  test('hides API key form when already connected', () => {
+    stubConnectedProvider();
+    renderPanel();
+
+    expect(screen.queryByTestId('claude-form')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Anthropic API key')).not.toBeInTheDocument();
+  });
+
+  test('beforeAdvance returns true immediately when already connected', async () => {
+    stubConnectedProvider();
+    renderPanel();
+
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(true);
+    expect(window.createSecret).not.toHaveBeenCalled();
+    expect(window.createInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('sets onboarding.secretName when already connected', () => {
+    stubConnectedProvider();
+    renderPanel();
+
+    expect(onboarding.secretName).toBe('anthropic');
+  });
+});
+
 describe('cleanup', () => {
   test('clears beforeAdvance when component is destroyed', () => {
     const { unmount } = render(ClaudePanel, { definition: claudeDefinition, onboarding });

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -28,7 +28,9 @@ let errorMessage = $state('');
 
 let claudeProvider = $derived($providerInfos.find(p => p.id === providerId));
 
-let existingConnection = $derived(claudeProvider?.inferenceConnections?.find(c => c.models.length > 0));
+let existingConnection = $derived(
+  claudeProvider?.inferenceConnections?.find(c => c.status === 'started' && c.models.length > 0),
+);
 let alreadyConnected = $derived(!!existingConnection);
 
 $effect(() => {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCircleCheck, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
@@ -28,7 +28,23 @@ let errorMessage = $state('');
 
 let claudeProvider = $derived($providerInfos.find(p => p.id === providerId));
 
+let existingConnection = $derived(claudeProvider?.inferenceConnections?.find(c => c.models.length > 0));
+let alreadyConnected = $derived(!!existingConnection);
+
+$effect(() => {
+  if (alreadyConnected && onboarding) {
+    onboarding.secretName = secretType;
+  }
+});
+
 async function validate(): Promise<boolean> {
+  if (alreadyConnected) {
+    if (onboarding) {
+      onboarding.secretName = secretType;
+    }
+    return true;
+  }
+
   errorMessage = '';
 
   if (!claudeProvider) {
@@ -68,6 +84,10 @@ async function validate(): Promise<boolean> {
     );
 
     await fetchProviders();
+
+    if (onboarding) {
+      onboarding.secretName = secretType;
+    }
     return true;
   } catch (err: unknown) {
     errorMessage = err instanceof Error ? err.message : String(err);
@@ -90,33 +110,50 @@ $effect(() => {
 <div
   class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
   data-testid="claude-panel">
-  <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
-    API Key
-  </h3>
-  <p class="text-xs text-(--pd-content-card-text) opacity-50 mb-4 leading-relaxed">
-    Enter your Anthropic API key. It will be verified and stored when you continue to the next step.
-  </p>
 
-  <div class="flex flex-col gap-3" data-testid="claude-form">
-    {#if !claudeProvider}
-      <div
-        class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-warning) p-3"
-        role="alert"
-        data-testid="claude-provider-missing">
-        <Icon icon={faTriangleExclamation} size="sm" class="text-(--pd-state-warning) shrink-0" />
-        <span class="text-xs text-(--pd-state-warning)">Claude provider extension not detected.</span>
+  {#if alreadyConnected}
+    <div
+      class="flex items-center gap-3 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-success) p-4"
+      role="status"
+      aria-live="polite"
+      data-testid="claude-already-connected">
+      <Icon icon={faCircleCheck} size="lg" class="text-(--pd-state-success)" />
+      <div>
+        <strong class="text-sm text-(--pd-state-success)">Connection configured</strong>
+        <p class="text-xs text-(--pd-content-card-text) opacity-70 mt-0.5">
+          {existingConnection?.models.length} model{existingConnection?.models.length !== 1 ? 's' : ''} available. You can continue to the next step.
+        </p>
       </div>
-    {/if}
+    </div>
+  {:else}
+    <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+      API Key
+    </h3>
+    <p class="text-xs text-(--pd-content-card-text) opacity-50 mb-4 leading-relaxed">
+      Enter your Anthropic API key. It will be verified and stored when you continue to the next step.
+    </p>
 
-    <Input
-      type="password"
-      placeholder="sk-ant-..."
-      bind:value={apiKey}
-      aria-label="Anthropic API key"
-      disabled={!claudeProvider} />
+    <div class="flex flex-col gap-3" data-testid="claude-form">
+      {#if !claudeProvider}
+        <div
+          class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-warning) p-3"
+          role="alert"
+          data-testid="claude-provider-missing">
+          <Icon icon={faTriangleExclamation} size="sm" class="text-(--pd-state-warning) shrink-0" />
+          <span class="text-xs text-(--pd-state-warning)">Claude provider extension not detected.</span>
+        </div>
+      {/if}
 
-    {#if errorMessage}
-      <ErrorMessage error={errorMessage} />
-    {/if}
-  </div>
+      <Input
+        type="password"
+        placeholder="sk-ant-..."
+        bind:value={apiKey}
+        aria-label="Anthropic API key"
+        disabled={!claudeProvider} />
+
+      {#if errorMessage}
+        <ErrorMessage error={errorMessage} />
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { StatusIcon } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import { handleNavigation } from '/@/navigation';
+import { modelKey } from '/@/stores/model-catalog';
+import { NavigationPage } from '/@api/navigation-page';
+
+import type { CatalogModelInfo } from './models-utils';
+
+type ModelCategory = 'cloud' | 'corporate' | 'local';
+
+const categoryLabels: Record<ModelCategory, string> = {
+  cloud: 'Cloud · LLM providers',
+  corporate: 'In-house · OpenShift AI',
+  local: 'Local · Ollama & Ramalama',
+};
+
+const statusMap: Record<string, string> = {
+  started: 'RUNNING',
+  starting: 'STARTING',
+  stopped: 'CREATED',
+  stopping: 'DELETING',
+  failed: 'DEGRADED',
+  unknown: 'RUNNING',
+};
+
+interface Props {
+  models: CatalogModelInfo[];
+  selectedKey?: string;
+  showCatalogLink?: boolean;
+  onselect?: (model: CatalogModelInfo) => void;
+}
+
+let { models, selectedKey = '', showCatalogLink = true, onselect }: Props = $props();
+
+let searchTerm = $state('');
+
+let displayedModels: CatalogModelInfo[] = $derived(filterBySearch(models, searchTerm));
+
+let cloudModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m.type === 'cloud'));
+let corporateModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m.type === 'self-hosted'));
+let localModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m.type === 'local'));
+let hasAnyModels: boolean = $derived(cloudModels.length > 0 || corporateModels.length > 0 || localModels.length > 0);
+
+let selectedModel: CatalogModelInfo | undefined = $derived(models.find(m => getKey(m) === selectedKey));
+
+function filterBySearch(allModels: CatalogModelInfo[], term: string): CatalogModelInfo[] {
+  if (!term.trim()) return allModels;
+  const q = term.trim().toLowerCase();
+  return allModels.filter(
+    m =>
+      m.label.toLowerCase().includes(q) ||
+      m.providerName.toLowerCase().includes(q) ||
+      m.connectionName.toLowerCase().includes(q),
+  );
+}
+
+function getKey(model: CatalogModelInfo): string {
+  return modelKey(model.providerId, model.label);
+}
+
+function getModelStatus(model: CatalogModelInfo): string {
+  return statusMap[model.connectionStatus] ?? 'RUNNING';
+}
+
+function navigateToModels(): void {
+  handleNavigation({ page: NavigationPage.MODELS });
+}
+</script>
+
+<!-- Toolbar -->
+<div class="flex items-center justify-between mb-3 gap-3">
+  <div
+    class="flex items-center gap-2 px-3 py-1.5 rounded-md border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)] flex-1 max-w-xs">
+    <Icon icon={faSearch} size="sm" class="text-[var(--pd-content-card-text)] opacity-50" />
+    <input
+      type="search"
+      bind:value={searchTerm}
+      placeholder="Filter models…"
+      autocomplete="off"
+      aria-label="Filter catalog models"
+      class="bg-transparent border-none outline-none text-sm text-[var(--pd-content-card-text)] placeholder:opacity-50 w-full" />
+  </div>
+  {#if showCatalogLink}
+    <button
+      type="button"
+      class="text-xs text-[var(--pd-link)] hover:underline whitespace-nowrap"
+      onclick={navigateToModels}>
+      Open Models catalog
+    </button>
+  {/if}
+</div>
+
+{#if !hasAnyModels}
+  <div class="text-sm text-[var(--pd-content-card-text)] opacity-70 py-4 text-center" data-testid="no-models">
+    No model sources match your settings.
+    <button type="button" class="text-[var(--pd-link)] hover:underline" onclick={navigateToModels}>
+      Enable a provider in Models
+    </button>, then return here.
+  </div>
+{:else}
+  <div class="flex flex-col gap-4">
+    {#each ([['cloud', cloudModels], ['corporate', corporateModels], ['local', localModels]] as const) as [category, catModels] (category)}
+      {#if catModels.length > 0}
+        <div>
+          <h4 class="text-xs font-semibold text-[var(--pd-content-card-text)] opacity-60 uppercase tracking-wide mb-2">
+            {categoryLabels[category]}
+          </h4>
+          <div class="rounded-md border border-[var(--pd-content-card-border)] overflow-x-auto">
+            <table class="w-full text-sm table-fixed" aria-label="{categoryLabels[category]} models">
+              <colgroup>
+                <col class="w-14" />
+                <col />
+                <col class="w-16" />
+                <col class="w-24" />
+                <col class="w-14" />
+              </colgroup>
+              <thead>
+                <tr class="border-b border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)]">
+                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Status</th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Name</th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Size</th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Runtime</th>
+                  <th class="px-3 py-2 text-center text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Use</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each catModels as model (getKey(model))}
+                  {@const key = getKey(model)}
+                  {@const isSelected = selectedKey === key}
+                  <tr
+                    role="button"
+                    tabindex="0"
+                    class="border-b border-[var(--pd-content-card-border)] last:border-b-0 transition-colors
+                      cursor-pointer hover:bg-[var(--pd-content-card-hover-inset-bg)]
+                      {isSelected ? 'bg-[var(--pd-content-card-hover-inset-bg)]' : ''}"
+                    onclick={onselect?.bind(undefined, model)}
+                    onkeydown={(e: KeyboardEvent): void => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onselect?.(model);
+                      }
+                    }}
+                    data-testid="model-row-{model.label}">
+                    <td class="px-3 py-2">
+                      <StatusIcon status={getModelStatus(model)} />
+                    </td>
+                    <td class="px-3 py-2">
+                      <div class="font-medium text-[var(--pd-table-body-text-highlight)]">{model.label}</div>
+                      <div class="text-[11px] text-[var(--pd-content-card-text)] opacity-60">{model.connectionName}</div>
+                    </td>
+                    <td class="px-3 py-2 text-[var(--pd-table-body-text)]">—</td>
+                    <td class="px-3 py-2 text-[var(--pd-table-body-text)]">{model.providerName}</td>
+                    <td class="px-3 py-2 text-center">
+                      <input
+                        type="radio"
+                        name="modelSelection"
+                        value={key}
+                        checked={isSelected}
+                        aria-label="Use {model.label}"
+                        onclick={(e: MouseEvent): void => e.stopPropagation()}
+                        onchange={onselect?.bind(undefined, model)} />
+                    </td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {/if}
+    {/each}
+  </div>
+
+  {#if selectedModel}
+    <p class="text-xs text-(--pd-state-success) mt-4" data-testid="selected-model">
+      Selected: {selectedModel.label}
+    </p>
+  {/if}
+{/if}

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -73,20 +73,20 @@ function navigateToModels(): void {
 <!-- Toolbar -->
 <div class="flex items-center justify-between mb-3 gap-3">
   <div
-    class="flex items-center gap-2 px-3 py-1.5 rounded-md border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)] flex-1 max-w-xs">
-    <Icon icon={faSearch} size="sm" class="text-[var(--pd-content-card-text)] opacity-50" />
+    class="flex items-center gap-2 px-3 py-1.5 rounded-md border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) flex-1 max-w-xs">
+    <Icon icon={faSearch} size="sm" class="text-(--pd-content-card-text) opacity-50" />
     <input
       type="search"
       bind:value={searchTerm}
       placeholder="Filter models…"
       autocomplete="off"
       aria-label="Filter catalog models"
-      class="bg-transparent border-none outline-none text-sm text-[var(--pd-content-card-text)] placeholder:opacity-50 w-full" />
+      class="bg-transparent border-none outline-none text-sm text-(--pd-content-card-text) placeholder:opacity-50 w-full" />
   </div>
   {#if showCatalogLink}
     <button
       type="button"
-      class="text-xs text-[var(--pd-link)] hover:underline whitespace-nowrap"
+      class="text-xs text-(--pd-link) hover:underline whitespace-nowrap"
       onclick={navigateToModels}>
       Open Models catalog
     </button>
@@ -94,9 +94,9 @@ function navigateToModels(): void {
 </div>
 
 {#if !hasAnyModels}
-  <div class="text-sm text-[var(--pd-content-card-text)] opacity-70 py-4 text-center" data-testid="no-models">
+  <div class="text-sm text-(--pd-content-card-text) opacity-70 py-4 text-center" data-testid="no-models">
     No model sources match your settings.
-    <button type="button" class="text-[var(--pd-link)] hover:underline" onclick={navigateToModels}>
+    <button type="button" class="text-(--pd-link) hover:underline" onclick={navigateToModels}>
       Enable a provider in Models
     </button>, then return here.
   </div>
@@ -105,10 +105,10 @@ function navigateToModels(): void {
     {#each ([['cloud', cloudModels], ['corporate', corporateModels], ['local', localModels]] as const) as [category, catModels] (category)}
       {#if catModels.length > 0}
         <div>
-          <h4 class="text-xs font-semibold text-[var(--pd-content-card-text)] opacity-60 uppercase tracking-wide mb-2">
+          <h4 class="text-xs font-semibold text-(--pd-content-card-text) opacity-60 uppercase tracking-wide mb-2">
             {categoryLabels[category]}
           </h4>
-          <div class="rounded-md border border-[var(--pd-content-card-border)] overflow-x-auto">
+          <div class="rounded-md border border-(--pd-content-card-border) overflow-x-auto">
             <table class="w-full text-sm table-fixed" aria-label="{categoryLabels[category]} models">
               <colgroup>
                 <col class="w-14" />
@@ -118,12 +118,12 @@ function navigateToModels(): void {
                 <col class="w-14" />
               </colgroup>
               <thead>
-                <tr class="border-b border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)]">
-                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Status</th>
-                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Name</th>
-                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Size</th>
-                  <th class="px-3 py-2 text-left text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Runtime</th>
-                  <th class="px-3 py-2 text-center text-xs font-medium text-[var(--pd-content-card-text)] opacity-60">Use</th>
+                <tr class="border-b border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg)">
+                  <th class="px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Status</th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Name</th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Size</th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Runtime</th>
+                  <th class="px-3 py-2 text-center text-xs font-medium text-(--pd-content-card-text) opacity-60">Use</th>
                 </tr>
               </thead>
               <tbody>
@@ -133,9 +133,9 @@ function navigateToModels(): void {
                   <tr
                     role="button"
                     tabindex="0"
-                    class="border-b border-[var(--pd-content-card-border)] last:border-b-0 transition-colors
-                      cursor-pointer hover:bg-[var(--pd-content-card-hover-inset-bg)]
-                      {isSelected ? 'bg-[var(--pd-content-card-hover-inset-bg)]' : ''}"
+                    class="border-b border-(--pd-content-card-border) last:border-b-0 transition-colors
+                      cursor-pointer hover:bg-(--pd-content-card-hover-inset-bg)
+                      {isSelected ? 'bg-(--pd-content-card-hover-inset-bg)' : ''}"
                     onclick={onselect?.bind(undefined, model)}
                     onkeydown={(e: KeyboardEvent): void => {
                       if (e.key === 'Enter' || e.key === ' ') {
@@ -148,11 +148,11 @@ function navigateToModels(): void {
                       <StatusIcon status={getModelStatus(model)} />
                     </td>
                     <td class="px-3 py-2">
-                      <div class="font-medium text-[var(--pd-table-body-text-highlight)]">{model.label}</div>
-                      <div class="text-[11px] text-[var(--pd-content-card-text)] opacity-60">{model.connectionName}</div>
+                      <div class="font-medium text-(--pd-table-body-text-highlight)">{model.label}</div>
+                      <div class="text-[11px] text-(--pd-content-card-text) opacity-60">{model.connectionName}</div>
                     </td>
-                    <td class="px-3 py-2 text-[var(--pd-table-body-text)]">—</td>
-                    <td class="px-3 py-2 text-[var(--pd-table-body-text)]">{model.providerName}</td>
+                    <td class="px-3 py-2 text-(--pd-table-body-text)">—</td>
+                    <td class="px-3 py-2 text-(--pd-table-body-text)">{model.providerName}</td>
                     <td class="px-3 py-2 text-center">
                       <input
                         type="radio"


### PR DESCRIPTION
Introduce a dedicated Model step in the guided setup that lets the user pick a default model for the selected coding agent, and persist the choice (along with secret references) into onboarding.defaultWorkspaceSettings. The model table is extracted into a reusable ModelSelectionTable component shared by both the onboarding wizard.

https://github.com/user-attachments/assets/f03d86fe-8605-4434-9d5d-5e940222f2df

Closes #1501