### PR TITLE
feat(agent-workspaces): add workspace general settings with name editing

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { access, readFile, rm } from 'node:fs/promises';
+import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { FileSystemWatcher } from '@openkaiden/api';
@@ -171,6 +171,10 @@ describe('init', () => {
 
   test('registers IPC handler for getConfiguration', () => {
     expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:getConfiguration', expect.any(Function));
+  });
+
+  test('registers IPC handler for updateConfiguration', () => {
+    expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:updateConfiguration', expect.any(Function));
   });
 
   test('registers IPC handler for start', () => {
@@ -815,6 +819,82 @@ describe('getConfiguration', () => {
     vi.mocked(readFile).mockRejectedValue(eacces);
 
     await expect(manager.getConfiguration('ws-1')).rejects.toThrow('EACCES: permission denied');
+  });
+});
+
+describe('updateConfiguration', () => {
+  test('delegates to kdnCli.updateWorkspaceConfig with the workspace configuration path', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
+    vi.mocked(kdnCli.updateWorkspaceConfig).mockResolvedValue(undefined);
+
+    await manager.updateConfiguration('ws-1', { skills: ['/path/to/skill'] });
+
+    expect(kdnCli.updateWorkspaceConfig).toHaveBeenCalledWith('/tmp/ws1/.kaiden', { skills: ['/path/to/skill'] });
+  });
+
+  test('emits agent-workspace-update event', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
+    vi.mocked(kdnCli.updateWorkspaceConfig).mockResolvedValue(undefined);
+
+    await manager.updateConfiguration('ws-1', { network: { mode: 'allow' } });
+
+    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
+  });
+
+  test('throws when workspace id is not found', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
+
+    await expect(manager.updateConfiguration('unknown-id', {})).rejects.toThrow(
+      'workspace "unknown-id" not found. Use "workspace list" to see available workspaces.',
+    );
+  });
+
+  test('propagates errors from kdnCli.updateWorkspaceConfig', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
+    vi.mocked(kdnCli.updateWorkspaceConfig).mockRejectedValue(new Error('permission denied'));
+
+    await expect(manager.updateConfiguration('ws-1', {})).rejects.toThrow('permission denied');
+  });
+});
+
+describe('updateSummary', () => {
+  const INSTANCES_JSON = [
+    { id: 'ws-1', name: 'old-name', paths: { source: '/tmp/ws1' } },
+    { id: 'ws-2', name: 'other-workspace', paths: { source: '/tmp/ws2' } },
+  ];
+
+  test('updates the name of the matching workspace in instances.json', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(INSTANCES_JSON));
+
+    await manager.updateSummary('ws-1', { name: 'new-name' });
+
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringMatching(/\.kdn[\\/]instances\.json$/),
+      expect.any(String),
+      'utf-8',
+    );
+    const written = JSON.parse(vi.mocked(writeFile).mock.calls[0]![1] as string) as { id: string; name: string }[];
+    expect(written.find(w => w.id === 'ws-1')?.name).toBe('new-name');
+    expect(written.find(w => w.id === 'ws-2')?.name).toBe('other-workspace');
+  });
+
+  test('throws when workspace id is not found', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(INSTANCES_JSON));
+
+    await expect(manager.updateSummary('unknown-id', { name: 'x' })).rejects.toThrow(
+      'workspace "unknown-id" not found in instances.json',
+    );
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('propagates file read errors', async () => {
+    vi.mocked(readFile).mockRejectedValue(new Error('EACCES: permission denied'));
+
+    await expect(manager.updateSummary('ws-1', { name: 'x' })).rejects.toThrow('EACCES: permission denied');
+  });
+
+  test('registers IPC handler for updateSummary', () => {
+    expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:updateSummary', expect.any(Function));
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { access, readFile, rm } from 'node:fs/promises';
+import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -267,6 +267,33 @@ export class AgentWorkspaceManager implements Disposable {
     }
   }
 
+  async updateConfiguration(id: string, config: Partial<AgentWorkspaceConfiguration>): Promise<void> {
+    const workspaces = await this.list();
+    const workspace = workspaces.find(ws => ws.id === id);
+    if (!workspace) {
+      throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
+    }
+    await this.kdnCli.updateWorkspaceConfig(workspace.paths.configuration, config);
+    this.apiSender.send('agent-workspace-update');
+  }
+
+  async updateSummary(id: string, update: Pick<AgentWorkspaceSummary, 'name'>): Promise<void> {
+    const instancesPath = join(homedir(), '.kdn', 'instances.json');
+    const raw = await readFile(instancesPath, 'utf-8');
+    const instances: unknown[] = JSON.parse(raw) as unknown[];
+    const entry = instances.find(
+      (item): item is Record<string, unknown> =>
+        typeof item === 'object' && item !== null && (item as Record<string, unknown>)['id'] === id,
+    );
+    if (!entry) {
+      throw new Error(`workspace "${id}" not found in instances.json`);
+    }
+    if (update.name !== undefined) {
+      entry['name'] = update.name;
+    }
+    await writeFile(instancesPath, JSON.stringify(instances, undefined, 4) + '\n', 'utf-8');
+  }
+
   async start(id: string): Promise<AgentWorkspaceId> {
     const result = await this.kdnCli.startWorkspace(id);
     this.apiSender.send('agent-workspace-update');
@@ -359,6 +386,20 @@ export class AgentWorkspaceManager implements Disposable {
       'agent-workspace:getConfiguration',
       async (_listener: unknown, id: string): Promise<AgentWorkspaceConfiguration> => {
         return this.getConfiguration(id);
+      },
+    );
+
+    this.ipcHandle(
+      'agent-workspace:updateConfiguration',
+      async (_listener: unknown, id: string, config: Partial<AgentWorkspaceConfiguration>): Promise<void> => {
+        return this.updateConfiguration(id, config);
+      },
+    );
+
+    this.ipcHandle(
+      'agent-workspace:updateSummary',
+      async (_listener: unknown, id: string, update: Pick<AgentWorkspaceSummary, 'name'>): Promise<void> => {
+        return this.updateSummary(id, update);
       },
     );
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -684,6 +684,59 @@ describe('create', () => {
   });
 });
 
