### PR TITLE
chore: replace catalog URL

### DIFF
--- a/product.json
+++ b/product.json
@@ -20,7 +20,7 @@
     "infoURL": "https://developers.redhat.com/article/tool-data-collection"
   },
   "catalog": {
-    "default": "https://gist.githubusercontent.com/benoitf/63df9e7193c6cabcd8fc0052e3e0cc4c/raw/6ed37b4e24975f54a4583a3dca998fbd3218777e/extensions.json"
+    "default": "https://registry.openkaiden.ai/api/extensions.json"
   },
   "extensions": {
     "remote": []


### PR DESCRIPTION
update catalog entry replacing the 'temporary' gist with a subdomain link from openkaiden.ai

fixes https://github.com/openkaiden/kaiden/issues/1589

### How to test

look at console.log traces, it should say it's fetching file from registry.openkaiden.ai