### PR TITLE
fix(chat): hide New Chat button when no AI models are enabled

### DIFF
--- a/packages/renderer/src/lib/chat/components/chat-header.spec.ts
+++ b/packages/renderer/src/lib/chat/components/chat-header.spec.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ChatHeader from './chat-header.svelte';
+import { useSidebar } from './ui/sidebar/context.svelte';
+import { Tooltip } from './ui/tooltip';
+
+vi.mock(import('tinro'));
+vi.mock(import('./sidebar-toggle.svelte'));
+vi.mock(import('./ui/sidebar/context.svelte'), () => ({
+  useSidebar: vi.fn(),
+  setSidebar: vi.fn(),
+}));
+vi.mock(import('./ui/tooltip'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(useSidebar).mockReturnValue({
+    open: false,
+    isMobile: false,
+    openMobile: false,
+    state: 'collapsed',
+    setOpen: vi.fn(),
+    setOpenMobile: vi.fn(),
+    toggle: vi.fn(),
+    handleShortcutKeydown: vi.fn(),
+  } as never);
+});
+
+describe('ChatHeader', () => {
+  test('should render New Chat tooltip when hasModels is true and sidebar is closed', () => {
+    render(ChatHeader, { hasModels: true });
+
+    expect(Tooltip).toHaveBeenCalled();
+  });
+
+  test('should hide New Chat button when hasModels is false', () => {
+    render(ChatHeader, { hasModels: false });
+
+    expect(Tooltip).not.toHaveBeenCalled();
+  });
+
+  test('should hide New Chat button when hasModels is not provided', () => {
+    render(ChatHeader);
+
+    expect(Tooltip).not.toHaveBeenCalled();
+  });
+
+  test('should hide New Chat button when sidebar is open on wide viewport', () => {
+    vi.mocked(useSidebar).mockReturnValue({
+      open: true,
+      isMobile: false,
+      openMobile: false,
+      state: 'expanded',
+      setOpen: vi.fn(),
+      setOpenMobile: vi.fn(),
+      toggle: vi.fn(),
+      handleShortcutKeydown: vi.fn(),
+    } as never);
+
+    render(ChatHeader, { hasModels: true });
+
+    expect(Tooltip).not.toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/chat/components/chat-header.spec.ts
+++ b/packages/renderer/src/lib/chat/components/chat-header.spec.ts
@@ -27,10 +27,7 @@ import { Tooltip } from './ui/tooltip';
 
 vi.mock(import('tinro'));
 vi.mock(import('./sidebar-toggle.svelte'));
-vi.mock(import('./ui/sidebar/context.svelte'), () => ({
-  useSidebar: vi.fn(),
-  setSidebar: vi.fn(),
-}));
+vi.mock(import('./ui/sidebar/context.svelte'));
 vi.mock(import('./ui/tooltip'));
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/chat/components/chat-header.spec.ts
+++ b/packages/renderer/src/lib/chat/components/chat-header.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render } from '@testing-library/svelte';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import ChatHeader from './chat-header.svelte';
 import { useSidebar } from './ui/sidebar/context.svelte';
@@ -31,6 +31,7 @@ vi.mock(import('./ui/sidebar/context.svelte'));
 vi.mock(import('./ui/tooltip'));
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
   vi.mocked(useSidebar).mockReturnValue({
     open: false,
@@ -42,6 +43,10 @@ beforeEach(() => {
     toggle: vi.fn(),
     handleShortcutKeydown: vi.fn(),
   } as never);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('ChatHeader', () => {

--- a/packages/renderer/src/lib/chat/components/chat-header.svelte
+++ b/packages/renderer/src/lib/chat/components/chat-header.svelte
@@ -12,13 +12,18 @@ import { Button } from './ui/button';
 import { useSidebar } from './ui/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
+interface Props {
+  hasModels?: boolean;
+}
+let { hasModels = false }: Props = $props();
+
 const sidebar = useSidebar();
 </script>
 
 <header class="bg-background sticky top-0 flex items-start gap-2 p-2">
 	<SidebarToggle />
 
-	{#if !sidebar.open || (innerWidth.current ?? 768) < 768}
+	{#if hasModels && (!sidebar.open || (innerWidth.current ?? 768) < 768)}
 		<Tooltip>
 			<TooltipTrigger>
 				{#snippet child({ props })}

--- a/packages/renderer/src/lib/chat/components/chat.svelte
+++ b/packages/renderer/src/lib/chat/components/chat.svelte
@@ -308,7 +308,7 @@ $effect(() => {
 
 <div class="bg-background flex h-full min-w-0 flex-col">
   {#if hasModels}
-    <ChatHeader />
+    <ChatHeader {hasModels} />
   {/if}
   <div class="flex min-h-0 flex-1">
         {#if hasModels}

--- a/packages/renderer/src/lib/chat/route/CustomChat.svelte
+++ b/packages/renderer/src/lib/chat/route/CustomChat.svelte
@@ -11,6 +11,7 @@ import { currentChatId } from '/@/lib/chat/state/current-chat-id.svelte';
 import { sidebarCollapsed } from '/@/lib/chat/state/sidebar-collapsed.svelte';
 import { getModels } from '/@/lib/models/models-utils';
 import { isDark } from '/@/stores/appearance';
+import { disabledModels, isModelEnabled } from '/@/stores/model-catalog';
 import { providerInfos } from '/@/stores/providers';
 
 interface Props {
@@ -30,7 +31,9 @@ const chatMessagesPromise = $derived(
 
 onDestroy(() => chatHistory.dispose());
 
-const hasModels = $derived(getModels($providerInfos).length > 0);
+const hasModels = $derived(
+  getModels($providerInfos).filter(m => isModelEnabled($disabledModels, m.providerId, m.label)).length > 0,
+);
 
 // Sync the chat's ThemeProvider with the app's appearance setting
 const forcedTheme = $derived($isDark ? 'dark' : 'light');


### PR DESCRIPTION
## Summary

The "New Chat" button in the sidebar and header remained visible and clickable even when all AI models were disabled via the model catalog, allowing users to click it without any functional outcome.

### Root cause

There was a mismatch in how `hasModels` was computed across components:

- **`CustomChat.svelte`** used `getModels($providerInfos).length > 0`, which checks all *registered* models regardless of whether they are disabled in the model catalog
- **`chat-header.svelte`** had no `hasModels` guard at all for its "New Chat" button (shown when the sidebar is collapsed or on mobile viewports)

Meanwhile, **`chat.svelte`** already correctly filtered models through `isModelEnabled($disabledModels, ...)`, creating an inconsistency where the chat area would show `NoModelsAvailable` but the header and sidebar buttons were still rendered.

### Fix

- **`CustomChat.svelte`**: align `hasModels` computation with the filtering logic already used in `chat.svelte` by consulting `isModelEnabled` from the `model-catalog` store
- **`chat-header.svelte`**: add a `hasModels` prop (default `false`) and include it in the conditional that controls the "New Chat" button visibility
- **`chat.svelte`**: pass the already-computed `hasModels` value down to `ChatHeader`

### Tests

Added `chat-header.spec.ts` with 4 test cases following the existing `app-sidebar.spec.ts` pattern:
- Button visible when `hasModels` is true and sidebar is closed
- Button hidden when `hasModels` is false
- Button hidden when `hasModels` is not provided (default behavior)
- Button hidden when sidebar is open on wide viewport

All existing tests continue to pass.

Closes #1630

Signed-off-by: Alexon Oliveira <alolivei@redhat.com>