### PR TITLE
fix: update Claude Vertex to generate setting using the right key

### DIFF
--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.spec.ts
@@ -229,7 +229,6 @@ test('persists default workspace settings when wizard completes', async () => {
       defaultAgentSettings: {
         opencode: {
           defaultModel: undefined,
-          workspaceConfiguration: {},
         },
       },
     });
@@ -312,7 +311,6 @@ test('persists defaultWorkspaceSettings with workspaceConfig when wizard complet
       defaultAgentSettings: {
         opencode: {
           defaultModel: undefined,
-          workspaceConfiguration: {},
         },
       },
     });

--- a/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
+++ b/packages/renderer/src/lib/guided-setup/GuidedSetup.svelte
@@ -4,8 +4,6 @@ import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { SvelteSet } from 'svelte/reactivity';
 
-import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
-
 import { getAgentDefinition } from './agent-registry';
 import { createDefaultOnboardingState, guidedSetupSteps } from './guided-setup-steps';
 
@@ -32,27 +30,14 @@ function getStepState(index: number): 'completed' | 'active' | 'upcoming' {
   return 'upcoming';
 }
 
-function buildWorkspaceConfig(): AgentWorkspaceConfiguration {
-  const resolved = getAgentDefinition(onboardingState.agent).cliAgent ?? onboardingState.agent;
-
-  if (resolved === 'claude' && onboardingState.secretName) {
-    return {
-      secrets: [onboardingState.secretName],
-    };
-  }
-
-  return {};
-}
-
 async function persistOnboardingDefaults(): Promise<void> {
-  const resolvedAgent = getAgentDefinition(onboardingState.agent).cliAgent ?? onboardingState.agent;
+  const resolvedAgent = getAgentDefinition(onboardingState.agent).cliName ?? onboardingState.agent;
   onboardingState.workspaceSetting.defaultAgent = resolvedAgent;
 
   const agentSettings = onboardingState.workspaceSetting.defaultAgentSettings?.[resolvedAgent] ?? {};
   onboardingState.workspaceSetting.defaultAgentSettings ??= {};
   onboardingState.workspaceSetting.defaultAgentSettings[resolvedAgent] = agentSettings;
   agentSettings.defaultModel = onboardingState.model;
-  agentSettings.workspaceConfiguration = buildWorkspaceConfig();
 
   await window.updateConfigurationValue(
     'onboarding.defaultWorkspaceSettings',

--- a/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
+++ b/packages/renderer/src/lib/guided-setup/guided-setup-steps.ts
@@ -29,7 +29,6 @@ export type CliAgent = 'opencode' | 'claude' | 'claude-vertex' | 'cursor' | 'goo
 
 export interface OnboardingState {
   agent: CliAgent;
-  secretName?: string;
   model?: DefaultWorkspaceModelSettings;
   workspaceSetting: DefaultWorkspaceSettings;
   beforeAdvance?: () => Promise<boolean>;

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -265,13 +265,6 @@ describe('already connected', () => {
     expect(window.createInferenceProviderConnection).not.toHaveBeenCalled();
   });
 
-  test('sets onboarding.secretName when already connected', () => {
-    stubConnectedProvider();
-    renderPanel();
-
-    expect(onboarding.secretName).toBe('anthropic');
-  });
-
   test('does not treat a stopped connection as already connected', () => {
     const providers = [
       {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -33,17 +33,8 @@ let existingConnection = $derived(
 );
 let alreadyConnected = $derived(!!existingConnection);
 
-$effect(() => {
-  if (alreadyConnected && onboarding) {
-    onboarding.secretName = secretType;
-  }
-});
-
 async function validate(): Promise<boolean> {
   if (alreadyConnected) {
-    if (onboarding) {
-      onboarding.secretName = secretType;
-    }
     return true;
   }
 
@@ -88,7 +79,15 @@ async function validate(): Promise<boolean> {
     await fetchProviders();
 
     if (onboarding) {
-      onboarding.secretName = secretType;
+      const agentSettings = onboarding.workspaceSetting.defaultAgentSettings?.[onboarding.agent] ?? {};
+      onboarding.workspaceSetting.defaultAgentSettings ??= {};
+      onboarding.workspaceSetting.defaultAgentSettings[onboarding.agent] = agentSettings;
+      agentSettings.workspaceConfiguration ??= {};
+      agentSettings.workspaceConfiguration.secrets ??= [];
+      agentSettings.workspaceConfiguration.secrets = agentSettings.workspaceConfiguration.secrets.filter(
+        secret => secret !== secretType,
+      );
+      agentSettings.workspaceConfiguration.secrets.push(secretType);
     }
     return true;
   } catch (err: unknown) {


### PR DESCRIPTION
To test:

- execute onboarding for Claude agent and check settings contains defaultModel and secret under the claude key
- execute onboarding for Claude Vertex and check settings contains defaultModel and env and secrets under the claude-vertex key

Fixes #1721
Fixes #1712