### PR TITLE
fix(agent-workspace): auto-create kdn vault secret from provider credentials on workspace creation

### DIFF
--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -198,6 +198,16 @@ export interface ProviderInfo {
   };
 }
 
+/**
+ * Credential metadata resolved from an inference connection, used to
+ * create a matching kdn vault secret during workspace creation.
+ */
+export interface InferenceConnectionCredentials {
+  credentials: Record<string, string>;
+  llmMetadataName?: string;
+  endpoint?: string;
+}
+
 export interface PreflightChecksCallback {
   startCheck: (status: CheckStatus) => void;
   endCheck: (status: CheckStatus) => void;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -29,6 +29,8 @@ import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
+import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import type { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type { Task } from '/@/plugin/tasks/tasks.js';
 import type { Exec } from '/@/plugin/util/exec.js';
@@ -113,6 +115,15 @@ const configurationRegistry = {
   }),
 } as unknown as IConfigurationRegistry;
 
+const providerRegistry = {
+  getInferenceConnectionCredentials: vi.fn(),
+} as unknown as ProviderRegistry;
+
+const secretManager = {
+  create: vi.fn(),
+  init: vi.fn(),
+} as unknown as SecretManager;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(taskManager.createTask).mockReturnValue(mockTask);
@@ -131,6 +142,8 @@ beforeEach(() => {
     filesystemMonitoring,
     webContents,
     configurationRegistry,
+    providerRegistry,
+    secretManager,
   );
   manager.init();
 });
