### PR TITLE
fix(agent-workspaces): show error dialog when workspace creation or start fails

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -1526,4 +1526,53 @@ test('Expect startWorkspace does not pass replaceConfig when configAction is mer
   );
 });
 
+test('Expect error dialog shown when createAgentWorkspace fails from use-all-defaults', async () => {
+  vi.mocked(window.createAgentWorkspace).mockRejectedValue(new Error('container runtime not available'));
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: expect.stringContaining('container runtime not available'),
+      }),
+    );
+  });
+});
+
+test('Expect error dialog shown when createAgentWorkspace fails from Start Workspace button', async () => {
+  vi.mocked(window.createAgentWorkspace).mockRejectedValue(new Error('sandbox init failed'));
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+
+  for (let i = 0; i < wizardStepCount - 1; i++) {
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  }
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: expect.stringContaining('sandbox init failed'),
+      }),
+    );
+  });
+});
+
 const wizardStepCount = 5;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -405,6 +405,12 @@ async function startAsIs(): Promise<void> {
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace (as-is)', err);
+    await window.showMessageBox({
+      title: 'Agent Workspace',
+      type: 'error',
+      message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
+      buttons: ['OK'],
+    });
   }
 }
 
@@ -455,6 +461,12 @@ async function startWorkspace(): Promise<void> {
     });
   } catch (err: unknown) {
     console.error('Failed to create agent workspace', err);
+    await window.showMessageBox({
+      title: 'Agent Workspace',
+      type: 'error',
+      message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
+      buttons: ['OK'],
+    });
   }
 }
 </script>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -325,6 +325,29 @@ test('Expect clicking terminal button does not start workspace when already runn
   expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
 });
 
+test('Expect error dialog shown when terminal button start fails', async () => {
+  vi.mocked(window.startAgentWorkspace).mockRejectedValue(new Error('sandbox init failed'));
+
+  render(AgentWorkspaceDetails, { workspaceId: 'ws-1' });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Terminal' })).toBeInTheDocument();
+  });
+
+  const terminalButton = screen.getByRole('button', { name: 'Open Terminal' });
+  await fireEvent.click(terminalButton);
+
+  await waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: expect.stringContaining('sandbox init failed'),
+      }),
+    );
+  });
+});
+
 test('Expect error dialog shown when stop fails', async () => {
   agentWorkspaces.set([{ ...workspaceSummary, state: 'running' }]);
   vi.mocked(window.stopAgentWorkspace).mockRejectedValue(new Error('stop timeout'));

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -76,7 +76,15 @@ async function handleStartStop(): Promise<void> {
 
 function handleTerminal(): void {
   if (!isRunning && !inProgress) {
-    startAgentWorkspace(workspaceId).catch(console.error);
+    startAgentWorkspace(workspaceId).catch(async (error: unknown) => {
+      const name = workspaceSummary?.name ?? workspaceId;
+      await window.showMessageBox({
+        title: 'Agent Workspace',
+        type: 'error',
+        message: `Error while starting workspace "${name}": ${error}`,
+        buttons: ['OK'],
+      });
+    });
   }
   router.goto(`/agent-workspaces/${encodeURIComponent(workspaceId)}/terminal`);
 }


### PR DESCRIPTION
Shows dialog when there is an error when creating workspace


https://github.com/user-attachments/assets/c2c48fd0-03ec-4453-b4b9-a7abb46a910d



Closes https://github.com/openkaiden/kaiden/issues/1740