### PR TITLE
feat(secret-manager): watch secrets file for external changes

### DIFF
--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -16,10 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { FileSystemWatcher } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
 import type { Exec } from '/@/plugin/util/exec.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
@@ -52,9 +54,20 @@ const apiSender: ApiSenderType = {
 const ipcHandle: IPCHandle = vi.fn();
 const kdnCli = new KdnCli({} as Exec, {} as CliToolRegistry);
 
+const mockWatcher = {
+  onDidChange: vi.fn(),
+  onDidCreate: vi.fn(),
+  onDidDelete: vi.fn(),
+  dispose: vi.fn(),
+} as unknown as FileSystemWatcher;
+const filesystemMonitoring = {
+  createFileSystemWatcher: vi.fn().mockReturnValue(mockWatcher),
+} as unknown as FilesystemMonitoring;
+
 beforeEach(() => {
   vi.resetAllMocks();
-  manager = new SecretManager(apiSender, ipcHandle, kdnCli);
+  vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
+  manager = new SecretManager(apiSender, ipcHandle, kdnCli, filesystemMonitoring);
   manager.init();
 });
 
@@ -69,6 +82,39 @@ describe('init', () => {
 
   test('registers IPC handler for remove', () => {
     expect(ipcHandle).toHaveBeenCalledWith('secret-manager:remove', expect.any(Function));
+  });
+});
+
+describe('watchSecretsFile', () => {
+  test('watches ~/.kdn/secrets.json on init', () => {
+    expect(filesystemMonitoring.createFileSystemWatcher).toHaveBeenCalledWith(
+      expect.stringMatching(/\.kdn[\\/]secrets\.json$/),
+    );
+  });
+
+  test('sends secret-manager-update on file change', () => {
+    const changeCallback = vi.mocked(mockWatcher.onDidChange).mock.calls[0]![0] as () => void;
+    changeCallback();
+    expect(apiSender.send).toHaveBeenCalledWith('secret-manager-update');
+  });
+
+  test('sends secret-manager-update on file create', () => {
+    const createCallback = vi.mocked(mockWatcher.onDidCreate).mock.calls[0]![0] as () => void;
+    createCallback();
+    expect(apiSender.send).toHaveBeenCalledWith('secret-manager-update');
+  });
+
+  test('sends secret-manager-update on file delete', () => {
+    const deleteCallback = vi.mocked(mockWatcher.onDidDelete).mock.calls[0]![0] as () => void;
+    deleteCallback();
+    expect(apiSender.send).toHaveBeenCalledWith('secret-manager-update');
+  });
+});
+
+describe('dispose', () => {
+  test('disposes the secrets watcher', () => {
+    manager.dispose();
+    expect(mockWatcher.dispose).toHaveBeenCalled();
   });
 });
 

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -16,18 +16,29 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { inject, injectable } from 'inversify';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
+import { inject, injectable, preDestroy } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
+import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { SecretCreateOptions, SecretInfo, SecretName, SecretService } from '/@api/secret-info.js';
 
 /**
  * Manages secrets by delegating to the `kdn` CLI.
+ *
+ * Watches `~/.kdn/secrets.json` so that external mutations
+ * (e.g. `kdn secret remove` run from a terminal) are picked
+ * up and forwarded to the renderer.
  */
 @injectable()
-export class SecretManager {
+export class SecretManager implements Disposable {
+  private secretsWatcher: FileSystemWatcher | undefined;
+
   constructor(
     @inject(ApiSenderType)
     private readonly apiSender: ApiSenderType,
@@ -35,6 +46,8 @@ export class SecretManager {
     private readonly ipcHandle: IPCHandle,
     @inject(KdnCli)
     private readonly kdnCli: KdnCli,
+    @inject(FilesystemMonitoring)
+    private readonly filesystemMonitoring: FilesystemMonitoring,
   ) {}
 
   async create(options: SecretCreateOptions): Promise<SecretName> {
@@ -76,5 +89,24 @@ export class SecretManager {
     this.ipcHandle('secret-manager:list-services', async (): Promise<SecretService[]> => {
       return this.listServices();
     });
+
+    this.watchSecretsFile();
+  }
+
+  private watchSecretsFile(): void {
+    this.secretsWatcher?.dispose();
+    const secretsPath = join(homedir(), '.kdn', 'secrets.json');
+    this.secretsWatcher = this.filesystemMonitoring.createFileSystemWatcher(secretsPath);
+    const notify = (): void => {
+      this.apiSender.send('secret-manager-update');
+    };
+    this.secretsWatcher.onDidChange(notify);
+    this.secretsWatcher.onDidCreate(notify);
+    this.secretsWatcher.onDidDelete(notify);
+  }
+
+  @preDestroy()
+  dispose(): void {
+    this.secretsWatcher?.dispose();
   }
 }


### PR DESCRIPTION
Inject FilesystemMonitoring into SecretManager and watch ~/.kdn/secrets.json so that mutations made outside the app (e.g. `kdn secret remove` from a terminal) are detected and forwarded to the renderer via the `secret-manager-update` event.


https://github.com/user-attachments/assets/08d313d8-8227-4d30-82d4-bc2a62d6c1e0



Closes https://github.com/openkaiden/kaiden/issues/1815