### PR TITLE
fix(ollama): restrict LAN IP rewrite to Windows only

### DIFF
--- a/extensions/ollama/src/ollama-extension.spec.ts
+++ b/extensions/ollama/src/ollama-extension.spec.ts
@@ -20,7 +20,7 @@ import type { NetworkInterfaceInfo } from 'node:os';
 import { networkInterfaces } from 'node:os';
 
 import type { ExtensionContext, Provider } from '@openkaiden/api';
-import { provider } from '@openkaiden/api';
+import { env, provider } from '@openkaiden/api';
 import { http, HttpResponse } from 'msw';
 import { setupServer, type SetupServerApi } from 'msw/node';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -63,8 +63,8 @@ describe('OllamaExtension', () => {
     server?.close();
   });
 
-  test('should create provider, register subscription, and update models on activate', async () => {
-    // use msw to mock fetch
+  test('should use local IP endpoint on Windows', async () => {
+    vi.mocked(env).isWindows = true;
     const handlers = [
       http.get('http://localhost:11434/api/tags', () =>
         HttpResponse.json({ models: [{ name: 'm1' }, { name: 'm2' }] }),
@@ -79,6 +79,21 @@ describe('OllamaExtension', () => {
       expect.objectContaining({ endpoint: 'http://192.168.1.100:11434/v1' }),
     );
     expect(vi.mocked(ollamaProvider.updateStatus)).toHaveBeenCalledWith('started');
+  });
+
+  test('should use localhost endpoint on macOS/Linux', async () => {
+    vi.mocked(env).isWindows = false;
+    const handlers = [
+      http.get('http://localhost:11434/api/tags', () =>
+        HttpResponse.json({ models: [{ name: 'm1' }, { name: 'm2' }] }),
+      ),
+    ];
+    server = setupServer(...handlers);
+    server.listen({ onUnhandledRequest: 'error' });
+    await extension.activate();
+    expect(vi.mocked(ollamaProvider.registerInferenceProviderConnection)).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'http://localhost:11434/v1' }),
+    );
   });
 
   test('should set status to stopped if fetch fails', async () => {

--- a/extensions/ollama/src/ollama-extension.ts
+++ b/extensions/ollama/src/ollama-extension.ts
@@ -17,14 +17,19 @@
 
 import { networkInterfaces } from 'node:os';
 
-import { type Disposable, type ExtensionContext, type Provider, provider } from '@openkaiden/api';
+import { type Disposable, env, type ExtensionContext, type Provider, provider } from '@openkaiden/api';
 import { createOllama } from 'ollama-ai-provider-v2';
 
-function getLocalIP(): string {
-  for (const entries of Object.values(networkInterfaces())) {
-    for (const entry of entries ?? []) {
-      if (entry.family === 'IPv4' && !entry.internal) {
-        return entry.address;
+function getContainerReachableHost(): string {
+  if (env.isWindows) {
+    // WSL2: host.containers.internal doesn't reach Windows loopback.
+    // Use the first non-internal address (the WSL2 gateway-facing NIC).
+    // Requires OLLAMA_HOST=0.0.0.0 on the Windows side.
+    for (const entries of Object.values(networkInterfaces())) {
+      for (const entry of entries ?? []) {
+        if (!entry.internal) {
+          return entry.family === 'IPv6' ? `[${entry.address}]` : entry.address;
+        }
       }
     }
   }
@@ -116,7 +121,7 @@ export class OllamaExtension {
           name: 'ollama',
           type: 'local',
           llmMetadata: { name: 'ollama' },
-          endpoint: `http://${getLocalIP()}:11434/v1`,
+          endpoint: `http://${getContainerReachableHost()}:11434/v1`,
           sdk,
           status() {
             return 'started';


### PR DESCRIPTION
## Summary
- On Windows/WSL2, `host.containers.internal` doesn't reach Windows loopback, so we resolve the first non-internal IPv4 address (the WSL2 gateway NIC) — requires `OLLAMA_HOST=0.0.0.0`
- On macOS/Linux, Kaiden UI will output `localhost` — the kdn extension with Podman runtime will rewrite to `host.containers.internal`, and VM runtimes will have their own rewrite that satisfies them
- Uses `env.isWindows` from `@openkaiden/api` to match existing extension patterns (e.g. kdn extension)

| Platform | Endpoint rewritten to | Requires |
|----------|----------------------|----------|
| macOS | `localhost` | Nothing extra |
| Linux | `localhost` | Nothing extra |
| Windows | LAN IP from `networkInterfaces()` | `OLLAMA_HOST=0.0.0.0` |

Fixes: https://github.com/openkaiden/kaiden/issues/1885

Fixes: https://github.com/openkaiden/kaiden/issues/1780

## Test plan
- [ ] **Windows**: Set `OLLAMA_HOST=0.0.0.0`, start Ollama, create a workspace with Ollama provider — verify container can reach Ollama via LAN IP
- [ ] **macOS/Linux**: Start Ollama normally, create a workspace — verify container reaches Ollama via `localhost`
- [ ] Unit tests pass: `npx vitest run extensions/ollama/src/ollama-extension.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)