### PR TITLE
fix(renderer): apply vertex-ai workspace config to non-Claude agents

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -722,6 +722,23 @@ const mockAnthropicProvider: ProviderInfo = {
   inferenceProviderConnectionCreation: false,
 } as unknown as ProviderInfo;
 
+const mockVertexProvider: ProviderInfo = {
+  id: 'vertex-ai',
+  name: 'Vertex AI',
+  internalId: 'vertex-ai-internal',
+  status: 'started',
+  inferenceConnections: [
+    {
+      name: 'Vertex AI Cloud',
+      type: 'cloud',
+      status: 'started',
+      llmMetadata: { name: 'vertexai' },
+      models: [{ label: 'claude-sonnet-4' }],
+    },
+  ],
+  inferenceProviderConnectionCreation: false,
+} as unknown as ProviderInfo;
+
 const mockOllamaProvider: ProviderInfo = {
   id: 'ollama',
   name: 'Ollama',
@@ -1217,6 +1234,161 @@ test('Expect tilde mount paths normalized to $HOME in workspaceConfiguration', a
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
       workspaceConfiguration: {
+        mounts: [
+          {
+            host: '$HOME/.config/gcloud/application_default_credentials.json',
+            target: '$HOME/.config/gcloud/application_default_credentials.json',
+            ro: true,
+          },
+        ],
+      },
+    }),
+  );
+});
+
+test('Expect opencode agent with vertex-ai model gets vertex workspace configuration', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'opencode',
+    defaultAgentSettings: {
+      opencode: {
+        defaultModel: { providerId: 'vertex-ai', connectionName: 'Vertex AI Cloud', label: 'claude-sonnet-4' },
+      },
+      'claude-vertex': {
+        workspaceConfiguration: {
+          environment: [
+            { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+            { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+            { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-project' },
+            { name: 'GOOGLE_CLOUD_PROJECT', value: 'my-project' },
+          ],
+          mounts: [
+            {
+              host: '$HOME/.config/gcloud/application_default_credentials.json',
+              target: '$HOME/.config/gcloud/application_default_credentials.json',
+              ro: true,
+            },
+          ],
+        },
+      },
+    },
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockVertexProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agent: 'opencode',
+      workspaceConfiguration: {
+        environment: [
+          { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+          { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+          { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-project' },
+          { name: 'GOOGLE_CLOUD_PROJECT', value: 'my-project' },
+        ],
+        mounts: [
+          {
+            host: '$HOME/.config/gcloud/application_default_credentials.json',
+            target: '$HOME/.config/gcloud/application_default_credentials.json',
+            ro: true,
+          },
+        ],
+      },
+    }),
+  );
+});
+
+test('Expect GOOGLE_CLOUD_PROJECT auto-derived from ANTHROPIC_VERTEX_PROJECT_ID when absent', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'opencode',
+    defaultAgentSettings: {
+      opencode: {
+        defaultModel: { providerId: 'vertex-ai', connectionName: 'Vertex AI Cloud', label: 'claude-sonnet-4' },
+      },
+      'claude-vertex': {
+        workspaceConfiguration: {
+          environment: [
+            { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+            { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-project' },
+          ],
+        },
+      },
+    },
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockVertexProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agent: 'opencode',
+      workspaceConfiguration: {
+        environment: [
+          { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+          { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-project' },
+          { name: 'GOOGLE_CLOUD_PROJECT', value: 'my-project' },
+        ],
+      },
+    }),
+  );
+});
+
+test('Expect agent-specific workspace config overrides provider config on merge', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue({
+    defaultAgent: 'opencode',
+    defaultAgentSettings: {
+      opencode: {
+        defaultModel: { providerId: 'vertex-ai', connectionName: 'Vertex AI Cloud', label: 'claude-sonnet-4' },
+        workspaceConfiguration: {
+          environment: [{ name: 'CLOUD_ML_REGION', value: 'europe-west1' }],
+        },
+      },
+      'claude-vertex': {
+        workspaceConfiguration: {
+          environment: [
+            { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+            { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+            { name: 'GOOGLE_CLOUD_PROJECT', value: 'my-project' },
+          ],
+          mounts: [
+            {
+              host: '$HOME/.config/gcloud/application_default_credentials.json',
+              target: '$HOME/.config/gcloud/application_default_credentials.json',
+              ro: true,
+            },
+          ],
+        },
+      },
+    },
+  });
+  vi.mocked(providerStore).providerInfos = writable<ProviderInfo[]>([mockVertexProvider]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agent: 'opencode',
+      workspaceConfiguration: {
+        environment: [
+          { name: 'CLOUD_ML_REGION', value: 'europe-west1' },
+          { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+          { name: 'GOOGLE_CLOUD_PROJECT', value: 'my-project' },
+        ],
         mounts: [
           {
             host: '$HOME/.config/gcloud/application_default_credentials.json',

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -332,13 +332,36 @@ function normalizeTildeToHome(p: string): string {
   return p.startsWith('~/') ? `$HOME/${p.slice(2)}` : p;
 }
 
-function getAgentWorkspaceConfiguration(agent: string): AgentWorkspaceConfiguration | undefined {
-  const resolvedAgent = agentDefinitions.find(d => d.cliName === agent)?.cliAgent ?? agent;
-  const config =
+function getAgentWorkspaceConfiguration(agent: string, model?: ModelInfo): AgentWorkspaceConfiguration | undefined {
+  const agentDef = agentDefinitions.find(d => d.cliName === agent);
+  const resolvedAgent = agentDef?.cliAgent ?? agent;
+  const agentConfig =
     defaultSettings?.defaultAgentSettings?.[resolvedAgent]?.workspaceConfiguration ??
     defaultSettings?.defaultAgentSettings?.[agent]?.workspaceConfiguration;
+
+  let providerConfig: AgentWorkspaceConfiguration | undefined;
+  const modelProvider = model?.llmMetadata?.name;
+  if (modelProvider) {
+    const providerAgent = agentDefinitions.find(
+      d => d.modelFilter === modelProvider && d.cliName !== agent && d.cliName !== resolvedAgent,
+    );
+    if (providerAgent) {
+      const providerResolved = providerAgent.cliAgent ?? providerAgent.cliName;
+      providerConfig =
+        defaultSettings?.defaultAgentSettings?.[providerResolved]?.workspaceConfiguration ??
+        defaultSettings?.defaultAgentSettings?.[providerAgent.cliName]?.workspaceConfiguration;
+    }
+  }
+
+  const config = mergeWorkspaceConfigs(providerConfig, agentConfig);
   if (!config) return undefined;
   const snapshot = $state.snapshot(config);
+  if (snapshot.environment) {
+    const vertexProject = snapshot.environment.find(e => e.name === 'ANTHROPIC_VERTEX_PROJECT_ID');
+    if (vertexProject && !snapshot.environment.some(e => e.name === 'GOOGLE_CLOUD_PROJECT')) {
+      snapshot.environment = [...snapshot.environment, { name: 'GOOGLE_CLOUD_PROJECT', value: vertexProject.value }];
+    }
+  }
   if (snapshot.mounts) {
     snapshot.mounts = snapshot.mounts.map(m => ({
       ...m,
@@ -347,6 +370,40 @@ function getAgentWorkspaceConfiguration(agent: string): AgentWorkspaceConfigurat
     }));
   }
   return snapshot;
+}
+
+function mergeWorkspaceConfigs(
+  base: AgentWorkspaceConfiguration | undefined,
+  override: AgentWorkspaceConfiguration | undefined,
+): AgentWorkspaceConfiguration | undefined {
+  if (!base) return override;
+  if (!override) return base;
+
+  const envEntries = [...(override.environment ?? []), ...(base.environment ?? [])];
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const seenEnv = new Set<string>();
+  const mergedEnv = envEntries.filter(e => {
+    if (seenEnv.has(e.name)) return false;
+    seenEnv.add(e.name);
+    return true;
+  });
+
+  const mountEntries = [...(override.mounts ?? []), ...(base.mounts ?? [])];
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const seenMounts = new Set<string>();
+  const mergedMounts = mountEntries.filter(m => {
+    const key = `${m.host}::${m.target}`;
+    if (seenMounts.has(key)) return false;
+    seenMounts.add(key);
+    return true;
+  });
+
+  return {
+    ...base,
+    ...override,
+    environment: mergedEnv.length > 0 ? mergedEnv : undefined,
+    mounts: mergedMounts.length > 0 ? mergedMounts : undefined,
+  };
 }
 
 function getFirstCompatibleModel(): ModelInfo | undefined {
@@ -446,7 +503,7 @@ async function startWorkspace(): Promise<void> {
             ...(commandServers.length > 0 ? { commands: commandServers } : {}),
           }
         : undefined,
-      workspaceConfiguration: getAgentWorkspaceConfiguration(selectedAgent),
+      workspaceConfiguration: getAgentWorkspaceConfiguration(selectedAgent, selectedModel),
       replaceConfig: configExists && configAction === 'replace' ? true : undefined,
     });
   } catch (err: unknown) {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.spec.ts
@@ -256,6 +256,10 @@ describe('beforeAdvance callback', () => {
                 name: 'ANTHROPIC_VERTEX_PROJECT_ID',
                 value: 'my-gcp-project',
               },
+              {
+                name: 'GOOGLE_CLOUD_PROJECT',
+                value: 'my-gcp-project',
+              },
             ],
             mounts: [
               {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudeVertexPanel.svelte
@@ -124,6 +124,13 @@ async function validate(): Promise<boolean> {
         name: 'ANTHROPIC_VERTEX_PROJECT_ID',
         value: projectId.trim(),
       });
+      agentSettings.workspaceConfiguration.environment = agentSettings.workspaceConfiguration.environment.filter(
+        e => e.name !== 'GOOGLE_CLOUD_PROJECT',
+      );
+      agentSettings.workspaceConfiguration.environment.push({
+        name: 'GOOGLE_CLOUD_PROJECT',
+        value: projectId.trim(),
+      });
       agentSettings.workspaceConfiguration.mounts ??= [];
       agentSettings.workspaceConfiguration.mounts = agentSettings.workspaceConfiguration.mounts.filter(
         e => e.target !== '$HOME/.config/gcloud/application_default_credentials.json',


### PR DESCRIPTION
When selecting a vertex-ai model with a non-Claude agent (e.g. opencode),
workspace creation now merges the vertex-ai env vars and mounts from
the claude-vertex onboarding settings. Also derives GOOGLE_CLOUD_PROJECT
from ANTHROPIC_VERTEX_PROJECT_ID for agents that need it.

fixes #1776