### PR TITLE
fix(agent-workspaces): restrict Vertex AI models to Claude on Vertex AI agent

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -13,7 +13,7 @@ import AgentWorkspaceCreateStepNetworking from '/@/lib/agent-workspaces/AgentWor
 import AgentWorkspaceCreateStepToolsSecrets from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte';
 import AgentWorkspaceCreateStepWorkspace from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte';
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
-import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
+import { agentDefinitions, matchesModelFilter } from '/@/lib/guided-setup/agent-registry';
 import { getCatalogModels, getModelId } from '/@/lib/models/models-utils';
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
@@ -362,7 +362,9 @@ function getFirstCompatibleModel(): ModelInfo | undefined {
     seen.add(key);
     return true;
   });
-  const compatible = agentDef?.modelFilter ? unique.filter(m => m.llmMetadata?.name === agentDef.modelFilter) : unique;
+  const compatible = agentDef?.modelFilter
+    ? unique.filter(m => matchesModelFilter(agentDef.modelFilter!, m.llmMetadata?.name))
+    : unique;
   return compatible[0];
 }
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
@@ -33,26 +33,42 @@ vi.mock(import('/@/navigation'));
 vi.mock(import('/@/stores/providers'));
 vi.mock(import('/@/stores/model-catalog'));
 vi.mock(import('/@/stores/agentworkspace-runtime'));
