### PR TITLE
fix: remove old defaultAgent setting

### DIFF
--- a/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.spec.ts
@@ -18,6 +18,7 @@
 
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { OnboardingSettings } from '/@/plugin/onboarding/onboarding-settings.js';
 import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { OnboardingInit } from './onboarding-init.js';
@@ -45,9 +46,9 @@ test('registers onboarding configuration with hidden properties', () => {
   const config = registeredConfigs.at(0);
   expect(config).toBeDefined();
   expect(config?.id).toBe('preferences.onboarding');
-  expect(config?.properties?.['onboarding.defaultAgent']).toEqual(
-    expect.objectContaining({ type: 'string', default: '', hidden: true }),
-  );
+  expect(
+    config?.properties?.[`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultWorkspaceSettings}`],
+  ).toBeDefined();
 });
 
 test('registers defaultWorkspaceSettings as hidden object property', () => {

--- a/packages/main/src/plugin/onboarding/onboarding-init.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-init.ts
@@ -32,12 +32,6 @@ export class OnboardingInit {
       title: 'Onboarding',
       type: 'object',
       properties: {
-        [`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultAgent}`]: {
-          description: 'Default coding agent selected during onboarding',
-          type: 'string',
-          default: '',
-          hidden: true,
-        },
         [`${OnboardingSettings.SectionName}.${OnboardingSettings.DefaultWorkspaceSettings}`]: {
           description: 'Default workspace settings selected during onboarding',
           type: 'object',

--- a/packages/main/src/plugin/onboarding/onboarding-settings.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-settings.ts
@@ -18,7 +18,6 @@
 
 export enum OnboardingSettings {
   SectionName = 'onboarding',
-  DefaultAgent = 'defaultAgent',
   DefaultWorkspaceSettings = 'defaultWorkspaceSettings',
   VertexProjectId = 'vertexProjectId',
   VertexRegion = 'vertexRegion',

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -615,8 +615,8 @@ test('Expect selecting a different network option updates the radio', async () =
   expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).not.toBeChecked();
 });
 
-test('Expect default agent from onboarding.defaultAgent setting when valid', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue('claude');
+test('Expect default agent from onboarding.defaultWorkspaceSettings when valid', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({ defaultAgent: 'claude' });
 
   render(AgentWorkspaceCreate);
 
@@ -625,7 +625,7 @@ test('Expect default agent from onboarding.defaultAgent setting when valid', asy
   });
   await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
 
-  expect(window.getConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent');
+  expect(window.getConfigurationValue).toHaveBeenCalledWith('onboarding.defaultWorkspaceSettings');
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
       agent: 'claude',
@@ -634,7 +634,7 @@ test('Expect default agent from onboarding.defaultAgent setting when valid', asy
 });
 
 test('Expect default agent falls back to opencode when setting is empty', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue('');
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({ defaultAgent: '' });
 
   render(AgentWorkspaceCreate);
 
@@ -655,7 +655,7 @@ test('Expect default agent falls back to opencode when setting is empty', async 
 });
 
 test('Expect default agent falls back to opencode when setting is unknown value', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue('unknown-agent');
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({ defaultAgent: 'unknown-agent' });
 
   render(AgentWorkspaceCreate);
 
@@ -734,11 +734,13 @@ const mockOllamaProvider: ProviderInfo = {
 } as unknown as ProviderInfo;
 
 test('Expect default model from onboarding.defaultWorkspaceSettings when valid', async () => {
-  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
-    if (key === 'onboarding.defaultAgent') return 'opencode';
-    if (key === 'onboarding.defaultWorkspaceSettings')
-      return { model: { providerId: 'claude', connectionName: 'Anthropic Cloud', label: 'claude-sonnet-4' } };
-    return undefined;
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'opencode',
+    defaultAgentSettings: {
+      opencode: {
+        defaultModel: { providerId: 'claude', connectionName: 'Anthropic Cloud', label: 'claude-sonnet-4' },
+      },
+    },
   });
   vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider]);
 
@@ -758,11 +760,7 @@ test('Expect default model from onboarding.defaultWorkspaceSettings when valid',
 });
 
 test('Expect first compatible model used when defaultWorkspaceSettings has no model and providers exist', async () => {
-  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
-    if (key === 'onboarding.defaultAgent') return 'opencode';
-    if (key === 'onboarding.defaultWorkspaceSettings') return {};
-    return undefined;
-  });
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({ defaultAgent: 'opencode' });
   vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider, mockOllamaProvider]);
 
   render(AgentWorkspaceCreate);
@@ -780,11 +778,7 @@ test('Expect first compatible model used when defaultWorkspaceSettings has no mo
 });
 
 test('Expect model empty when no setting and no providers', async () => {
-  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
-    if (key === 'onboarding.defaultAgent') return 'opencode';
-    if (key === 'onboarding.defaultWorkspaceSettings') return {};
-    return undefined;
-  });
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({ defaultAgent: 'opencode' });
 
   render(AgentWorkspaceCreate);
 
