### PR TITLE
feat(kdn): add version upgrade/downgrade support via CLI Tools page

### DIFF
--- a/extensions/kdn/src/kdn-download.spec.ts
+++ b/extensions/kdn/src/kdn-download.spec.ts
@@ -24,7 +24,7 @@ import { PassThrough } from 'node:stream';
 import * as tar from 'tar';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { downloadKdn, getLatestRelease } from './kdn-download';
+import { downloadKdn, getAvailableVersions, getLatestRelease } from './kdn-download';
 import { sha256 } from './sha256';
 
 const getEntriesMock = vi.fn();
@@ -182,5 +182,116 @@ describe('getLatestRelease', () => {
     expect(release.digests.get('kdn_1.2.3_linux_amd64.tar.gz')).toBe('abc123');
     expect(release.digests.get('kdn_1.2.3_darwin_arm64.tar.gz')).toBe('def456');
     expect(release.digests.has('no-digest-asset.txt')).toBe(false);
+  });
+
+  test('passes signal to fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => ({ tag_name: 'v1.0.0', assets: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+
+    await getLatestRelease(controller.signal);
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal: controller.signal }));
+  });
+});
+
+describe('downloadKdn signal', () => {
+  test('passes signal through to fetch calls', async () => {
+    const fetchMock: ReturnType<typeof vi.fn> = vi.fn(() => Promise.resolve({ ok: true, body: new PassThrough() }));
+    vi.stubGlobal('fetch', fetchMock);
+    const digests = new Map([['kdn_0.5.0_linux_amd64.tar.gz', 'abc123']]);
+
+    vi.mocked(tar.extract).mockImplementation(async (opts: { cwd?: string }) => {
+      fileMap.set(normPath(path.join(opts.cwd ?? '', 'kdn')), true);
+    });
+
+    const controller = new AbortController();
+    await downloadKdn('0.5.0', 'linux', 'x64', '/output', digests, controller.signal);
+
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]).toEqual(expect.objectContaining({ signal: controller.signal }));
+    }
+  });
+});
+
+describe('getAvailableVersions', () => {
+  test('filters by platform/arch asset and excludes prereleases and legacy names', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => [
+          {
+            tag_name: 'v0.6.0',
+            name: 'kdn v0.6.0',
+            prerelease: false,
+            assets: [{ name: 'kdn_0.6.0_linux_amd64.tar.gz' }],
+          },
+          {
+            tag_name: 'v0.6.0-rc1',
+            name: 'kdn v0.6.0-rc1',
+            prerelease: true,
+            assets: [{ name: 'kdn_0.6.0-rc1_linux_amd64.tar.gz' }],
+          },
+          {
+            tag_name: 'v0.5.0',
+            name: 'kdn v0.5.0',
+            prerelease: false,
+            assets: [{ name: 'kdn_0.5.0_linux_amd64.tar.gz' }],
+          },
+          {
+            tag_name: 'v0.4.0',
+            name: null,
+            prerelease: false,
+            assets: [{ name: 'kortex-cli_0.4.0_linux_amd64.tar.gz' }],
+          },
+        ],
+      }),
+    );
+
+    const versions = await getAvailableVersions('linux', 'x64');
+
+    expect(versions).toEqual([
+      { label: 'kdn v0.6.0', tag: '0.6.0' },
+      { label: 'kdn v0.5.0', tag: '0.5.0' },
+    ]);
+  });
+
+  test('excludes releases missing the target platform archive', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => [
+          {
+            tag_name: 'v0.6.0',
+            name: 'kdn v0.6.0',
+            prerelease: false,
+            assets: [{ name: 'kdn_0.6.0_linux_amd64.tar.gz' }],
+          },
+        ],
+      }),
+    );
+
+    const versions = await getAvailableVersions('win32', 'x64');
+
+    expect(versions).toEqual([]);
+  });
+
+  test('limits to 5 versions', async () => {
+    const releases = Array.from({ length: 10 }, (_, i) => ({
+      tag_name: `v0.${10 - i}.0`,
+      name: `kdn v0.${10 - i}.0`,
+      prerelease: false,
+      assets: [{ name: `kdn_0.${10 - i}.0_linux_amd64.tar.gz` }],
+    }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => releases }));
+
+    const versions = await getAvailableVersions('linux', 'x64');
+
+    expect(versions).toHaveLength(5);
   });
 });