-vi.mock('/@/lib/guided-setup/agent-registry', () => ({
-  agentDefinitions: [
-    { cliName: 'opencode', title: 'OpenCode', description: 'Open-source agent.', badge: 'Recommended' },
-    {
-      cliName: 'claude',
-      title: 'Claude Code',
-      description: 'Anthropic Claude.',
-      badge: 'Cloud',
-      modelFilter: 'anthropic',
-    },
-    {
-      cliName: 'claude-vertex',
-      title: 'Claude on Vertex AI',
-      description: 'Claude via Vertex AI.',
-      modelFilter: 'vertexai',
-    },
-    { cliName: 'cursor', title: 'Cursor', description: 'AI code editor.' },
-    { cliName: 'goose', title: 'Goose', description: 'Autonomous coding agent.', runtimes: ['podman'] },
-  ],
-}));
+vi.mock(import('/@/lib/guided-setup/agent-registry'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    matchesModelFilter: actual.matchesModelFilter,
+    agentDefinitions: [
+      {
+        cliName: 'opencode',
+        title: 'OpenCode',
+        description: 'Open-source agent.',
+        badge: 'Recommended',
+        modelFilter: '!vertexai',
+      },
+      {
+        cliName: 'claude',
+        title: 'Claude Code',
+        description: 'Anthropic Claude.',
+        badge: 'Cloud',
+        modelFilter: 'anthropic',
+      },
+      {
+        cliName: 'claude-vertex',
+        title: 'Claude on Vertex AI',
+        description: 'Claude via Vertex AI.',
+        modelFilter: 'vertexai',
+      },
+      { cliName: 'cursor', title: 'Cursor', description: 'AI code editor.', modelFilter: '!vertexai' },
+      {
+        cliName: 'goose',
+        title: 'Goose',
+        description: 'Autonomous coding agent.',
+        runtimes: ['podman'],
+        modelFilter: '!vertexai',
+      },
+    ] as unknown as typeof actual.agentDefinitions,
+  };
+});
 
 const mockAnthropicProvider: ProviderInfo = {
   id: 'claude',
@@ -66,6 +82,23 @@ const mockAnthropicProvider: ProviderInfo = {
       status: 'started',
       llmMetadata: { name: 'anthropic' },
       models: [{ label: 'claude-sonnet-4' }, { label: 'claude-opus-4' }],
+    },
+  ],
+  inferenceProviderConnectionCreation: false,
+} as unknown as ProviderInfo;
+
+const mockVertexProvider: ProviderInfo = {
+  id: 'vertex-ai',
+  name: 'Vertex AI',
+  internalId: 'vertex-ai-internal',
+  status: 'started',
+  inferenceConnections: [
+    {
+      name: 'Vertex AI',
+      type: 'cloud',
+      status: 'started',
+      llmMetadata: { name: 'vertexai' },
+      models: [{ label: 'claude-sonnet-4' }],
     },
   ],
   inferenceProviderConnectionCreation: false,
@@ -273,6 +306,43 @@ test('agent with matching runtime is shown', () => {
   render(AgentWorkspaceCreateStepAgentModel);
 
   expect(screen.getByText('Goose')).toBeInTheDocument();
+});
+
+test('OpenCode excludes Vertex AI models', async () => {
+  vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([
+    mockAnthropicProvider,
+    mockVertexProvider,
+    mockOllamaProvider,
+  ]);
+
+  render(AgentWorkspaceCreateStepAgentModel);
+
+  await fireEvent.click(screen.getByText('OpenCode'));
+
+  expect(screen.getByText('llama3.2:3b')).toBeInTheDocument();
+  expect(screen.getByText('claude-opus-4')).toBeInTheDocument();
+  // Vertex AI claude-sonnet-4 excluded, only Anthropic claude-sonnet-4 shown
+  expect(screen.getAllByText('claude-sonnet-4')).toHaveLength(1);
+  // No Vertex AI provider column
+  const providerCells = screen.getAllByText('Anthropic');
+  expect(providerCells.length).toBeGreaterThan(0);
+  expect(screen.queryAllByText('Vertex AI').filter(el => el.tagName === 'TD')).toHaveLength(0);
+});
+
+test('Claude on Vertex AI shows only Vertex AI models', async () => {
+  vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([
+    mockAnthropicProvider,
+    mockVertexProvider,
+    mockOllamaProvider,
+  ]);
+
+  render(AgentWorkspaceCreateStepAgentModel);
+
+  await fireEvent.click(screen.getByText('Claude on Vertex AI'));
+
+  expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
+  expect(screen.queryByText('llama3.2:3b')).not.toBeInTheDocument();
+  expect(screen.queryByText('claude-opus-4')).not.toBeInTheDocument();
 });
 
 test('agent with non-matching runtime is hidden', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -2,7 +2,7 @@
 import { untrack } from 'svelte';
 
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
-import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
+import { agentDefinitions, matchesModelFilter } from '/@/lib/guided-setup/agent-registry';
 import { type CatalogModelInfo, getCatalogModels } from '/@/lib/models/models-utils';
 import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
 import { agentWorkspaceRuntime } from '/@/stores/agentworkspace-runtime';
@@ -41,7 +41,7 @@ function filterByAgent(models: CatalogModelInfo[], agent: string): CatalogModelI
   if (!agent) return models;
   const def = agentDefinitions.find(d => d.cliName === agent);
   if (!def?.modelFilter) return models;
-  return models.filter(m => m.llmMetadata?.name === def.modelFilter);
+  return models.filter(m => matchesModelFilter(def.modelFilter!, m.llmMetadata?.name));
 }
 
 function handleModelSelect(model: CatalogModelInfo): void {

--- a/packages/renderer/src/lib/guided-setup/ModelStep.svelte
+++ b/packages/renderer/src/lib/guided-setup/ModelStep.svelte
@@ -3,7 +3,7 @@
 import { untrack } from 'svelte';
 import { SvelteSet } from 'svelte/reactivity';
 
-import { agentDefinitions } from '/@/lib/guided-setup/agent-registry';
+import { agentDefinitions, matchesModelFilter } from '/@/lib/guided-setup/agent-registry';
 import type { CatalogModelInfo } from '/@/lib/models/models-utils';
 import { getCatalogModels } from '/@/lib/models/models-utils';
 import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
@@ -35,7 +35,7 @@ let allModels: CatalogModelInfo[] = $derived.by(() => {
 
 let agentFilteredModels: CatalogModelInfo[] = $derived.by(() => {
   if (!agentDef?.modelFilter) return allModels;
-  return allModels.filter(m => m.llmMetadata?.name === agentDef!.modelFilter);
+  return allModels.filter(m => matchesModelFilter(agentDef!.modelFilter!, m.llmMetadata?.name));
 });
 
 let effectiveModel: CatalogModelInfo | undefined = $derived.by(() => {
@@ -75,7 +75,7 @@ function selectModel(model: CatalogModelInfo): void {
 
   <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
     <p class="text-xs text-(--pd-content-card-text) opacity-70 mb-4">
-      {#if agentDef?.modelFilter}
+      {#if agentDef?.modelFilter && !agentDef.modelFilter.startsWith('!')}
         Cloud catalog on <strong class="text-(--pd-modal-text)">Models</strong> — {selectedAgentLabel} rows (enabled). Click a row to choose.
       {:else}
         Same rows as <strong class="text-(--pd-modal-text)">Models</strong>. Click a line or use the <strong class="text-(--pd-modal-text)">Use</strong> control to pick your default for <strong class="text-(--pd-modal-text)">local</strong> models.

--- a/packages/renderer/src/lib/guided-setup/agent-registry.ts
+++ b/packages/renderer/src/lib/guided-setup/agent-registry.ts
@@ -47,7 +47,7 @@ export interface AgentDefinition {
   description?: string;
   badge?: string;
   panel?: Component;
-  /** When set, only models whose `llmMetadata.name` matches this value are shown for this agent. */
+  /** When set, filters models by `llmMetadata.name`. Prefix with `!` to exclude instead (e.g. `'!vertexai'`). */
   modelFilter?: string;
   /** Compound selector in the form `extensionId:providerId` (e.g. `kaiden.claude:claude`). */
   providerSelector?: string;
@@ -71,6 +71,7 @@ export const agentDefinitions: AgentDefinition[] = [
       'Open-source agent on your machine — local models via Ollama or Ramalama, or cloud APIs (OpenAI, Gemini, and other providers OpenCode supports).',
     badge: 'Recommended',
     panel: OpenRuntimePanel,
+    modelFilter: '!vertexai',
   },
   {
     cliName: 'claude',
@@ -107,6 +108,7 @@ export const agentDefinitions: AgentDefinition[] = [
     iconComponent: OpenClawIcon,
     colorClass: 'bg-gradient-to-br from-red-600 to-red-700',
     panel: OpenRuntimePanel,
+    modelFilter: '!vertexai',
   },
   {
     cliName: 'goose',
@@ -116,6 +118,7 @@ export const agentDefinitions: AgentDefinition[] = [
     iconComponent: GooseIcon,
     colorClass: 'bg-gradient-to-br from-emerald-600 to-emerald-700',
     runtimes: ['podman'],
+    modelFilter: '!vertexai',
   },
 ];
 
@@ -125,4 +128,11 @@ const agentMap = new Map<string, AgentDefinition>(agentDefinitions.map(d => [d.c
 
 export function getAgentDefinition(name: string): ResolvedAgentDefinition {
   return agentMap.get(name) ?? { ...DEFAULT_DEFINITION, cliName: name, title: name };
+}
+
+export function matchesModelFilter(filter: string, llmMetadataName: string | undefined): boolean {
+  if (filter.startsWith('!')) {
+    return llmMetadataName !== filter.slice(1);
+  }
+  return llmMetadataName === filter;
 }


### PR DESCRIPTION
Vertex AI models were visible to all agents without a modelFilter.
Add negation support to modelFilter (e.g. '!vertexai') and apply it
to opencode, openclaw, and goose so only the claude-vertex agent
can select Vertex AI models.

Alternative fix for https://github.com/openkaiden/kaiden/issues/1776, as mentioned in https://github.com/openkaiden/kaiden/pull/1812#pullrequestreview-4264796165

Fixes https://github.com/openkaiden/kaiden/issues/1786
