### PR TITLE
feat(agent-workspace): propagate runtime settings when creating a workspace

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -70,4 +70,5 @@ export interface AgentWorkspaceCreateOptions {
   network?: NetworkConfiguration;
   secrets?: string[];
   mcp?: AgentWorkspaceMcpConfig;
+  workspaceConfiguration?: AgentWorkspaceConfiguration;
 }

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -569,6 +569,23 @@ describe('create', () => {
       { host: '$HOME/.config/gcloud/adc.json', target: '$HOME/.config/gcloud/adc.json', ro: true },
     ]);
   });
+
+  test('preserves existing workspace.json secrets when no secrets provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({ secrets: ['existing-secret'], skills: ['/home/user/.kaiden/skills/k8s'] }),
+    );
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/kubernetes'],
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.secrets).toEqual(['existing-secret']);
+  });
 });
 
 describe('list', () => {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -290,7 +290,7 @@ describe('create', () => {
     expect(exec.exec).toHaveBeenCalled();
   });
 
-  test('does not write workspace.json when no skills, network, secrets, or mcp provided', async () => {
+  test('does not write workspace.json when no skills, network, secrets, mcp, or workspaceConfiguration provided', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
@@ -449,6 +449,125 @@ describe('create', () => {
     const configCall = calls.find(c => String(c[0]).endsWith('workspace.json'));
     const parsed = JSON.parse(configCall![1] as string);
     expect(parsed.features).toEqual({ './uv-feature': { version: '3.12' } });
+  });
+
+  test('writes workspace.json with environment and mounts from workspaceConfiguration', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      workspaceConfiguration: {
+        environment: [
+          { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+          { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+        ],
+        mounts: [
+          {
+            host: '$HOME/.config/gcloud/application_default_credentials.json',
+            target: '$HOME/.config/gcloud/application_default_credentials.json',
+            ro: true,
+          },
+        ],
+      },
+    });
+
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/my-project', '.kaiden'), { recursive: true });
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.environment).toEqual([
+      { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+      { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+    ]);
+    expect(parsed.mounts).toEqual([
+      {
+        host: '$HOME/.config/gcloud/application_default_credentials.json',
+        target: '$HOME/.config/gcloud/application_default_credentials.json',
+        ro: true,
+      },
+    ]);
+  });
+
+  test('merges workspaceConfiguration environment into existing workspace.json', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ environment: [{ name: 'EXISTING_VAR', value: 'keep' }] }));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      workspaceConfiguration: {
+        environment: [{ name: 'NEW_VAR', value: 'added' }],
+      },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.environment).toEqual([
+      { name: 'EXISTING_VAR', value: 'keep' },
+      { name: 'NEW_VAR', value: 'added' },
+    ]);
+  });
+
+  test('merges workspaceConfiguration secrets with explicit secrets deduplicating', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      secrets: ['github-token', 'shared-secret'],
+      workspaceConfiguration: {
+        secrets: ['vertex-creds', 'shared-secret'],
+      },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.secrets).toEqual(['github-token', 'shared-secret', 'vertex-creds']);
+  });
+
+  test('writes workspace.json with workspaceConfiguration alone when no other options set', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      workspaceConfiguration: {
+        environment: [{ name: 'FOO', value: 'bar' }],
+      },
+    });
+
+    expect(writeFile).toHaveBeenCalled();
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.environment).toEqual([{ name: 'FOO', value: 'bar' }]);
+  });
+
+  test('writes workspace.json combining workspaceConfiguration with explicit skills and network', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/kubernetes'],
+      network: { mode: 'deny', hosts: ['registry.npmjs.org'] },
+      workspaceConfiguration: {
+        environment: [{ name: 'CLAUDE_CODE_USE_VERTEX', value: '1' }],
+        mounts: [{ host: '$HOME/.config/gcloud/adc.json', target: '$HOME/.config/gcloud/adc.json', ro: true }],
+      },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/home/user/.kaiden/skills/kubernetes']);
+    expect(parsed.network).toEqual({ mode: 'deny', hosts: ['registry.npmjs.org'] });
+    expect(parsed.environment).toEqual([{ name: 'CLAUDE_CODE_USE_VERTEX', value: '1' }]);
+    expect(parsed.mounts).toEqual([
+      { host: '$HOME/.config/gcloud/adc.json', target: '$HOME/.config/gcloud/adc.json', ro: true },
+    ]);
   });
 });
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -509,6 +509,58 @@ describe('create', () => {
     ]);
   });
 
