### PR TITLE
feat(secret-vault): add quick remove action to secret list

### DIFF
--- a/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
@@ -9,6 +9,7 @@ import { NavigationPage } from '/@api/navigation-page';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 
 import SecretVaultAccount from './columns/SecretVaultAccount.svelte';
+import SecretVaultActions from './columns/SecretVaultActions.svelte';
 import SecretVaultIntegration from './columns/SecretVaultIntegration.svelte';
 import SecretVaultMaskedSecret from './columns/SecretVaultMaskedSecret.svelte';
 import { isKnownService, KNOWN_GROUP_LABEL, OTHER_GROUP_LABEL } from './secret-vault-utils';
@@ -41,7 +42,14 @@ const secretColumn = new TableColumn<SecretVaultSelectable>('Secret', {
   renderer: SecretVaultMaskedSecret,
 });
 
-const columns = [integrationColumn, accountColumn, secretColumn];
+const actionsColumn = new TableColumn<SecretVaultSelectable>('', {
+  align: 'right',
+  width: '40px',
+  renderer: SecretVaultActions,
+  overflow: true,
+});
+
+const columns = [integrationColumn, accountColumn, secretColumn, actionsColumn];
 
 const secrets: SecretVaultSelectable[] = $derived(
   $filteredSecretVaultInfos.map(secret => ({ ...secret, selected: false })),

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+import SecretVaultActions from './SecretVaultActions.svelte';
+
+const secret: SecretVaultInfo = {
+  id: 'github-pat',
+  name: 'GitHub',
+  type: 'github',
+  description: 'Personal access token',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.mocked(window.removeSecret).mockResolvedValue({ name: 'github-pat' });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+});
+
+test('should display remove button', () => {
+  render(SecretVaultActions, { object: secret });
+
+  expect(screen.getByRole('button', { name: 'Remove secret' })).toBeInTheDocument();
+});
+
+test('should show confirmation dialog when remove button clicked', async () => {
+  render(SecretVaultActions, { object: secret });
+
+  const removeButton = screen.getByRole('button', { name: 'Remove secret' });
+  await fireEvent.click(removeButton);
+
+  expect(window.showMessageBox).toHaveBeenCalledOnce();
+});
+
+test('should remove secret when user confirms removal', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  render(SecretVaultActions, { object: secret });
+
+  const removeButton = screen.getByRole('button', { name: 'Remove secret' });
+  await fireEvent.click(removeButton);
+
+  await waitFor(() => {
+    expect(window.removeSecret).toHaveBeenCalledWith('github-pat');
+  });
+});
+
+test('should not remove secret when user cancels removal', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+
+  render(SecretVaultActions, { object: secret });
+
+  const removeButton = screen.getByRole('button', { name: 'Remove secret' });
+  await fireEvent.click(removeButton);
+
+  expect(window.removeSecret).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.svelte
+++ b/packages/renderer/src/lib/secret-vault/columns/SecretVaultActions.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
+import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
+
+interface Props {
+  object: SecretVaultInfo;
+}
+
+let { object }: Props = $props();
+
+function handleRemove(): void {
+  withConfirmation(() => window.removeSecret(object.id).catch(console.error), `remove secret ${object.name}`);
+}
+</script>
+
+<ListItemButtonIcon
+  title="Remove secret"
+  icon={faTrash}
+  onClick={handleRemove} />


### PR DESCRIPTION
Allow users to delete a secret directly from the list view instead of having to navigate to the details page first.
<img width="1499" height="225" alt="Captura de pantalla 2026-05-13 a las 11 16 26" src="https://github.com/user-attachments/assets/f09c4eaf-168b-457b-8848-f850deafd1b4" />
<img width="669" height="288" alt="Captura de pantalla 2026-05-13 a las 11 16 35" src="https://github.com/user-attachments/assets/f9765329-186a-4872-a666-388f81356b47" />
Closes #1816