### PR TITLE
refactor(agent-workspaces): extract wizard form state into persistent draft store

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -435,6 +435,7 @@ test('Expect createAgentWorkspace excludes disabled skill paths', async () => {
       managed: true,
     },
   ]);
+  wizard.draft.selectedSkillIds = ['kubernetes'];
 
   render(AgentWorkspaceCreate);
 
@@ -1531,8 +1532,28 @@ test('Expect startWorkspace does not pass replaceConfig when configAction is mer
   );
 });
 
-test('Expect error dialog shown when createAgentWorkspace fails from use-all-defaults', async () => {
-  vi.mocked(window.createAgentWorkspace).mockRejectedValue(new Error('container runtime not available'));
+test('Expect draft preserved when startAsIs fails', async () => {
+  vi.mocked(window.createAgentWorkspace).mockRejectedValue(new Error('creation failed'));
+  vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(true);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/existing-project' },
+  });
+
+  await vi.waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Start workspace as-is' })).toBeInTheDocument();
+  });
+
+  wizard.draft.currentStepIndex = 0;
+  await fireEvent.click(screen.getByRole('button', { name: 'Start workspace as-is' }));
+
+  expect(wizard.draft.sourcePath).toBe('/home/user/existing-project');
+});
+
+test('Expect draft preserved when startWorkspace fails', async () => {
+  vi.mocked(window.createAgentWorkspace).mockRejectedValue(new Error('creation failed'));
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   render(AgentWorkspaceCreate);
@@ -1547,10 +1568,13 @@ test('Expect error dialog shown when createAgentWorkspace fails from use-all-def
       expect.objectContaining({
         title: 'Agent Workspace',
         type: 'error',
-        message: expect.stringContaining('container runtime not available'),
+        message: expect.stringContaining('creation failed'),
       }),
     );
   });
+
+  expect(wizard.draft.sourcePath).toBe('/home/user/my-repo');
+  expect(wizard.draft.sessionName).toBe('my-repo');
 });
 
 test('Expect error dialog shown when createAgentWorkspace fails from Start Workspace button', async () => {
@@ -1577,6 +1601,46 @@ test('Expect error dialog shown when createAgentWorkspace fails from Start Works
         message: expect.stringContaining('sandbox init failed'),
       }),
     );
+  });
+});
+
+test('Expect navigation still called when startAsIs fails', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+  vi.mocked(window.createAgentWorkspace).mockRejectedValue(new Error('creation failed'));
+  vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(true);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/existing-project' },
+  });
+
+  await vi.waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Start workspace as-is' })).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Start workspace as-is' }));
+
+  await vi.waitFor(() => {
+    expect(handleNavigation).toHaveBeenCalledWith({ page: 'agent-workspaces' });
+  });
+});
+
+test('Expect navigation still called when startWorkspace fails', async () => {
+  const { handleNavigation } = await import('/@/navigation');
+  vi.mocked(window.createAgentWorkspace).mockRejectedValue(new Error('creation failed'));
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  await vi.waitFor(() => {
+    expect(handleNavigation).toHaveBeenCalledWith({ page: 'agent-workspaces' });
   });
 });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -70,6 +70,7 @@ beforeEach(() => {
     (providerId: string, label: string): string => `${providerId}::${label}`,
   );
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   resetDraft();
 });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -23,6 +23,7 @@ import userEvent from '@testing-library/user-event';
 import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { resetDraft, wizard } from '/@/stores/agent-workspace-create-draft.svelte';
 import * as agentWorkspaceRuntimeStore from '/@/stores/agentworkspace-runtime';
 import * as mcpStore from '/@/stores/mcp-remote-servers';
 import * as modelCatalogStore from '/@/stores/model-catalog';
@@ -69,6 +70,7 @@ beforeEach(() => {
     (providerId: string, label: string): string => `${providerId}::${label}`,
   );
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
+  resetDraft();
 });
 
 test('Expect page title displayed', () => {
@@ -477,6 +479,7 @@ test('Expect createAgentWorkspace called with skill paths', async () => {
       managed: true,
     },
   ]);
+  wizard.draft.selectedSkillIds = ['kubernetes', 'code-review'];
 
   render(AgentWorkspaceCreate);
 
@@ -522,6 +525,7 @@ test('Expect createAgentWorkspace called with secret ids when vault has entries'
       description: 'API key',
     },
   ]);
+  wizard.draft.selectedSecretIds = ['github-token', 'anthropic-key'];
 
   render(AgentWorkspaceCreate);
 
@@ -961,6 +965,7 @@ test('Expect createAgentWorkspace splits MCP servers into remote and command ent
       tools: {},
     },
   ]);
+  wizard.draft.selectedMcpIds = ['mcp-remote', 'mcp-pkg'];
 
   render(AgentWorkspaceCreate);
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -19,12 +19,12 @@ import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
+import { resetDraft, wizard } from '/@/stores/agent-workspace-create-draft.svelte';
 import { agentWorkspaceRuntime } from '/@/stores/agentworkspace-runtime';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
 import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
-import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
 import type {
   AgentWorkspaceConfiguration,
@@ -109,8 +109,6 @@ let networkOptions: NetworkAccessOption[] = $derived(
   })),
 );
 
