### PR TITLE
feat(agent-workspace): expose runtime configuration as user-facing setting

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -164,14 +164,15 @@ describe('init', () => {
     expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:getCliInfo', expect.any(Function));
   });
 
-  test('registers hidden runtime configuration', () => {
+  test('registers runtime configuration with enum', () => {
     expect(configurationRegistry.registerConfigurations).toHaveBeenCalledWith([
       expect.objectContaining({
-        id: 'agentWorkspace.runtime',
+        id: 'preferences.agentWorkspace',
         properties: expect.objectContaining({
           'agentWorkspace.runtime': expect.objectContaining({
             type: 'string',
-            hidden: true,
+            enum: ['podman', 'openshell'],
+            default: 'podman',
           }),
         }),
       }),

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -170,14 +170,15 @@ export class AgentWorkspaceManager implements Disposable {
 
   init(): void {
     const runtimeConfiguration: IConfigurationNode = {
-      id: `${AgentWorkspaceSettings.SectionName}.${AgentWorkspaceSettings.Runtime}`,
+      id: `preferences.${AgentWorkspaceSettings.SectionName}`,
       title: 'Agent Workspace',
       type: 'object',
       properties: {
         [`${AgentWorkspaceSettings.SectionName}.${AgentWorkspaceSettings.Runtime}`]: {
           description: 'Override the container runtime used when creating agent workspaces.',
           type: 'string',
-          hidden: true,
+          enum: ['podman', 'openshell'],
+          default: 'podman',
         },
       },
     };


### PR DESCRIPTION
Replace hidden runtime config with an enum-based preference (podman/openshell) with podman as the default, and update the config node id to use the preferences. prefix.

<img width="1188" height="971" alt="Screenshot 2026-05-06 at 14 19 31" src="https://github.com/user-attachments/assets/94848601-2cf3-4c98-b76d-0d3fd3da5cfe" />


You can test this by changing the runtime preferences in the settings and checking if the models changes in the create workspace flow

Closes https://github.com/openkaiden/kaiden/issues/1704