### PR TITLE
feat: rewrite host-native service URLs for WSL2 container access

### DIFF
--- a/extensions/ollama/src/ollama-extension.spec.ts
+++ b/extensions/ollama/src/ollama-extension.spec.ts
@@ -70,6 +70,9 @@ describe('OllamaExtension', () => {
     expect(vi.mocked(provider.createProvider)).toHaveBeenCalled();
     expect(extensionContext.subscriptions).toContain(ollamaProvider);
     expect(vi.mocked(ollamaProvider.registerInferenceProviderConnection)).toHaveBeenCalled();
+    expect(vi.mocked(ollamaProvider.registerInferenceProviderConnection)).toHaveBeenCalledWith(
+      expect.objectContaining({ hostNative: true }),
+    );
     expect(vi.mocked(ollamaProvider.updateStatus)).toHaveBeenCalledWith('started');
   });
 

--- a/extensions/ollama/src/ollama-extension.ts
+++ b/extensions/ollama/src/ollama-extension.ts
@@ -102,6 +102,7 @@ export class OllamaExtension {
         const disposable = ollamaProvider.registerInferenceProviderConnection({
           name: 'ollama',
           type: 'local',
+          hostNative: true,
           llmMetadata: { name: 'ollama' },
           endpoint: 'http://localhost:11434/v1',
           sdk,

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -77,6 +77,7 @@ export interface ProviderInferenceConnectionInfo {
   type: InferenceProviderConnectionType;
   llmMetadata?: LLMMetadata;
   endpoint?: string;
+  hostNative?: boolean;
   status: ProviderConnectionStatus;
   lifecycleMethods?: LifecycleMethod[];
   models: Array<{

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -659,6 +659,7 @@ declare module '@openkaiden/api' {
     type: InferenceProviderConnectionType;
     llmMetadata?: LLMMetadata;
     endpoint?: string;
+    hostNative?: boolean;
     sdk: AISDKInferenceProvider;
     credentials(): Record<string, string>;
     lifecycle?: ProviderConnectionLifecycle;

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -794,6 +794,7 @@ export class ProviderRegistry {
         type: connection.type,
         llmMetadata: connection.llmMetadata,
         endpoint: connection.endpoint,
+        hostNative: connection.hostNative,
         models: connection.models,
         status: connection.status(),
       };

--- a/packages/renderer/src/lib/chat/components/model-info.ts
+++ b/packages/renderer/src/lib/chat/components/model-info.ts
@@ -24,5 +24,6 @@ export interface ModelInfo {
   type: InferenceProviderConnectionType;
   llmMetadata?: LLMMetadata;
   endpoint?: string;
+  hostNative?: boolean;
   label: string;
 }

--- a/packages/renderer/src/lib/models/models-utils.spec.ts
+++ b/packages/renderer/src/lib/models/models-utils.spec.ts
@@ -27,7 +27,9 @@ import {
   getInferenceConnectionSummaries,
   getInHouseCatalogModels,
   getInHouseConnectionSummaries,
+  getModelId,
   getModels,
+  rewriteHostNativeEndpoint,
 } from './models-utils';
 
 test('getModels returns empty array for providers without inference connections', () => {
@@ -335,4 +337,33 @@ test('getInHouseConnectionSummaries returns empty when no self-hosted providers'
   ] as unknown as ProviderInfo[];
 
   expect(getInHouseConnectionSummaries(providers)).toEqual([]);
+});
+
+test('rewriteHostNativeEndpoint rewrites localhost aliases to native-host.internal', () => {
+  expect(rewriteHostNativeEndpoint('http://localhost:11434/v1')).toBe('http://native-host.internal:11434/v1');
+  expect(rewriteHostNativeEndpoint('http://127.0.0.1:8080/v1')).toBe('http://native-host.internal:8080/v1');
+  expect(rewriteHostNativeEndpoint('http://192.168.1.50:11434/v1')).toBe('http://192.168.1.50:11434/v1');
+  expect(rewriteHostNativeEndpoint(undefined)).toBeUndefined();
+});
+
+test('getModelId rewrites endpoint only for hostNative models', () => {
+  const hostNative = {
+    providerId: 'ollama',
+    connectionName: 'ollama',
+    type: 'local' as const,
+    hostNative: true,
+    llmMetadata: { name: 'ollama' },
+    endpoint: 'http://localhost:11434/v1',
+    label: 'llama3',
+  };
+  const container = {
+    providerId: 'ramalama',
+    connectionName: 'port/8080',
+    type: 'local' as const,
+    llmMetadata: { name: 'openai' },
+    endpoint: 'http://localhost:8080',
+    label: 'granite',
+  };
+  expect(getModelId(hostNative)).toBe('ollama::llama3::http://native-host.internal:11434/v1');
+  expect(getModelId(container)).toBe('openai::granite::http://localhost:8080');
 });

--- a/packages/renderer/src/lib/models/models-utils.ts
+++ b/packages/renderer/src/lib/models/models-utils.ts
@@ -23,7 +23,7 @@ export function getModels(providerInfos: ProviderInfo[]): ModelInfo[] {
   return providerInfos.reduce(
     (accumulator, current) => {
       if (current.inferenceConnections.length > 0) {
-        for (const { name, type, llmMetadata, endpoint, models } of current.inferenceConnections) {
+        for (const { name, type, llmMetadata, endpoint, hostNative, models } of current.inferenceConnections) {
           accumulator.push(
             ...models.map((model: { label: string }) => ({
               providerId: current.id,
@@ -31,6 +31,7 @@ export function getModels(providerInfos: ProviderInfo[]): ModelInfo[] {
               type,
               llmMetadata: llmMetadata,
               endpoint,
+              hostNative,
               label: model.label,
             })),
           );
@@ -65,6 +66,8 @@ export function getCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInf
           connectionName: connection.name,
           type: connection.type,
           llmMetadata: connection.llmMetadata,
+          endpoint: connection.endpoint,
+          hostNative: connection.hostNative,
           label: model.label,
           connectionStatus: connection.status,
         });
@@ -125,6 +128,24 @@ export function getInferenceConnectionSummaries(providerInfos: ProviderInfo[]): 
   return result;
 }
 
+const NATIVE_HOST = 'native-host.internal';
+const LOCALHOST_ALIASES = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '::1'];
+
+export function rewriteHostNativeEndpoint(endpoint: string | undefined): string | undefined {
+  if (!endpoint) return endpoint;
+  try {
+    const url = new URL(endpoint);
+    if (LOCALHOST_ALIASES.includes(url.hostname.toLowerCase())) {
+      url.hostname = NATIVE_HOST;
+      return url.toString();
+    }
+  } catch {
+    // not a URL, return as-is
+  }
+  return endpoint;
+}
+
 export function getModelId(model: ModelInfo): string {
-  return `${model.llmMetadata?.name ?? ''}::${model.label}::${model.endpoint ?? ''}`;
+  const endpoint = model.hostNative ? rewriteHostNativeEndpoint(model.endpoint) : model.endpoint;
+  return `${model.llmMetadata?.name ?? ''}::${model.label}::${endpoint ?? ''}`;
 }


### PR DESCRIPTION
## Summary
- Add `hostNative` field to `InferenceProviderConnection` so extensions can declare they run on the OS host (not in a container)
- Ollama extension sets `hostNative: true`
- `getModelId()` rewrites `localhost` → `native-host.internal` for host-native services when building workspace model IDs
- Paired with [kdn#fix/wsl2-host-containers-internal] which injects `native-host.internal` → Windows gateway IP inside containers

Fixes: https://github.com/openkaiden/kaiden/issues/1718

On WSL2 with pasta networking, `host.containers.internal` resolves to the podman VM (169.254.1.2), not the Windows host. Host-native services like Ollama are unreachable through that address. `native-host.internal` is a sentinel hostname that kdn resolves to the correct IP per platform. On Mac/Linux this is a no-op since both resolve to the same place.

## Test plan
- [x] Unit tests for `rewriteHostNativeEndpoint()` and `getModelId()` with host-native vs container models
- [x] Unit test verifying Ollama extension registers with `hostNative: true`
- [ ] Manual: create workspace with Ollama model → verify `kdn init --model` receives `native-host.internal` in endpoint
- [ ] Manual: create workspace with RamaLama model → verify endpoint stays `localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)