+describe('updateWorkspaceConfig', () => {
+  const CONFIG_DIR = '/tmp/ws1/.kaiden';
+
+  test('merges update into existing workspace.json', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ skills: ['/path/to/skill1'] }));
+
+    await kdnCli.updateWorkspaceConfig(CONFIG_DIR, { network: { mode: 'deny', hosts: ['api.example.com'] } });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/path/to/skill1']);
+    expect(parsed.network).toEqual({ mode: 'deny', hosts: ['api.example.com'] });
+  });
+
+  test('creates new workspace.json when file does not exist', async () => {
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+
+    await kdnCli.updateWorkspaceConfig(CONFIG_DIR, { skills: ['/path/to/skill1'] });
+
+    expect(writeFile).toHaveBeenCalledWith(join(CONFIG_DIR, 'workspace.json'), expect.any(String), 'utf-8');
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/path/to/skill1']);
+  });
+
+  test('overwrites existing fields when update contains the same key', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ skills: ['/old/skill'], network: { mode: 'allow' } }));
+
+    await kdnCli.updateWorkspaceConfig(CONFIG_DIR, { skills: ['/new/skill'] });
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]![1] as string;
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.skills).toEqual(['/new/skill']);
+    expect(parsed.network).toEqual({ mode: 'allow' });
+  });
+
+  test('propagates non-ENOENT read errors', async () => {
+    const permError: NodeJS.ErrnoException = new Error('EACCES');
+    permError.code = 'EACCES';
+    vi.mocked(readFile).mockRejectedValue(permError);
+
+    await expect(kdnCli.updateWorkspaceConfig(CONFIG_DIR, { skills: [] })).rejects.toThrow('EACCES');
+  });
+
+  test('writes to correct path under configurationPath', async () => {
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+
+    await kdnCli.updateWorkspaceConfig('/custom/config/path', { ports: [8080] });
+
+    expect(writeFile).toHaveBeenCalledWith(join('/custom/config/path', 'workspace.json'), expect.any(String), 'utf-8');
+  });
+});
+
 describe('list', () => {
   test('executes kdn workspace list and returns items', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -269,6 +269,24 @@ export class KdnCli {
     await writeFile(configPath, output, 'utf-8');
   }
 
+  async updateWorkspaceConfig(configurationPath: string, update: Partial<WorkspaceConfiguration>): Promise<void> {
+    const configPath = join(configurationPath, 'workspace.json');
+
+    let existing: WorkspaceConfiguration = {};
+    try {
+      const content = await readFile(configPath, 'utf-8');
+      existing = JSON.parse(content) as WorkspaceConfiguration;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw err;
+      }
+    }
+
+    const merged = { ...existing, ...update };
+    const output = JSON.stringify(merged, undefined, 2) + '\n';
+    await writeFile(configPath, output, 'utf-8');
+  }
+
   async listWorkspaces(): Promise<AgentWorkspaceSummary[]> {
     const response = await this.execCLI<{ items: AgentWorkspaceSummary[] }>(['workspace', 'list']);
     return response.items;

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -352,6 +352,20 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld(
+    'updateAgentWorkspaceConfiguration',
+    async (id: string, config: AgentWorkspaceConfiguration): Promise<void> => {
+      return ipcInvoke('agent-workspace:updateConfiguration', id, config);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'updateAgentWorkspaceSummary',
+    async (id: string, update: Pick<AgentWorkspaceSummary, 'name'>): Promise<void> => {
+      return ipcInvoke('agent-workspace:updateSummary', id, update);
+    },
+  );
+
   contextBridge.exposeInMainWorld('startAgentWorkspace', async (id: string): Promise<AgentWorkspaceId> => {
     return ipcInvoke('agent-workspace:start', id);
   });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -379,10 +379,10 @@ test('Expect files tab is not present', async () => {
   });
 });
 
-test('Expect settings tab is not present', async () => {
+test('Expect settings tab is present', async () => {
   render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
 
   await waitFor(() => {
-    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
   });
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -4,6 +4,7 @@ import { ErrorMessage, Tab } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import AgentWorkspaceDetailsOverview from '/@/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte';
+import AgentWorkspaceDetailsSettings from '/@/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte';
 import AgentWorkspaceTerminal from '/@/lib/agent-workspaces/AgentWorkspaceTerminal.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
@@ -122,7 +123,7 @@ function handleRemove(): void {
     <Tab title="Overview" selected={isTabSelected($router.path, 'overview')} url={getTabUrl($router.path, 'overview')} />
     <Tab title="Terminal" selected={isTabSelected($router.path, 'terminal')} url={getTabUrl($router.path, 'terminal')} />
     <!-- <Tab title="Files" selected={isTabSelected($router.path, 'files')} url={getTabUrl($router.path, 'files')} /> -->
-    <!-- <Tab title="Settings" selected={isTabSelected($router.path, 'settings')} url={getTabUrl($router.path, 'settings')} /> -->
+    <Tab title="Settings" selected={isTabSelected($router.path, 'settings')} url={getTabUrl($router.path, 'settings')} />
   {/snippet}
   {#snippet contentSnippet()}
     <Route path="/overview" breadcrumb="Overview" navigationHint="tab">
@@ -139,9 +140,9 @@ function handleRemove(): void {
     </Route>
     <!-- <Route path="/files" breadcrumb="Files" navigationHint="tab">
       <AgentWorkspaceDetailsFiles />
-    </Route>
-    <Route path="/settings" breadcrumb="Settings" navigationHint="tab">
-      <AgentWorkspaceDetailsSettings />
     </Route> -->
+    <Route path="/settings" breadcrumb="Settings" navigationHint="tab">
+      <AgentWorkspaceDetailsSettings {workspaceId} {workspaceSummary} {configuration} />
+    </Route>
   {/snippet}
 </DetailsPage>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -1,0 +1,179 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { AgentWorkspaceConfiguration, AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+
+import AgentWorkspaceDetailsSettings from './AgentWorkspaceDetailsSettings.svelte';
+
+vi.mock(import('tinro'));
+
+const routerStore = writable({
+  path: '/agent-workspaces/ws-1/settings',
+  url: '/agent-workspaces/ws-1/settings',
+  from: '/',
+  query: {} as Record<string, string>,
+  hash: '',
+});
+
+const workspaceSummary: AgentWorkspaceSummary = {
+  id: 'ws-1',
+  name: 'api-refactor',
+  project: 'backend',
+  agent: 'opencode',
+  model: 'gpt-4o',
+  runtime: 'podman',
+  state: 'stopped',
+  paths: {
+    source: '/home/user/projects/backend',
+    configuration: '/home/user/.config/kaiden/workspaces/api-refactor.yaml',
+  },
+  timestamps: { created: 1700000000000, started: 1700100000000 },
+  forwards: [],
+};
+
+const configuration: AgentWorkspaceConfiguration = {
+  mounts: [{ host: '$SOURCES/../shared-lib', target: '/workspace/shared-lib', ro: false }],
+  environment: [{ name: 'API_KEY', value: 'test-key' }],
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(router).subscribe.mockImplementation(routerStore.subscribe);
+  vi.mocked(window.updateAgentWorkspaceSummary).mockResolvedValue(undefined);
+});
+
+test('Expect General section is active by default with workspace info', () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  expect(screen.getByText('Workspace Information')).toBeInTheDocument();
+});
+
+test('Expect workspace name is displayed in input', () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  expect(nameInput).toHaveValue('api-refactor');
+});
+
+test('Expect working directory is displayed in input', () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const dirInput = screen.getByRole('textbox', { name: 'Working Directory' });
+  expect(dirInput).toHaveValue('/home/user/projects/backend');
+});
+
+test('Expect switching to a placeholder section shows future update message', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const skillsNav = screen.getByRole('link', { name: 'Agent Skills' });
+  await fireEvent.click(skillsNav);
+
+  expect(screen.getByText('Agent Skills settings will be available in a future update.')).toBeInTheDocument();
+});
+
+test('Expect all settings nav sections are rendered', () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  for (const label of ['General', 'Agent Skills', 'MCP Servers', 'Knowledge', 'File Access', 'Network', 'Advanced']) {
+    expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+  }
+});
+
+test('Expect workspace name input is editable', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  expect(nameInput).not.toHaveAttribute('readonly');
+  await fireEvent.input(nameInput, { target: { value: 'new-name' } });
+  expect(nameInput).toHaveValue('new-name');
+});
+
+test('Expect save/discard bar shown when workspace name is modified', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  await fireEvent.input(nameInput, { target: { value: 'renamed' } });
+
+  expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Discard changes' })).toBeInTheDocument();
+});
+
+test('Expect save/discard bar not shown when workspace name matches original', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  await fireEvent.input(nameInput, { target: { value: 'api-refactor' } });
+
+  expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+});
+
+test('Expect clicking Save changes calls updateAgentWorkspaceSummary', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  await fireEvent.input(nameInput, { target: { value: 'renamed' } });
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.updateAgentWorkspaceSummary).toHaveBeenCalledWith('ws-1', { name: 'renamed' });
+});
+
+test('Expect clicking Discard changes resets workspace name to original', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  await fireEvent.input(nameInput, { target: { value: 'renamed' } });
+  await fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+
+  expect(nameInput).toHaveValue('api-refactor');
+  expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+  expect(window.updateAgentWorkspaceSummary).not.toHaveBeenCalled();
+});
+
+test('Expect no save when workspace name has not changed', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  await fireEvent.input(nameInput, { target: { value: 'api-refactor' } });
+
+  expect(window.updateAgentWorkspaceSummary).not.toHaveBeenCalled();
+});
+
+test('Expect working directory input is readonly', () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const dirInput = screen.getByRole('textbox', { name: 'Working Directory' });
+  expect(dirInput).toHaveAttribute('readonly');
+});
+
+test('Expect empty inputs when workspace summary is undefined', () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary: undefined, configuration: {} });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  expect(nameInput).toHaveValue('');
+
+  const dirInput = screen.getByRole('textbox', { name: 'Working Directory' });
+  expect(dirInput).toHaveValue('');
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -177,3 +177,22 @@ test('Expect empty inputs when workspace summary is undefined', () => {
   const dirInput = screen.getByRole('textbox', { name: 'Working Directory' });
   expect(dirInput).toHaveValue('');
 });
