### PR TITLE
fix: mask OpenAI extension apiKey field as password

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,3 +286,4 @@ const task = taskManager.createTask({
 - Safe storage for credentials via `SafeStorageRegistry`
 - Configuration scopes limit exposure of sensitive data
 - Preload scripts enforce security boundaries between processes
+- Extension configuration properties for API keys, tokens, or secrets must use `"format": "password"` to ensure input masking in the UI

--- a/extensions/openai-compatible/package.json
+++ b/extensions/openai-compatible/package.json
@@ -22,7 +22,8 @@
         "openai.factory.apiKey": {
           "type": "string",
           "scope": "InferenceProviderConnectionFactory",
-          "description": "apiKey"
+          "description": "apiKey",
+          "format": "password"
         }
       }
     }


### PR DESCRIPTION
Add `"format": "password"` to the openai-compatible extension's apiKey
configuration property so the input is masked in the UI. Also document
the requirement in AGENTS.md Security Considerations.

<img width="937" height="712" alt="Screenshot 2026-05-12 at 16 02 33" src="https://github.com/user-attachments/assets/96b1fff0-09bc-4923-b43d-d1d4f4b1e851" />


Fixes #1831
