### PR TITLE
fix: align workspace name

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceName.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceName.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { faRobot } from '@fortawesome/free-solid-svg-icons';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+
+import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
+
+import AgentWorkspaceName from './AgentWorkspaceName.svelte';
+
+vi.mock('/@/lib/guided-setup/agent-registry', () => ({
+  getAgentDefinition: vi.fn(() => ({
+    title: 'Test Agent',
+    icon: faRobot,
+    colorClass: 'bg-blue-500',
+  })),
+}));
+
+vi.mock('tinro', () => ({
+  router: {
+    goto: vi.fn(),
+  },
+}));
+
+test('Button has correct classes', async () => {
+  const workspace: AgentWorkspaceSummaryUI = {
+    id: 'test-workspace-id',
+    name: 'Test Workspace Name',
+    agent: 'claude',
+  } as AgentWorkspaceSummaryUI;
+
+  render(AgentWorkspaceName, {
+    object: workspace,
+  });
+
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('flex');
+  expect(button).toHaveClass('items-start');
+});
+
+test('Clicking button navigates to workspace overview', async () => {
+  const { router } = await import('tinro');
+
+  const workspace: AgentWorkspaceSummaryUI = {
+    id: 'test-workspace-id',
+    name: 'Test Workspace Name',
+    agent: 'claude',
+  } as AgentWorkspaceSummaryUI;
+
+  render(AgentWorkspaceName, {
+    object: workspace,
+  });
+
+  const button = screen.getByRole('button');
+  await fireEvent.click(button);
+
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/test-workspace-id/overview');
+});

--- a/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceName.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceName.spec.ts
@@ -19,25 +19,25 @@ import '@testing-library/jest-dom/vitest';
 
 import { faRobot } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
+import { getAgentDefinition } from '/@/lib/guided-setup/agent-registry';
 import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
 
 import AgentWorkspaceName from './AgentWorkspaceName.svelte';
 
-vi.mock('/@/lib/guided-setup/agent-registry', () => ({
-  getAgentDefinition: vi.fn(() => ({
+vi.mock(import('/@/lib/guided-setup/agent-registry'));
+
+vi.mock(import('tinro'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getAgentDefinition).mockReturnValue({
     title: 'Test Agent',
     icon: faRobot,
     colorClass: 'bg-blue-500',
-  })),
-}));
-
-vi.mock('tinro', () => ({
-  router: {
-    goto: vi.fn(),
-  },
-}));
+  } as ReturnType<typeof getAgentDefinition>);
+});
 
 test('Button has correct classes', async () => {
   const workspace: AgentWorkspaceSummaryUI = {

--- a/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceName.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceName.svelte
@@ -29,7 +29,7 @@ function openDetails(): void {
     </div>
   {/if}
   <div class="flex flex-col gap-1 overflow-hidden min-w-0">
-    <button class="items-start" onclick={openDetails}>
+    <button class="flex items-start" onclick={openDetails}>
       <span
         class="text-(--pd-table-body-text-highlight) text-[14px] font-semibold leading-normal overflow-hidden text-ellipsis whitespace-nowrap"
         title={object.name}>


### PR DESCRIPTION
Button was using items-start without being in a flex layout. Added tests.

Before:
<img width="172" height="70" alt="Screenshot 2026-05-07 at 11 12 55 AM" src="https://github.com/user-attachments/assets/22c71a98-8cac-4a59-ac6e-d5e5d94d2e58" />

After:
<img width="172" height="70" alt="Screenshot 2026-05-07 at 11 16 24 AM" src="https://github.com/user-attachments/assets/4085dc70-e6ad-4345-8a05-2cc77e2e53f3" />

Fixes #1759.
Fixes https://github.com/openkaiden/kaiden/issues/1735