### PR TITLE
feat(agent-workspaces): inject API key env var for OpenAI and Mistral models

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -411,6 +411,7 @@ describe('ensureModelSecret', () => {
       header: 'Authorization',
       headerTemplate: 'Bearer ${value}',
     });
+    expect(options.workspaceConfiguration?.environment).toEqual([{ name: 'OPENAI_API_KEY', value: 'provided' }]);
   });
 
   test('defaults openai host when no endpoint', async () => {
@@ -450,6 +451,39 @@ describe('ensureModelSecret', () => {
       header: 'Authorization',
       headerTemplate: 'Bearer ${value}',
     });
+    expect(options.workspaceConfiguration?.environment).toEqual([{ name: 'MISTRAL_API_KEY', value: 'provided' }]);
+  });
+
+  test('does not add env var for anthropic provider', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'claude:tokens': 'sk-ant-key' },
+      llmMetadataName: 'anthropic',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-anthropic' });
+
+    const options = { ...baseOptions, model: 'anthropic::claude-sonnet-4-20250514::' };
+    await manager.ensureModelSecret(options);
+
+    expect(options.workspaceConfiguration).toBeUndefined();
+  });
+
+  test('deduplicates env var if already present in workspaceConfiguration', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { 'mistral:tokens': 'mistral-key' },
+      llmMetadataName: 'mistral',
+      endpoint: undefined,
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-mistral' });
+
+    const options = {
+      ...baseOptions,
+      model: 'mistral::mistral-large::',
+      workspaceConfiguration: { environment: [{ name: 'MISTRAL_API_KEY', value: 'old' }] },
+    } as AgentWorkspaceCreateOptions;
+    await manager.ensureModelSecret(options);
+
+    expect(options.workspaceConfiguration?.environment).toEqual([{ name: 'MISTRAL_API_KEY', value: 'provided' }]);
   });
 
   test('skips when no model is provided', async () => {
@@ -620,7 +654,15 @@ describe('buildSecretOptions', () => {
       { credentials: { key: 'value' }, llmMetadataName: 'anthropic', endpoint: undefined },
       'my-project',
     );
-    expect(result?.name).toBe('my-project-anthropic');
+    expect(result?.secret.name).toBe('my-project-anthropic');
+  });
+
+  test('does not include environmentVariable for anthropic', () => {
+    const result = manager.buildSecretOptions(
+      { credentials: { key: 'value' }, llmMetadataName: 'anthropic', endpoint: undefined },
+      'ws',
+    );
+    expect(result?.environmentVariable).toBeUndefined();
   });
 
   test('treats undefined provider as openai-compatible with endpoint host', () => {
@@ -629,12 +671,15 @@ describe('buildSecretOptions', () => {
       'ws',
     );
     expect(result).toEqual({
-      name: 'ws-secret',
-      type: 'other',
-      value: 'sk-key',
-      hosts: ['my-llm.example.com'],
-      header: 'Authorization',
-      headerTemplate: 'Bearer ${value}',
+      secret: {
+        name: 'ws-secret',
+        type: 'other',
+        value: 'sk-key',
+        hosts: ['my-llm.example.com'],
+        header: 'Authorization',
+        headerTemplate: 'Bearer ${value}',
+      },
+      environmentVariable: { name: 'OPENAI_API_KEY', value: 'provided' },
     });
   });
 
@@ -644,13 +689,24 @@ describe('buildSecretOptions', () => {
       'ws',
     );
     expect(result).toEqual({
-      name: 'ws-secret',
-      type: 'other',
-      value: 'sk-key',
-      hosts: ['api.openai.com'],
-      header: 'Authorization',
-      headerTemplate: 'Bearer ${value}',
+      secret: {
+        name: 'ws-secret',
+        type: 'other',
+        value: 'sk-key',
+        hosts: ['api.openai.com'],
+        header: 'Authorization',
+        headerTemplate: 'Bearer ${value}',
+      },
+      environmentVariable: { name: 'OPENAI_API_KEY', value: 'provided' },
     });
+  });
+
+  test('includes MISTRAL_API_KEY env var for mistral provider', () => {
+    const result = manager.buildSecretOptions(
+      { credentials: { key: 'mistral-key' }, llmMetadataName: 'mistral', endpoint: undefined },
+      'ws',
+    );
+    expect(result?.environmentVariable).toEqual({ name: 'MISTRAL_API_KEY', value: 'provided' });
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -141,17 +141,26 @@ export class AgentWorkspaceManager implements Disposable {
     if (entries.length !== 1) return;
 
     const workspaceSecretPrefix = options.name ?? basename(options.sourcePath);
-    const secretOptions = this.buildSecretOptions(connectionInfo, workspaceSecretPrefix);
-    if (!secretOptions) return;
+    const result = this.buildSecretOptions(connectionInfo, workspaceSecretPrefix);
+    if (!result) return;
 
     try {
-      await this.secretManager.create(secretOptions);
+      await this.secretManager.create(result.secret);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes('already exists')) throw err;
     }
 
-    options.secrets = [...new Set([...(options.secrets ?? []), secretOptions.name])];
+    options.secrets = [...new Set([...(options.secrets ?? []), result.secret.name])];
+
+    if (result.environmentVariable) {
+      options.workspaceConfiguration ??= {};
+      options.workspaceConfiguration.environment ??= [];
+      options.workspaceConfiguration.environment = options.workspaceConfiguration.environment.filter(
+        e => e.name !== result.environmentVariable!.name,
+      );
+      options.workspaceConfiguration.environment.push(result.environmentVariable);
+    }
   }
 
   /**
@@ -165,7 +174,7 @@ export class AgentWorkspaceManager implements Disposable {
   buildSecretOptions(
     connectionInfo: InferenceConnectionCredentials,
     workspaceName: string,
-  ): SecretCreateOptions | undefined {
+  ): { secret: SecretCreateOptions; environmentVariable?: { name: string; value: string } } | undefined {
     const apiKey = Object.values(connectionInfo.credentials)[0];
     if (!apiKey) return undefined;
 
@@ -174,29 +183,35 @@ export class AgentWorkspaceManager implements Disposable {
 
     switch (provider) {
       case 'anthropic':
-        return { name: secretName, type: 'anthropic', value: apiKey };
+        return { secret: { name: secretName, type: 'anthropic', value: apiKey } };
       case 'gemini':
-        return { name: secretName, type: 'gemini', value: apiKey };
+        return { secret: { name: secretName, type: 'gemini', value: apiKey } };
       case 'openai':
       case undefined: {
         const host = this.extractHost(connectionInfo.endpoint) ?? 'api.openai.com';
         return {
-          name: secretName,
-          type: 'other',
-          value: apiKey,
-          hosts: [host],
-          header: 'Authorization',
-          headerTemplate: 'Bearer ${value}',
+          secret: {
+            name: secretName,
+            type: 'other',
+            value: apiKey,
+            hosts: [host],
+            header: 'Authorization',
+            headerTemplate: 'Bearer ${value}',
+          },
+          environmentVariable: { name: 'OPENAI_API_KEY', value: 'provided' },
         };
       }
       case 'mistral':
         return {
-          name: secretName,
-          type: 'other',
-          value: apiKey,
-          hosts: ['api.mistral.ai'],
-          header: 'Authorization',
-          headerTemplate: 'Bearer ${value}',
+          secret: {
+            name: secretName,
+            type: 'other',
+            value: apiKey,
+            hosts: ['api.mistral.ai'],
+            header: 'Authorization',
+            headerTemplate: 'Bearer ${value}',
+          },
+          environmentVariable: { name: 'MISTRAL_API_KEY', value: 'provided' },
         };
       default:
         return undefined;


### PR DESCRIPTION
When creating a workspace with an OpenAI or Mistral model, the
corresponding env var (OPENAI_API_KEY or MISTRAL_API_KEY) is now
written to workspace.json with value "provided". The env var is
co-located with the secret in buildSecretOptions so it is only
generated when a matching secret exists.

fixes #1779 
fixes #1813 