### PR TITLE
feat(workspaces): add custom host allowlist management in networking step

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -582,10 +582,11 @@ test('Expect Developer Preset selected by default on networking step', async () 
   expect(screen.getByRole('radio', { name: 'Use Deny All' })).not.toBeChecked();
 });
 
-test('Expect allowlists hint text displayed on networking step', async () => {
+test('Expect allowlists hint text displayed when Unrestricted selected on networking step', async () => {
   render(AgentWorkspaceCreate);
 
   await navigateToNetworkingStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Unrestricted' }));
 
   expect(screen.getByText(/Fine-grained host allowlists and static egress rules/)).toBeInTheDocument();
 });
@@ -808,6 +809,134 @@ test('Expect first compatible model used when defaultWorkspaceSettings is undefi
       model: 'ollama::llama3.2:3b',
     }),
   );
+});
+
+test('Expect custom hosts input shown when Deny All is selected on networking step', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Deny All' }));
+
+  expect(screen.getByLabelText('Custom host 1')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Add Another Host' })).toBeInTheDocument();
+});
+
+test('Expect custom hosts pre-populated with registry hosts when Developer Preset is selected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect(screen.getByLabelText('Custom host 1')).toBeInTheDocument();
+  expect((screen.getByLabelText('Custom host 1') as HTMLInputElement).value).toBe('registry.npmjs.org');
+  expect((screen.getByLabelText('Custom host 2') as HTMLInputElement).value).toBe('pypi.python.org');
+  expect(screen.getByRole('button', { name: 'Add Another Host' })).toBeInTheDocument();
+});
+
+test('Expect custom hosts input hidden when Agent mode is selected on networking step', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Agent mode' }));
+
+  expect(screen.queryByLabelText('Custom host 1')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Add Another Host' })).not.toBeInTheDocument();
+});
+
+test('Expect custom hosts input hidden when Unrestricted is selected on networking step', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Unrestricted' }));
+
+  expect(screen.queryByLabelText('Custom host 1')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Add Another Host' })).not.toBeInTheDocument();
+});
+
+test('Expect createAgentWorkspace called with registry hosts plus custom host for Developer Preset', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Another Host' }));
+  await fireEvent.input(screen.getByLabelText('Custom host 3'), {
+    target: { value: 'api.example.com' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      network: { mode: 'deny', hosts: ['registry.npmjs.org', 'pypi.python.org', 'api.example.com'] },
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called with custom hosts only for Deny All with custom host', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Deny All' }));
+
+  await fireEvent.input(screen.getByLabelText('Custom host 1'), {
+    target: { value: 'internal.corp.io' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      network: { mode: 'deny', hosts: ['internal.corp.io'] },
+    }),
+  );
+});
+
+test('Expect Add Another Host button adds a new input field', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect(screen.queryByLabelText('Custom host 3')).not.toBeInTheDocument();
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Another Host' }));
+
+  expect(screen.getByLabelText('Custom host 3')).toBeInTheDocument();
+});
+
+test('Expect Remove button removes a registry host', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect(screen.getByLabelText('Custom host 2')).toBeInTheDocument();
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Remove host 2' }));
+
+  expect(screen.queryByLabelText('Custom host 2')).not.toBeInTheDocument();
+});
+
+test('Expect createAgentWorkspace called without removed registry host for Developer Preset', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Remove host 1' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      network: { mode: 'deny', hosts: ['pypi.python.org'] },
+    }),
+  );
+});
+
+test('Expect Deny All resets to empty host list when switching from Developer Preset', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToNetworkingStep();
+
+  expect((screen.getByLabelText('Custom host 1') as HTMLInputElement).value).toBe('registry.npmjs.org');
+
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Deny All' }));
+
+  expect((screen.getByLabelText('Custom host 1') as HTMLInputElement).value).toBe('');
 });
 
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -94,14 +94,14 @@ const networkOptions: NetworkAccessOption[] = [
 
 const REGISTRY_HOSTS = ['registry.npmjs.org', 'pypi.python.org'];
 
-function mapNetworkSelection(value: string): NetworkConfiguration | undefined {
+function mapNetworkSelection(value: string, hosts: string[]): NetworkConfiguration | undefined {
+  const filtered = hosts.filter(h => h.trim() !== '');
   switch (value) {
     case 'open':
       return { mode: 'allow' };
     case 'registries':
-      return { mode: 'deny', hosts: REGISTRY_HOSTS };
     case 'blocked':
-      return { mode: 'deny' };
+      return { mode: 'deny', hosts: filtered.length ? filtered : undefined };
     default:
       return undefined;
   }
@@ -175,6 +175,11 @@ let selectedMcpIds = $derived(mcpItems.map(m => m.id));
 let selectedSecretIds = $derived($secretVaultInfos.map(s => s.id));
 let selectedKnowledgeIds = $derived(knowledgeItems.map(k => k.id));
 let customPaths = $state<string[]>(['']);
+let hostsByMode = $state<Record<string, string[]>>({
+  registries: [...REGISTRY_HOSTS],
+  blocked: [''],
+});
+let customHosts = $derived(hostsByMode[selectedNetwork] ?? []);
 
 // --- Step 1 UI state ---
 let nameManuallyEdited = $state(false);
@@ -224,6 +229,22 @@ function removeCustomPath(index: number): void {
 
 function updateCustomPath(index: number, value: string): void {
   customPaths = customPaths.map((p, i) => (i === index ? value : p));
+}
+
+function addCustomHost(): void {
+  const current = hostsByMode[selectedNetwork] ?? [];
+  hostsByMode = { ...hostsByMode, [selectedNetwork]: [...current, ''] };
+}
+
+function removeCustomHost(index: number): void {
+  const current = hostsByMode[selectedNetwork] ?? [];
+  if (current.length <= 1) return;
+  hostsByMode = { ...hostsByMode, [selectedNetwork]: current.filter((_, i) => i !== index) };
+}
+
+function updateCustomHost(index: number, value: string): void {
+  const current = hostsByMode[selectedNetwork] ?? [];
+  hostsByMode = { ...hostsByMode, [selectedNetwork]: current.map((h, i) => (i === index ? value : h)) };
 }
 
 async function handleBrowseCustomPath(index: number): Promise<void> {
@@ -283,7 +304,7 @@ async function startWorkspace(): Promise<void> {
 
   try {
     const selectedSkillPaths = $skillInfos.filter(s => selectedSkillIds.includes(s.name)).map(s => s.path);
-    const network = mapNetworkSelection(selectedNetwork);
+    const network = mapNetworkSelection(selectedNetwork, customHosts);
 
     const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
     await window.createAgentWorkspace({
@@ -352,7 +373,13 @@ async function startWorkspace(): Promise<void> {
                 onRemoveCustomPath={removeCustomPath}
                 onUpdateCustomPath={updateCustomPath} />
             {:else if currentStepId === 'networking'}
-              <AgentWorkspaceCreateStepNetworking {networkOptions} bind:selectedNetwork />
+              <AgentWorkspaceCreateStepNetworking
+                {networkOptions}
+                bind:selectedNetwork
+                {customHosts}
+                onAddCustomHost={addCustomHost}
+                onRemoveCustomHost={removeCustomHost}
+                onUpdateCustomHost={updateCustomHost} />
             {/if}
           </div>
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { faShieldHalved } from '@fortawesome/free-solid-svg-icons';
+import { faPlus, faShieldHalved } from '@fortawesome/free-solid-svg-icons';
+import { Button, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 export interface NetworkAccessOption {
@@ -14,9 +15,22 @@ export interface NetworkAccessOption {
 interface Props {
   networkOptions: NetworkAccessOption[];
   selectedNetwork: string;
+  customHosts: string[];
+  onAddCustomHost: () => void;
+  onRemoveCustomHost: (index: number) => void;
+  onUpdateCustomHost: (index: number, value: string) => void;
 }
 
-let { networkOptions, selectedNetwork = $bindable() }: Props = $props();
+let {
+  networkOptions,
+  selectedNetwork = $bindable(),
+  customHosts,
+  onAddCustomHost,
+  onRemoveCustomHost,
+  onUpdateCustomHost,
+}: Props = $props();
+
+let showCustomHosts = $derived(selectedNetwork === 'blocked' || selectedNetwork === 'registries');
 </script>
 
 <div class="flex items-center gap-3 mb-5">
@@ -64,6 +78,27 @@ let { networkOptions, selectedNetwork = $bindable() }: Props = $props();
   {/each}
 </div>
 
-<p class="mt-4 text-xs text-[var(--pd-content-card-text)] opacity-70 leading-relaxed max-w-2xl">
-  <strong class="text-[var(--pd-modal-text)]">Allowlists and more</strong> — Fine-grained host allowlists and static egress rules live in project or workspace settings when you need them.
-</p>
+{#if showCustomHosts}
+  <div class="mt-4 p-4 rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)]">
+    <p class="text-xs text-[var(--pd-content-card-text)] opacity-70 mb-3">Additional hosts to allow outbound access to. You can refine this list later in workspace settings.</p>
+    {#each customHosts as host, index (index)}
+      <div class="flex gap-3 mb-2 items-center">
+        <Input
+          value={host}
+          placeholder="e.g. api.example.com"
+          class="flex-1 font-mono text-sm"
+          aria-label="Custom host {index + 1}"
+          oninput={(e: Event): void => onUpdateCustomHost(index, (e.target as HTMLInputElement).value)}
+        />
+        {#if customHosts.length > 1}
+          <Button onclick={(): void => onRemoveCustomHost(index)} aria-label="Remove host {index + 1}">Remove</Button>
+        {/if}
+      </div>
+    {/each}
+    <Button class="mt-2" icon={faPlus} onclick={onAddCustomHost}>Add Another Host</Button>
+  </div>
+{:else}
+  <p class="mt-4 text-xs text-[var(--pd-content-card-text)] opacity-70 leading-relaxed max-w-2xl">
+    <strong class="text-[var(--pd-modal-text)]">Allowlists and more</strong> — Fine-grained host allowlists and static egress rules live in project or workspace settings when you need them.
+  </p>
+{/if}


### PR DESCRIPTION
Allow users to add, remove, and edit custom hosts when Deny All or Developer Preset network modes are selected in the workspace creation wizard.

<img width="1280" height="659" alt="Screenshot 2026-05-05 at 21 44 31" src="https://github.com/user-attachments/assets/6e875403-ccd4-4439-aef3-4afe78148678" />


<img width="1188" height="971" alt="Screenshot 2026-05-06 at 7 38 46" src="https://github.com/user-attachments/assets/47feb4bd-3b1d-4354-a117-62b09376702f" />



Closes https://github.com/openkaiden/kaiden/issues/1626