+  test('deduplicates environment entries by name keeping first occurrence', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({ environment: [{ name: 'CLOUD_ML_REGION', value: 'existing-region' }] }),
+    );
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      workspaceConfiguration: {
+        environment: [
+          { name: 'CLOUD_ML_REGION', value: 'new-region' },
+          { name: 'NEW_VAR', value: 'added' },
+        ],
+      },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.environment).toEqual([
+      { name: 'CLOUD_ML_REGION', value: 'existing-region' },
+      { name: 'NEW_VAR', value: 'added' },
+    ]);
+  });
+
+  test('deduplicates mounts by host and target keeping first occurrence', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({
+        mounts: [{ host: '$HOME/.config/gcloud/adc.json', target: '$HOME/.config/gcloud/adc.json', ro: true }],
+      }),
+    );
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      workspaceConfiguration: {
+        mounts: [
+          { host: '$HOME/.config/gcloud/adc.json', target: '$HOME/.config/gcloud/adc.json', ro: false },
+          { host: '$HOME/.ssh/config', target: '$HOME/.ssh/config', ro: true },
+        ],
+      },
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mounts).toEqual([
+      { host: '$HOME/.config/gcloud/adc.json', target: '$HOME/.config/gcloud/adc.json', ro: true },
+      { host: '$HOME/.ssh/config', target: '$HOME/.ssh/config', ro: true },
+    ]);
+  });
+
   test('merges workspaceConfiguration secrets with explicit secrets deduplicating', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(readFile).mockRejectedValue(mockEnoent());

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -167,10 +167,23 @@ export class KdnCli {
     if (hasWsConfig) {
       const wc = options.workspaceConfiguration!;
       if (wc.environment?.length) {
-        existing.environment = [...(existing.environment ?? []), ...wc.environment];
+        const merged = [...(existing.environment ?? []), ...wc.environment];
+        const seen = new Set<string>();
+        existing.environment = merged.filter(e => {
+          if (seen.has(e.name)) return false;
+          seen.add(e.name);
+          return true;
+        });
       }
       if (wc.mounts?.length) {
-        existing.mounts = [...(existing.mounts ?? []), ...wc.mounts];
+        const merged = [...(existing.mounts ?? []), ...wc.mounts];
+        const seen = new Set<string>();
+        existing.mounts = merged.filter(m => {
+          const key = `${m.host}::${m.target}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
       }
     }
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -145,7 +145,8 @@ export class KdnCli {
     const mcpCommands = options.mcp?.commands;
     const hasSkills = !!options.skills?.length;
     const hasMcp = !!mcpServers?.length || !!mcpCommands?.length;
-    if (!hasSkills && !options.secrets?.length && !options.network && !hasMcp) {
+    const hasWsConfig = !!options.workspaceConfiguration;
+    if (!hasSkills && !options.secrets?.length && !options.network && !hasMcp && !hasWsConfig) {
       return;
     }
 
@@ -163,11 +164,25 @@ export class KdnCli {
       }
     }
 
+    if (hasWsConfig) {
+      const wc = options.workspaceConfiguration!;
+      if (wc.environment?.length) {
+        existing.environment = [...(existing.environment ?? []), ...wc.environment];
+      }
+      if (wc.mounts?.length) {
+        existing.mounts = [...(existing.mounts ?? []), ...wc.mounts];
+      }
+    }
+
     if (hasSkills) {
       existing.skills = options.skills;
     }
     existing.network = options.network;
-    existing.secrets = options.secrets;
+
+    const wsConfigSecrets = options.workspaceConfiguration?.secrets ?? [];
+    const explicitSecrets = options.secrets ?? [];
+    const mergedSecrets = [...new Set([...explicitSecrets, ...wsConfigSecrets])];
+    existing.secrets = mergedSecrets.length > 0 ? mergedSecrets : undefined;
 
     if (hasMcp) {
       const reqsByCommand = new Map<string, WorkspaceRequirements | undefined>();

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -181,8 +181,10 @@ export class KdnCli {
 
     const wsConfigSecrets = options.workspaceConfiguration?.secrets ?? [];
     const explicitSecrets = options.secrets ?? [];
-    const mergedSecrets = [...new Set([...explicitSecrets, ...wsConfigSecrets])];
-    existing.secrets = mergedSecrets.length > 0 ? mergedSecrets : undefined;
+    if (explicitSecrets.length > 0 || wsConfigSecrets.length > 0) {
+      const mergedSecrets = [...new Set([...explicitSecrets, ...wsConfigSecrets])];
+      existing.secrets = mergedSecrets;
+    }
 
     if (hasMcp) {
       const reqsByCommand = new Map<string, WorkspaceRequirements | undefined>();

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -1004,4 +1004,194 @@ test('Expect Unrestricted network option enabled when runtime is podman', async 
   expect(screen.getByRole('radio', { name: 'Use Unrestricted' })).toBeEnabled();
 });
 
+test('Expect createAgentWorkspace called with workspaceConfiguration from settings for selected agent', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'claude',
+    defaultAgentSettings: {
+      claude: {
+        defaultModel: { providerId: 'claude', connectionName: 'Anthropic Cloud', label: 'claude-sonnet-4' },
+        workspaceConfiguration: {
+          environment: [
+            { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+            { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+          ],
+          mounts: [
+            {
+              host: '$HOME/.config/gcloud/application_default_credentials.json',
+              target: '$HOME/.config/gcloud/application_default_credentials.json',
+              ro: true,
+            },
+          ],
+        },
+      },
+    },
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agent: 'claude',
+      workspaceConfiguration: {
+        environment: [
+          { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+          { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+        ],
+        mounts: [
+          {
+            host: '$HOME/.config/gcloud/application_default_credentials.json',
+            target: '$HOME/.config/gcloud/application_default_credentials.json',
+            ro: true,
+          },
+        ],
+      },
+    }),
+  );
+});
+
+test('Expect workspaceConfiguration undefined when no settings for selected agent', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'opencode',
+    defaultAgentSettings: {
+      opencode: {
+        defaultModel: { providerId: 'claude', connectionName: 'Anthropic Cloud', label: 'claude-sonnet-4' },
+      },
+    },
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agent: 'opencode',
+      workspaceConfiguration: undefined,
+    }),
+  );
+});
+
+test('Expect workspaceConfiguration resolved via cliAgent for variant agents like claude-vertex', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'claude-vertex',
+    defaultAgentSettings: {
+      claude: {
+        workspaceConfiguration: {
+          environment: [{ name: 'CLAUDE_CODE_USE_VERTEX', value: '1' }],
+        },
+      },
+    },
+  });
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agent: 'claude',
+      workspaceConfiguration: {
+        environment: [{ name: 'CLAUDE_CODE_USE_VERTEX', value: '1' }],
+      },
+    }),
+  );
+});
+
+test('Expect workspaceConfiguration falls back to raw agent key when resolved key has no config', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'claude-vertex',
+    defaultAgentSettings: {
+      'claude-vertex': {
+        workspaceConfiguration: {
+          environment: [{ name: 'CLOUD_ML_REGION', value: 'us-east5' }],
+          mounts: [
+            {
+              host: '$HOME/.config/gcloud/application_default_credentials.json',
+              target: '$HOME/.config/gcloud/application_default_credentials.json',
+              ro: true,
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agent: 'claude',
+      workspaceConfiguration: {
+        environment: [{ name: 'CLOUD_ML_REGION', value: 'us-east5' }],
+        mounts: [
+          {
+            host: '$HOME/.config/gcloud/application_default_credentials.json',
+            target: '$HOME/.config/gcloud/application_default_credentials.json',
+            ro: true,
+          },
+        ],
+      },
+    }),
+  );
+});
+
+test('Expect tilde mount paths normalized to $HOME in workspaceConfiguration', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'claude',
+    defaultAgentSettings: {
+      claude: {
+        workspaceConfiguration: {
+          mounts: [
+            {
+              host: '~/.config/gcloud/application_default_credentials.json',
+              target: '~/.config/gcloud/application_default_credentials.json',
+              ro: true,
+            },
+          ],
+        },
+      },
+    },
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockAnthropicProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      workspaceConfiguration: {
+        mounts: [
+          {
+            host: '$HOME/.config/gcloud/application_default_credentials.json',
+            target: '$HOME/.config/gcloud/application_default_credentials.json',
+            ro: true,
+          },
+        ],
+      },
+    }),
+  );
+});
+
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -49,6 +49,7 @@ vi.mock(import('/@/stores/model-catalog'));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   HTMLElement.prototype.animate = vi.fn().mockReturnValue({
     finished: Promise.resolve(),
     cancel: vi.fn(),

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -26,7 +26,7 @@ import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
-import type { NetworkConfiguration } from '/@api/agent-workspace-info';
+import type { AgentWorkspaceConfiguration, NetworkConfiguration } from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
 import type { DefaultWorkspaceSettings } from '/@api/onboarding-settings-info';
 
@@ -161,11 +161,10 @@ let sessionName = $state('');
 let description = $state('');
 let selectedAgent = $state('opencode');
 let selectedModel = $state<ModelInfo | undefined>(undefined);
+let defaultSettings = $state<DefaultWorkspaceSettings | undefined>(undefined);
 
 onMount(async () => {
-  const defaultSettings = await window.getConfigurationValue<DefaultWorkspaceSettings>(
-    'onboarding.defaultWorkspaceSettings',
-  );
+  defaultSettings = await window.getConfigurationValue<DefaultWorkspaceSettings>('onboarding.defaultWorkspaceSettings');
 
   const defaultAgent = defaultSettings?.defaultAgent;
   if (defaultAgent && agentDefinitions.some(d => d.cliName === defaultAgent)) {
@@ -307,6 +306,27 @@ function cancel(): void {
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 }
 
+function normalizeTildeToHome(p: string): string {
+  return p.startsWith('~/') ? `$HOME/${p.slice(2)}` : p;
+}
+
+function getAgentWorkspaceConfiguration(agent: string): AgentWorkspaceConfiguration | undefined {
+  const resolvedAgent = agentDefinitions.find(d => d.cliName === agent)?.cliAgent ?? agent;
+  const config =
+    defaultSettings?.defaultAgentSettings?.[resolvedAgent]?.workspaceConfiguration ??
+    defaultSettings?.defaultAgentSettings?.[agent]?.workspaceConfiguration;
+  if (!config) return undefined;
+  const snapshot = $state.snapshot(config);
+  if (snapshot.mounts) {
+    snapshot.mounts = snapshot.mounts.map(m => ({
+      ...m,
+      host: normalizeTildeToHome(m.host),
+      target: normalizeTildeToHome(m.target),
+    }));
+  }
+  return snapshot;
+}
+
 function getFirstCompatibleModel(): ModelInfo | undefined {
   const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
   const enabled = getCatalogModels($providerInfos).filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
@@ -361,6 +381,7 @@ async function startWorkspace(): Promise<void> {
             ...(commandServers.length > 0 ? { commands: commandServers } : {}),
           }
         : undefined,
+      workspaceConfiguration: getAgentWorkspaceConfiguration(selectedAgent),
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);


### PR DESCRIPTION
Read the workspaceConfiguration for the selected agent from settings.json and merge environment, mounts, and secrets into workspace.json during workspace creation. Tilde paths in mounts are normalized to $HOME for CLI compatibility.

## Test plan
- [ ] Delete `onboarding.defaultWorkspaceSettings` from settings.json (or reset settings) to trigger the onboarding flow, then complete onboarding with Vertex AI
- [ ] Create workspace → verify `workspace.json` contains vertex environment and mounts from settings
- [ ] Create workspace with a non-vertex agent (e.g. opencode) → verify no extra workspace config injected
- [ ] Verify `~` mount paths are normalized to `$HOME` in the resulting `workspace.json`

Closes #1709