@@ -289,6 +302,264 @@ describe('create', () => {
     await manager.create(defaultOptions);
 
     expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
+  });
+});
+
+describe('ensureModelSecret', () => {
+  const baseOptions: AgentWorkspaceCreateOptions = {
+    sourcePath: '/tmp/my-project',
+    agent: 'claude',
+    name: 'my-workspace',
+  };
+
+  test('creates an anthropic secret when connection has single credential entry', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'claude:tokens': 'sk-ant-secret' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-anthropic' });
+
+    const options = { ...baseOptions, model: 'anthropic::claude-sonnet-4-20250514::' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).toHaveBeenCalledWith({
+      name: 'my-workspace-anthropic',
+      type: 'anthropic',
+      value: 'sk-ant-secret',
+    });
+    expect(options.secrets).toContain('my-workspace-anthropic');
+  });
+
+  test('creates a gemini secret for gemini provider', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'gemini:tokens': 'gemini-key' },
+      llmMetadataName: 'gemini',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-gemini' });
+
+    const options = { ...baseOptions, model: 'gemini::gemini-2.5-pro::' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).toHaveBeenCalledWith({
+      name: 'my-workspace-gemini',
+      type: 'gemini',
+      value: 'gemini-key',
+    });
+    expect(options.secrets).toContain('my-workspace-gemini');
+  });
+
+  test('creates an openai secret with host from endpoint', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'openai:tokens': 'sk-openai-key' },
+      llmMetadataName: 'openai',
+      endpoint: 'https://api.openai.com/v1',
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-openai' });
+
+    const options = { ...baseOptions, model: 'openai::gpt-4o::https://api.openai.com/v1' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).toHaveBeenCalledWith({
+      name: 'my-workspace-openai',
+      type: 'other',
+      value: 'sk-openai-key',
+      hosts: ['api.openai.com'],
+      header: 'Authorization',
+      headerTemplate: 'Bearer ${value}',
+    });
+  });
+
+  test('defaults openai host when no endpoint', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'openai:tokens': 'sk-key' },
+      llmMetadataName: 'openai',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-openai' });
+
+    const options = { ...baseOptions, model: 'openai::gpt-4o::' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hosts: ['api.openai.com'],
+      }),
+    );
+  });
+
+  test('creates a mistral secret with correct host', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'mistral:tokens': 'mistral-key' },
+      llmMetadataName: 'mistral',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-mistral' });
+
+    const options = { ...baseOptions, model: 'mistral::mistral-large::' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).toHaveBeenCalledWith({
+      name: 'my-workspace-mistral',
+      type: 'other',
+      value: 'mistral-key',
+      hosts: ['api.mistral.ai'],
+      header: 'Authorization',
+      headerTemplate: 'Bearer ${value}',
+    });
+  });
+
+  test('skips when no model is provided', async () => {
+    const options = { ...baseOptions, model: undefined };
+    await manager.ensureModelSecret(options);
+
+    expect(providerRegistry.getInferenceConnectionCredentials).not.toHaveBeenCalled();
+    expect(secretManager.create).not.toHaveBeenCalled();
+  });
+
+  test('skips when workspaceConfiguration already has secrets (e.g. onboarding)', async () => {
+    const options = {
+      ...baseOptions,
+      model: 'anthropic::claude-sonnet-4-20250514::',
+      workspaceConfiguration: { secrets: ['anthropic'] },
+    } as AgentWorkspaceCreateOptions;
+    await manager.ensureModelSecret(options);
+
+    expect(providerRegistry.getInferenceConnectionCredentials).not.toHaveBeenCalled();
+    expect(secretManager.create).not.toHaveBeenCalled();
+  });
+
+  test('skips when connection cannot be resolved', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue(undefined);
+
+    const options = { ...baseOptions, model: 'unknown::model::' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).not.toHaveBeenCalled();
+  });
+
+  test('skips when credentials map is empty (local provider)', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: {},
+      llmMetadataName: 'ollama',
+      endpoint: 'http://localhost:11434/v1',
+    });
+
+    const options = { ...baseOptions, model: 'ollama::llama3::http://localhost:11434/v1' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).not.toHaveBeenCalled();
+  });
+
+  test('skips when credentials map has multiple entries (Vertex AI)', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { projectId: 'my-project', region: 'us-east5', credentialsFile: '/path/to/creds.json' },
+      llmMetadataName: 'vertexai',
+      endpoint: undefined,
+    });
+
+    const options = { ...baseOptions, model: 'vertexai::claude-sonnet-4-20250514::' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).not.toHaveBeenCalled();
+  });
+
+  test('skips when llmMetadataName is unknown', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { token: 'some-key' },
+      llmMetadataName: 'unknown-provider',
+      endpoint: undefined,
+    });
+
+    const options = { ...baseOptions, model: 'unknown-provider::model::' };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).not.toHaveBeenCalled();
+  });
+
+  test('tolerates "already exists" error from secret creation', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'claude:tokens': 'sk-ant-secret' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockRejectedValue(new Error('secret already exists: my-workspace-anthropic'));
+
+    const options = { ...baseOptions, model: 'anthropic::claude-sonnet-4-20250514::' };
+    await manager.ensureModelSecret(options);
+
+    expect(options.secrets).toContain('my-workspace-anthropic');
+  });
+
+  test('rethrows non-"already exists" errors from secret creation', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'claude:tokens': 'sk-ant-secret' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockRejectedValue(new Error('keychain unavailable'));
+
+    const options = { ...baseOptions, model: 'anthropic::claude-sonnet-4-20250514::' };
+    await expect(manager.ensureModelSecret(options)).rejects.toThrow('keychain unavailable');
+  });
+
+  test('merges secret name with existing secrets', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'claude:tokens': 'sk-ant-secret' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-anthropic' });
+
+    const options = { ...baseOptions, model: 'anthropic::claude-sonnet-4-20250514::', secrets: ['github-token'] };
+    await manager.ensureModelSecret(options);
+
+    expect(options.secrets).toEqual(['github-token', 'my-workspace-anthropic']);
+  });
+
+  test('does not duplicate secret name if already present', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'claude:tokens': 'sk-ant-secret' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-anthropic' });
+
+    const options = {
+      ...baseOptions,
+      model: 'anthropic::claude-sonnet-4-20250514::',
+      secrets: ['my-workspace-anthropic'],
+    };
+    await manager.ensureModelSecret(options);
+
+    expect(options.secrets).toEqual(['my-workspace-anthropic']);
+  });
+});
+
+describe('buildSecretOptions', () => {
+  test('returns undefined when credentials value is empty', () => {
+    const result = manager.buildSecretOptions(
+      { credentials: { key: '' }, llmMetadataName: 'anthropic', endpoint: undefined },
+      'ws',
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for unknown provider', () => {
+    const result = manager.buildSecretOptions(
+      { credentials: { key: 'value' }, llmMetadataName: 'somethingElse', endpoint: undefined },
+      'ws',
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test('derives secret name from workspace name and provider', () => {
+    const result = manager.buildSecretOptions(
+      { credentials: { key: 'value' }, llmMetadataName: 'anthropic', endpoint: undefined },
+      'my-project',
+    );
+    expect(result?.name).toBe('my-project-anthropic');
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -518,6 +518,25 @@ describe('ensureModelSecret', () => {
     expect(options.secrets).toEqual(['github-token', 'my-workspace-anthropic']);
   });
 
+  test('derives secret name from sourcePath when name is omitted', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'claude:tokens': 'sk-ant-secret' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-project-anthropic' });
+
+    const options: AgentWorkspaceCreateOptions = {
+      sourcePath: '/tmp/my-project',
+      agent: 'claude',
+      model: 'anthropic::claude-sonnet-4-20250514::',
+    };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'my-project-anthropic' }));
+    expect(options.secrets).toContain('my-project-anthropic');
+  });
+
   test('does not duplicate secret name if already present', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { 'claude:tokens': 'sk-ant-secret' },

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -29,6 +29,8 @@ import { spawn } from 'node-pty';
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
+import { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { AgentWorkspaceSettings } from '/@api/agent-workspace/agent-workspace-settings.js';
 import type {
@@ -41,6 +43,8 @@ import type {
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationNode } from '/@api/configuration/models.js';
 import { IConfigurationRegistry } from '/@api/configuration/models.js';
+import type { InferenceConnectionCredentials } from '/@api/provider-info.js';
+import type { SecretCreateOptions } from '/@api/secret-info.js';
 
 /**
  * Manages agent workspaces by delegating to the `kdn` CLI.
@@ -69,6 +73,10 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly webContents: WebContents,
     @inject(IConfigurationRegistry)
     private readonly configurationRegistry: IConfigurationRegistry,
+    @inject(ProviderRegistry)
+    private readonly providerRegistry: ProviderRegistry,
+    @inject(SecretManager)
+    private readonly secretManager: SecretManager,
   ) {}
 
   async getCliInfo(): Promise<CliInfo> {
@@ -81,6 +89,7 @@ export class AgentWorkspaceManager implements Disposable {
     task.state = 'running';
     task.status = 'in-progress';
     try {
+      await this.ensureModelSecret(options);
       const workspaceId = await this.kdnCli.createWorkspace(options);
       this.apiSender.send('agent-workspace-update');
       task.status = 'success';
@@ -92,6 +101,98 @@ export class AgentWorkspaceManager implements Disposable {
       throw new Error(detail);
     } finally {
       task.state = 'completed';
+    }
+  }
+
+  /**
+   * If the selected model's provider connection holds a single credential
+   * entry (assumed to be an API key), create a matching kdn vault secret
+   * and attach it to the workspace options so the CLI can inject it at
+   * runtime.
+   *
+   * Silently skips when: no model is selected, the connection cannot be
+   * resolved, credentials are empty or multi-valued (e.g. Vertex AI ADC),
+   * the provider type is unknown, or secrets were already explicitly
+   * configured (e.g. by the onboarding flow via workspaceConfiguration).
+   */
+  async ensureModelSecret(options: AgentWorkspaceCreateOptions): Promise<void> {
+    if (!options.model) return;
+
+    if (options.workspaceConfiguration?.secrets?.length) return;
+
+    const connectionInfo = this.providerRegistry.getInferenceConnectionCredentials(options.model);
+    if (!connectionInfo) return;
+
+    const entries = Object.entries(connectionInfo.credentials);
+    if (entries.length !== 1) return;
+
+    const secretOptions = this.buildSecretOptions(connectionInfo, options.name ?? 'workspace');
+    if (!secretOptions) return;
+
+    try {
+      await this.secretManager.create(secretOptions);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes('already exists')) throw err;
+    }
+
+    options.secrets = [...new Set([...(options.secrets ?? []), secretOptions.name])];
+  }
+
+  /**
+   * Maps provider metadata to the kdn secret create options.
+   *
+   * - `anthropic` / `gemini`: builtin secret types (header + hosts preconfigured in the CLI).
+   * - `openai`: `other` type; host derived from the connection endpoint or defaulting to
+   *    `api.openai.com`.
+   * - `mistral`: `other` type; host `api.mistral.ai`.
+   */
+  buildSecretOptions(
+    connectionInfo: InferenceConnectionCredentials,
+    workspaceName: string,
+  ): SecretCreateOptions | undefined {
+    const apiKey = Object.values(connectionInfo.credentials)[0];
+    if (!apiKey) return undefined;
+
+    const provider = connectionInfo.llmMetadataName;
+    const secretName = `${workspaceName}-${provider ?? 'secret'}`;
+
+    switch (provider) {
+      case 'anthropic':
+        return { name: secretName, type: 'anthropic', value: apiKey };
+      case 'gemini':
+        return { name: secretName, type: 'gemini', value: apiKey };
+      case 'openai': {
+        const host = this.extractHost(connectionInfo.endpoint) ?? 'api.openai.com';
+        return {
+          name: secretName,
+          type: 'other',
+          value: apiKey,
+          hosts: [host],
+          header: 'Authorization',
+          headerTemplate: 'Bearer ${value}',
+        };
+      }
+      case 'mistral':
+        return {
+          name: secretName,
+          type: 'other',
+          value: apiKey,
+          hosts: ['api.mistral.ai'],
+          header: 'Authorization',
+          headerTemplate: 'Bearer ${value}',
+        };
+      default:
+        return undefined;
+    }
+  }
+
+  private extractHost(endpoint?: string): string | undefined {
+    if (!endpoint) return undefined;
+    try {
+      return new URL(endpoint).host;
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -18,7 +18,7 @@
 
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
@@ -126,7 +126,8 @@ export class AgentWorkspaceManager implements Disposable {
     const entries = Object.entries(connectionInfo.credentials);
     if (entries.length !== 1) return;
 
-    const secretOptions = this.buildSecretOptions(connectionInfo, options.name ?? 'workspace');
+    const workspaceSecretPrefix = options.name ?? basename(options.sourcePath);
+    const secretOptions = this.buildSecretOptions(connectionInfo, workspaceSecretPrefix);
     if (!secretOptions) return;
 
     try {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -819,7 +819,7 @@ describe('createSecret', () => {
     );
   });
 
-  test('includes optional header-template flag when provided', async () => {
+  test('includes optional headerTemplate flag when provided', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
@@ -827,7 +827,7 @@ describe('createSecret', () => {
 
     expect(exec.exec).toHaveBeenCalledWith(
       KAIDEN_CLI_PATH,
-      expect.arrayContaining(['--header-template', 'Bearer ${value}']),
+      expect.arrayContaining(['--headerTemplate', 'Bearer ${value}']),
       undefined,
     );
   });

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -306,7 +306,7 @@ export class KdnCli {
       args.push('--header', options.header);
     }
     if (options.headerTemplate) {
-      args.push('--header-template', options.headerTemplate);
+      args.push('--headerTemplate', options.headerTemplate);
     }
     if (options.path) {
       args.push('--path', options.path);

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -2654,3 +2654,110 @@ test('getConnectionFactories should return the connection factories', async () =
     images: provider2Images,
   });
 });
+
+describe('getInferenceConnectionCredentials', () => {
+  function registerProvider(
+    id: string,
+    connections: Array<{
+      name: string;
+      llmMetadataName: string;
+      endpoint?: string;
+      models: string[];
+      credentials: Record<string, string>;
+    }>,
+  ): void {
+    const provider = providerRegistry.createProvider(id, id, {
+      id,
+      name: id,
+      status: 'installed',
+    });
+    for (const conn of connections) {
+      provider.registerInferenceProviderConnection({
+        name: conn.name,
+        type: 'cloud',
+        llmMetadata: { name: conn.llmMetadataName },
+        endpoint: conn.endpoint,
+        sdk: {} as never,
+        credentials: () => conn.credentials,
+        status: () => 'started',
+        models: conn.models.map(label => ({ label })),
+      });
+    }
+  }
+
+  test('returns credentials for matching anthropic connection', () => {
+    registerProvider('claude', [
+      {
+        name: 'sk-a*****',
+        llmMetadataName: 'anthropic',
+        models: ['claude-sonnet-4-20250514'],
+        credentials: { 'claude:tokens': 'sk-ant-secret' },
+      },
+    ]);
+
+    const result = providerRegistry.getInferenceConnectionCredentials('anthropic::claude-sonnet-4-20250514::');
+
+    expect(result).toEqual({
+      credentials: { 'claude:tokens': 'sk-ant-secret' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+  });
+
+  test('returns credentials for openai connection with endpoint', () => {
+    registerProvider('openai', [
+      {
+        name: 'https://api.openai.com/v1',
+        llmMetadataName: 'openai',
+        endpoint: 'https://api.openai.com/v1',
+        models: ['gpt-4o', 'gpt-4.1'],
+        credentials: { 'openai:tokens': 'sk-openai-key' },
+      },
+    ]);
+
+    const result = providerRegistry.getInferenceConnectionCredentials('openai::gpt-4o::https://api.openai.com/v1');
+
+    expect(result).toEqual({
+      credentials: { 'openai:tokens': 'sk-openai-key' },
+      llmMetadataName: 'openai',
+      endpoint: 'https://api.openai.com/v1',
+    });
+  });
+
+  test('returns undefined when no connection matches the model', () => {
+    registerProvider('claude', [
+      {
+        name: 'sk-a*****',
+        llmMetadataName: 'anthropic',
+        models: ['claude-sonnet-4-20250514'],
+        credentials: { 'claude:tokens': 'sk-ant-secret' },
+      },
+    ]);
+
+    const result = providerRegistry.getInferenceConnectionCredentials('anthropic::nonexistent-model::');
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when no providers are registered', () => {
+    const result = providerRegistry.getInferenceConnectionCredentials('anthropic::claude-sonnet-4-20250514::');
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for mismatched endpoint', () => {
+    registerProvider('openai', [
+      {
+        name: 'custom',
+        llmMetadataName: 'openai',
+        endpoint: 'https://custom.api.com',
+        models: ['gpt-4o'],
+        credentials: { 'openai:tokens': 'sk-key' },
+      },
+    ]);
+
+    const result = providerRegistry.getInferenceConnectionCredentials('openai::gpt-4o::https://other.api.com');
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -75,6 +75,7 @@ import { SkillManager } from '/@/plugin/skill/skill-manager.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { Event } from '/@api/event.js';
 import type {
+  InferenceConnectionCredentials,
   LifecycleMethod,
   PreflightChecksCallback,
   ProviderCleanupActionInfo,
@@ -2067,6 +2068,36 @@ export class ProviderRegistry {
       throw new Error('No inference connection found');
     }
     return connections[0].sdk;
+  }
+
+  /**
+   * Finds the inference connection owning a model (identified by the composite
+   * model-id string `llmMetadataName::label::endpoint`) and returns credentials
+   * together with provider metadata needed to derive a kdn vault secret.
+   *
+   * Returns `undefined` when no matching connection is found.
+   */
+  getInferenceConnectionCredentials(modelId: string): InferenceConnectionCredentials | undefined {
+    const [metadataName = '', modelLabel = '', endpoint = ''] = modelId.split('::');
+
+    for (const provider of this.providers.values()) {
+      for (const connection of provider.inferenceConnections) {
+        const connMetadataName = connection.llmMetadata?.name ?? '';
+        const connEndpoint = connection.endpoint ?? '';
+        if (
+          connMetadataName === metadataName &&
+          connEndpoint === endpoint &&
+          connection.models.some(m => m.label === modelLabel)
+        ) {
+          return {
+            credentials: connection.credentials(),
+            llmMetadataName: connection.llmMetadata?.name,
+            endpoint: connection.endpoint,
+          };
+        }
+      }
+    }
+    return undefined;
   }
 
   getFlowProviderConnection(internalProviderId: string): Array<FlowProviderConnection> {


### PR DESCRIPTION
When creating a workspace with a cloud model selected, the provider connection's credentials are now used to automatically create a matching kdn vault secret so the CLI can inject API keys at runtime. This avoids requiring users to manually duplicate their API key in the secret vault after configuring a provider via Settings. Skips providers that don't use simple API-key auth (Vertex AI, Ollama) and defers to existing secrets when the onboarding flow has already configured them via workspaceConfiguration.

Also fixes a pre-existing bug in KdnCli.createSecret where the --headerTemplate flag was incorrectly passed as --header-template (kebab-case), causing all type=other secret creations with a header template to fail silently.

## Test plan

- [ ] Configure a provider connection via **Settings** (not onboarding), create a workspace selecting a model of that provider → A secret with the folder name and the agent provider (e.g.: "folder-anthropic") should be created and it should be included in the workspace.json.

Closes #1738
Closes #1726