### PR TITLE
feat(agent-workspaces): display runtime in workspace list and details

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@eslint/compat": "^2.0.1",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
-    "@openkaiden/kdn-api": "^0.9.0",
+    "@openkaiden/kdn-api": "^0.12.0",
     "@openkaiden/workspace-configuration": "^0.11.0",
     "@openkaiden/api": "workspace:",
     "@openkaiden/mcp-registry-types": "^1.3.10",

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -55,8 +55,10 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     agent: 'coder-v1',
     state: 'stopped',
     model: 'gpt-4o',
+    runtime: 'podman',
     paths: { source: '/tmp/ws1', configuration: '/tmp/ws1/.kaiden' },
     timestamps: { created: 1700000000 },
+    forwards: [],
   },
   {
     id: 'ws-2',
@@ -64,8 +66,10 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     project: 'project-beta',
     agent: 'coder-v2',
     state: 'running',
+    runtime: 'podman',
     paths: { source: '/tmp/ws2', configuration: '/tmp/ws2/.kaiden' },
     timestamps: { created: 1700000001, started: 1700000002 },
+    forwards: [],
   },
 ];
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -44,8 +44,10 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     agent: 'coder-v1',
     state: 'stopped',
     model: 'gpt-4o',
+    runtime: 'podman',
     paths: { source: '/tmp/ws1', configuration: '/tmp/ws1/.kaiden' },
     timestamps: { created: 1700000000 },
