### PR TITLE
feat(models): implement in-house self-hosted models tab

### DIFF
--- a/extensions/claude/src/manager/claude-inference-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.spec.ts
@@ -100,6 +100,7 @@ describe('init', () => {
 
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      connectionTypes: ['cloud'],
       create: expect.any(Function),
     });
   });

--- a/extensions/claude/src/manager/claude-inference-manager.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.ts
@@ -39,7 +39,10 @@ export class ClaudeInferenceManager {
   private connections: Map<string, Disposable> = new Map();
 
   async init(): Promise<void> {
-    this.claudeProvider.setInferenceProviderConnectionFactory({ create: this.factory.bind(this) });
+    this.claudeProvider.setInferenceProviderConnectionFactory({
+      connectionTypes: ['cloud'],
+      create: this.factory.bind(this),
+    });
     await this.restoreConnections();
   }
 

--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -144,6 +144,7 @@ describe('init', () => {
 
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      connectionTypes: ['cloud'],
       create: expect.any(Function),
     });
   });

--- a/extensions/gemini/src/gemini.ts
+++ b/extensions/gemini/src/gemini.ts
@@ -56,7 +56,10 @@ export class Gemini implements Disposable {
     });
 
     // register MCP Provider connection factory
-    this.provider?.setInferenceProviderConnectionFactory({ create: this.mcpFactory.bind(this) });
+    this.provider?.setInferenceProviderConnectionFactory({
+      connectionTypes: ['cloud'],
+      create: this.mcpFactory.bind(this),
+    });
 
     // restore persistent connections
     await this.restoreConnections();

--- a/extensions/mistral/src/manager/mistral-inference-manager.spec.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.spec.ts
@@ -92,6 +92,7 @@ describe('init', () => {
 
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      connectionTypes: ['cloud'],
       create: expect.any(Function),
     });
   });

--- a/extensions/mistral/src/manager/mistral-inference-manager.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.ts
@@ -39,7 +39,10 @@ export class MistralInferenceManager {
   private connections: Map<string, Disposable> = new Map();
 
   async init(): Promise<void> {
-    this.mistralProvider.setInferenceProviderConnectionFactory({ create: this.factory.bind(this) });
+    this.mistralProvider.setInferenceProviderConnectionFactory({
+      connectionTypes: ['cloud'],
+      create: this.factory.bind(this),
+    });
     await this.restoreConnections();
   }
 

--- a/extensions/openai-compatible/src/openAI.spec.ts
+++ b/extensions/openai-compatible/src/openAI.spec.ts
@@ -107,6 +107,7 @@ describe('init', () => {
 
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      connectionTypes: ['cloud'],
       create: expect.any(Function),
     });
   });

--- a/extensions/openai-compatible/src/openAI.ts
+++ b/extensions/openai-compatible/src/openAI.ts
@@ -54,7 +54,10 @@ export class OpenAI implements Disposable {
     });
 
     // register MCP Provider connection factory
-    this.provider?.setInferenceProviderConnectionFactory({ create: this.inferenceFactory.bind(this) });
+    this.provider?.setInferenceProviderConnectionFactory({
+      connectionTypes: ['cloud'],
+      create: this.inferenceFactory.bind(this),
+    });
 
     // restore persistent connections
     await this.restoreConnections();

--- a/extensions/openshift-ai/src/openshiftai.spec.ts
+++ b/extensions/openshift-ai/src/openshiftai.spec.ts
@@ -122,6 +122,7 @@ describe('init', () => {
 
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      connectionTypes: ['self-hosted'],
       create: expect.any(Function),
     });
   });

--- a/extensions/openshift-ai/src/openshiftai.ts
+++ b/extensions/openshift-ai/src/openshiftai.ts
@@ -62,7 +62,10 @@ export class OpenShiftAI implements Disposable {
     });
 
     // register inference Provider connection factory
-    this.provider.setInferenceProviderConnectionFactory({ create: this.inferenceFactory.bind(this) });
+    this.provider.setInferenceProviderConnectionFactory({
+      connectionTypes: ['self-hosted'],
+      create: this.inferenceFactory.bind(this),
+    });
 
     // restore persistent connections
     await this.restoreConnections();

