### PR TITLE
fix: cleanup watchers on stop

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -181,7 +181,9 @@ const kubernetesClient: KubernetesClient = {
   dispose: vi.fn(),
 } as unknown as KubernetesClient;
 
-const fileSystemMonitoring: FilesystemMonitoring = {} as unknown as FilesystemMonitoring;
+const fileSystemMonitoring: FilesystemMonitoring = {
+  disposeAll: vi.fn().mockResolvedValue(undefined),
+} as unknown as FilesystemMonitoring;
 
 const proxy: Proxy = {} as unknown as Proxy;
 
@@ -2916,6 +2918,13 @@ test('ExtensionLoader async dispose should stop all extensions', async () => {
   await extensionLoader.asyncDispose();
 
   expect(deactivateMock).toHaveBeenCalledOnce();
+  expect(fileSystemMonitoring.disposeAll).toHaveBeenCalledOnce();
+});
+
+test('asyncDispose should call fileSystemMonitoring.disposeAll', async () => {
+  await extensionLoader.asyncDispose();
+
+  expect(fileSystemMonitoring.disposeAll).toHaveBeenCalledOnce();
 });
 
 describe('env API', () => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -243,6 +243,7 @@ export class ExtensionLoader implements IAsyncDisposable {
   @preDestroy()
   async asyncDispose(): Promise<void> {
     await this.stopAllExtensions();
+    await this.fileSystemMonitoring.disposeAll();
 
     // clear maps
     this.activatedExtensions.clear();

--- a/packages/main/src/plugin/filesystem-monitoring.spec.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.spec.ts
@@ -21,11 +21,11 @@ import os from 'node:os';
 import path, { join } from 'node:path';
 
 import { watch } from 'chokidar';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { isWindows } from '/@/util.js';
 
-import { FileSystemWatcherImpl } from './filesystem-monitoring.js';
+import { FilesystemMonitoring, FileSystemWatcherImpl } from './filesystem-monitoring.js';
 import { Uri } from './types/uri.js';
 
 let rootdir: string;
@@ -202,4 +202,49 @@ test.runIf(os.platform() === 'darwin')('Watch a directory with a lot of files', 
   });
 
   await vi.waitFor(() => expect(counter).toBeGreaterThan(3));
+});
+
+describe('FilesystemMonitoring', () => {
+  let monitoring: FilesystemMonitoring;
+
+  beforeEach(() => {
+    monitoring = new FilesystemMonitoring();
+  });
+
+  test('createFileSystemWatcher should return a FileSystemWatcher', () => {
+    const fsWatcher = monitoring.createFileSystemWatcher(path.join(rootdir, 'somefile'));
+    expect(fsWatcher).toBeDefined();
+    expect(fsWatcher.dispose).toBeDefined();
+    expect(fsWatcher.onDidCreate).toBeDefined();
+    expect(fsWatcher.onDidChange).toBeDefined();
+    expect(fsWatcher.onDidDelete).toBeDefined();
+    fsWatcher.dispose();
+  });
+
+  test('disposeAll should dispose all tracked watchers', async () => {
+    const watcher1 = monitoring.createFileSystemWatcher(path.join(rootdir, 'file1'));
+    const watcher2 = monitoring.createFileSystemWatcher(path.join(rootdir, 'file2'));
+    const disposeSpy1 = vi.spyOn(watcher1, 'dispose');
+    const disposeSpy2 = vi.spyOn(watcher2, 'dispose');
+
+    await monitoring.disposeAll();
+
+    expect(disposeSpy1).toHaveBeenCalledOnce();
+    expect(disposeSpy2).toHaveBeenCalledOnce();
+  });
+
+  test('disposeAll should clear the watchers so subsequent calls are no-ops', async () => {
+    const fsWatcher = monitoring.createFileSystemWatcher(path.join(rootdir, 'file'));
+    const disposeSpy = vi.spyOn(fsWatcher, 'dispose');
+
+    await monitoring.disposeAll();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+
+    await monitoring.disposeAll();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+  });
+
+  test('disposeAll on empty instance should resolve without error', async () => {
+    await expect(monitoring.disposeAll()).resolves.toBeUndefined();
+  });
 });

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -109,7 +109,22 @@ export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatc
 
 @injectable()
 export class FilesystemMonitoring {
+  private watchers: FileSystemWatcherImpl[] = [];
+
   createFileSystemWatcher(path: string): containerDesktopAPI.FileSystemWatcher {
-    return new FileSystemWatcherImpl(path);
+    const watcher = new FileSystemWatcherImpl(path);
+    this.watchers.push(watcher);
+    return watcher;
+  }
+
+  async disposeAll(): Promise<void> {
+    await Promise.all(
+      this.watchers.map(watcher =>
+        Promise.resolve().then(() => {
+          watcher.dispose();
+        }),
+      ),
+    );
+    this.watchers = [];
   }
 }


### PR DESCRIPTION
cleanup watchers on stop (holding reference to the filesystem that may cause crash)

backported from https://github.com/podman-desktop/podman-desktop/pull/17403

fixes https://github.com/openkaiden/kaiden/issues/1634


### how to test:

1. without my patch, on macOS do: 
`pnpm compile:current --mac dmg --arm64`
then launch `./dist/mac-arm64/Kaiden.app/Contents/MacOS/Kaiden`
exit from the app and notice the crash

2. apply the PR fix, and redo the steps
