### PR TITLE
fix(ramalama): use ramalama as provider id instead of openai

### DIFF
--- a/extensions/ramalama/src/manager/inference-model-manager.spec.ts
+++ b/extensions/ramalama/src/manager/inference-model-manager.spec.ts
@@ -70,7 +70,7 @@ describe('InferenceModelManager', () => {
       expect.objectContaining({
         name: `port/${modelPort}`,
         type: 'local',
-        llmMetadata: { name: 'openai' },
+        llmMetadata: { name: 'ramalama' },
         endpoint: `http://localhost:${modelPort}`,
         sdk: sdkInstance,
         models: [{ label: modelName }],

--- a/extensions/ramalama/src/manager/inference-model-manager.ts
+++ b/extensions/ramalama/src/manager/inference-model-manager.ts
@@ -58,7 +58,7 @@ export class InferenceModelManager {
       const disposable = this.ramaLamaProvider.registerInferenceProviderConnection({
         name: `port/${modelinfo.port}`,
         type: 'local',
-        llmMetadata: { name: 'openai' },
+        llmMetadata: { name: 'ramalama' },
         endpoint: `http://localhost:${modelinfo.port}`,
         sdk,
         status() {


### PR DESCRIPTION
Mainly a cosmetic fix, it's notably displayed as the provider name in opencode on the lower right

Before:

<img width="1162" height="812" alt="Screenshot 2026-05-07 at 23 06 27" src="https://github.com/user-attachments/assets/9eb04b3e-1662-4d9a-b059-f6b74b0e3b6f" />

After:
<img width="1162" height="812" alt="Screenshot 2026-05-07 at 23 42 01" src="https://github.com/user-attachments/assets/074e3be5-6f53-42ea-abee-277e3b5c8b1c" />


