### PR TITLE
fix(ollama): use local IP for reported endpoint

### DIFF
--- a/extensions/ollama/src/ollama-extension.spec.ts
+++ b/extensions/ollama/src/ollama-extension.spec.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NetworkInterfaceInfo } from 'node:os';
+import { networkInterfaces } from 'node:os';
+
 import type { ExtensionContext, Provider } from '@openkaiden/api';
 import { provider } from '@openkaiden/api';
 import { http, HttpResponse } from 'msw';
@@ -24,6 +27,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { OllamaExtension } from './ollama-extension';
 
+vi.mock(import('node:os'));
 vi.mock(import('@openkaiden/api'));
 vi.mock(import('ollama-ai-provider-v2'));
 
@@ -47,7 +51,9 @@ describe('OllamaExtension', () => {
       dispose: vi.fn(),
     } as unknown as Provider;
     vi.resetAllMocks();
-    vi.clearAllMocks();
+    vi.mocked(networkInterfaces).mockReturnValue({
+      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false } as NetworkInterfaceInfo],
+    });
     vi.mocked(provider.createProvider).mockReturnValue(ollamaProvider);
     extensionContext = { subscriptions: [] } as unknown as ExtensionContext;
     extension = new TestOllamaExtension(extensionContext);
@@ -69,7 +75,9 @@ describe('OllamaExtension', () => {
     await extension.activate();
     expect(vi.mocked(provider.createProvider)).toHaveBeenCalled();
     expect(extensionContext.subscriptions).toContain(ollamaProvider);
-    expect(vi.mocked(ollamaProvider.registerInferenceProviderConnection)).toHaveBeenCalled();
+    expect(vi.mocked(ollamaProvider.registerInferenceProviderConnection)).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'http://192.168.1.100:11434/v1' }),
+    );
     expect(vi.mocked(ollamaProvider.updateStatus)).toHaveBeenCalledWith('started');
   });
 

--- a/extensions/ollama/src/ollama-extension.ts
+++ b/extensions/ollama/src/ollama-extension.ts
@@ -15,8 +15,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { networkInterfaces } from 'node:os';
+
 import { type Disposable, type ExtensionContext, type Provider, provider } from '@openkaiden/api';
 import { createOllama } from 'ollama-ai-provider-v2';
+
+function getLocalIP(): string {
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (entry.family === 'IPv4' && !entry.internal) {
+        return entry.address;
+      }
+    }
+  }
+  return 'localhost';
+}
 
 export class OllamaExtension {
   #extensionContext: ExtensionContext;
@@ -103,7 +116,7 @@ export class OllamaExtension {
           name: 'ollama',
           type: 'local',
           llmMetadata: { name: 'ollama' },
-          endpoint: 'http://localhost:11434/v1',
+          endpoint: `http://${getLocalIP()}:11434/v1`,
           sdk,
           status() {
             return 'started';


### PR DESCRIPTION
## Summary
- Containers cannot access `localhost` on the host machine, so the Ollama endpoint was unreachable from within containers
- Added `getLocalIP()` helper that resolves the first non-internal IPv4 address from network interfaces (falls back to `localhost`)
- The reported inference endpoint now uses the local IP; the health check fetch remains on `localhost` since it runs on the host

Fixes: https://github.com/openkaiden/kaiden/issues/1756

## Test plan (Windows only)

`taskkill /F /IM ollama.exe` (if ollama is running)

`$env:OLLAMA_HOST="0.0.0.0"; ollama serve`

 If you dont have any models you can either download one from the gui or do

`ollama run qwen3.5:8b` (or 4b for a quicker test)

Create a workspace in kaiden choosing ollama and a model. I recommend opencode

do kdn terminal (open-code workspace name)

see if you can interact with it

For documentation, we can point users to https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama for setting up Ollama with the default 0.0.0.0 so it auto starts with it and users never have to worry about it again!!

🤖 Generated with [Claude Code](https://claude.com/claude-code)