--- a/extensions/kdn/src/kdn-download.ts
+++ b/extensions/kdn/src/kdn-download.ts
@@ -34,7 +34,7 @@ interface ReleaseInfo {
   digests: Map<string, string>;
 }
 
-export async function getLatestRelease(): Promise<ReleaseInfo> {
+export async function getLatestRelease(signal?: AbortSignal): Promise<ReleaseInfo> {
   const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
   const token = process.env['GITHUB_TOKEN'];
   if (token) {
@@ -43,6 +43,7 @@ export async function getLatestRelease(): Promise<ReleaseInfo> {
   const res = await fetch(`https://api.github.com/repos/${KDN_REPO}/releases/latest`, {
     headers,
     redirect: 'follow',
+    signal,
   });
   if (!res.ok) {
     throw new Error(`failed to fetch latest kdn release: ${res.status} ${res.statusText}`);
@@ -58,11 +59,84 @@ export async function getLatestRelease(): Promise<ReleaseInfo> {
   return { version, digests };
 }
 
+export async function getReleaseByTag(version: string, signal?: AbortSignal): Promise<ReleaseInfo> {
+  const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
+  const token = process.env['GITHUB_TOKEN'];
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`https://api.github.com/repos/${KDN_REPO}/releases/tags/v${version}`, {
+    headers,
+    redirect: 'follow',
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`failed to fetch kdn release v${version}: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { tag_name: string; assets: { name: string; digest: string | null }[] };
+  const digests = new Map<string, string>();
+  for (const asset of data.assets) {
+    if (asset.digest) {
+      digests.set(asset.name, asset.digest.replace(/^sha256:/, ''));
+    }
+  }
+  return { version: data.tag_name.replace(/^v/, ''), digests };
+}
+
+interface KdnRelease {
+  label: string;
+  tag: string;
+}
+
 const PLATFORM_MAP: Record<string, string> = { darwin: 'darwin', linux: 'linux', win32: 'windows' };
 const ARCH_MAP: Record<string, string> = { x64: 'amd64', arm64: 'arm64' };
 
-export async function download(url: string, dest: string): Promise<void> {
-  const res = await fetch(url, { redirect: 'follow' });
+export async function getAvailableVersions(
+  platform: string,
+  arch: string,
+  signal?: AbortSignal,
+): Promise<KdnRelease[]> {
+  const kdnPlatform = PLATFORM_MAP[platform];
+  const kdnArch = ARCH_MAP[arch];
+  if (!kdnPlatform || !kdnArch) return [];
+
+  const ext = platform === 'win32' ? 'zip' : 'tar.gz';
+
+  const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
+  const token = process.env['GITHUB_TOKEN'];
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`https://api.github.com/repos/${KDN_REPO}/releases`, {
+    headers,
+    redirect: 'follow',
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`failed to fetch kdn releases: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as Array<{
+    tag_name: string;
+    name: string | null;
+    prerelease: boolean;
+    assets: Array<{ name: string }>;
+  }>;
+  return data
+    .filter(r => !r.prerelease)
+    .filter(r => {
+      const version = r.tag_name.replace(/^v/, '');
+      const expectedAsset = `kdn_${version}_${kdnPlatform}_${kdnArch}.${ext}`;
+      return r.assets.some(a => a.name === expectedAsset);
+    })
+    .slice(0, 5)
+    .map(r => ({
+      label: r.name ?? r.tag_name,
+      tag: r.tag_name.replace(/^v/, ''),
+    }));
+}
+
+export async function download(url: string, dest: string, signal?: AbortSignal): Promise<void> {
+  const res = await fetch(url, { redirect: 'follow', signal });
   if (!res.ok || !res.body) {
     throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
   }
@@ -122,6 +196,7 @@ export async function downloadKdn(
   arch: string,
   outputDir: string,
   digests: Map<string, string>,
+  signal?: AbortSignal,
 ): Promise<void> {
   const versionFile = join(outputDir, '.kdn-version');
   const versionMarker = `${version}-${platform}-${arch}`;
@@ -148,7 +223,7 @@ export async function downloadKdn(
   const archivePath = join(outputDir, assetFileName);
 
   console.log(`downloading kdn ${version} for ${platform}/${arch}...`);
-  await download(url, archivePath);
+  await download(url, archivePath, signal);
   await verifyChecksum(digests, assetFileName, archivePath);
 
   console.log(`extracting to ${outputDir}...`);

--- a/extensions/kdn/src/kdn-extension.spec.ts
+++ b/extensions/kdn/src/kdn-extension.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ***********************************************************************/
+ **********************************************************************/
 
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
@@ -23,9 +23,11 @@ import type { ExtensionContext } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
 import { afterAll, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import { downloadKdn, getAvailableVersions, getReleaseByTag } from './kdn-download';
 import { KdnExtension } from './kdn-extension';
 
 vi.mock(import('node:fs'));
+vi.mock(import('./kdn-download'));
 
 let extensionContext: ExtensionContext;
 let kdnExtension: KdnExtension;
@@ -62,6 +64,14 @@ beforeEach(() => {
   } as unknown as ExtensionContext;
 
   kdnExtension = new KdnExtension(extensionContext);
+
+  vi.mocked(getReleaseByTag).mockResolvedValue({ version: '0.6.0', digests: new Map() });
+
+  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({
+    dispose: vi.fn(),
+    registerUpdate: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    updateVersion: vi.fn(),
+  } as never);
 });
 
 test('registers from custom binary path setting when configured', async () => {
@@ -74,7 +84,6 @@ test('registers from custom binary path setting when configured', async () => {
     stdout: '',
     stderr: 'kdn version 2.0.0',
   });
-  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
 
   await kdnExtension.activate();
 
@@ -98,7 +107,6 @@ test('falls through when custom binary path is configured but file does not exis
     stdout: '',
     stderr: 'kdn version 0.5.0',
   });
-  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
 
   await kdnExtension.activate();
 
@@ -117,10 +125,10 @@ test('registers from extension storage when binary exists', async () => {
     stdout: '',
     stderr: 'kdn version 0.5.0',
   });
-  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
 
   await kdnExtension.activate();
 
+  expect(downloadKdn).not.toHaveBeenCalled();
   expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith(
     expect.objectContaining({
       name: 'kdn',
@@ -131,7 +139,7 @@ test('registers from extension storage when binary exists', async () => {
   );
 });
 
-test('registers from system PATH when not in extension storage', async () => {
+test('falls back to system PATH before attempting download', async () => {
   vi.mocked(existsSync).mockReturnValue(false);
   vi.mocked(extensionApi.process.exec)
     .mockResolvedValueOnce({
@@ -144,10 +152,10 @@ test('registers from system PATH when not in extension storage', async () => {
       stdout: '/usr/local/bin/kdn\n',
       stderr: '',
     });
-  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
 
   await kdnExtension.activate();
 
+  expect(downloadKdn).not.toHaveBeenCalled();
   expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith(
     expect.objectContaining({
       name: 'kdn',
@@ -158,17 +166,15 @@ test('registers from system PATH when not in extension storage', async () => {
   );
 });
 
-test('registers from bundled resources when not in extension storage or PATH', async () => {
+test('falls back to bundled resources before attempting download', async () => {
   vi.mocked(existsSync).mockReturnValueOnce(false).mockReturnValueOnce(true);
-  vi.mocked(extensionApi.process.exec).mockRejectedValueOnce(new Error('not found')).mockResolvedValueOnce({
-    command: 'kdn',
-    stdout: '',
-    stderr: 'kdn version 0.4.0',
-  });
-  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({ dispose: vi.fn() } as never);
+  vi.mocked(extensionApi.process.exec)
+    .mockRejectedValueOnce(new Error('not found'))
+    .mockResolvedValueOnce({ command: 'kdn', stdout: '', stderr: 'kdn version 0.4.0' });
 
   await kdnExtension.activate();
 
+  expect(downloadKdn).not.toHaveBeenCalled();
   expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith(
     expect.objectContaining({
       name: 'kdn',
@@ -190,16 +196,96 @@ test('throws when not found anywhere', async () => {
 });
 
 test('pushes cli tool to subscriptions for cleanup', async () => {
-  const disposable = { dispose: vi.fn() };
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(extensionApi.process.exec).mockResolvedValue({
     command: 'kdn',
     stdout: 'kdn version 0.5.0',
     stderr: '',
   });
-  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue(disposable as never);
 
   await kdnExtension.activate();
 
-  expect(extensionContext.subscriptions).toContain(disposable);
+  expect(extensionContext.subscriptions.length).toBeGreaterThanOrEqual(1);
+});
+
+test('registers updater when installationSource is extension', async () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    command: 'kdn',
+    stdout: '',
+    stderr: 'kdn version 0.5.0',
+  });
+
+  await kdnExtension.activate();
+
+  const cliTool = vi.mocked(extensionApi.cli.createCliTool).mock.results[0]?.value;
+  expect(cliTool.registerUpdate).toHaveBeenCalledWith(
+    expect.objectContaining({
+      selectVersion: expect.any(Function),
+      doUpdate: expect.any(Function),
+    }),
+  );
+});
+
+test('does not register updater when installationSource is external', async () => {
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(extensionApi.process.exec)
+    .mockResolvedValueOnce({
+      command: 'kdn',
+      stdout: '',
+      stderr: 'kdn version 1.0.0',
+    })
+    .mockResolvedValueOnce({
+      command: 'which',
+      stdout: '/usr/local/bin/kdn\n',
+      stderr: '',
+    });
+
+  await kdnExtension.activate();
+
+  const cliTool = vi.mocked(extensionApi.cli.createCliTool).mock.results[0]?.value;
+  expect(cliTool.registerUpdate).not.toHaveBeenCalled();
+});
+
+test('doUpdate downloads selected version and updates cli tool', async () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    command: 'kdn',
+    stdout: '',
+    stderr: 'kdn version 0.5.0',
+  });
+  vi.mocked(getAvailableVersions).mockResolvedValue([
+    { label: 'kdn v0.6.0', tag: '0.6.0' },
+    { label: 'kdn v0.4.0', tag: '0.4.0' },
+  ]);
+  vi.mocked(extensionApi.window.showQuickPick).mockResolvedValue({ label: 'kdn v0.6.0', tag: '0.6.0' } as never);
+
+  await kdnExtension.activate();
+
+  const cliTool = vi.mocked(extensionApi.cli.createCliTool).mock.results[0]?.value;
+  const updater = vi.mocked(cliTool.registerUpdate).mock.calls[0]?.[0];
+
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    command: 'kdn',
+    stdout: '',
+    stderr: 'kdn version 0.6.0',
+  });
+
+  await updater.selectVersion();
+  await updater.doUpdate();
+
+  expect(getReleaseByTag).toHaveBeenCalledWith('0.6.0');
+  expect(downloadKdn).toHaveBeenCalledWith(
+    '0.6.0',
+    process.platform,
+    expect.any(String),
+    join('/storage', 'bin'),
+    expect.any(Map),
+  );
+  expect(cliTool.updateVersion).toHaveBeenCalledWith(
+    expect.objectContaining({
+      version: '0.6.0',
+      path: join('/storage', 'bin', 'kdn'),
+    }),
+  );
 });

--- a/extensions/kdn/src/kdn-extension.ts
+++ b/extensions/kdn/src/kdn-extension.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ***********************************************************************/
+ **********************************************************************/
 
 import { existsSync } from 'node:fs';
+import { arch } from 'node:os';
 import { join } from 'node:path';
 
 import type { CliToolInstallationSource, ExtensionContext } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
+
+import { downloadKdn, getAvailableVersions, getReleaseByTag } from './kdn-download';
 
 export class KdnExtension {
   constructor(private readonly extensionContext: ExtensionContext) {}
@@ -92,6 +95,16 @@ export class KdnExtension {
       throw new Error('kdn CLI not found in custom path, extension storage, PATH, or bundled resources');
     }
 
+    this.registerCliTool(binaryPath, version, installationSource);
+  }
+
+  async deactivate(): Promise<void> {}
+
+  private registerCliTool(
+    binaryPath: string,
+    version: string | undefined,
+    installationSource: CliToolInstallationSource,
+  ): void {
     const cliTool = extensionApi.cli.createCliTool({
       name: 'kdn',
       displayName: 'kdn',
@@ -102,9 +115,48 @@ export class KdnExtension {
       installationSource,
     });
     this.extensionContext.subscriptions.push(cliTool);
-  }
 
-  async deactivate(): Promise<void> {}
+    if (installationSource === 'extension') {
+      const binDir = join(this.extensionContext.storagePath, 'bin');
+      const binaryName = extensionApi.env.isWindows ? 'kdn.exe' : 'kdn';
+      const localBinaryPath = join(binDir, binaryName);
+      let currentVersion = version;
+      let versionToUpdate: string | undefined;
+
+      const updater = cliTool.registerUpdate({
+        selectVersion: async (): Promise<string> => {
+          const releases = await getAvailableVersions(process.platform, arch());
+          const filtered = releases.filter(r => r.tag !== currentVersion);
+          const selected = await extensionApi.window.showQuickPick(filtered, {
+            placeHolder: 'Select kdn version to install',
+          });
+          if (!selected) {
+            throw new Error('No version selected');
+          }
+          versionToUpdate = selected.tag;
+          return versionToUpdate;
+        },
+        doUpdate: async (): Promise<void> => {
+          if (!versionToUpdate) {
+            throw new Error('No version selected for update');
+          }
+          const { digests } = await getReleaseByTag(versionToUpdate);
+          await downloadKdn(versionToUpdate, process.platform, arch(), binDir, digests);
+          const newVersion = await this.getVersion(localBinaryPath);
+          if (!newVersion) {
+            throw new Error('failed to determine version after update');
+          }
+          cliTool.updateVersion({
+            version: newVersion,
+            path: localBinaryPath,
+          });
+          currentVersion = newVersion;
+          versionToUpdate = undefined;
+        },
+      });
+      this.extensionContext.subscriptions.push(updater);
+    }
+  }
 
   private getCustomBinaryPath(): string | undefined {
     return extensionApi.configuration.getConfiguration('kdn').get<string>('binary.path') ?? undefined;


### PR DESCRIPTION
## Summary
- Add a version updater to the CLI Tools page that lets users select and install any available kdn release when kdn is installed via extension/bundled resources
- Filter selectable versions by platform/arch so only compatible binaries are shown
- Use digest-based checksum verification for all downloads (via `getReleaseByTag`)
- No auto-download fallback — kdn must be present via bundled resources, extension storage, or system PATH

Fixes: https://github.com/openkaiden/kaiden/issues/1469

## Test plan
- [ ] CLI Tools page shows kdn with an update option when installed via extension (`installationSource: 'extension'`)
- [ ] Version picker lists available releases filtered to the current platform/arch
- [ ] Selecting a version downloads and installs it, updating the displayed version
- [ ] Externally installed kdn (PATH) does not show the updater
- [ ] When kdn is not found anywhere, activation throws with a clear error message
- [ ] `pnpm -F kdn test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)