### PR TITLE
fix(renderer): prevent duplicate markdown rendering for type: 'markdown' preferences

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -40,6 +40,7 @@ const EXPERIMENTAL_RECORD: IConfigurationPropertyRecordedSchema = {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.openExternal).mockResolvedValue(undefined);
+  (window as unknown as Record<string, unknown>).getUrlProtocol = vi.fn().mockResolvedValue('podman-desktop');
 });
 
 test('experimental record should have clickable GitHub link', async () => {
@@ -135,4 +136,24 @@ test('locked record should not show reset to default button', async () => {
   // Verify reset button is not present
   const resetButton = queryByRole('button', { name: 'Reset to default value' });
   expect(resetButton).not.toBeInTheDocument();
+});
+
+test('type markdown record with markdownDescription should render markdown content only once', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'ext.markdown.info',
+    title: 'Info',
+    parentId: 'ext',
+    description: 'plain description text',
+    markdownDescription: 'Some **markdown** content',
+    type: 'markdown',
+  };
+
+  const { getAllByLabelText, getByText } = render(PreferencesRenderingItem, { record });
+
+  await vi.waitFor(() => {
+    const markdownSections = getAllByLabelText('markdown-content');
+    expect(markdownSections).toHaveLength(1);
+  });
+
+  expect(getByText('plain description text')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -113,7 +113,7 @@ async function openGitHubDiscussion(): Promise<void> {
           </div>
         {/if}
       </div>
-      {#if recordUI.markdownDescription}
+      {#if recordUI.markdownDescription && recordUI.original.type !== 'markdown'}
         <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">
           <Markdown markdown={recordUI.markdownDescription} />
         </div>


### PR DESCRIPTION
Backporting podman-desktop/podman-desktop#17444

When a configuration property has type: 'markdown' and a markdownDescription, the content was rendered twice: once in the description area and again via PreferencesRenderingItemFormat. Adds a guard to skip the description-area render for markdown-type records, matching the existing pattern in
PreferencesConnectionCreationOrEditRendering.svelte.