### PR TITLE
feat(guided-setup): wire Vertex AI panel to extension for onboarding

### DIFF
--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -24,6 +24,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { getAgentDefinition } from './agent-registry';
 import type { GuidedSetupStep, OnboardingState } from './guided-setup-steps';
+import { createDefaultOnboardingState } from './guided-setup-steps';
 import GuidedSetup from './GuidedSetup.svelte';
 
 vi.mock(import('./agent-registry'));
@@ -61,7 +62,7 @@ vi.mock(import('./guided-setup-steps'), async importOriginal => {
         isSkippable: false,
       },
     ] satisfies GuidedSetupStep[],
-    createDefaultOnboardingState: (): OnboardingState => ({
+    createDefaultOnboardingState: vi.fn<() => OnboardingState>().mockReturnValue({
       agent: 'opencode',
       workspaceSetting: {},
     }),
@@ -76,6 +77,10 @@ beforeEach(() => {
   vi.mocked(getAgentDefinition).mockReturnValue({ cliName: 'opencode', title: 'OpenCode' } as ReturnType<
     typeof getAgentDefinition
   >);
+  vi.mocked(createDefaultOnboardingState).mockReturnValue({
+    agent: 'opencode',
+    workspaceSetting: {},
+  });
   vi.stubGlobal('updateConfigurationValue', vi.fn().mockResolvedValue(undefined));
 });
 
@@ -320,6 +325,55 @@ test('persists defaultWorkspaceSettings with workspaceConfig when wizard complet
         opencode: {
           defaultModel: undefined,
           workspaceConfiguration: {},
+        },
+      },
+    });
+  });
+});
+
+test('persists vertex AI environment and mounts in workspaceConfiguration', async () => {
+  vi.mocked(getAgentDefinition).mockReturnValue({
+    cliName: 'claude-vertex',
+    cliAgent: 'claude',
+    title: 'Claude on Vertex AI',
+  } as ReturnType<typeof getAgentDefinition>);
+
+  vi.mocked(createDefaultOnboardingState).mockReturnValue({
+    agent: 'claude-vertex',
+    workspaceSetting: {},
+    vertexConfig: {
+      projectId: 'my-project',
+      region: 'us-east5',
+      credentialsPath: '/home/user/.config/gcloud/application_default_credentials.json',
+    },
+  });
+
+  render(GuidedSetup, { onclose: closeMock });
+
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  await fireEvent.click(screen.getByRole('button', { name: /Go to Dashboard/ }));
+
+  await waitFor(() => {
+    expect(window.updateConfigurationValue).toHaveBeenCalledWith('onboarding.defaultWorkspaceSettings', {
+      defaultAgent: 'claude',
+      defaultAgentSettings: {
+        claude: {
+          defaultModel: undefined,
+          workspaceConfiguration: {
+            environment: [
+              { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-project' },
+              { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+              { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+            ],
+            mounts: [
+              {
+                host: '/home/user/.config/gcloud/application_default_credentials.json',
+                target: '$HOME/.config/gcloud/application_default_credentials.json',
+                ro: true,
+              },
+            ],
+          },
         },
       },
     });

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -41,6 +41,20 @@ function buildWorkspaceConfig(): AgentWorkspaceConfiguration {
     };
   }
 
+  const vertex = onboardingState.vertexConfig;
+  if (onboardingState.agent === 'claude-vertex' && vertex) {
+    return {
+      environment: [
+        { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: vertex.projectId },
+        { name: 'CLOUD_ML_REGION', value: vertex.region },
+        { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+      ],
+      mounts: [
+        { host: vertex.credentialsPath, target: '$HOME/.config/gcloud/application_default_credentials.json', ro: true },
+      ],
+    };
+  }
+
   return {};
 }
 

--- a/packages/renderer/src/lib/guided-setup/agent-registry.ts
+++ b/packages/renderer/src/lib/guided-setup/agent-registry.ts
@@ -96,6 +96,7 @@ export const agentDefinitions: AgentDefinition[] = [
     colorClass: 'bg-gradient-to-br from-blue-500 to-blue-600',
     modelFilter: 'vertexai',
     panel: ClaudeVertexPanel,
+    providerSelector: 'kaiden.vertex-ai:vertex-ai',
     runtimes: ['podman'],
   },
   {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
@@ -18,12 +18,54 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { faGoogle } from '@fortawesome/free-brands-svg-icons';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import type { Writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { fetchProviders, providerInfos } from '/@/stores/providers';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import type { AgentDefinition } from '../agent-registry';
 import type { OnboardingState } from '../guided-setup-steps';
 import ClaudeVertexPanel from './ClaudeVertexPanel.svelte';
+
+vi.mock(import('/@/stores/providers'), async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    providerInfos: writable<ProviderInfo[]>([]),
+    fetchProviders: vi.fn().mockResolvedValue([]),
+  };
+});
+
+const vertexDefinition: AgentDefinition = {
+  cliName: 'claude-vertex',
+  cliAgent: 'claude',
+  title: 'Claude on Vertex AI',
+  description: 'Run Claude Code through Google Cloud Vertex AI using your GCP project credentials.',
+  badge: 'Vertex AI',
+  icon: faGoogle,
+  colorClass: 'bg-gradient-to-br from-blue-500 to-blue-600',
+  providerSelector: 'kaiden.vertex-ai:vertex-ai',
+};
+
+function stubVertexProvider(options?: { withModels?: boolean }): void {
+  const models = options?.withModels ? [{ label: 'claude-sonnet-4-6' }, { label: 'claude-opus-4-5' }] : [];
+  const providers = [
+    {
+      id: 'vertex-ai',
+      internalId: 'vertex-ai-internal-1',
+      inferenceConnections: models.length > 0 ? [{ type: 'cloud', status: 'started', models }] : [],
+      inferenceProviderConnectionCreation: true,
+    },
+  ];
+  (providerInfos as Writable<ProviderInfo[]>).set(providers as unknown as ProviderInfo[]);
+}
+
+function stubNoProvider(): void {
+  (providerInfos as Writable<ProviderInfo[]>).set([]);
+}
 
 let onboarding: OnboardingState;
 
@@ -31,12 +73,14 @@ beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
   onboarding = { agent: 'claude-vertex', workspaceSetting: {} };
-  vi.stubGlobal('openExternal', vi.fn().mockResolvedValue(undefined));
+  vi.stubGlobal('createInferenceProviderConnection', vi.fn().mockResolvedValue(undefined));
   vi.stubGlobal('openDialog', vi.fn().mockResolvedValue(undefined));
+  vi.stubGlobal('openExternal', vi.fn().mockResolvedValue(undefined));
+  stubVertexProvider();
 });
 
-function renderPanel(): void {
-  render(ClaudeVertexPanel, { onboarding });
+function renderPanel(definition: AgentDefinition = vertexDefinition): void {
+  render(ClaudeVertexPanel, { definition, onboarding });
 }
 
 describe('rendering', () => {
@@ -47,56 +91,42 @@ describe('rendering', () => {
     expect(screen.getByText('Google Cloud Vertex AI')).toBeInTheDocument();
   });
 
-  test('shows the form with environment variable inputs', () => {
+  test('shows the form with project ID, region, and credentials file inputs', () => {
     renderPanel();
 
     expect(screen.getByTestId('claude-vertex-form')).toBeInTheDocument();
-    expect(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID')).toBeInTheDocument();
-    expect(screen.getByLabelText('CLOUD_ML_REGION')).toBeInTheDocument();
+    expect(screen.getByLabelText('Google Cloud project ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('Region')).toBeInTheDocument();
+    expect(screen.getByLabelText('Credentials file')).toBeInTheDocument();
   });
 
-  test('does not expose CLAUDE_CODE_USE_VERTEX field', () => {
+  test('shows warning when Vertex AI provider extension is not detected', () => {
+    stubNoProvider();
     renderPanel();
 
-    expect(screen.queryByLabelText('CLAUDE_CODE_USE_VERTEX')).not.toBeInTheDocument();
+    expect(screen.getByTestId('vertex-provider-missing')).toBeInTheDocument();
+    expect(screen.getByLabelText('Google Cloud project ID')).toBeDisabled();
+    expect(screen.getByLabelText('Region')).toBeDisabled();
+    expect(screen.getByLabelText('Credentials file')).toBeDisabled();
   });
 
   test('region input defaults to global', () => {
     renderPanel();
 
-    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
+    const regionInput = screen.getByLabelText('Region') as HTMLInputElement;
     expect(regionInput.value).toBe('global');
   });
 
-  test('shows informational text about workspace.json mapping', () => {
+  test('shows browse button for credentials file', () => {
     renderPanel();
 
-    expect(screen.getByText(/workspace\.json/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Browse credentials file')).toBeInTheDocument();
   });
 
-  test('shows note about gcloud auth', () => {
+  test('shows Vertex AI documentation link', () => {
     renderPanel();
 
-    expect(screen.getByText(/gcloud auth application-default login/)).toBeInTheDocument();
-  });
-
-  test('shows note about ANTHROPIC_API_KEY not being required', () => {
-    renderPanel();
-
-    expect(screen.getByText(/ANTHROPIC_API_KEY/)).toBeInTheDocument();
-  });
-
-  test('shows credentials directory input with browse button', () => {
-    renderPanel();
-
-    expect(screen.getByLabelText('Google Cloud credentials path')).toBeInTheDocument();
-    expect(screen.getByLabelText('Browse credentials')).toBeInTheDocument();
-  });
-
-  test('shows kdn README link', () => {
-    renderPanel();
-
-    expect(screen.getByText(/kdn README/)).toBeInTheDocument();
+    expect(screen.getByText(/Vertex AI documentation/)).toBeInTheDocument();
   });
 
   test('does not show error message initially', () => {
@@ -126,9 +156,9 @@ describe('beforeAdvance callback', () => {
   test('returns false and shows error when region is empty', async () => {
     renderPanel();
 
-    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-project');
+    await userEvent.type(screen.getByLabelText('Google Cloud project ID'), 'my-project');
 
-    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
+    const regionInput = screen.getByLabelText('Region') as HTMLInputElement;
     await userEvent.clear(regionInput);
 
     const result = await onboarding.beforeAdvance!();
@@ -137,111 +167,215 @@ describe('beforeAdvance callback', () => {
     expect(screen.getByText(/Please enter a region/)).toBeInTheDocument();
   });
 
-  test('returns false and shows error when credentials path is empty', async () => {
+  test('returns false and shows error when credentials file is empty', async () => {
     renderPanel();
 
-    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-project');
+    await userEvent.type(screen.getByLabelText('Google Cloud project ID'), 'my-project');
 
     const result = await onboarding.beforeAdvance!();
 
     expect(result).toBe(false);
-    expect(screen.getByText(/Please provide the path to your Google Cloud credentials directory/)).toBeInTheDocument();
+    expect(screen.getByText(/Please provide the path to your gcloud credentials file/)).toBeInTheDocument();
   });
 
-  test('returns true and stores vertexConfig when all inputs are valid', async () => {
+  test('returns false when provider is not available', async () => {
+    stubNoProvider();
     renderPanel();
 
-    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-gcp-project');
-    await userEvent.type(screen.getByLabelText('Google Cloud credentials path'), '/home/user/.config/gcloud');
+    const result = await onboarding.beforeAdvance!();
+
+    expect(result).toBe(false);
+    expect(screen.getByText(/Vertex AI provider extension is not available/)).toBeInTheDocument();
+  });
+
+  test('creates inference connection with factory params when all inputs are valid', async () => {
+    vi.mocked(fetchProviders).mockImplementation(async () => {
+      stubVertexProvider({ withModels: true });
+      return [] as ProviderInfo[];
+    });
+
+    renderPanel();
+
+    await userEvent.type(screen.getByLabelText('Google Cloud project ID'), 'my-gcp-project');
+    await userEvent.type(
+      screen.getByLabelText('Credentials file'),
+      '/home/user/.config/gcloud/application_default_credentials.json',
+    );
 
     const result = await onboarding.beforeAdvance!();
 
     expect(result).toBe(true);
+    expect(window.createInferenceProviderConnection).toHaveBeenCalledWith(
+      'vertex-ai-internal-1',
+      {
+        'vertex-ai.factory.projectId': 'my-gcp-project',
+        'vertex-ai.factory.region': 'global',
+        'vertex-ai.factory.credentialsFile': '/home/user/.config/gcloud/application_default_credentials.json',
+      },
+      expect.any(Symbol),
+      expect.any(Function),
+      undefined,
+      undefined,
+    );
+  });
+
+  test('stores vertexConfig in onboarding state on success', async () => {
+    vi.mocked(fetchProviders).mockImplementation(async () => {
+      stubVertexProvider({ withModels: true });
+      return [] as ProviderInfo[];
+    });
+
+    renderPanel();
+
+    await userEvent.type(screen.getByLabelText('Google Cloud project ID'), 'my-gcp-project');
+    await userEvent.type(
+      screen.getByLabelText('Credentials file'),
+      '/home/user/.config/gcloud/application_default_credentials.json',
+    );
+
+    const regionInput = screen.getByLabelText('Region') as HTMLInputElement;
+    await userEvent.clear(regionInput);
+    await userEvent.type(regionInput, 'us-east5');
+
+    await onboarding.beforeAdvance!();
+
     expect(onboarding.vertexConfig).toEqual({
       projectId: 'my-gcp-project',
-      region: 'global',
-      credentialsPath: '/home/user/.config/gcloud',
+      region: 'us-east5',
+      credentialsPath: '/home/user/.config/gcloud/application_default_credentials.json',
     });
   });
 
-  test('stores custom region in vertexConfig', async () => {
+  test('returns false and shows error when inference connection fails', async () => {
+    vi.mocked(window.createInferenceProviderConnection).mockRejectedValue(new Error('Credentials file not found'));
+
     renderPanel();
 
-    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), 'my-project');
-    await userEvent.type(screen.getByLabelText('Google Cloud credentials path'), '/home/user/.config/gcloud');
-
-    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
-    await userEvent.clear(regionInput);
-    await userEvent.type(regionInput, 'europe-west1');
+    await userEvent.type(screen.getByLabelText('Google Cloud project ID'), 'my-project');
+    await userEvent.type(screen.getByLabelText('Credentials file'), '/bad/path.json');
 
     const result = await onboarding.beforeAdvance!();
 
-    expect(result).toBe(true);
-    expect(onboarding.vertexConfig).toEqual({
-      projectId: 'my-project',
-      region: 'europe-west1',
-      credentialsPath: '/home/user/.config/gcloud',
-    });
+    expect(result).toBe(false);
+    expect(screen.getByText('Credentials file not found')).toBeInTheDocument();
   });
 
   test('trims whitespace from inputs', async () => {
+    vi.mocked(fetchProviders).mockImplementation(async () => {
+      stubVertexProvider({ withModels: true });
+      return [] as ProviderInfo[];
+    });
+
     renderPanel();
 
-    await userEvent.type(screen.getByLabelText('ANTHROPIC_VERTEX_PROJECT_ID'), '  my-project  ');
-    await userEvent.type(screen.getByLabelText('Google Cloud credentials path'), '  /home/user/.config/gcloud  ');
+    await userEvent.type(screen.getByLabelText('Google Cloud project ID'), '  my-project  ');
+    await userEvent.type(screen.getByLabelText('Credentials file'), '  /home/user/creds.json  ');
 
-    const regionInput = screen.getByLabelText('CLOUD_ML_REGION') as HTMLInputElement;
+    const regionInput = screen.getByLabelText('Region') as HTMLInputElement;
     await userEvent.clear(regionInput);
     await userEvent.type(regionInput, '  europe-west1  ');
+
+    await onboarding.beforeAdvance!();
+
+    expect(window.createInferenceProviderConnection).toHaveBeenCalledWith(
+      'vertex-ai-internal-1',
+      {
+        'vertex-ai.factory.projectId': 'my-project',
+        'vertex-ai.factory.region': 'europe-west1',
+        'vertex-ai.factory.credentialsFile': '/home/user/creds.json',
+      },
+      expect.any(Symbol),
+      expect.any(Function),
+      undefined,
+      undefined,
+    );
+  });
+});
+
+describe('already connected', () => {
+  function stubConnectedProvider(): void {
+    const providers = [
+      {
+        id: 'vertex-ai',
+        internalId: 'vertex-ai-internal-1',
+        inferenceConnections: [
+          {
+            type: 'cloud',
+            status: 'started',
+            models: [{ label: 'claude-sonnet-4-6' }, { label: 'claude-opus-4-5' }],
+          },
+        ],
+        inferenceProviderConnectionCreation: true,
+      },
+    ];
+    (providerInfos as Writable<ProviderInfo[]>).set(providers as unknown as ProviderInfo[]);
+  }
+
+  test('shows already-connected message when inference connection with models exists', () => {
+    stubConnectedProvider();
+    renderPanel();
+
+    expect(screen.getByTestId('vertex-already-connected')).toBeInTheDocument();
+    expect(screen.getByText('Connection configured')).toBeInTheDocument();
+    expect(screen.getByText(/2 models/)).toBeInTheDocument();
+  });
+
+  test('hides form when already connected', () => {
+    stubConnectedProvider();
+    renderPanel();
+
+    expect(screen.queryByTestId('claude-vertex-form')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Google Cloud project ID')).not.toBeInTheDocument();
+  });
+
+  test('beforeAdvance returns true immediately when already connected', async () => {
+    stubConnectedProvider();
+    renderPanel();
 
     const result = await onboarding.beforeAdvance!();
 
     expect(result).toBe(true);
-    expect(onboarding.vertexConfig).toEqual({
-      projectId: 'my-project',
-      region: 'europe-west1',
-      credentialsPath: '/home/user/.config/gcloud',
-    });
+    expect(window.createInferenceProviderConnection).not.toHaveBeenCalled();
   });
 });
 
 describe('credentials browse', () => {
   test('opens file dialog when browse button is clicked', async () => {
-    vi.mocked(window.openDialog).mockResolvedValue(['/home/user/.config/gcloud']);
+    vi.mocked(window.openDialog).mockResolvedValue(['/home/user/.config/gcloud/application_default_credentials.json']);
     renderPanel();
 
-    await fireEvent.click(screen.getByLabelText('Browse credentials'));
+    await fireEvent.click(screen.getByLabelText('Browse credentials file'));
 
     expect(window.openDialog).toHaveBeenCalledWith({
-      title: 'Select Google Cloud credentials directory',
-      selectors: ['openDirectory'],
+      title: 'Select gcloud credentials file',
+      selectors: ['openFile'],
     });
   });
 
-  test('sets credentials path from dialog result', async () => {
-    vi.mocked(window.openDialog).mockResolvedValue(['/home/user/.config/gcloud']);
+  test('sets credentials file from dialog result', async () => {
+    vi.mocked(window.openDialog).mockResolvedValue(['/home/user/.config/gcloud/application_default_credentials.json']);
     renderPanel();
 
-    await fireEvent.click(screen.getByLabelText('Browse credentials'));
+    await fireEvent.click(screen.getByLabelText('Browse credentials file'));
 
-    const credInput = screen.getByLabelText('Google Cloud credentials path') as HTMLInputElement;
-    expect(credInput.value).toBe('/home/user/.config/gcloud');
+    const credInput = screen.getByLabelText('Credentials file') as HTMLInputElement;
+    expect(credInput.value).toBe('/home/user/.config/gcloud/application_default_credentials.json');
   });
 
-  test('does not update credentials path when dialog is cancelled', async () => {
+  test('does not update credentials file when dialog is cancelled', async () => {
     vi.mocked(window.openDialog).mockResolvedValue(undefined as unknown as string[]);
     renderPanel();
 
-    await fireEvent.click(screen.getByLabelText('Browse credentials'));
+    await fireEvent.click(screen.getByLabelText('Browse credentials file'));
 
-    const credInput = screen.getByLabelText('Google Cloud credentials path') as HTMLInputElement;
+    const credInput = screen.getByLabelText('Credentials file') as HTMLInputElement;
     expect(credInput.value).toBe('');
   });
 });
 
 describe('cleanup', () => {
   test('clears beforeAdvance when component is destroyed', () => {
-    const { unmount } = render(ClaudeVertexPanel, { onboarding });
+    const { unmount } = render(ClaudeVertexPanel, { definition: vertexDefinition, onboarding });
 
     expect(onboarding.beforeAdvance).toBeDefined();
 

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
@@ -1,48 +1,71 @@
 <script lang="ts">
-import { faArrowUpRightFromSquare, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
-import { Button, Checkbox, ErrorMessage, Input, Link } from '@podman-desktop/ui-svelte';
+import {
+  faArrowUpRightFromSquare,
+  faCircleCheck,
+  faFolderOpen,
+  faTriangleExclamation,
+} from '@fortawesome/free-solid-svg-icons';
+import { Button, ErrorMessage, Input, Link } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
+import { fetchProviders, providerInfos } from '/@/stores/providers';
+
+import type { AgentDefinition } from '../agent-registry';
 import type { OnboardingState } from '../guided-setup-steps';
 
 interface Props {
+  definition?: AgentDefinition;
   onboarding?: OnboardingState;
 }
 
-let { onboarding }: Props = $props();
+let { definition, onboarding }: Props = $props();
+
+function parseSelector(selector?: string): { extensionId: string; providerId: string } {
+  const [extensionId = 'kaiden.vertex-ai', providerId = 'vertex-ai'] = (selector ?? 'kaiden.vertex-ai:vertex-ai').split(
+    ':',
+  );
+  return { extensionId, providerId };
+}
+
+const { providerId } = $derived(parseSelector(definition?.providerSelector));
 
 let projectId = $state('');
 let region = $state('global');
-let credentialsPath = $state('');
-let mountClaudeConfig = $state(false);
+let credentialsFile = $state('');
 let errorMessage = $state('');
-let defaultGcloudPath = $state('~/.config/gcloud');
 
-async function detectDefaultGcloudPath(): Promise<void> {
-  const platform = await window.getOsPlatform();
-  defaultGcloudPath = platform === 'win32' ? '%APPDATA%\\gcloud' : '~/.config/gcloud';
-}
-
-detectDefaultGcloudPath().catch(() => {});
-
-const KDN_VERTEX_README = 'https://github.com/openkaiden/kdn/blob/main/README.md#claude-with-a-model-from-vertex-ai';
+const KDN_VERTEX_README = 'https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude';
 
 function openReadmeLink(): void {
   window.openExternal(KDN_VERTEX_README).catch(() => {});
 }
 
-async function browseCredentials(): Promise<void> {
+let vertexProvider = $derived($providerInfos.find(p => p.id === providerId));
+
+let existingConnection = $derived(vertexProvider?.inferenceConnections?.find(c => c.models.length > 0));
+let alreadyConnected = $derived(!!existingConnection);
+
+async function browseCredentialsFile(): Promise<void> {
   const result = await window.openDialog({
-    title: 'Select Google Cloud credentials directory',
-    selectors: ['openDirectory'],
+    title: 'Select gcloud credentials file',
+    selectors: ['openFile'],
   });
   if (result?.[0]) {
-    credentialsPath = result[0];
+    credentialsFile = result[0];
   }
 }
 
 async function validate(): Promise<boolean> {
+  if (alreadyConnected) {
+    return true;
+  }
+
   errorMessage = '';
+
+  if (!vertexProvider) {
+    errorMessage = 'Vertex AI provider extension is not available. Make sure the Vertex AI extension is enabled.';
+    return false;
+  }
 
   if (!projectId.trim()) {
     errorMessage = 'Please enter your Google Cloud project ID.';
@@ -50,24 +73,45 @@ async function validate(): Promise<boolean> {
   }
 
   if (!region.trim()) {
-    errorMessage = 'Please enter a region (e.g. us-east5, europe-west1).';
+    errorMessage = 'Please enter a region (e.g. us-east5, europe-west1, global).';
     return false;
   }
 
-  if (!credentialsPath.trim()) {
-    errorMessage = 'Please provide the path to your Google Cloud credentials directory.';
+  if (!credentialsFile.trim()) {
+    errorMessage = 'Please provide the path to your gcloud credentials file.';
     return false;
   }
 
-  if (onboarding) {
-    onboarding.vertexConfig = {
-      projectId: projectId.trim(),
-      region: region.trim(),
-      credentialsPath: credentialsPath.trim(),
-    };
-  }
+  try {
+    const loggerKey = Symbol('onboarding-vertex-ai');
+    const noop = (): void => {};
+    await window.createInferenceProviderConnection(
+      vertexProvider.internalId,
+      {
+        'vertex-ai.factory.projectId': projectId.trim(),
+        'vertex-ai.factory.region': region.trim(),
+        'vertex-ai.factory.credentialsFile': credentialsFile.trim(),
+      },
+      loggerKey,
+      noop,
+      undefined,
+      undefined,
+    );
 
-  return true;
+    await fetchProviders();
+
+    if (onboarding) {
+      onboarding.vertexConfig = {
+        projectId: projectId.trim(),
+        region: region.trim(),
+        credentialsPath: credentialsFile.trim(),
+      };
+    }
+    return true;
+  } catch (err: unknown) {
+    errorMessage = err instanceof Error ? err.message : String(err);
+    return false;
+  }
 }
 
 $effect(() => {
@@ -85,71 +129,100 @@ $effect(() => {
 <div
   class="rounded-xl border border-(--pd-content-divider) bg-(--pd-content-card-inset-bg) p-6"
   data-testid="claude-vertex-panel">
-  <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
-    Google Cloud Vertex AI
-  </h3>
-  <p class="text-xs text-(--pd-content-card-text) opacity-50 mb-4 leading-relaxed">
-    These values map to <code class="font-mono">environment</code> entries for the Claude agent
-    in <code class="font-mono">$PROJECT_DIR/.kaiden/workspace.json</code>.
-    Run <code class="font-mono">gcloud auth application-default login</code> on the host before starting the workspace.
-  </p>
 
-  <div class="flex flex-col gap-4" data-testid="claude-vertex-form">
-    <div class="flex flex-col gap-1.5">
-      <label for="vertex-project-id" class="text-xs font-medium text-(--pd-content-card-text) font-mono">
-        ANTHROPIC_VERTEX_PROJECT_ID
-      </label>
-      <Input
-        id="vertex-project-id"
-        placeholder="my-gcp-project-id"
-        bind:value={projectId}
-        aria-label="ANTHROPIC_VERTEX_PROJECT_ID" />
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label for="vertex-region" class="text-xs font-medium text-(--pd-content-card-text) font-mono">
-        CLOUD_ML_REGION
-      </label>
-      <Input
-        id="vertex-region"
-        placeholder="us-east5"
-        bind:value={region}
-        aria-label="CLOUD_ML_REGION" />
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label for="vertex-credentials" class="text-xs font-medium text-(--pd-content-card-text)">
-        Google Cloud credentials directory
-      </label>
-      <div class="flex flex-row grow space-x-1.5">
-        <Input
-          id="vertex-credentials"
-          placeholder={defaultGcloudPath}
-          bind:value={credentialsPath}
-          aria-label="Google Cloud credentials path" />
-        <Button type="secondary" aria-label="Browse credentials" icon={faFolderOpen} onclick={browseCredentials} />
+  {#if alreadyConnected}
+    <div
+      class="flex items-center gap-3 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-success) p-4"
+      role="status"
+      aria-live="polite"
+      data-testid="vertex-already-connected">
+      <Icon icon={faCircleCheck} size="lg" class="text-(--pd-state-success)" />
+      <div>
+        <strong class="text-sm text-(--pd-state-success)">Connection configured</strong>
+        <p class="text-xs text-(--pd-content-card-text) opacity-70 mt-0.5">
+          {existingConnection?.models.length} model{existingConnection?.models.length !== 1 ? 's' : ''} available. You can continue to the next step.
+        </p>
       </div>
-      <span class="text-[10px] text-(--pd-content-card-text) opacity-40">
-        This directory will be mounted read-only into the workspace so Claude Code can
-        authenticate with Vertex AI via application default credentials.
-      </span>
     </div>
-
-    <Checkbox
-      bind:checked={mountClaudeConfig}
-      title="Mount Claude config">Also mount ~/.claude and ~/.claude.json (optional; reuse host Claude Code settings)</Checkbox>
-
-    <p class="text-[10px] text-(--pd-content-card-text) opacity-40 leading-relaxed">
-      No <code class="font-mono">ANTHROPIC_API_KEY</code> is required when using Vertex;
-      credentials come from your gcloud application default credentials.
+  {:else}
+    <h3 class="text-xs font-bold uppercase tracking-wider text-(--pd-content-card-text) opacity-50 mb-3">
+      Google Cloud Vertex AI
+    </h3>
+    <p class="text-xs text-(--pd-content-card-text) opacity-50 mb-4 leading-relaxed">
+      Connect to Anthropic models on Google Cloud Vertex AI.
+      Run <code class="font-mono">gcloud auth application-default login</code> on the host first.
     </p>
 
-    {#if errorMessage}
-      <ErrorMessage error={errorMessage} />
-    {/if}
+    <div class="flex flex-col gap-4" data-testid="claude-vertex-form">
+      {#if !vertexProvider}
+        <div
+          class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-warning) p-3"
+          role="alert"
+          data-testid="vertex-provider-missing">
+          <Icon icon={faTriangleExclamation} size="sm" class="text-(--pd-state-warning) shrink-0" />
+          <span class="text-xs text-(--pd-state-warning)">Vertex AI provider extension not detected.</span>
+        </div>
+      {/if}
 
-    <div class="pt-1">
-    <Link class="flex flex-row w-fit items-center" on:click={openReadmeLink}>  <Icon class="ml-1 self-center" icon={faArrowUpRightFromSquare} />&nbsp;kdn README: Claude Code with a model from Vertex AI </Link>
+      <div class="flex flex-col gap-1.5">
+        <label for="vertex-project-id" class="text-xs font-medium text-(--pd-content-card-text)">
+          Google Cloud project ID
+        </label>
+        <Input
+          id="vertex-project-id"
+          placeholder="my-gcp-project-id"
+          bind:value={projectId}
+          disabled={!vertexProvider}
+          aria-label="Google Cloud project ID" />
+        <span class="text-[10px] text-(--pd-content-card-text) opacity-40">
+          The project where Anthropic models are enabled (not the ADC quota_project_id).
+        </span>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="vertex-region" class="text-xs font-medium text-(--pd-content-card-text)">
+          Region
+        </label>
+        <Input
+          id="vertex-region"
+          placeholder="us-east5"
+          bind:value={region}
+          disabled={!vertexProvider}
+          aria-label="Region" />
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="vertex-credentials" class="text-xs font-medium text-(--pd-content-card-text)">
+          Credentials file
+        </label>
+        <div class="flex flex-row grow space-x-1.5">
+          <Input
+            id="vertex-credentials"
+            placeholder="~/.config/gcloud/application_default_credentials.json"
+            bind:value={credentialsFile}
+            disabled={!vertexProvider}
+            aria-label="Credentials file" />
+          <Button
+            type="secondary"
+            aria-label="Browse credentials file"
+            icon={faFolderOpen}
+            disabled={!vertexProvider}
+            onclick={browseCredentialsFile} />
+        </div>
+        <span class="text-[10px] text-(--pd-content-card-text) opacity-40">
+          Path to your gcloud application default credentials file.
+        </span>
+      </div>
+
+      {#if errorMessage}
+        <ErrorMessage error={errorMessage} />
+      {/if}
+
+      <div class="pt-1">
+        <Link class="flex flex-row w-fit items-center" on:click={openReadmeLink}>
+          <Icon class="ml-1 self-center" icon={faArrowUpRightFromSquare} />&nbsp;Vertex AI documentation
+        </Link>
+      </div>
     </div>
-  </div>
+  {/if}
 </div>


### PR DESCRIPTION
Connect ClaudeVertexPanel to the vertex-ai extension's inference provider so users can create a Vertex AI connection directly from the onboarding wizard. Persist environment variables and credentials mount in workspaceConfiguration so workspaces get the correct ANTHROPIC_VERTEX_PROJECT_ID, CLOUD_ML_REGION, CLAUDE_CODE_USE_VERTEX and gcloud ADC file mount.

<img width="1144" height="762" alt="Captura de pantalla 2026-05-06 a las 17 25 34" src="https://github.com/user-attachments/assets/fd2302b1-c036-4b1d-968e-8fdf12aba8b1" />

<img width="1146" height="762" alt="Captura de pantalla 2026-05-06 a las 17 26 41" src="https://github.com/user-attachments/assets/19bbb838-cec3-4454-a383-51947014ce1d" />

<img width="616" height="449" alt="Captura de pantalla 2026-05-06 a las 17 28 17 1" src="https://github.com/user-attachments/assets/b0d2ac8e-71ba-488e-bb24-02857836f768" />

<img width="531" height="272" alt="Captura de pantalla 2026-05-06 a las 17 26 54" src="https://github.com/user-attachments/assets/7addc544-1e40-4a79-a6ac-25704855957e" />

Closes #1707 