--- a/extensions/vertex-ai/src/vertex-ai.spec.ts
+++ b/extensions/vertex-ai/src/vertex-ai.spec.ts
@@ -117,6 +117,7 @@ describe('init', () => {
       }),
     );
     expect(PROVIDER_MOCK.setInferenceProviderConnectionFactory).toHaveBeenCalledWith({
+      connectionTypes: ['cloud'],
       create: expect.any(Function),
     });
   });

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -113,7 +113,10 @@ export class VertexAi implements Disposable {
       },
     });
 
-    this.provider?.setInferenceProviderConnectionFactory({ create: this.factory.bind(this) });
+    this.provider?.setInferenceProviderConnectionFactory({
+      connectionTypes: ['cloud'],
+      create: this.factory.bind(this),
+    });
 
     await this.restoreConnections();
   }

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -158,6 +158,8 @@ export interface ProviderInfo {
   inferenceProviderConnectionCreationDisplayName?: string;
   // optional creation button title (if defined)
   inferenceProviderConnectionCreationButtonTitle?: string;
+  // optional connection types from the factory (e.g. ['cloud', 'self-hosted'])
+  inferenceProviderConnectionCreationTypes?: InferenceProviderConnectionType[];
 
   /**
    * RAG Provider connection

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -761,6 +761,7 @@ declare module '@openkaiden/api' {
 
   // create programmatically a InferenceProviderConnection
   export interface InferenceProviderConnectionFactory extends ProviderConnectionFactory {
+    connectionTypes: InferenceProviderConnectionType[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     create(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -915,6 +915,7 @@ export class ProviderRegistry {
       provider.inferenceProviderConnectionFactory?.creationDisplayName;
     const inferenceProviderConnectionCreationButtonTitle =
       provider.inferenceProviderConnectionFactory?.creationButtonTitle;
+    const inferenceProviderConnectionCreationTypes = provider.inferenceProviderConnectionFactory?.connectionTypes;
     if (provider?.inferenceProviderConnectionFactory?.initialize) {
       inferenceProviderConnectionInitialization = true;
     }
@@ -977,6 +978,7 @@ export class ProviderRegistry {
       inferenceProviderConnectionInitialization,
       inferenceProviderConnectionCreationDisplayName,
       inferenceProviderConnectionCreationButtonTitle,
+      inferenceProviderConnectionCreationTypes,
       // RAG
       ragProviderConnectionCreation,
       ragProviderConnectionInitialization,

--- a/packages/renderer/src/lib/models/ModelsCatalog.svelte
+++ b/packages/renderer/src/lib/models/ModelsCatalog.svelte
@@ -20,6 +20,8 @@ import {
   type CatalogModelInfo,
   getCloudCatalogModels,
   getCloudConnectionSummaries,
+  getInHouseCatalogModels,
+  getInHouseConnectionSummaries,
   getLocalCatalogModels,
   getLocalConnectionSummaries,
   type InferenceConnectionSummary,
@@ -50,6 +52,8 @@ let searchTerm = $state('');
 
 let cloudModels: CatalogModelInfo[] = $derived(getCloudCatalogModels($providerInfos));
 let cloudConnections: InferenceConnectionSummary[] = $derived(getCloudConnectionSummaries($providerInfos));
+let inHouseModels: CatalogModelInfo[] = $derived(getInHouseCatalogModels($providerInfos));
+let inHouseConnections: InferenceConnectionSummary[] = $derived(getInHouseConnectionSummaries($providerInfos));
 let localModels: CatalogModelInfo[] = $derived(getLocalCatalogModels($providerInfos));
 let localConnections: InferenceConnectionSummary[] = $derived(getLocalConnectionSummaries($providerInfos));
 
@@ -58,6 +62,12 @@ let filteredCloudModels: ModelSelectable[] = $derived(
 );
 let filteredCloudConnections: InferenceConnectionSummary[] = $derived(
   filterConnectionsBySearch(cloudConnections, searchTerm),
+);
+let filteredInHouseModels: ModelSelectable[] = $derived(
+  filterBySearch(inHouseModels, searchTerm).map(m => ({ ...m, selected: false })),
+);
+let filteredInHouseConnections: InferenceConnectionSummary[] = $derived(
+  filterConnectionsBySearch(inHouseConnections, searchTerm),
 );
 let filteredLocalModels: ModelSelectable[] = $derived(
   filterBySearch(localModels, searchTerm).map(m => ({ ...m, selected: false })),
@@ -196,11 +206,36 @@ function selectCategory(cat: Category): void {
           </div>
         </div>
       {:else if activeCategory === 'corporate'}
-        <div class="flex items-center justify-center h-full">
-          <div class="text-center text-[var(--pd-content-text)]">
-            <Icon icon={faIndustry} class="mb-3 opacity-40" size="2.5em" />
-            <p class="text-sm">In-house models coming soon</p>
-            <p class="text-xs mt-1 opacity-60">OpenShift AI integration will be available here</p>
+        <div class="px-5 pb-3">
+          <p class="text-xs text-[var(--pd-content-text)] opacity-70">
+            Self-hosted inference endpoints from OpenShift AI and similar platforms. Connection status and models are shown below.
+          </p>
+        </div>
+        <div class="flex min-w-full h-full">
+          <div class="flex flex-col w-full">
+            {#if inHouseModels.length === 0 && inHouseConnections.length === 0}
+              <div class="flex items-center justify-center h-full">
+                <div class="text-center text-[var(--pd-content-text)]">
+                  <Icon icon={faIndustry} class="mb-3 opacity-40" size="2.5em" />
+                  <p class="text-sm">No in-house providers configured</p>
+                  <p class="text-xs mt-1 opacity-60">Connect an OpenShift AI instance to see models here</p>
+                </div>
+              </div>
+            {:else if searchTerm && filteredInHouseModels.length === 0 && filteredInHouseConnections.length === 0}
+              <FilteredEmptyScreen icon={NoLogIcon} kind="models" bind:searchTerm />
+            {:else}
+              {#if filteredInHouseConnections.length > 0}
+                <div class="px-5 pt-4 pb-2">
+                  <ProviderConnectionTiles connections={filteredInHouseConnections} />
+                </div>
+              {/if}
+
+              {#if filteredInHouseModels.length > 0}
+                <div class="flex min-w-full">
+                  <Table kind="models" data={filteredInHouseModels} columns={columns} row={row} defaultSortColumn="Name" />
+                </div>
+              {/if}
+            {/if}
           </div>
         </div>
       {:else if activeCategory === 'local'}

--- a/packages/renderer/src/lib/models/models-utils.spec.ts
+++ b/packages/renderer/src/lib/models/models-utils.spec.ts
@@ -123,6 +123,7 @@ test('getInferenceConnectionSummaries emits not-configured entry when creation i
     inferenceConnections: [],
     inferenceProviderConnectionCreation: true,
     inferenceProviderConnectionCreationDisplayName: 'OpenAI (Hosted)',
+    inferenceProviderConnectionCreationTypes: ['cloud'],
   } as unknown as ProviderInfo;
 
   const result = getInferenceConnectionSummaries([provider]);
@@ -135,8 +136,75 @@ test('getInferenceConnectionSummaries emits not-configured entry when creation i
     status: 'not-configured',
     modelCount: 0,
     creationDisplayName: 'OpenAI (Hosted)',
+    connectionType: 'cloud',
   });
-  expect(result[0].connectionType).toBeUndefined();
+});
+
+test('getCloudConnectionSummaries includes not-configured entries with cloud factory type', () => {
+  const providers = [
+    {
+      id: 'claude',
+      name: 'Claude',
+      internalId: 'claude-internal',
+      inferenceConnections: [],
+      inferenceProviderConnectionCreation: true,
+      inferenceProviderConnectionCreationTypes: ['cloud'],
+    },
+    {
+      id: 'gemini',
+      name: 'Gemini',
+      internalId: 'gemini-internal',
+      inferenceConnections: [{ name: 'default', type: 'cloud', status: 'started', models: [{ label: 'gemini-pro' }] }],
+    },
+  ] as unknown as ProviderInfo[];
+
+  const result = getCloudConnectionSummaries(providers);
+  expect(result).toHaveLength(2);
+  expect(result.map(c => c.providerId)).toEqual(['claude', 'gemini']);
+});
+
+test('getCloudConnectionSummaries excludes not-configured entries with self-hosted factory type', () => {
+  const providers = [
+    {
+      id: 'openshift-ai',
+      name: 'OpenShift AI',
+      internalId: 'oai-internal',
+      inferenceConnections: [],
+      inferenceProviderConnectionCreation: true,
+      inferenceProviderConnectionCreationTypes: ['self-hosted'],
+    },
+    {
+      id: 'gemini',
+      name: 'Gemini',
+      internalId: 'gemini-internal',
+      inferenceConnections: [{ name: 'default', type: 'cloud', status: 'started', models: [{ label: 'gemini-pro' }] }],
+    },
+  ] as unknown as ProviderInfo[];
+
+  const result = getCloudConnectionSummaries(providers);
+  expect(result).toHaveLength(1);
+  expect(result[0].providerId).toBe('gemini');
+});
+
+test('getInHouseConnectionSummaries includes not-configured entries with self-hosted factory type', () => {
+  const providers = [
+    {
+      id: 'openshift-ai',
+      name: 'OpenShift AI',
+      internalId: 'oai-internal',
+      inferenceConnections: [],
+      inferenceProviderConnectionCreation: true,
+      inferenceProviderConnectionCreationTypes: ['self-hosted'],
+    },
+  ] as unknown as ProviderInfo[];
+
+  const result = getInHouseConnectionSummaries(providers);
+  expect(result).toHaveLength(1);
+  expect(result[0]).toMatchObject({
+    providerId: 'openshift-ai',
+    connectionType: 'self-hosted',
+    status: 'not-configured',
+  });
 });
 
 test('getCloudCatalogModels excludes self-hosted models', () => {

--- a/packages/renderer/src/lib/models/models-utils.spec.ts
+++ b/packages/renderer/src/lib/models/models-utils.spec.ts
@@ -20,7 +20,15 @@ import { expect, test } from 'vitest';
 
 import type { ProviderInfo } from '/@api/provider-info';
 
-import { getCatalogModels, getInferenceConnectionSummaries, getModels } from './models-utils';
+import {
+  getCatalogModels,
+  getCloudCatalogModels,
+  getCloudConnectionSummaries,
+  getInferenceConnectionSummaries,
+  getInHouseCatalogModels,
+  getInHouseConnectionSummaries,
+  getModels,
+} from './models-utils';
 
 test('getModels returns empty array for providers without inference connections', () => {
   const provider = { inferenceConnections: [] } as unknown as ProviderInfo;
@@ -129,4 +137,134 @@ test('getInferenceConnectionSummaries emits not-configured entry when creation i
     creationDisplayName: 'OpenAI (Hosted)',
   });
   expect(result[0].connectionType).toBeUndefined();
+});
+
+test('getCloudCatalogModels excludes self-hosted models', () => {
+  const providers = [
+    {
+      id: 'gemini',
+      name: 'Gemini',
+      inferenceConnections: [{ name: 'default', type: 'cloud', status: 'started', models: [{ label: 'gemini-pro' }] }],
+    },
+    {
+      id: 'openshift-ai',
+      name: 'OpenShift AI',
+      inferenceConnections: [
+        { name: 'cluster', type: 'self-hosted', status: 'started', models: [{ label: 'llama-3' }] },
+      ],
+    },
+  ] as unknown as ProviderInfo[];
+
+  const result = getCloudCatalogModels(providers);
+  expect(result).toHaveLength(1);
+  expect(result[0].providerId).toBe('gemini');
+});
+
+test('getCloudConnectionSummaries excludes self-hosted connections', () => {
+  const providers = [
+    {
+      id: 'gemini',
+      name: 'Gemini',
+      internalId: 'gemini-internal',
+      inferenceConnections: [{ name: 'default', type: 'cloud', status: 'started', models: [{ label: 'gemini-pro' }] }],
+    },
+    {
+      id: 'openshift-ai',
+      name: 'OpenShift AI',
+      internalId: 'oai-internal',
+      inferenceConnections: [
+        { name: 'cluster', type: 'self-hosted', status: 'started', models: [{ label: 'llama-3' }] },
+      ],
+    },
+  ] as unknown as ProviderInfo[];
+
+  const result = getCloudConnectionSummaries(providers);
+  expect(result).toHaveLength(1);
+  expect(result[0].providerId).toBe('gemini');
+});
+
+test('getInHouseCatalogModels returns only self-hosted models', () => {
+  const providers = [
+    {
+      id: 'gemini',
+      name: 'Gemini',
+      inferenceConnections: [{ name: 'default', type: 'cloud', status: 'started', models: [{ label: 'gemini-pro' }] }],
+    },
+    {
+      id: 'openshift-ai',
+      name: 'OpenShift AI',
+      inferenceConnections: [
+        {
+          name: 'cluster',
+          type: 'self-hosted',
+          status: 'started',
+          models: [{ label: 'llama-3' }, { label: 'mistral' }],
+        },
+      ],
+    },
+    {
+      id: 'ollama',
+      name: 'Ollama',
+      inferenceConnections: [{ name: 'local', type: 'local', status: 'started', models: [{ label: 'phi-3' }] }],
+    },
+  ] as unknown as ProviderInfo[];
+
+  const result = getInHouseCatalogModels(providers);
+  expect(result).toHaveLength(2);
+  expect(result.every(m => m.providerId === 'openshift-ai')).toBe(true);
+  expect(result.map(m => m.label)).toEqual(['llama-3', 'mistral']);
+});
+
+test('getInHouseCatalogModels returns empty when no self-hosted providers', () => {
+  const providers = [
+    {
+      id: 'gemini',
+      name: 'Gemini',
+      inferenceConnections: [{ name: 'default', type: 'cloud', status: 'started', models: [{ label: 'gemini-pro' }] }],
+    },
+  ] as unknown as ProviderInfo[];
+
+  expect(getInHouseCatalogModels(providers)).toEqual([]);
+});
+
+test('getInHouseConnectionSummaries returns only self-hosted connections', () => {
+  const providers = [
+    {
+      id: 'gemini',
+      name: 'Gemini',
+      internalId: 'gemini-internal',
+      inferenceConnections: [{ name: 'default', type: 'cloud', status: 'started', models: [{ label: 'gemini-pro' }] }],
+    },
+    {
+      id: 'openshift-ai',
+      name: 'OpenShift AI',
+      internalId: 'oai-internal',
+      inferenceConnections: [
+        { name: 'cluster', type: 'self-hosted', status: 'started', models: [{ label: 'llama-3' }] },
+      ],
+    },
+  ] as unknown as ProviderInfo[];
+
+  const result = getInHouseConnectionSummaries(providers);
+  expect(result).toHaveLength(1);
+  expect(result[0]).toMatchObject({
+    providerName: 'OpenShift AI',
+    providerId: 'openshift-ai',
+    connectionType: 'self-hosted',
+    status: 'started',
+    modelCount: 1,
+  });
+});
+
+test('getInHouseConnectionSummaries returns empty when no self-hosted providers', () => {
+  const providers = [
+    {
+      id: 'ollama',
+      name: 'Ollama',
+      internalId: 'ollama-internal',
+      inferenceConnections: [{ name: 'local', type: 'local', status: 'started', models: [{ label: 'phi-3' }] }],
+    },
+  ] as unknown as ProviderInfo[];
+
+  expect(getInHouseConnectionSummaries(providers)).toEqual([]);
 });

--- a/packages/renderer/src/lib/models/models-utils.ts
+++ b/packages/renderer/src/lib/models/models-utils.ts
@@ -42,12 +42,8 @@ export function getModels(providerInfos: ProviderInfo[]): ModelInfo[] {
   );
 }
 
-function isCloudLike(type: InferenceProviderConnectionType | undefined): boolean {
-  return type === 'cloud' || !type;
-}
-
 export function getCloudCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInfo[] {
-  return getCatalogModels(providerInfos).filter(m => isCloudLike(m.type));
+  return getCatalogModels(providerInfos).filter(m => m.type === 'cloud');
 }
 
 export function getInHouseCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInfo[] {
@@ -79,7 +75,7 @@ export function getCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInf
 }
 
 export function getCloudConnectionSummaries(providerInfos: ProviderInfo[]): InferenceConnectionSummary[] {
-  return getInferenceConnectionSummaries(providerInfos).filter(c => isCloudLike(c.connectionType));
+  return getInferenceConnectionSummaries(providerInfos).filter(c => c.connectionType === 'cloud');
 }
 
 export function getInHouseConnectionSummaries(providerInfos: ProviderInfo[]): InferenceConnectionSummary[] {
@@ -93,6 +89,10 @@ export function getLocalConnectionSummaries(providerInfos: ProviderInfo[]): Infe
 export function getInferenceConnectionSummaries(providerInfos: ProviderInfo[]): InferenceConnectionSummary[] {
   const result: InferenceConnectionSummary[] = [];
   for (const provider of providerInfos) {
+    const factoryTypes = provider.inferenceProviderConnectionCreationTypes ?? [];
+    const creationDisplayName = provider.inferenceProviderConnectionCreationDisplayName ?? provider.name;
+    const coveredTypes = new Set(provider.inferenceConnections.map(c => c.type));
+
     if (provider.inferenceConnections.length > 0) {
       const started = provider.inferenceConnections.find(c => c.status === 'started');
       const representative = started ?? provider.inferenceConnections[0];
@@ -105,17 +105,20 @@ export function getInferenceConnectionSummaries(providerInfos: ProviderInfo[]): 
         connectionType: representative.type,
         status: representative.status,
         modelCount: totalModels,
-        creationDisplayName: provider.inferenceProviderConnectionCreationDisplayName ?? provider.name,
+        creationDisplayName,
       });
-    } else if (provider.inferenceProviderConnectionCreation) {
+    }
+
+    for (const type of factoryTypes.filter(t => !coveredTypes.has(t))) {
       result.push({
         providerName: provider.name,
         providerId: provider.id,
         providerInternalId: provider.internalId,
         connectionName: '',
+        connectionType: type,
         status: 'not-configured',
         modelCount: 0,
-        creationDisplayName: provider.inferenceProviderConnectionCreationDisplayName ?? provider.name,
+        creationDisplayName,
       });
     }
   }

--- a/packages/renderer/src/lib/models/models-utils.ts
+++ b/packages/renderer/src/lib/models/models-utils.ts
@@ -43,11 +43,15 @@ export function getModels(providerInfos: ProviderInfo[]): ModelInfo[] {
 }
 
 function isCloudLike(type: InferenceProviderConnectionType | undefined): boolean {
-  return type === 'cloud' || type === 'self-hosted' || !type;
+  return type === 'cloud' || !type;
 }
 
 export function getCloudCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInfo[] {
   return getCatalogModels(providerInfos).filter(m => isCloudLike(m.type));
+}
+
+export function getInHouseCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInfo[] {
+  return getCatalogModels(providerInfos).filter(m => m.type === 'self-hosted');
 }
 
 export function getLocalCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInfo[] {
@@ -76,6 +80,10 @@ export function getCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInf
 
 export function getCloudConnectionSummaries(providerInfos: ProviderInfo[]): InferenceConnectionSummary[] {
   return getInferenceConnectionSummaries(providerInfos).filter(c => isCloudLike(c.connectionType));
+}
+
+export function getInHouseConnectionSummaries(providerInfos: ProviderInfo[]): InferenceConnectionSummary[] {
+  return getInferenceConnectionSummaries(providerInfos).filter(c => c.connectionType === 'self-hosted');
 }
 
 export function getLocalConnectionSummaries(providerInfos: ProviderInfo[]): InferenceConnectionSummary[] {


### PR DESCRIPTION
Replace the "coming soon" placeholder in the corporate/in-house tab with real content driven by getInHouseCatalogModels and getInHouseConnectionSummaries. Also correct isCloudLike to exclude self-hosted connections from the cloud tab.


https://github.com/user-attachments/assets/2007b587-a343-4186-bd19-30516ba66375



NOTE: I haven't set up the OpenshiftAI

Closes https://github.com/openkaiden/kaiden/issues/1627#event-25209775214