### PR TITLE
fix(agent-workspaces): inject Vertex AI config into workspace at creation time

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -532,7 +532,7 @@ describe('ensureModelSecret', () => {
     expect(secretManager.create).not.toHaveBeenCalled();
   });
 
-  test('skips when credentials map has multiple entries (Vertex AI)', async () => {
+  test('applies Vertex AI workspace configuration instead of creating a secret', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { projectId: 'my-project', region: 'us-east5', credentialsFile: '/path/to/creds.json' },
       llmMetadataName: 'vertexai',
@@ -543,6 +543,83 @@ describe('ensureModelSecret', () => {
     await manager.ensureModelSecret(options);
 
     expect(secretManager.create).not.toHaveBeenCalled();
+    expect(options.workspaceConfiguration?.environment).toEqual([
+      { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+      { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+      { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-project' },
+    ]);
+    expect(options.workspaceConfiguration?.mounts).toEqual([
+      { host: '/path/to/creds.json', target: '$HOME/.config/gcloud/application_default_credentials.json', ro: true },
+    ]);
+  });
+
+  test('deduplicates Vertex AI env vars when workspaceConfiguration already has entries', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { projectId: 'my-project', region: 'us-east5', credentialsFile: '/path/to/creds.json' },
+      llmMetadataName: 'vertexai',
+      endpoint: undefined,
+    });
+
+    const options = {
+      ...baseOptions,
+      model: 'vertexai::claude-sonnet-4-20250514::',
+      workspaceConfiguration: {
+        environment: [
+          { name: 'CLOUD_ML_REGION', value: 'old-region' },
+          { name: 'OTHER_VAR', value: 'keep' },
+        ],
+        mounts: [
+          { host: '/old/creds.json', target: '$HOME/.config/gcloud/application_default_credentials.json', ro: true },
+        ],
+      },
+    } as AgentWorkspaceCreateOptions;
+    await manager.ensureModelSecret(options);
+
+    expect(options.workspaceConfiguration?.environment).toEqual([
+      { name: 'OTHER_VAR', value: 'keep' },
+      { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+      { name: 'CLOUD_ML_REGION', value: 'us-east5' },
+      { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-project' },
+    ]);
+    expect(options.workspaceConfiguration?.mounts).toEqual([
+      { host: '/path/to/creds.json', target: '$HOME/.config/gcloud/application_default_credentials.json', ro: true },
+    ]);
+  });
+
+  test('replaces tilde with $HOME in Vertex AI credentials file path', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: {
+        projectId: 'my-project',
+        region: 'us-east5',
+        credentialsFile: '~/.config/gcloud/application_default_credentials.json',
+      },
+      llmMetadataName: 'vertexai',
+      endpoint: undefined,
+    });
+
+    const options = { ...baseOptions, model: 'vertexai::claude-sonnet-4-20250514::' };
+    await manager.ensureModelSecret(options);
+
+    expect(options.workspaceConfiguration?.mounts).toEqual([
+      {
+        host: '$HOME/.config/gcloud/application_default_credentials.json',
+        target: '$HOME/.config/gcloud/application_default_credentials.json',
+        ro: true,
+      },
+    ]);
+  });
+
+  test('skips Vertex AI config when credentials are incomplete', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { projectId: 'my-project', region: '', credentialsFile: '' },
+      llmMetadataName: 'vertexai',
+      endpoint: undefined,
+    });
+
+    const options = { ...baseOptions, model: 'vertexai::claude-sonnet-4-20250514::' };
+    await manager.ensureModelSecret(options);
+
+    expect(options.workspaceConfiguration).toBeUndefined();
   });
 
   test('skips when llmMetadataName is unknown', async () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -137,6 +137,11 @@ export class AgentWorkspaceManager implements Disposable {
     const connectionInfo = this.providerRegistry.getInferenceConnectionCredentials(options.model);
     if (!connectionInfo) return;
 
+    if (connectionInfo.llmMetadataName === 'vertexai') {
+      this.applyVertexAiConfiguration(options, connectionInfo.credentials);
+      return;
+    }
+
     const entries = Object.entries(connectionInfo.credentials);
     if (entries.length !== 1) return;
 
@@ -161,6 +166,32 @@ export class AgentWorkspaceManager implements Disposable {
       );
       options.workspaceConfiguration.environment.push(result.environmentVariable);
     }
+  }
+
+  private applyVertexAiConfiguration(options: AgentWorkspaceCreateOptions, credentials: Record<string, string>): void {
+    const { projectId, region, credentialsFile } = credentials;
+    if (!projectId || !region || !credentialsFile) return;
+
+    options.workspaceConfiguration ??= {};
+    options.workspaceConfiguration.environment ??= [];
+    options.workspaceConfiguration.mounts ??= [];
+
+    const envVars: Array<{ name: string; value: string }> = [
+      { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+      { name: 'CLOUD_ML_REGION', value: region },
+      { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: projectId },
+    ];
+    for (const env of envVars) {
+      options.workspaceConfiguration.environment = options.workspaceConfiguration.environment.filter(
+        e => e.name !== env.name,
+      );
+      options.workspaceConfiguration.environment.push(env);
+    }
+
+    const adcTarget = '$HOME/.config/gcloud/application_default_credentials.json';
+    const hostPath = credentialsFile.startsWith('~/') ? `$HOME/${credentialsFile.slice(2)}` : credentialsFile;
+    options.workspaceConfiguration.mounts = options.workspaceConfiguration.mounts.filter(m => m.target !== adcTarget);
+    options.workspaceConfiguration.mounts.push({ host: hostPath, target: adcTarget, ro: true });
   }
 
   /**


### PR DESCRIPTION
When a Vertex AI model is selected, ensureModelSecret now populates
the workspace configuration with the required environment variables
(CLAUDE_CODE_USE_VERTEX, CLOUD_ML_REGION, ANTHROPIC_VERTEX_PROJECT_ID)
and mounts the ADC credentials file. Previously this was only done
by the onboarding panel, which silently skipped it when a connection
already existed.

Fixes #1861
