### PR TITLE
fix: include endpoint in catalog model info for workspace creation

### DIFF
--- a/packages/renderer/src/lib/models/models-utils.spec.ts
+++ b/packages/renderer/src/lib/models/models-utils.spec.ts
@@ -69,6 +69,34 @@ test('getCatalogModels includes connectionStatus and providerName', () => {
   });
 });
 
+test('getCatalogModels includes endpoint when connection provides one', () => {
+  const provider = {
+    id: 'openai-compatible',
+    name: 'OpenAI Compatible',
+    inferenceConnections: [
+      {
+        name: 'https://my-custom-api.example.com/v1',
+        type: 'cloud',
+        status: 'started',
+        endpoint: 'https://my-custom-api.example.com/v1',
+        models: [{ label: 'gpt-4o' }],
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  const result = getCatalogModels([provider]);
+  expect(result).toHaveLength(1);
+  expect(result[0]).toEqual({
+    providerId: 'openai-compatible',
+    providerName: 'OpenAI Compatible',
+    connectionName: 'https://my-custom-api.example.com/v1',
+    type: 'cloud',
+    endpoint: 'https://my-custom-api.example.com/v1',
+    label: 'gpt-4o',
+    connectionStatus: 'started',
+  });
+});
+
 test('getCatalogModels returns empty array when no providers', () => {
   expect(getCatalogModels([])).toEqual([]);
 });

--- a/packages/renderer/src/lib/models/models-utils.ts
+++ b/packages/renderer/src/lib/models/models-utils.ts
@@ -65,6 +65,7 @@ export function getCatalogModels(providerInfos: ProviderInfo[]): CatalogModelInf
           connectionName: connection.name,
           type: connection.type,
           llmMetadata: connection.llmMetadata,
+          endpoint: connection.endpoint,
           label: model.label,
           connectionStatus: connection.status,
         });


### PR DESCRIPTION
getCatalogModels() was not passing through the connection endpoint,
causing model IDs to lack the endpoint URL when creating agent
workspaces with custom OpenAI, Ollama, RamaLama, or OpenShift AI
providers.

Partially addresses #1755

There is an issue with opencode now complaining about a missing OpenAPI token, might be related to recent changes in https://github.com/openkaiden/kdn/pull/468 ... or not)