@@ -804,11 +798,7 @@ test('Expect model empty when no setting and no providers', async () => {
 });
 
 test('Expect first compatible model used when defaultWorkspaceSettings is undefined and providers exist', async () => {
-  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
-    if (key === 'onboarding.defaultAgent') return 'opencode';
-    if (key === 'onboarding.defaultWorkspaceSettings') return undefined;
-    return undefined;
-  });
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
   vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockOllamaProvider]);
 
   render(AgentWorkspaceCreate);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -155,24 +155,25 @@ let selectedAgent = $state('opencode');
 let selectedModel = $state<ModelInfo | undefined>(undefined);
 
 onMount(async () => {
-  const defaultAgent = await window.getConfigurationValue<string>('onboarding.defaultAgent');
+  const defaultSettings = await window.getConfigurationValue<DefaultWorkspaceSettings>(
+    'onboarding.defaultWorkspaceSettings',
+  );
+
+  const defaultAgent = defaultSettings?.defaultAgent;
   if (defaultAgent && agentDefinitions.some(d => d.cliName === defaultAgent)) {
     selectedAgent = defaultAgent;
   }
 
-  const defaultSettings = await window.getConfigurationValue<DefaultWorkspaceSettings>(
-    'onboarding.defaultWorkspaceSettings',
-  );
   if (
     defaultAgent &&
-    defaultSettings?.defaultAgentSettings?.[defaultAgent].defaultModel?.providerId &&
-    defaultSettings?.defaultAgentSettings?.[defaultAgent].defaultModel?.label
+    defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.providerId &&
+    defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.label
   ) {
     const allModels = getCatalogModels($providerInfos);
     const match = allModels.find(
       m =>
-        m.providerId === defaultSettings?.defaultAgentSettings?.[defaultAgent].defaultModel?.providerId &&
-        m.label === defaultSettings?.defaultAgentSettings?.[defaultAgent].defaultModel?.label,
+        m.providerId === defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.providerId &&
+        m.label === defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.label,
     );
     if (match) {
       selectedModel = match;

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -202,18 +202,6 @@ test('Skip button is not shown for non-skippable steps', async () => {
   expect(screen.queryByRole('button', { name: 'Skip' })).not.toBeInTheDocument();
 });
 
-test('persists default agent to settings.json when wizard completes', async () => {
-  render(GuidedSetup, { onclose: closeMock });
-
-  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
-  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
-  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
-
-  await waitFor(() => {
-    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultAgent', 'opencode');
-  });
-});
-
 test('Skip closes without persisting any settings', async () => {
   render(GuidedSetup, { onclose: closeMock });
 

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -47,7 +47,6 @@ function buildWorkspaceConfig(): AgentWorkspaceConfiguration {
 async function persistOnboardingDefaults(): Promise<void> {
   const resolvedAgent = getAgentDefinition(onboardingState.agent).cliAgent ?? onboardingState.agent;
   onboardingState.workspaceSetting.defaultAgent = resolvedAgent;
-  await window.updateConfigurationValue('onboarding.defaultAgent', resolvedAgent);
 
   const agentSettings = onboardingState.workspaceSetting.defaultAgentSettings?.[resolvedAgent] ?? {};
   onboardingState.workspaceSetting.defaultAgentSettings ??= {};


### PR DESCRIPTION
Mostly code removal but if you run the onboarding, you should not see `onboarding.defaultAgent` in settings.json (if you removed it before your test !!!)

Fixes #1706