### PR TITLE
fix: resolve full kdn CLI path for node-pty on Windows

### DIFF
--- a/extensions/kdn/src/kdn-extension.spec.ts
+++ b/extensions/kdn/src/kdn-extension.spec.ts
@@ -83,11 +83,17 @@ test('registers from extension storage when binary exists', async () => {
 
 test('registers from system PATH when not in extension storage', async () => {
   vi.mocked(existsSync).mockReturnValue(false);
-  vi.mocked(extensionApi.process.exec).mockResolvedValue({
-    command: 'kdn',
-    stdout: '',
-    stderr: 'kdn version 1.0.0',
-  });
+  vi.mocked(extensionApi.process.exec)
+    .mockResolvedValueOnce({
+      command: 'kdn',
+      stdout: '',
+      stderr: 'kdn version 1.0.0',
+    })
+    .mockResolvedValueOnce({
+      command: 'which',
+      stdout: '/usr/local/bin/kdn\n',
+      stderr: '',
+    });
   vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
 
   await kdnExtension.activate();
@@ -96,7 +102,7 @@ test('registers from system PATH when not in extension storage', async () => {
     expect.objectContaining({
       name: 'kdn',
       version: '1.0.0',
-      path: 'kdn',
+      path: '/usr/local/bin/kdn',
       installationSource: 'external',
     }),
   );

--- a/extensions/kdn/src/kdn-extension.ts
+++ b/extensions/kdn/src/kdn-extension.ts
@@ -48,7 +48,7 @@ export class KdnExtension {
     if (!binaryPath) {
       const systemResult = await this.findOnPath();
       if (systemResult) {
-        binaryPath = binaryName;
+        binaryPath = systemResult.path;
         version = systemResult.version;
         installationSource = 'external';
         console.log('kdn binary found in system PATH');
@@ -108,14 +108,23 @@ export class KdnExtension {
     }
   }
 
-  private async findOnPath(): Promise<{ version: string } | undefined> {
+  private async findOnPath(): Promise<{ version: string; path: string } | undefined> {
     try {
       const result = await extensionApi.process.exec('kdn', ['version']);
       const version = this.parseVersion(result.stdout || result.stderr);
-      if (version) return { version };
+      if (version) {
+        const resolvedPath = await this.resolveFromPath();
+        return { version, path: resolvedPath };
+      }
     } catch {
       // not on PATH
     }
     return undefined;
+  }
+
+  private async resolveFromPath(): Promise<string> {
+    const cmd = extensionApi.env.isWindows ? 'where' : 'which';
+    const result = await extensionApi.process.exec(cmd, ['kdn']);
+    return result.stdout.trim().split(/\r?\n/)[0];
   }
 }


### PR DESCRIPTION
## Summary
- When `kdn` was found on the system PATH, the extension registered just the bare binary name (`kdn`/`kdn.exe`) instead of the absolute path
- `child_process.spawn` searches PATH and handles this fine, but `node-pty`'s `spawn` does not, causing "File not found" when opening the workspace terminal on Windows
- Added `resolveFromPath()` which uses `where` (Windows) / `which` (Mac/Linux) to resolve the full absolute path before registering the CLI tool

Fixes: https://github.com/openkaiden/kaiden/issues/1787

## Test plan
- [ ] On Windows: open a workspace terminal — should no longer throw "File not found"
- [ ] On Mac/Linux: verify terminal still opens correctly
- [ ] With kdn installed via extension storage (not PATH): verify that path still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)