+    forwards: [],
   },
   {
     id: 'ws-2',
@@ -53,8 +55,10 @@ const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
     project: 'project-beta',
     agent: 'coder-v2',
     state: 'running',
+    runtime: 'podman',
     paths: { source: '/tmp/ws2', configuration: '/tmp/ws2/.kaiden' },
     timestamps: { created: 1700000001, started: 1700000002 },
+    forwards: [],
   },
 ];
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceActions.spec.ts
@@ -35,11 +35,13 @@ const workspace: AgentWorkspaceSummary = {
   project: 'backend',
   agent: 'coder-v1',
   state: 'stopped',
+  runtime: 'podman',
   paths: {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
   timestamps: { created: 1700000000 },
+  forwards: [],
 };
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -49,11 +49,13 @@ const workspaceSummary: AgentWorkspaceSummary = {
   project: 'backend',
   agent: 'coder-v1',
   state: 'stopped',
+  runtime: 'podman',
   paths: {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
   timestamps: { created: 1700000000 },
+  forwards: [],
 };
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.spec.ts
@@ -32,11 +32,13 @@ const workspaceSummary: AgentWorkspaceSummary = {
   agent: 'coder-v1',
   state: 'stopped',
   model: 'gpt-4o',
+  runtime: 'podman',
   paths: {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
   timestamps: { created: 1700000000000 },
+  forwards: [],
 };
 
 const configuration: AgentWorkspaceConfiguration = {
@@ -158,6 +160,20 @@ test('Expect no MCP servers message when configuration has no MCP', () => {
   render(AgentWorkspaceDetailsOverview, { workspaceSummary, configuration: {} });
 
   expect(screen.getByText('No MCP servers configured')).toBeInTheDocument();
+});
+
+test('Expect runtime label is displayed', () => {
+  render(AgentWorkspaceDetailsOverview, { workspaceSummary, configuration });
+
+  expect(screen.getByText('Runtime')).toBeInTheDocument();
+  expect(screen.getByText('podman')).toBeInTheDocument();
+});
+
+test('Expect runtime shows dash when workspace is undefined', () => {
+  render(AgentWorkspaceDetailsOverview, { workspaceSummary: undefined, configuration });
+
+  expect(screen.getByText('Runtime')).toBeInTheDocument();
+  expect(screen.getByText('—')).toBeInTheDocument();
 });
 
 test('Expect component renders without error when workspace is undefined', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte
@@ -70,6 +70,8 @@ function formatRelativeTime(ts: number | undefined): string {
 const referenceTime = $derived(workspaceSummary ? getReferenceTime(workspaceSummary) : undefined);
 const timeLabel = $derived(workspaceSummary && isActiveWorkspace(workspaceSummary) ? 'Started' : 'Created');
 
+const runtimeLabel = $derived(workspaceSummary?.runtime ?? '—');
+
 const networkMode = $derived(configuration?.network?.mode ?? 'deny');
 const networkHosts = $derived(configuration?.network?.hosts ?? []);
 const networkLabel = $derived.by(() => {
@@ -148,6 +150,12 @@ const filesystemBadge = $derived.by(() => {
           <div class="text-[10px] text-[var(--pd-content-text)] opacity-60 uppercase tracking-wider">{timeLabel}</div>
           <div class="text-[13px] font-semibold text-[var(--pd-content-card-header-text)]">
             {formatRelativeTime(referenceTime)}
+          </div>
+        </div>
+        <div class="flex flex-col gap-0.5">
+          <div class="text-[10px] text-(--pd-content-text) opacity-60 uppercase tracking-wider">Runtime</div>
+          <div class="text-[13px] font-semibold text-(--pd-content-card-header-text)">
+            {runtimeLabel}
           </div>
         </div>
         <div class="flex flex-col gap-0.5">

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -57,11 +57,13 @@ test('Expect stat cards show correct counts with workspaces', () => {
       project: 'backend',
       agent: 'coder-v1',
       state: 'stopped',
+      runtime: 'podman',
       paths: {
         source: '/home/user/projects/backend',
         configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
       },
       timestamps: { created: 1700000000 },
+      forwards: [],
     },
     {
       id: 'ws-2',
@@ -69,11 +71,13 @@ test('Expect stat cards show correct counts with workspaces', () => {
       project: 'frontend',
       agent: 'coder-v2',
       state: 'running',
+      runtime: 'podman',
       paths: {
         source: '/home/user/projects/frontend',
         configuration: '/home/user/.config/kaiden/workspaces/frontend-redesign.yaml',
       },
       timestamps: { created: 1700000001, started: 1700000002 },
+      forwards: [],
     },
   ];
   agentWorkspaces.set(workspaces);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -21,6 +21,7 @@ import AgentWorkspaceStatCards from './AgentWorkspaceStatCards.svelte';
 import AgentWorkspaceActions from './columns/AgentWorkspaceActions.svelte';
 import AgentWorkspaceContext from './columns/AgentWorkspaceContext.svelte';
 import AgentWorkspaceName from './columns/AgentWorkspaceName.svelte';
+import AgentWorkspaceRuntime from './columns/AgentWorkspaceRuntime.svelte';
 import { ACTIVE_GROUP_LABEL, getReferenceTime, isActiveWorkspace, STOPPED_GROUP_LABEL } from './workspace-utils';
 
 type WorkspaceSelectable = AgentWorkspaceSummaryUI & { selected: boolean };
@@ -62,6 +63,12 @@ const contextColumn = new TableColumn<WorkspaceSelectable>('Context', {
   renderer: AgentWorkspaceContext,
 });
 
+const runtimeColumn = new TableColumn<WorkspaceSelectable>('Runtime', {
+  width: '1fr',
+  renderer: AgentWorkspaceRuntime,
+  comparator: (a, b): number => a.runtime.localeCompare(b.runtime),
+});
+
 const timeColumn = new TableColumn<WorkspaceSelectable, Date | undefined>('Time', {
   renderer: TableDurationColumn,
   renderMapping: (ws): Date | undefined => {
@@ -80,7 +87,7 @@ const actionsColumn = new TableColumn<WorkspaceSelectable>('', {
   overflow: true,
 });
 
-const columns = [nameColumn, contextColumn, timeColumn, actionsColumn];
+const columns = [nameColumn, contextColumn, runtimeColumn, timeColumn, actionsColumn];
 </script>
 
 <NavPage bind:searchTerm={searchTerm} searchEnabled={false} title="Agentic Workspaces">

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.spec.ts
@@ -35,6 +35,7 @@ const workspace: AgentWorkspaceSummaryUI = {
   project: 'test-project',
   agent: 'test-agent',
   state: 'stopped',
+  runtime: 'podman',
   paths: {
     source: '/home/user/projects/test',
     configuration: '/home/user/.config/kaiden/workspaces/test.yaml',
@@ -42,6 +43,7 @@ const workspace: AgentWorkspaceSummaryUI = {
   timestamps: {
     created: Date.now(),
   },
+  forwards: [],
 };
 
 vi.mock(import('tinro'));

--- a/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceRuntime.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceRuntime.spec.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
+
+import AgentWorkspaceRuntime from './AgentWorkspaceRuntime.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+function createWorkspace(runtime: string): AgentWorkspaceSummaryUI {
+  return {
+    id: 'ws-1',
+    name: 'test-workspace',
+    project: 'test-project',
+    agent: 'claude',
+    state: 'running',
+    runtime,
+    paths: { source: '/tmp/ws', configuration: '/tmp/ws/.kaiden' },
+    timestamps: { created: 1700000000 },
+    forwards: [],
+  };
+}
+
+test('Expect runtime value is displayed', () => {
+  render(AgentWorkspaceRuntime, { object: createWorkspace('podman') });
+
+  expect(screen.getByText('podman')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceRuntime.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/columns/AgentWorkspaceRuntime.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
+
+interface Props {
+  object: AgentWorkspaceSummaryUI;
+}
+
+let { object }: Props = $props();
+</script>
+
+<span class="text-xs text-(--pd-table-body-text)">{object.runtime}</span>

--- a/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-terminal-store.spec.ts
@@ -57,10 +57,12 @@ test('removes terminal entries when workspace disappears from agentWorkspaces', 
       project: 'proj',
       agent: 'agent',
       state: 'stopped',
+      runtime: 'podman',
       paths: { source: '/s', configuration: '/c' },
       timestamps: {
         created: Date.now(),
       },
+      forwards: [],
     },
   ]);
 
@@ -79,10 +81,12 @@ test('keeps terminal entries when workspace still exists', () => {
       project: 'proj',
       agent: 'agent',
       state: 'stopped',
+      runtime: 'podman',
       paths: { source: '/s', configuration: '/c' },
       timestamps: {
         created: Date.now(),
       },
+      forwards: [],
     },
   ]);
 
@@ -95,10 +99,12 @@ test('keeps terminal entries when workspace still exists', () => {
       project: 'proj',
       agent: 'agent',
       state: 'stopped',
+      runtime: 'podman',
       paths: { source: '/s', configuration: '/c' },
       timestamps: {
         created: Date.now(),
       },
+      forwards: [],
     },
   ]);
   expect(get(agentWorkspaceTerminals)).toHaveLength(1);

--- a/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspaces.svelte.spec.ts
@@ -29,11 +29,13 @@ const workspace: AgentWorkspaceSummary = {
   project: 'backend',
   agent: 'coder-v1',
   state: 'stopped',
+  runtime: 'podman',
   paths: {
     source: '/home/user/projects/backend',
     configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
   },
   timestamps: { created: 1700000000 },
+  forwards: [],
 };
 
 beforeEach(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: 'workspace:'
         version: link:packages/extension-api
       '@openkaiden/kdn-api':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.12.0
+        version: 0.12.0
       '@openkaiden/mcp-registry-types':
         specifier: ^1.3.10
         version: 1.3.10
@@ -1867,8 +1867,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@openkaiden/kdn-api@0.9.0':
-    resolution: {integrity: sha512-Tc0btrG95VrdGjHQDTIFPYhdwsMhQfjbQur3qeheze78FQJVBydTeEkCsa+ilcp5L/JlmPZ875MdT39APS04Vg==}
+  '@openkaiden/kdn-api@0.12.0':
+    resolution: {integrity: sha512-VkBzkBaRyTQ9xyNCAlWSHkm7e+F7I1X///MAalMrsh7uPJPgZ2Sub7/kD7xGCSKQWsvKKpN+QWAW3fTHEcrDdA==}
 
   '@openkaiden/mcp-registry-types@1.3.10':
     resolution: {integrity: sha512-3DJ7Pi+FtnkBC5ynYPDqK0jP9l9KkUS4GLgC/+uv0vTYRXXn/NrjOnqXqPqCmlyLTTYtwEegIR4X5vKUU2dDaw==}
@@ -8972,7 +8972,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openkaiden/kdn-api@0.9.0': {}
+  '@openkaiden/kdn-api@0.12.0': {}
 
   '@openkaiden/mcp-registry-types@1.3.10':
     dependencies:


### PR DESCRIPTION
Add a Runtime column to the workspace list table and a runtime label in the workspace details view, using the new runtime field from kdn-api. Bump @openkaiden/kdn-api from 0.9.0 to 0.12.0.
<img width="1470" height="389" alt="Captura de pantalla 2026-05-12 a las 16 28 43" src="https://github.com/user-attachments/assets/ba8031b9-955b-4e2d-ab9c-3da06498fd1c" />
<img width="1505" height="643" alt="Captura de pantalla 2026-05-12 a las 16 28 55" src="https://github.com/user-attachments/assets/4c73f91f-2f9d-4189-9fb8-3aaba7f920d5" />

## Note on dependency bump
The `@openkaiden/kdn-api` bump from `0.9.0` to `0.12.0` includes changes beyond this PR's scope (forwards, timestamps, secrets, etc.). The bump was required to pick up the new `runtime` field added to the `Workspace` schema in `0.12.0` (openkaiden/kdn-api#63). All intermediate changes (`0.10.0`–`0.11.0`) are additive and should not introduce breaking changes.

Closes #1768