### PR TITLE
fix(renderer): hide Configure button for non-configurable providers

### DIFF
--- a/packages/renderer/src/lib/models/LocalRuntimeTiles.svelte
+++ b/packages/renderer/src/lib/models/LocalRuntimeTiles.svelte
@@ -75,12 +75,14 @@ function getStatusBadges(status: string): BadgeInfo[] {
           </span>
         {/each}
       </div>
-      <button
-        class="text-xs font-semibold text-[var(--pd-link)] hover:text-[var(--pd-link-hover)] mt-auto pt-2 self-start"
-        aria-label={`Configure ${connection.providerName}`}
-        onclick={(): void => configure(connection)}>
-        Configure
-      </button>
+      {#if connection.configurable}
+        <button
+          class="text-xs font-semibold text-[var(--pd-link)] hover:text-[var(--pd-link-hover)] mt-auto pt-2 self-start"
+          aria-label={`Configure ${connection.providerName}`}
+          onclick={(): void => configure(connection)}>
+          Configure
+        </button>
+      {/if}
     </div>
   {/each}
 </div>

--- a/packages/renderer/src/lib/models/ProviderConnectionTiles.svelte
+++ b/packages/renderer/src/lib/models/ProviderConnectionTiles.svelte
@@ -94,12 +94,14 @@ function getSecondBadge(status: string): BadgeInfo | undefined {
           </span>
         {/if}
       </div>
-      <button
-        class="text-xs font-semibold text-[var(--pd-link)] hover:text-[var(--pd-link-hover)] mt-auto pt-2 self-start"
-        aria-label={`Configure ${connection.providerName}`}
-        onclick={(): void => configure(connection)}>
-        Configure
-      </button>
+      {#if connection.configurable}
+        <button
+          class="text-xs font-semibold text-[var(--pd-link)] hover:text-[var(--pd-link-hover)] mt-auto pt-2 self-start"
+          aria-label={`Configure ${connection.providerName}`}
+          onclick={(): void => configure(connection)}>
+          Configure
+        </button>
+      {/if}
     </div>
   {/each}
 </div>

--- a/packages/renderer/src/lib/models/models-utils.spec.ts
+++ b/packages/renderer/src/lib/models/models-utils.spec.ts
@@ -114,6 +114,7 @@ test('getInferenceConnectionSummaries returns one summary per provider with aggr
     id: 'openai',
     name: 'OpenAI',
     internalId: 'internal-1',
+    inferenceProviderConnectionCreation: true,
     inferenceConnections: [
       { name: 'conn-1', type: 'cloud', status: 'started', models: [{ label: 'gpt-4' }, { label: 'gpt-3.5' }] },
       { name: 'conn-2', type: 'self-hosted', status: 'stopped', models: [{ label: 'custom-model' }] },
@@ -131,6 +132,7 @@ test('getInferenceConnectionSummaries returns one summary per provider with aggr
     status: 'started',
     modelCount: 3,
     creationDisplayName: 'OpenAI',
+    configurable: true,
   });
 });
 
@@ -165,6 +167,7 @@ test('getInferenceConnectionSummaries emits not-configured entry when creation i
     modelCount: 0,
     creationDisplayName: 'OpenAI (Hosted)',
     connectionType: 'cloud',
+    configurable: true,
   });
 });
 
@@ -363,4 +366,18 @@ test('getInHouseConnectionSummaries returns empty when no self-hosted providers'
   ] as unknown as ProviderInfo[];
 
   expect(getInHouseConnectionSummaries(providers)).toEqual([]);
+});
+
+test('getInferenceConnectionSummaries sets configurable false for providers without factory', () => {
+  const provider = {
+    id: 'ollama',
+    name: 'Ollama',
+    internalId: 'ollama-internal',
+    inferenceProviderConnectionCreation: false,
+    inferenceConnections: [{ name: 'ollama', type: 'local', status: 'started', models: [{ label: 'phi-3' }] }],
+  } as unknown as ProviderInfo;
+
+  const result = getInferenceConnectionSummaries([provider]);
+  expect(result).toHaveLength(1);
+  expect(result[0].configurable).toBe(false);
 });

--- a/packages/renderer/src/lib/models/models-utils.ts
+++ b/packages/renderer/src/lib/models/models-utils.ts
@@ -17,6 +17,7 @@ export interface InferenceConnectionSummary {
   status: ProviderConnectionStatus | 'not-configured';
   modelCount: number;
   creationDisplayName: string;
+  configurable: boolean;
 }
 
 export function getModels(providerInfos: ProviderInfo[]): ModelInfo[] {
@@ -107,6 +108,7 @@ export function getInferenceConnectionSummaries(providerInfos: ProviderInfo[]): 
         status: representative.status,
         modelCount: totalModels,
         creationDisplayName,
+        configurable: provider.inferenceProviderConnectionCreation,
       });
     }
 
@@ -120,6 +122,7 @@ export function getInferenceConnectionSummaries(providerInfos: ProviderInfo[]): 
         status: 'not-configured',
         modelCount: 0,
         creationDisplayName,
+        configurable: provider.inferenceProviderConnectionCreation,
       });
     }
   }


### PR DESCRIPTION
Add `configurable` field to `InferenceConnectionSummary` derived from `inferenceProviderConnectionCreation`, and conditionally render the Configure button in LocalRuntimeTiles and ProviderConnectionTiles only when the connection is configurable.

Closes https://github.com/openkaiden/kaiden/issues/1613

<img width="1159" height="819" alt="Screenshot 2026-05-11 at 7 40 53" src="https://github.com/user-attachments/assets/5e797ea9-3804-4e82-9ef3-806e2472494e" />
