### PR TITLE
feat(agent-workspace): add filesystem mount configuration

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -56,6 +56,8 @@ export type AgentWorkspaceMcpCommandServer = configComponents['schemas']['McpCom
 
 export type AgentWorkspaceMcpConfig = configComponents['schemas']['McpConfiguration'];
 
+export type AgentWorkspaceMount = configComponents['schemas']['Mount'];
+
 /**
  * Options for creating (initializing) a new workspace via `kdn init`.
  */
@@ -71,4 +73,5 @@ export interface AgentWorkspaceCreateOptions {
   secrets?: string[];
   mcp?: AgentWorkspaceMcpConfig;
   workspaceConfiguration?: AgentWorkspaceConfiguration;
+  mounts?: AgentWorkspaceMount[];
 }

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -324,7 +324,7 @@ describe('create', () => {
 
   test('merges mounts into existing workspace.json preserving other fields', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ mcp: { servers: [] } }));
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ mcp: { servers: [] }, network: { mode: 'allow' } }));
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
     await kdnCli.createWorkspace({
@@ -335,6 +335,7 @@ describe('create', () => {
     const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
     const parsed = JSON.parse(writtenContent);
     expect(parsed.mcp).toEqual({ servers: [] });
+    expect(parsed.network).toEqual({ mode: 'allow' });
     expect(parsed.mounts).toEqual([{ host: '$HOME', target: '$HOME', ro: false }]);
   });
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -290,13 +290,52 @@ describe('create', () => {
     expect(exec.exec).toHaveBeenCalled();
   });
 
-  test('does not write workspace.json when no skills, network, secrets, mcp, or workspaceConfiguration provided', async () => {
+  test('does not write workspace.json when no skills, network, secrets, mcp, mounts provided or workspaceConfiguration provided', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
 
     await kdnCli.createWorkspace(defaultOptions);
 
     expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('writes workspace.json with mounts before calling kdn init', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      mounts: [
+        { host: '/home/user/data', target: '/workspace/data', ro: false },
+        { host: '$HOME/.gitconfig', target: '$HOME/.gitconfig', ro: true },
+      ],
+    });
+
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/my-project', '.kaiden'), { recursive: true });
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mounts).toEqual([
+      { host: '/home/user/data', target: '/workspace/data', ro: false },
+      { host: '$HOME/.gitconfig', target: '$HOME/.gitconfig', ro: true },
+    ]);
+    expect(exec.exec).toHaveBeenCalled();
+  });
+
+  test('merges mounts into existing workspace.json preserving other fields', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ mcp: { servers: [] } }));
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ id: 'ws-new' })));
+
+    await kdnCli.createWorkspace({
+      ...defaultOptions,
+      mounts: [{ host: '$HOME', target: '$HOME', ro: false }],
+    });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.mcp).toEqual({ servers: [] });
+    expect(parsed.mounts).toEqual([{ host: '$HOME', target: '$HOME', ro: false }]);
   });
 
   test('merges network into existing workspace.json', async () => {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -146,7 +146,8 @@ export class KdnCli {
     const hasSkills = !!options.skills?.length;
     const hasMcp = !!mcpServers?.length || !!mcpCommands?.length;
     const hasWsConfig = !!options.workspaceConfiguration;
-    if (!hasSkills && !options.secrets?.length && !options.network && !hasMcp && !hasWsConfig) {
+    const hasMounts = !!options.mounts?.length;
+    if (!hasSkills && !options.secrets?.length && !options.network && !hasMcp && !hasMounts && !hasWsConfig) {
       return;
     }
 
@@ -197,6 +198,10 @@ export class KdnCli {
     if (explicitSecrets.length > 0 || wsConfigSecrets.length > 0) {
       const mergedSecrets = [...new Set([...explicitSecrets, ...wsConfigSecrets])];
       existing.secrets = mergedSecrets;
+    }
+
+    if (hasMounts) {
+      existing.mounts = options.mounts;
     }
 
     if (hasMcp) {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -191,7 +191,9 @@ export class KdnCli {
     if (hasSkills) {
       existing.skills = options.skills;
     }
-    existing.network = options.network;
+    if (options.network !== undefined) {
+      existing.network = options.network;
+    }
 
     const wsConfigSecrets = options.workspaceConfiguration?.secrets ?? [];
     const explicitSecrets = options.secrets ?? [];

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -216,7 +216,7 @@ test('Expect Start Workspace button visible on last step', async () => {
   expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
 });
 
-test('Expect custom paths section shown when Custom Paths selected on filesystem step', async () => {
+test('Expect custom mounts section shown when Custom Paths selected on filesystem step', async () => {
   render(AgentWorkspaceCreate);
 
   await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
@@ -229,8 +229,9 @@ test('Expect custom paths section shown when Custom Paths selected on filesystem
 
   await fireEvent.click(screen.getByRole('radio', { name: 'Use Custom Paths' }));
 
-  expect(screen.getByPlaceholderText('/path/to/allowed/directory')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Add Another Path' })).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('/path/on/host')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('Leave empty to use host path')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Add Another Mount' })).toBeInTheDocument();
 });
 
 async function navigateToToolsSecretsStep(): Promise<void> {
@@ -1191,6 +1192,104 @@ test('Expect tilde mount paths normalized to $HOME in workspaceConfiguration', a
           },
         ],
       },
+    }),
+  );
+});
+
+async function navigateToFileSystemStep(): Promise<void> {
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  // Workspace → Agent & Model → Tools & Secrets → File System
+  for (let i = 0; i < 3; i++) {
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  }
+}
+
+test('Expect createAgentWorkspace called without mounts when workspace (default) file access selected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mounts: undefined,
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called with home mount when Home Directory selected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToFileSystemStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Home Directory' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mounts: [{ host: '$HOME', target: '$HOME', ro: false }],
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called with full mount when Full System Access selected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToFileSystemStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Full System Access' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mounts: [{ host: '/', target: '/', ro: false }],
+    }),
+  );
+});
+
+test('Expect createAgentWorkspace called with custom mounts when Custom Paths selected', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToFileSystemStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Custom Paths' }));
+
+  await fireEvent.input(screen.getByLabelText('Host path 1'), {
+    target: { value: '/home/user/data' },
+  });
+  await fireEvent.input(screen.getByLabelText('Target path 1'), {
+    target: { value: '/workspace/data' },
+  });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mounts: [{ host: '/home/user/data', target: '/workspace/data', ro: false }],
+    }),
+  );
+});
+
+test('Expect custom mount defaults target to host path when target is empty', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToFileSystemStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Custom Paths' }));
+
+  await fireEvent.input(screen.getByLabelText('Host path 1'), {
+    target: { value: '/home/user/configs' },
+  });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mounts: [{ host: '/home/user/configs', target: '/home/user/configs', ro: false }],
     }),
   );
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -1274,6 +1274,27 @@ test('Expect createAgentWorkspace called with custom mounts when Custom Paths se
   );
 });
 