+
+test('Expect error dialog shown when save fails', async () => {
+  vi.mocked(window.updateAgentWorkspaceSummary).mockRejectedValue(new Error('network timeout'));
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
+  await fireEvent.input(nameInput, { target: { value: 'new-name' } });
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.showMessageBox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      title: 'Agent Workspace',
+      type: 'error',
+      message: expect.stringContaining('network timeout'),
+    }),
+  );
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -40,7 +40,16 @@ const hasChanges = $derived(workspaceName.trim() !== originalName && workspaceNa
 async function saveChanges(): Promise<void> {
   const trimmed = workspaceName.trim();
   if (!trimmed || trimmed === originalName) return;
-  await window.updateAgentWorkspaceSummary(workspaceId, { name: trimmed });
+  try {
+    await window.updateAgentWorkspaceSummary(workspaceId, { name: trimmed });
+  } catch (err: unknown) {
+    await window.showMessageBox({
+      title: 'Agent Workspace',
+      type: 'error',
+      message: `Failed to save workspace settings: ${err instanceof Error ? err.message : String(err)}`,
+      buttons: ['OK'],
+    });
+  }
 }
 
 function discardChanges(): void {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-import { SettingsNavItem } from '@podman-desktop/ui-svelte';
+import { Button, Input, SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
+
+import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
+import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
 
 type SettingsSection = 'general' | 'skills' | 'mcp' | 'knowledge' | 'file-access' | 'network' | 'advanced';
 
@@ -8,6 +11,14 @@ interface SectionConfig {
   id: SettingsSection;
   label: string;
 }
+
+interface Props {
+  workspaceId: string;
+  workspaceSummary: AgentWorkspaceSummaryUI | undefined;
+  configuration: AgentWorkspaceConfiguration;
+}
+
+let { workspaceId, workspaceSummary, configuration = $bindable() }: Props = $props();
 
 const sections: SectionConfig[] = [
   { id: 'general', label: 'General' },
@@ -21,6 +32,20 @@ const sections: SectionConfig[] = [
 
 let activeSection: SettingsSection = $state('general');
 const activeLabel = $derived(sections.find(s => s.id === activeSection)?.label ?? '');
+
+const originalName = $derived(workspaceSummary?.name ?? '');
+let workspaceName = $state(originalName);
+const hasChanges = $derived(workspaceName.trim() !== originalName && workspaceName.trim().length > 0);
+
+async function saveChanges(): Promise<void> {
+  const trimmed = workspaceName.trim();
+  if (!trimmed || trimmed === originalName) return;
+  await window.updateAgentWorkspaceSummary(workspaceId, { name: trimmed });
+}
+
+function discardChanges(): void {
+  workspaceName = originalName;
+}
 </script>
 
 <div class="flex flex-row w-full h-full">
@@ -46,17 +71,59 @@ const activeLabel = $derived(sections.find(s => s.id === activeSection)?.label ?
   </nav>
 
   <div class="flex flex-col flex-1 min-w-0 h-full bg-[var(--pd-content-bg)]">
+    <div class="flex flex-row items-center gap-3 px-8 py-3 bg-[var(--pd-content-card-bg)] border-b border-[var(--pd-content-card-border)]">
+      <span class="text-sm text-[var(--pd-content-text)]">{hasChanges ? 'You have unsaved changes' : 'No changes to save'}</span>
+      <div class="flex flex-row gap-2 ml-auto">
+        <Button type="secondary" onclick={discardChanges} disabled={!hasChanges}>Discard changes</Button>
+        <Button onclick={saveChanges} disabled={!hasChanges}>Save changes</Button>
+      </div>
+    </div>
     <div class="p-8 overflow-auto h-full">
       <div class="max-w-[800px]">
         <h2 class="text-xl font-semibold text-[var(--pd-content-header)] mb-2">{activeLabel}</h2>
-        <p class="text-sm text-[var(--pd-content-text)] mb-7">
-          Configure {activeLabel.toLowerCase()} settings for this workspace.
-        </p>
-        <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg p-6">
-          <p class="text-sm text-[var(--pd-content-text)] opacity-60">
-            {activeLabel} settings will be available in a future update.
+
+        {#if activeSection === 'general'}
+          <p class="text-sm text-[var(--pd-content-text)] mb-7">
+            Configure the basic settings for your workspace.
           </p>
-        </div>
+
+          <div class="flex flex-col gap-5">
+            <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg p-6">
+              <div class="mb-5">
+                <h3 class="text-[15px] font-semibold text-[var(--pd-content-card-header-text)] mb-1">Workspace Information</h3>
+                <p class="text-[13px] text-[var(--pd-content-text)] opacity-60 m-0">Basic details about this workspace</p>
+              </div>
+              <div class="flex flex-col gap-5">
+                <div class="flex flex-col gap-2">
+                  <label for="input-workspace-name" class="text-[13px] font-semibold text-[var(--pd-content-card-header-text)]">Workspace Name</label>
+                  <Input
+                    id="input-workspace-name"
+                    aria-label="Workspace Name"
+                    bind:value={workspaceName} />
+                </div>
+                <div class="flex flex-col gap-2">
+                  <label for="input-working-directory" class="text-[13px] font-semibold text-[var(--pd-content-card-header-text)]">Working Directory</label>
+                  <Input
+                    id="input-working-directory"
+                    aria-label="Working Directory"
+                    value={workspaceSummary?.paths.source ?? ''}
+                    readonly />
+                  <p class="text-[12px] text-[var(--pd-content-text)] opacity-50 m-0">The directory where the agent will operate</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+        {:else}
+          <p class="text-sm text-[var(--pd-content-text)] mb-7">
+            Configure {activeLabel.toLowerCase()} settings for this workspace.
+          </p>
+          <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] rounded-lg p-6">
+            <p class="text-sm text-[var(--pd-content-text)] opacity-60">
+              {activeLabel} settings will be available in a future update.
+            </p>
+          </div>
+        {/if}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Enables the Settings tab in workspace details and implements the General settings section, allowing users to edit the workspace name. Adds updateConfiguration and updateSummary methods to AgentWorkspaceManager and KdnCli, with corresponding IPC handlers and preload bridge exposure.


https://github.com/user-attachments/assets/d49b7bec-6122-4324-ae62-7eda42131d77



Closes  https://github.com/openkaiden/kaiden/issues/1617

Folows the design of the mockup and adds an option to update the workspace name