-const REGISTRY_HOSTS = ['registry.npmjs.org', 'pypi.python.org'];
-
 function mapNetworkSelection(value: string, hosts: string[]): NetworkConfiguration | undefined {
   const filtered = hosts.filter(h => h.trim() !== '');
   switch (value) {
@@ -161,62 +159,44 @@ let knowledgeItems: ChecklistItem[] = $derived(
     }),
 );
 
-// --- Form state ---
-let sourcePath = $state('');
-let sessionName = $state('');
-let description = $state('');
-let configExists = $state(false);
-let configAction = $state<'merge' | 'replace'>('merge');
-let selectedAgent = $state('opencode');
-let selectedModel = $state<ModelInfo | undefined>(undefined);
+// --- Form state (backed by persistent draft store) ---
 let defaultSettings = $state<DefaultWorkspaceSettings | undefined>(undefined);
 
 onMount(async () => {
   defaultSettings = await window.getConfigurationValue<DefaultWorkspaceSettings>('onboarding.defaultWorkspaceSettings');
 
-  const defaultAgent = defaultSettings?.defaultAgent;
-  if (defaultAgent && agentDefinitions.some(d => d.cliName === defaultAgent)) {
-    selectedAgent = defaultAgent;
-  }
+  if (!wizard.draft.initialized) {
+    const defaultAgent = defaultSettings?.defaultAgent;
+    if (defaultAgent && agentDefinitions.some(d => d.cliName === defaultAgent)) {
+      wizard.draft.selectedAgent = defaultAgent;
+    }
 
-  if (
-    defaultAgent &&
-    defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.providerId &&
-    defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.label
-  ) {
-    const allModels = getCatalogModels($providerInfos);
-    const match = allModels.find(
-      m =>
-        m.providerId === defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.providerId &&
-        m.label === defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.label,
-    );
-    if (match) {
-      selectedModel = match;
+    if (
+      defaultAgent &&
+      defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.providerId &&
+      defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.label
+    ) {
+      const allModels = getCatalogModels($providerInfos);
+      const match = allModels.find(
+        m =>
+          m.providerId === defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.providerId &&
+          m.label === defaultSettings?.defaultAgentSettings?.[defaultAgent]?.defaultModel?.label,
+      );
+      if (match) {
+        wizard.draft.selectedModel = match;
+      }
     }
-  }
-  if (!selectedModel) {
-    const firstModel = getFirstCompatibleModel();
-    if (firstModel) {
-      selectedModel = firstModel;
+    if (!wizard.draft.selectedModel) {
+      const firstModel = getFirstCompatibleModel();
+      if (firstModel) {
+        wizard.draft.selectedModel = firstModel;
+      }
     }
+
+    wizard.draft.initialized = true;
   }
 });
-let selectedFileAccess = $state('workspace');
-let selectedNetwork = $state('registries');
-let selectedSkillIds = $derived(skillItems.map(s => s.id));
-let selectedMcpIds = $derived(mcpItems.map(m => m.id));
-let selectedSecretIds = $derived($secretVaultInfos.map(s => s.id));
-let selectedKnowledgeIds = $derived(knowledgeItems.map(k => k.id));
-let customMounts = $state<CustomMount[]>([{ host: '', target: '', ro: false }]);
-let hostsByMode = $state<Record<string, string[]>>({
-  registries: [...REGISTRY_HOSTS],
-  blocked: [''],
-});
-let customHosts = $derived(hostsByMode[selectedNetwork] ?? []);
-
-// --- Step 1 UI state ---
-let nameManuallyEdited = $state(false);
-let descriptionOpen = $state(false);
+let customHosts = $derived(wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? []);
 
 function getDefaultSessionName(path: string): string {
   const normalized = path.trim().replace(/[\\/]+$/, '');
@@ -224,76 +204,84 @@ function getDefaultSessionName(path: string): string {
 }
 
 $effect(() => {
-  if (nameManuallyEdited) return;
-  const last = getDefaultSessionName(sourcePath);
-  if (last) sessionName = last;
+  if (wizard.draft.nameManuallyEdited) return;
+  const last = getDefaultSessionName(wizard.draft.sourcePath);
+  if (last) wizard.draft.sessionName = last;
 });
 
 $effect(() => {
-  const trimmed = sourcePath.trim();
+  const trimmed = wizard.draft.sourcePath.trim();
   if (trimmed) {
     window
       .checkAgentWorkspaceConfigExists(trimmed)
       .then(exists => {
-        configExists = exists;
+        wizard.draft.configExists = exists;
       })
       .catch(() => {
-        configExists = false;
+        wizard.draft.configExists = false;
       });
   } else {
-    configExists = false;
+    wizard.draft.configExists = false;
   }
 });
 
 // --- Wizard navigation ---
-let currentStepIndex = $state(0);
+let currentStepIndex = $derived(wizard.draft.currentStepIndex);
 let error = $state('');
 
-let currentStepId = $derived(wizardSteps[currentStepIndex]?.id ?? '');
-let isLastStep = $derived(currentStepIndex === wizardSteps.length - 1);
+let currentStepId = $derived(wizardSteps[wizard.draft.currentStepIndex]?.id ?? '');
+let isLastStep = $derived(wizard.draft.currentStepIndex === wizardSteps.length - 1);
 let isCurrentStepComplete = $derived(
-  currentStepId === 'workspace' ? sessionName.trim() !== '' && sourcePath.trim() !== '' : true,
+  currentStepId === 'workspace'
+    ? wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== ''
+    : true,
 );
 
 function goNext(): void {
-  if (currentStepIndex < wizardSteps.length - 1) currentStepIndex++;
+  if (wizard.draft.currentStepIndex < wizardSteps.length - 1) wizard.draft.currentStepIndex++;
 }
 
 function goBack(): void {
-  if (currentStepIndex > 0) currentStepIndex--;
+  if (wizard.draft.currentStepIndex > 0) wizard.draft.currentStepIndex--;
 }
 
 function handleStepClick(index: number): void {
-  currentStepIndex = index;
+  wizard.draft.currentStepIndex = index;
 }
 
 function addCustomMount(): void {
-  customMounts = [...customMounts, { host: '', target: '', ro: false }];
+  wizard.draft.customMounts = [...wizard.draft.customMounts, { host: '', target: '', ro: false }];
 }
 
 function removeCustomMount(index: number): void {
-  if (customMounts.length <= 1) return;
-  customMounts = customMounts.filter((_, i) => i !== index);
+  if (wizard.draft.customMounts.length <= 1) return;
+  wizard.draft.customMounts = wizard.draft.customMounts.filter((_, i) => i !== index);
 }
 
 function updateCustomMount(index: number, field: keyof CustomMount, value: string | boolean): void {
-  customMounts = customMounts.map((m, i) => (i === index ? { ...m, [field]: value } : m));
+  wizard.draft.customMounts = wizard.draft.customMounts.map((m, i) => (i === index ? { ...m, [field]: value } : m));
 }
 
 function addCustomHost(): void {
-  const current = hostsByMode[selectedNetwork] ?? [];
-  hostsByMode = { ...hostsByMode, [selectedNetwork]: [...current, ''] };
+  const current = wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? [];
+  wizard.draft.hostsByMode = { ...wizard.draft.hostsByMode, [wizard.draft.selectedNetwork]: [...current, ''] };
 }
 
 function removeCustomHost(index: number): void {
-  const current = hostsByMode[selectedNetwork] ?? [];
+  const current = wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? [];
   if (current.length <= 1) return;
-  hostsByMode = { ...hostsByMode, [selectedNetwork]: current.filter((_, i) => i !== index) };
+  wizard.draft.hostsByMode = {
+    ...wizard.draft.hostsByMode,
+    [wizard.draft.selectedNetwork]: current.filter((_, i) => i !== index),
+  };
 }
 
 function updateCustomHost(index: number, value: string): void {
-  const current = hostsByMode[selectedNetwork] ?? [];
-  hostsByMode = { ...hostsByMode, [selectedNetwork]: current.map((h, i) => (i === index ? value : h)) };
+  const current = wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? [];
+  wizard.draft.hostsByMode = {
+    ...wizard.draft.hostsByMode,
+    [wizard.draft.selectedNetwork]: current.map((h, i) => (i === index ? value : h)),
+  };
 }
 
 async function handleBrowseCustomPath(index: number): Promise<void> {
@@ -313,10 +301,10 @@ async function handleBrowseSource(): Promise<void> {
     const result = await window.openDialog({ title: 'Select a working directory', selectors: ['openDirectory'] });
     const selected = result?.[0];
     if (selected) {
-      sourcePath = selected;
-      if (!nameManuallyEdited) {
+      wizard.draft.sourcePath = selected;
+      if (!wizard.draft.nameManuallyEdited) {
         const lastSegment = getDefaultSessionName(selected);
-        if (lastSegment) sessionName = lastSegment;
+        if (lastSegment) wizard.draft.sessionName = lastSegment;
       }
     }
   } catch (err: unknown) {
@@ -327,6 +315,7 @@ async function handleBrowseSource(): Promise<void> {
 }
 
 function cancel(): void {
+  resetDraft();
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 }
 
@@ -352,7 +341,7 @@ function getAgentWorkspaceConfiguration(agent: string): AgentWorkspaceConfigurat
 }
 
 function getFirstCompatibleModel(): ModelInfo | undefined {
-  const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
+  const agentDef = agentDefinitions.find(d => d.cliName === wizard.draft.selectedAgent);
   const enabled = getCatalogModels($providerInfos).filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   const seen = new Set<string>();
@@ -368,14 +357,14 @@ function getFirstCompatibleModel(): ModelInfo | undefined {
   return compatible[0];
 }
 
-function buildMounts(): AgentWorkspaceMount[] | undefined {
-  switch (selectedFileAccess) {
+function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorkspaceMount[] | undefined {
+  switch (fileAccess) {
     case 'home':
       return [{ host: '$HOME', target: '$HOME', ro: false }];
     case 'full':
       return [{ host: '/', target: '/', ro: false }];
     case 'custom': {
-      const mounts = customMounts
+      const filtered = mounts
         .filter(m => m.host.trim() !== '')
         .map(m => {
           const host = m.host.trim();
@@ -383,7 +372,7 @@ function buildMounts(): AgentWorkspaceMount[] | undefined {
           const target = trimmedTarget !== '' ? trimmedTarget : host;
           return { host, target, ro: m.ro };
         });
-      return mounts.length > 0 ? mounts : undefined;
+      return filtered.length > 0 ? filtered : undefined;
     }
     default:
       return undefined;
@@ -391,17 +380,19 @@ function buildMounts(): AgentWorkspaceMount[] | undefined {
 }
 
 async function startAsIs(): Promise<void> {
-  if (!sourcePath.trim()) return;
+  if (!wizard.draft.sourcePath.trim()) return;
 
+  const draftSnapshot = $state.snapshot(wizard.draft);
+  resetDraft();
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 
   try {
-    const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
+    const agentDef = agentDefinitions.find(d => d.cliName === draftSnapshot.selectedAgent);
     await window.createAgentWorkspace({
-      sourcePath,
+      sourcePath: draftSnapshot.sourcePath,
       runtime: $agentWorkspaceRuntime,
-      agent: agentDef?.cliAgent ?? selectedAgent,
-      name: sessionName || getDefaultSessionName(sourcePath),
+      agent: agentDef?.cliAgent ?? draftSnapshot.selectedAgent,
+      name: draftSnapshot.sessionName || getDefaultSessionName(draftSnapshot.sourcePath),
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace (as-is)', err);
@@ -415,18 +406,25 @@ async function startAsIs(): Promise<void> {
 }
 
 async function startWorkspace(): Promise<void> {
-  if (!sessionName.trim() || !sourcePath.trim()) return;
+  if (!wizard.draft.sessionName.trim() || !wizard.draft.sourcePath.trim()) return;
 
+  const draftSnapshot = $state.snapshot(wizard.draft);
+  resetDraft();
   handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 
   try {
-    const selectedSkillPaths = $skillInfos.filter(s => selectedSkillIds.includes(s.name)).map(s => s.path);
-    const network = mapNetworkSelection(selectedNetwork, customHosts);
-    const mounts = buildMounts();
+    const selectedSkillPaths = $skillInfos
+      .filter(s => draftSnapshot.selectedSkillIds.includes(s.name))
+      .map(s => s.path);
+    const network = mapNetworkSelection(
+      draftSnapshot.selectedNetwork,
+      draftSnapshot.hostsByMode[draftSnapshot.selectedNetwork] ?? [],
+    );
+    const mounts = buildMountsFrom(draftSnapshot.selectedFileAccess, draftSnapshot.customMounts);
 
-    const agentDef = agentDefinitions.find(d => d.cliName === selectedAgent);
+    const agentDef = agentDefinitions.find(d => d.cliName === draftSnapshot.selectedAgent);
 
-    const selected = $mcpRemoteServerInfos.filter(m => selectedMcpIds.includes(m.id));
+    const selected = $mcpRemoteServerInfos.filter(m => draftSnapshot.selectedMcpIds.includes(m.id));
     const remoteServers = selected
       .filter(m => m.setupType === 'remote' || (!m.setupType && m.url))
       .map(m => ({ name: m.name, url: m.url }));
@@ -441,14 +439,14 @@ async function startWorkspace(): Promise<void> {
     const hasMcp = remoteServers.length > 0 || commandServers.length > 0;
 
     await window.createAgentWorkspace({
-      sourcePath,
+      sourcePath: draftSnapshot.sourcePath,
       runtime: $agentWorkspaceRuntime,
-      agent: agentDef?.cliAgent ?? selectedAgent,
-      model: selectedModel ? getModelId(selectedModel) : undefined,
-      name: sessionName,
+      agent: agentDef?.cliAgent ?? draftSnapshot.selectedAgent,
+      model: draftSnapshot.selectedModel ? getModelId(draftSnapshot.selectedModel) : undefined,
+      name: draftSnapshot.sessionName,
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
       network,
-      secrets: selectedSecretIds.length > 0 ? [...selectedSecretIds] : undefined,
+      secrets: draftSnapshot.selectedSecretIds.length > 0 ? [...draftSnapshot.selectedSecretIds] : undefined,
       mounts,
       mcp: hasMcp
         ? {
@@ -456,8 +454,8 @@ async function startWorkspace(): Promise<void> {
             ...(commandServers.length > 0 ? { commands: commandServers } : {}),
           }
         : undefined,
-      workspaceConfiguration: getAgentWorkspaceConfiguration(selectedAgent),
-      replaceConfig: configExists && configAction === 'replace' ? true : undefined,
+      workspaceConfiguration: getAgentWorkspaceConfiguration(draftSnapshot.selectedAgent),
+      replaceConfig: draftSnapshot.configExists && draftSnapshot.configAction === 'replace' ? true : undefined,
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);
@@ -495,31 +493,31 @@ async function startWorkspace(): Promise<void> {
           <div class="rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)] p-6">
             {#if currentStepId === 'workspace'}
               <AgentWorkspaceCreateStepWorkspace
-                bind:sourcePath
-                bind:sessionName
-                bind:description
-                bind:nameManuallyEdited
-                bind:descriptionOpen
+                bind:sourcePath={wizard.draft.sourcePath}
+                bind:sessionName={wizard.draft.sessionName}
+                bind:description={wizard.draft.description}
+                bind:nameManuallyEdited={wizard.draft.nameManuallyEdited}
+                bind:descriptionOpen={wizard.draft.descriptionOpen}
                 onBrowseSource={handleBrowseSource}
-                {configExists}
-                bind:configAction
+                configExists={wizard.draft.configExists}
+                bind:configAction={wizard.draft.configAction}
                 onStartAsIs={startAsIs} />
             {:else if currentStepId === 'agent-model'}
-              <AgentWorkspaceCreateStepAgentModel bind:selectedAgent bind:selectedModel />
+              <AgentWorkspaceCreateStepAgentModel bind:selectedAgent={wizard.draft.selectedAgent} bind:selectedModel={wizard.draft.selectedModel} />
             {:else if currentStepId === 'tools-secrets'}
               <AgentWorkspaceCreateStepToolsSecrets
                 {skillItems}
-                bind:selectedSkillIds
+                bind:selectedSkillIds={wizard.draft.selectedSkillIds}
                 {mcpItems}
-                bind:selectedMcpIds
-                bind:selectedSecretIds
+                bind:selectedMcpIds={wizard.draft.selectedMcpIds}
+                bind:selectedSecretIds={wizard.draft.selectedSecretIds}
                 {knowledgeItems}
-                bind:selectedKnowledgeIds />
+                bind:selectedKnowledgeIds={wizard.draft.selectedKnowledgeIds} />
             {:else if currentStepId === 'filesystem'}
               <AgentWorkspaceCreateStepFileSystem
                 {fileAccessOptions}
-                bind:selectedFileAccess
-                {customMounts}
+                bind:selectedFileAccess={wizard.draft.selectedFileAccess}
+                customMounts={wizard.draft.customMounts}
                 onBrowseCustomPath={handleBrowseCustomPath}
                 onAddCustomMount={addCustomMount}
                 onRemoveCustomMount={removeCustomMount}
@@ -527,8 +525,8 @@ async function startWorkspace(): Promise<void> {
             {:else if currentStepId === 'networking'}
               <AgentWorkspaceCreateStepNetworking
                 {networkOptions}
-                bind:selectedNetwork
-                {customHosts}
+                bind:selectedNetwork={wizard.draft.selectedNetwork}
+                customHosts={customHosts}
                 onAddCustomHost={addCustomHost}
                 onRemoveCustomHost={removeCustomHost}
                 onUpdateCustomHost={updateCustomHost} />

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -209,16 +209,23 @@ $effect(() => {
   if (last) wizard.draft.sessionName = last;
 });
 
+let configCheckToken = 0;
+
 $effect(() => {
   const trimmed = wizard.draft.sourcePath.trim();
+  const token = ++configCheckToken;
   if (trimmed) {
     window
       .checkAgentWorkspaceConfigExists(trimmed)
       .then(exists => {
-        wizard.draft.configExists = exists;
+        if (token === configCheckToken) {
+          wizard.draft.configExists = exists;
+        }
       })
       .catch(() => {
-        wizard.draft.configExists = false;
+        if (token === configCheckToken) {
+          wizard.draft.configExists = false;
+        }
       });
   } else {
     wizard.draft.configExists = false;
@@ -383,8 +390,6 @@ async function startAsIs(): Promise<void> {
   if (!wizard.draft.sourcePath.trim()) return;
 
   const draftSnapshot = $state.snapshot(wizard.draft);
-  resetDraft();
-  handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 
   try {
     const agentDef = agentDefinitions.find(d => d.cliName === draftSnapshot.selectedAgent);
@@ -394,14 +399,19 @@ async function startAsIs(): Promise<void> {
       agent: agentDef?.cliAgent ?? draftSnapshot.selectedAgent,
       name: draftSnapshot.sessionName || getDefaultSessionName(draftSnapshot.sourcePath),
     });
+    resetDraft();
   } catch (err: unknown) {
     console.error('Failed to create agent workspace (as-is)', err);
-    await window.showMessageBox({
-      title: 'Agent Workspace',
-      type: 'error',
-      message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
-      buttons: ['OK'],
-    });
+    window
+      .showMessageBox({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
+        buttons: ['OK'],
+      })
+      .catch(console.error);
+  } finally {
+    handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
   }
 }
 
@@ -409,8 +419,6 @@ async function startWorkspace(): Promise<void> {
   if (!wizard.draft.sessionName.trim() || !wizard.draft.sourcePath.trim()) return;
 
   const draftSnapshot = $state.snapshot(wizard.draft);
-  resetDraft();
-  handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 
   try {
     const selectedSkillPaths = $skillInfos
@@ -457,14 +465,19 @@ async function startWorkspace(): Promise<void> {
       workspaceConfiguration: getAgentWorkspaceConfiguration(draftSnapshot.selectedAgent),
       replaceConfig: draftSnapshot.configExists && draftSnapshot.configAction === 'replace' ? true : undefined,
     });
+    resetDraft();
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);
-    await window.showMessageBox({
-      title: 'Agent Workspace',
-      type: 'error',
-      message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
-      buttons: ['OK'],
-    });
+    window
+      .showMessageBox({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
+        buttons: ['OK'],
+      })
+      .catch(console.error);
+  } finally {
+    handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
   }
 }
 </script>

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.spec.ts
@@ -160,7 +160,25 @@ describe('resetDraft selects all available items', () => {
   });
 });
 
-describe('store subscriptions', () => {
+describe('first emission seeding', () => {
+  test('should seed selections from pre-populated stores on first emission after reset', () => {
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: true, managed: false },
+    ]);
+    mcpRemoteServerInfos.set([{ id: 'srv-1', name: 'Server 1' } as MCPRemoteServerInfo]);
+    secretVaultInfos.set([{ id: 'sec-1', name: 'Secret 1', type: 'api', description: '' } as SecretVaultInfo]);
+    ragEnvironments.set([{ name: 'kb-1', mcpServer: { id: 'mcp-1' } } as unknown as RagEnvironment]);
+
+    expect(wizard.draft.selectedSkillIds).toContain('k8s');
+    expect(wizard.draft.selectedSkillIds).toContain('docker');
+    expect(wizard.draft.selectedMcpIds).toContain('srv-1');
+    expect(wizard.draft.selectedSecretIds).toContain('sec-1');
+    expect(wizard.draft.selectedKnowledgeIds).toContain('kb-1');
+  });
+});
+
+describe('selection syncing from subscriptions', () => {
   test('should remove skills no longer available', () => {
     skillInfos.set([
       { name: 'k8s', description: '', path: '', enabled: true, managed: false },

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.spec.ts
@@ -1,0 +1,219 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
+import { ragEnvironments } from '/@/stores/rag-environments';
+import { secretVaultInfos } from '/@/stores/secret-vault';
+import { skillInfos } from '/@/stores/skills';
+import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
+import type { RagEnvironment } from '/@api/rag/rag-environment';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+import { resetDraft, wizard } from './agent-workspace-create-draft.svelte';
+
+beforeEach(() => {
+  skillInfos.set([]);
+  mcpRemoteServerInfos.set([]);
+  secretVaultInfos.set([]);
+  ragEnvironments.set([]);
+  resetDraft();
+});
+
+describe('wizard.draft initial state', () => {
+  test('should start with step index 0', () => {
+    expect(wizard.draft.currentStepIndex).toBe(0);
+  });
+
+  test('should start with empty form fields', () => {
+    expect(wizard.draft.sourcePath).toBe('');
+    expect(wizard.draft.sessionName).toBe('');
+    expect(wizard.draft.description).toBe('');
+  });
+
+  test('should start with default agent opencode', () => {
+    expect(wizard.draft.selectedAgent).toBe('opencode');
+  });
+
+  test('should start with no model selected', () => {
+    expect(wizard.draft.selectedModel).toBeUndefined();
+  });
+
+  test('should start with workspace file access', () => {
+    expect(wizard.draft.selectedFileAccess).toBe('workspace');
+  });
+
+  test('should start with registries network', () => {
+    expect(wizard.draft.selectedNetwork).toBe('registries');
+  });
+
+  test('should start with empty selection arrays', () => {
+    expect(wizard.draft.selectedSkillIds).toEqual([]);
+    expect(wizard.draft.selectedMcpIds).toEqual([]);
+    expect(wizard.draft.selectedSecretIds).toEqual([]);
+    expect(wizard.draft.selectedKnowledgeIds).toEqual([]);
+  });
+
+  test('should start uninitialized', () => {
+    expect(wizard.draft.initialized).toBe(false);
+  });
+
+  test('should start with default hostsByMode', () => {
+    expect(wizard.draft.hostsByMode).toEqual({
+      registries: ['registry.npmjs.org', 'pypi.python.org'],
+      blocked: [''],
+    });
+  });
+});
+
+describe('resetDraft', () => {
+  test('should reset all fields to defaults', () => {
+    wizard.draft.currentStepIndex = 3;
+    wizard.draft.sourcePath = '/some/path';
+    wizard.draft.sessionName = 'my-session';
+    wizard.draft.selectedAgent = 'claude';
+    wizard.draft.initialized = true;
+    wizard.draft.selectedSkillIds = ['skill-1', 'skill-2'];
+
+    resetDraft();
+
+    expect(wizard.draft.currentStepIndex).toBe(0);
+    expect(wizard.draft.sourcePath).toBe('');
+    expect(wizard.draft.sessionName).toBe('');
+    expect(wizard.draft.selectedAgent).toBe('opencode');
+    expect(wizard.draft.initialized).toBe(false);
+    expect(wizard.draft.selectedSkillIds).toEqual([]);
+  });
+});
+
+describe('state persistence', () => {
+  test('should retain values between accesses', () => {
+    wizard.draft.sourcePath = '/home/user/project';
+    wizard.draft.currentStepIndex = 2;
+    wizard.draft.selectedSkillIds = ['k8s', 'docker'];
+
+    expect(wizard.draft.sourcePath).toBe('/home/user/project');
+    expect(wizard.draft.currentStepIndex).toBe(2);
+    expect(wizard.draft.selectedSkillIds).toEqual(['k8s', 'docker']);
+  });
+});
+
+describe('resetDraft selects all available items', () => {
+  test('should select all enabled skills', () => {
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: true, managed: false },
+    ]);
+    resetDraft();
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['k8s', 'docker']);
+  });
+
+  test('should exclude disabled skills', () => {
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: false, managed: false },
+    ]);
+    resetDraft();
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['k8s']);
+  });
+
+  test('should select all MCP servers', () => {
+    mcpRemoteServerInfos.set([{ id: 'srv-1', name: 'Server 1' } as MCPRemoteServerInfo]);
+    resetDraft();
+
+    expect(wizard.draft.selectedMcpIds).toEqual(['srv-1']);
+  });
+
+  test('should select all secrets', () => {
+    secretVaultInfos.set([{ id: 'sec-1', name: 'Secret 1', type: 'api', description: '' } as SecretVaultInfo]);
+    resetDraft();
+
+    expect(wizard.draft.selectedSecretIds).toEqual(['sec-1']);
+  });
+
+  test('should select knowledge bases with mcpServer only', () => {
+    ragEnvironments.set([
+      { name: 'with-mcp', mcpServer: { id: 'mcp-1' } } as unknown as RagEnvironment,
+      { name: 'without-mcp', mcpServer: undefined } as unknown as RagEnvironment,
+    ]);
+    resetDraft();
+
+    expect(wizard.draft.selectedKnowledgeIds).toEqual(['with-mcp']);
+  });
+});
+
+describe('store subscriptions', () => {
+  test('should remove skills no longer available', () => {
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: true, managed: false },
+    ]);
+    resetDraft();
+
+    skillInfos.set([{ name: 'k8s', description: '', path: '', enabled: true, managed: false }]);
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['k8s']);
+  });
+
+  test('should preserve user deselections when store re-emits', () => {
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: true, managed: false },
+    ]);
+    resetDraft();
+
+    wizard.draft.selectedSkillIds = ['k8s'];
+
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: true, managed: false },
+    ]);
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['k8s']);
+  });
+
+  test('should auto-select newly added items', () => {
+    skillInfos.set([{ name: 'k8s', description: '', path: '', enabled: true, managed: false }]);
+    resetDraft();
+
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: true, managed: false },
+    ]);
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['k8s', 'docker']);
+  });
+
+  test('should remove skill when it becomes disabled', () => {
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: true, managed: false },
+    ]);
+    resetDraft();
+
+    skillInfos.set([
+      { name: 'k8s', description: '', path: '', enabled: true, managed: false },
+      { name: 'docker', description: '', path: '', enabled: false, managed: false },
+    ]);
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['k8s']);
+  });
+});

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
@@ -1,0 +1,123 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+
+import type { CustomMount } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
+import type { ModelInfo } from '/@/lib/chat/components/model-info';
+import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
+import { ragEnvironments } from '/@/stores/rag-environments';
+import { secretVaultInfos } from '/@/stores/secret-vault';
+import { skillInfos } from '/@/stores/skills';
+
+const REGISTRY_HOSTS = ['registry.npmjs.org', 'pypi.python.org'];
+
+interface WorkspaceCreateDraft {
+  currentStepIndex: number;
+  sourcePath: string;
+  sessionName: string;
+  description: string;
+  configExists: boolean;
+  configAction: 'merge' | 'replace';
+  selectedAgent: string;
+  selectedModel: ModelInfo | undefined;
+  selectedFileAccess: string;
+  selectedNetwork: string;
+  customMounts: CustomMount[];
+  hostsByMode: Record<string, string[]>;
+  nameManuallyEdited: boolean;
+  descriptionOpen: boolean;
+  selectedSkillIds: string[];
+  selectedMcpIds: string[];
+  selectedSecretIds: string[];
+  selectedKnowledgeIds: string[];
+  initialized: boolean;
+}
+
+function createInitialDraft(): WorkspaceCreateDraft {
+  return {
+    currentStepIndex: 0,
+    sourcePath: '',
+    sessionName: '',
+    description: '',
+    configExists: false,
+    configAction: 'merge',
+    selectedAgent: 'opencode',
+    selectedModel: undefined,
+    selectedFileAccess: 'workspace',
+    selectedNetwork: 'registries',
+    customMounts: [{ host: '', target: '', ro: false }],
+    hostsByMode: {
+      registries: [...REGISTRY_HOSTS],
+      blocked: [''],
+    },
+    nameManuallyEdited: false,
+    descriptionOpen: false,
+    selectedSkillIds: [],
+    selectedMcpIds: [],
+    selectedSecretIds: [],
+    selectedKnowledgeIds: [],
+    initialized: false,
+  };
+}
+
+export const wizard = $state<{ draft: WorkspaceCreateDraft }>({ draft: createInitialDraft() });
+
+export function resetDraft(): void {
+  wizard.draft = createInitialDraft();
+  wizard.draft.selectedSkillIds = get(skillInfos)
+    .filter(s => s.enabled)
+    .map(s => s.name);
+  wizard.draft.selectedMcpIds = get(mcpRemoteServerInfos).map(m => m.id);
+  wizard.draft.selectedSecretIds = get(secretVaultInfos).map(s => s.id);
+  wizard.draft.selectedKnowledgeIds = get(ragEnvironments)
+    .filter(r => r.mcpServer)
+    .map(r => r.name);
+}
+
+let prevSkills: Set<string> | undefined;
+skillInfos.subscribe(skills => {
+  const available = new Set(skills.filter(s => s.enabled).map(s => s.name));
+  const added = prevSkills ? [...available].filter(id => !prevSkills!.has(id)) : [];
+  wizard.draft.selectedSkillIds = [...wizard.draft.selectedSkillIds.filter(id => available.has(id)), ...added];
+  prevSkills = available;
+});
+
+let prevMcp: Set<string> | undefined;
+mcpRemoteServerInfos.subscribe(servers => {
+  const available = new Set(servers.map(m => m.id));
+  const added = prevMcp ? [...available].filter(id => !prevMcp!.has(id)) : [];
+  wizard.draft.selectedMcpIds = [...wizard.draft.selectedMcpIds.filter(id => available.has(id)), ...added];
+  prevMcp = available;
+});
+
+let prevSecrets: Set<string> | undefined;
+secretVaultInfos.subscribe(secrets => {
+  const available = new Set(secrets.map(s => s.id));
+  const added = prevSecrets ? [...available].filter(id => !prevSecrets!.has(id)) : [];
+  wizard.draft.selectedSecretIds = [...wizard.draft.selectedSecretIds.filter(id => available.has(id)), ...added];
+  prevSecrets = available;
+});
+
+let prevKnowledge: Set<string> | undefined;
+ragEnvironments.subscribe(envs => {
+  const available = new Set(envs.filter(r => r.mcpServer).map(r => r.name));
+  const added = prevKnowledge ? [...available].filter(id => !prevKnowledge!.has(id)) : [];
+  wizard.draft.selectedKnowledgeIds = [...wizard.draft.selectedKnowledgeIds.filter(id => available.has(id)), ...added];
+  prevKnowledge = available;
+});

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
@@ -93,7 +93,7 @@ export function resetDraft(): void {
 let prevSkills: Set<string> | undefined;
 skillInfos.subscribe(skills => {
   const available = new Set(skills.filter(s => s.enabled).map(s => s.name));
-  const added = prevSkills ? [...available].filter(id => !prevSkills!.has(id)) : [];
+  const added = prevSkills ? [...available].filter(id => !prevSkills!.has(id)) : [...available];
   wizard.draft.selectedSkillIds = [...wizard.draft.selectedSkillIds.filter(id => available.has(id)), ...added];
   prevSkills = available;
 });
@@ -101,7 +101,7 @@ skillInfos.subscribe(skills => {
 let prevMcp: Set<string> | undefined;
 mcpRemoteServerInfos.subscribe(servers => {
   const available = new Set(servers.map(m => m.id));
-  const added = prevMcp ? [...available].filter(id => !prevMcp!.has(id)) : [];
+  const added = prevMcp ? [...available].filter(id => !prevMcp!.has(id)) : [...available];
   wizard.draft.selectedMcpIds = [...wizard.draft.selectedMcpIds.filter(id => available.has(id)), ...added];
   prevMcp = available;
 });
@@ -109,7 +109,7 @@ mcpRemoteServerInfos.subscribe(servers => {
 let prevSecrets: Set<string> | undefined;
 secretVaultInfos.subscribe(secrets => {
   const available = new Set(secrets.map(s => s.id));
-  const added = prevSecrets ? [...available].filter(id => !prevSecrets!.has(id)) : [];
+  const added = prevSecrets ? [...available].filter(id => !prevSecrets!.has(id)) : [...available];
   wizard.draft.selectedSecretIds = [...wizard.draft.selectedSecretIds.filter(id => available.has(id)), ...added];
   prevSecrets = available;
 });
@@ -117,7 +117,7 @@ secretVaultInfos.subscribe(secrets => {
 let prevKnowledge: Set<string> | undefined;
 ragEnvironments.subscribe(envs => {
   const available = new Set(envs.filter(r => r.mcpServer).map(r => r.name));
-  const added = prevKnowledge ? [...available].filter(id => !prevKnowledge!.has(id)) : [];
+  const added = prevKnowledge ? [...available].filter(id => !prevKnowledge!.has(id)) : [...available];
   wizard.draft.selectedKnowledgeIds = [...wizard.draft.selectedKnowledgeIds.filter(id => available.has(id)), ...added];
   prevKnowledge = available;
 });


### PR DESCRIPTION
Moves all local $state variables from AgentWorkspaceCreate.svelte into a shared wizard draft store so form state survives navigation away and back. The draft is reset on cancel and before workspace creation completes.


https://github.com/user-attachments/assets/1b815fb4-011d-45d2-924a-72984b20f825


https://github.com/user-attachments/assets/1c26cf5f-bc24-48ea-ac16-d819fca1c1cf



Closes https://github.com/openkaiden/kaiden/issues/1604