+test('Expect createAgentWorkspace called with ro:true when read-only toggled for custom mount', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToFileSystemStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Custom Paths' }));
+
+  await fireEvent.input(screen.getByLabelText('Host path 1'), {
+    target: { value: '/home/user/data' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Toggle read-only for mount 1' }));
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mounts: [{ host: '/home/user/data', target: '/home/user/data', ro: true }],
+    }),
+  );
+});
+
 test('Expect custom mount defaults target to host path when target is empty', async () => {
   render(AgentWorkspaceCreate);
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -6,7 +6,7 @@ import { onMount } from 'svelte';
 import { toast } from 'svelte-sonner';
 
 import AgentWorkspaceCreateStepAgentModel from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte';
-import type { FileAccessOption } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
+import type { CustomMount, FileAccessOption } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
 import AgentWorkspaceCreateStepFileSystem from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
 import type { NetworkAccessOption } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte';
 import AgentWorkspaceCreateStepNetworking from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte';
@@ -26,7 +26,7 @@ import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
-import type { AgentWorkspaceConfiguration, NetworkConfiguration } from '/@api/agent-workspace-info';
+import type { AgentWorkspaceConfiguration, AgentWorkspaceMount, NetworkConfiguration } from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
 import type { DefaultWorkspaceSettings } from '/@api/onboarding-settings-info';
 
@@ -199,7 +199,7 @@ let selectedSkillIds = $derived(skillItems.map(s => s.id));
 let selectedMcpIds = $derived(mcpItems.map(m => m.id));
 let selectedSecretIds = $derived($secretVaultInfos.map(s => s.id));
 let selectedKnowledgeIds = $derived(knowledgeItems.map(k => k.id));
-let customPaths = $state<string[]>(['']);
+let customMounts = $state<CustomMount[]>([{ host: '', target: '', ro: false }]);
 let hostsByMode = $state<Record<string, string[]>>({
   registries: [...REGISTRY_HOSTS],
   blocked: [''],
@@ -243,17 +243,17 @@ function handleStepClick(index: number): void {
   currentStepIndex = index;
 }
 
-function addCustomPath(): void {
-  customPaths = [...customPaths, ''];
+function addCustomMount(): void {
+  customMounts = [...customMounts, { host: '', target: '', ro: false }];
 }
 
-function removeCustomPath(index: number): void {
-  if (customPaths.length <= 1) return;
-  customPaths = customPaths.filter((_, i) => i !== index);
+function removeCustomMount(index: number): void {
+  if (customMounts.length <= 1) return;
+  customMounts = customMounts.filter((_, i) => i !== index);
 }
 
-function updateCustomPath(index: number, value: string): void {
-  customPaths = customPaths.map((p, i) => (i === index ? value : p));
+function updateCustomMount(index: number, field: keyof CustomMount, value: string | boolean): void {
+  customMounts = customMounts.map((m, i) => (i === index ? { ...m, [field]: value } : m));
 }
 
 function addCustomHost(): void {
@@ -276,7 +276,7 @@ async function handleBrowseCustomPath(index: number): Promise<void> {
   try {
     const result = await window.openDialog({ title: 'Select a directory', selectors: ['openDirectory'] });
     const selected = result?.[0];
-    if (selected) updateCustomPath(index, selected);
+    if (selected) updateCustomMount(index, 'host', selected);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     error = message;
@@ -342,6 +342,23 @@ function getFirstCompatibleModel(): ModelInfo | undefined {
   return compatible[0];
 }
 
+function buildMounts(): AgentWorkspaceMount[] | undefined {
+  switch (selectedFileAccess) {
+    case 'home':
+      return [{ host: '$HOME', target: '$HOME', ro: false }];
+    case 'full':
+      return [{ host: '/', target: '/', ro: false }];
+    case 'custom': {
+      const mounts = customMounts
+        .filter(m => m.host.trim() !== '')
+        .map(m => ({ host: m.host, target: m.target.trim() !== '' ? m.target.trim() : m.host, ro: m.ro }));
+      return mounts.length > 0 ? mounts : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
 async function startWorkspace(): Promise<void> {
   if (!sessionName.trim() || !sourcePath.trim()) return;
 
@@ -350,6 +367,7 @@ async function startWorkspace(): Promise<void> {
   try {
     const selectedSkillPaths = $skillInfos.filter(s => selectedSkillIds.includes(s.name)).map(s => s.path);
     const network = mapNetworkSelection(selectedNetwork, customHosts);
+    const mounts = buildMounts();
 
     const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
 
@@ -375,6 +393,7 @@ async function startWorkspace(): Promise<void> {
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
       network,
       secrets: selectedSecretIds.length > 0 ? [...selectedSecretIds] : undefined,
+      mounts,
       mcp: hasMcp
         ? {
             ...(remoteServers.length > 0 ? { servers: remoteServers } : {}),
@@ -434,11 +453,11 @@ async function startWorkspace(): Promise<void> {
               <AgentWorkspaceCreateStepFileSystem
                 {fileAccessOptions}
                 bind:selectedFileAccess
-                {customPaths}
+                {customMounts}
                 onBrowseCustomPath={handleBrowseCustomPath}
-                onAddCustomPath={addCustomPath}
-                onRemoveCustomPath={removeCustomPath}
-                onUpdateCustomPath={updateCustomPath} />
+                onAddCustomMount={addCustomMount}
+                onRemoveCustomMount={removeCustomMount}
+                onUpdateCustomMount={updateCustomMount} />
             {:else if currentStepId === 'networking'}
               <AgentWorkspaceCreateStepNetworking
                 {networkOptions}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -26,7 +26,11 @@ import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
-import type { AgentWorkspaceConfiguration, AgentWorkspaceMount, NetworkConfiguration } from '/@api/agent-workspace-info';
+import type {
+  AgentWorkspaceConfiguration,
+  AgentWorkspaceMount,
+  NetworkConfiguration,
+} from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
 import type { DefaultWorkspaceSettings } from '/@api/onboarding-settings-info';
 
@@ -351,7 +355,12 @@ function buildMounts(): AgentWorkspaceMount[] | undefined {
     case 'custom': {
       const mounts = customMounts
         .filter(m => m.host.trim() !== '')
-        .map(m => ({ host: m.host, target: m.target.trim() !== '' ? m.target.trim() : m.host, ro: m.ro }));
+        .map(m => {
+          const host = m.host.trim();
+          const trimmedTarget = m.target.trim();
+          const target = trimmedTarget !== '' ? trimmedTarget : host;
+          return { host, target, ro: m.ro };
+        });
       return mounts.length > 0 ? mounts : undefined;
     }
     default:

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
@@ -12,24 +12,30 @@ export interface FileAccessOption {
   badge?: string;
 }
 
+export interface CustomMount {
+  host: string;
+  target: string;
+  ro: boolean;
+}
+
 interface Props {
   fileAccessOptions: FileAccessOption[];
   selectedFileAccess: string;
-  customPaths: string[];
+  customMounts: CustomMount[];
   onBrowseCustomPath: (index: number) => Promise<void>;
-  onAddCustomPath: () => void;
-  onRemoveCustomPath: (index: number) => void;
-  onUpdateCustomPath: (index: number, value: string) => void;
+  onAddCustomMount: () => void;
+  onRemoveCustomMount: (index: number) => void;
+  onUpdateCustomMount: (index: number, field: keyof CustomMount, value: string | boolean) => void;
 }
 
 let {
   fileAccessOptions,
   selectedFileAccess = $bindable(),
-  customPaths,
+  customMounts,
   onBrowseCustomPath,
-  onAddCustomPath,
-  onRemoveCustomPath,
-  onUpdateCustomPath,
+  onAddCustomMount,
+  onRemoveCustomMount,
+  onUpdateCustomMount,
 }: Props = $props();
 
 function selectOption(value: string): void {
@@ -85,21 +91,47 @@ function selectOption(value: string): void {
 
 {#if selectedFileAccess === 'custom'}
   <div class="mt-4 p-4 rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)]">
-    <p class="text-xs text-[var(--pd-content-card-text)] opacity-70 mb-3">Allowed paths for custom access. You can refine paths later in project or workspace settings.</p>
-    {#each customPaths as path, index (index)}
-      <div class="flex gap-3 mb-2 items-center">
-        <Input
-          value={path}
-          placeholder="/path/to/allowed/directory"
-          class="flex-1 font-mono text-sm"
-          oninput={(e: Event): void => onUpdateCustomPath(index, (e.target as HTMLInputElement).value)}
-        />
-        <Button onclick={(): Promise<void> => onBrowseCustomPath(index)} aria-label="Browse for directory" icon={faFolderOpen} />
-        {#if customPaths.length > 1}
-          <Button class="text-red-400" onclick={(): void => onRemoveCustomPath(index)}>Remove</Button>
-        {/if}
+    <p class="text-xs text-[var(--pd-content-card-text)] opacity-70 mb-3">Mount host directories into the workspace. Target is optional (defaults to the host path).</p>
+    {#each customMounts as mount, index (index)}
+      <div class="flex flex-col gap-2 mb-3 p-3 rounded-lg bg-[var(--pd-content-card-inset-bg)] border border-[var(--pd-content-card-border)]">
+        <div class="flex gap-3 items-center">
+          <div class="flex-1 min-w-0">
+            <span class="text-[11px] text-[var(--pd-content-card-text)] opacity-60 mb-1 block">Host path</span>
+            <div class="flex gap-2 items-center">
+              <Input
+                value={mount.host}
+                placeholder="/path/on/host"
+                class="flex-1 font-mono text-sm"
+                aria-label="Host path {index + 1}"
+                oninput={(e: Event): void => onUpdateCustomMount(index, 'host', (e.target as HTMLInputElement).value)}
+              />
+              <Button onclick={(): Promise<void> => onBrowseCustomPath(index)} aria-label="Browse for directory" icon={faFolderOpen} />
+            </div>
+          </div>
+        </div>
+        <div class="flex gap-3 items-end">
+          <div class="flex-1 min-w-0">
+            <span class="text-[11px] text-[var(--pd-content-card-text)] opacity-60 mb-1 block">Target path in workspace</span>
+            <Input
+              value={mount.target}
+              placeholder="Leave empty to use host path"
+              class="flex-1 font-mono text-sm"
+              aria-label="Target path {index + 1}"
+              oninput={(e: Event): void => onUpdateCustomMount(index, 'target', (e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <Button
+            type="secondary"
+            aria-label="Toggle read-only for mount {index + 1}"
+            onclick={(): void => onUpdateCustomMount(index, 'ro', !mount.ro)}>
+            {mount.ro ? 'read-only' : 'read-write'}
+          </Button>
+          {#if customMounts.length > 1}
+            <Button onclick={(): void => onRemoveCustomMount(index)}>Remove</Button>
+          {/if}
+        </div>
       </div>
     {/each}
-    <Button class="mt-2" icon={faPlus} onclick={onAddCustomPath}>Add Another Path</Button>
+    <Button class="mt-2" icon={faPlus} onclick={onAddCustomMount}>Add Another Mount</Button>
   </div>
 {/if}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
@@ -96,7 +96,7 @@ function selectOption(value: string): void {
       <div class="flex flex-col gap-2 mb-3 p-3 rounded-lg bg-[var(--pd-content-card-inset-bg)] border border-[var(--pd-content-card-border)]">
         <div class="flex gap-3 items-center">
           <div class="flex-1 min-w-0">
-            <span class="text-[11px] text-[var(--pd-content-card-text)] opacity-60 mb-1 block">Host path</span>
+            <span class="text-[11px] text-[var(--pd-table-body-text)] mb-1 block">Host path</span>
             <div class="flex gap-2 items-center">
               <Input
                 value={mount.host}
@@ -111,7 +111,7 @@ function selectOption(value: string): void {
         </div>
         <div class="flex gap-3 items-end">
           <div class="flex-1 min-w-0">
-            <span class="text-[11px] text-[var(--pd-content-card-text)] opacity-60 mb-1 block">Target path in workspace</span>
+            <span class="text-[11px] text-[var(--pd-table-body-text)] mb-1 block">Target path in workspace</span>
             <Input
               value={mount.target}
               placeholder="Leave empty to use host path"
@@ -127,7 +127,7 @@ function selectOption(value: string): void {
             {mount.ro ? 'read-only' : 'read-write'}
           </Button>
           {#if customMounts.length > 1}
-            <Button onclick={(): void => onRemoveCustomMount(index)}>Remove</Button>
+            <Button aria-label="Remove mount {index + 1}" onclick={(): void => onRemoveCustomMount(index)}>Remove</Button>
           {/if}
         </div>
       </div>

--- a/tests/playwright/src/model/pages/agent-workspace-create-page.ts
+++ b/tests/playwright/src/model/pages/agent-workspace-create-page.ts
@@ -55,8 +55,8 @@ export class AgentWorkspaceCreatePage extends BasePage {
     this.customizeExpandable = this.page.getByText('Customize skills, MCP servers, vault, and knowledges');
     this.mcpServersPanel = this.page.getByText('MCP Servers', { exact: true });
     this.fileAccessHeading = this.page.getByText('File System Access');
-    this.firstCustomPathInput = this.page.getByPlaceholder('/path/to/allowed/directory').first();
-    this.addPathButton = this.page.getByRole('button', { name: 'Add Another Path' });
+    this.firstCustomPathInput = this.page.getByPlaceholder('/path/on/host').first();
+    this.addPathButton = this.page.getByRole('button', { name: 'Add Another Mount' });
     this.wizardStepper = this.page.getByLabel('Wizard progress');
     this.cancelButton = this.page.getByRole('button', { name: 'Cancel' });
     this.continueButton = this.page.getByRole('button', { name: 'Continue' });


### PR DESCRIPTION
Replace the single-path custom access model with structured mounts (host, target, read-only). Preset modes (workspace, home, full, custom) map to concrete mount entries passed to kdn init via workspace.json.

<img width="1159" height="819" alt="Screenshot 2026-05-07 at 13 13 16" src="https://github.com/user-attachments/assets/a1638724-6f71-40d2-8bb7-02d6f94d384b" />


Closes https://github.com/openkaiden/kaiden/issues/1741
Closes #1744