### PR TITLE
fix(secrets): properly set header template

### DIFF
--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -819,7 +819,7 @@ describe('createSecret', () => {
     );
   });
 
-  test('includes optional header-template flag when provided', async () => {
+  test('includes optional headerTemplate flag when provided', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
@@ -827,7 +827,7 @@ describe('createSecret', () => {
 
     expect(exec.exec).toHaveBeenCalledWith(
       KAIDEN_CLI_PATH,
-      expect.arrayContaining(['--header-template', 'Bearer ${value}']),
+      expect.arrayContaining(['--headerTemplate', 'Bearer ${value}']),
       undefined,
     );
   });

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -306,7 +306,7 @@ export class KdnCli {
       args.push('--header', options.header);
     }
     if (options.headerTemplate) {
-      args.push('--header-template', options.headerTemplate);
+      args.push('--headerTemplate', options.headerTemplate);
     }
     if (options.path) {
       args.push('--path', options.path);

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -173,6 +173,24 @@ test('submits Other secret with injection settings', async () => {
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
 });
 
+test('does not double-prefix ${value} when user types it directly in value format', async () => {
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  });
+
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-api-key' } });
+  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-123' } });
+  await fireEvent.input(screen.getByLabelText('Host pattern'), { target: { value: 'api.example.com' } });
+  await fireEvent.input(screen.getByLabelText('Header name'), { target: { value: 'Authorization' } });
+  await fireEvent.input(screen.getByLabelText('Value format'), { target: { value: 'Bearer ${value}' } });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
+
+  expect(window.createSecret).toHaveBeenCalledWith(expect.objectContaining({ headerTemplate: 'Bearer ${value}' }));
+});
+
 test('submits Other secret using default Authorization header when header name is not changed', async () => {
   const { handleNavigation } = await import('/@/navigation');
 

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -109,7 +109,7 @@ async function addSecret(): Promise<void> {
         options.path = pathPattern.trim();
       }
       if (valueFormat.trim()) {
-        options.headerTemplate = valueFormat.trim().replaceAll('{value}', '${value}');
+        options.headerTemplate = valueFormat.trim().replace(/(?<!\$)\{value\}/g, '${value}');
       }
     }
 


### PR DESCRIPTION
- **fix(kdn-cli): use --headerTemplate flag for secret create**
- **fix(secret-vault): avoid double-prefixing \${value} in header template**

fixes #1761
