### PR TITLE
fix: remove non-functional action buttons from local models list

### DIFF
--- a/packages/renderer/src/lib/models/ModelsCatalog.svelte
+++ b/packages/renderer/src/lib/models/ModelsCatalog.svelte
@@ -105,7 +105,8 @@ const actionsColumn = new TableColumn<ModelSelectable>('Actions', {
   overflow: true,
 });
 
-const columns = [statusColumn, nameColumn, sizeColumn, runtimeColumn, actionsColumn];
+const columns = [statusColumn, nameColumn, sizeColumn, runtimeColumn];
+const columnsWithActions = [statusColumn, nameColumn, sizeColumn, runtimeColumn, actionsColumn];
 
 function filterBySearch(models: CatalogModelInfo[], term: string): CatalogModelInfo[] {
   if (!term.trim()) return models;
@@ -196,7 +197,7 @@ function selectCategory(cat: Category): void {
               {/if}
 
               <div class="flex min-w-full">
-                <Table kind="models" data={filteredCloudModels} columns={columns} row={row} defaultSortColumn="Name" />
+                <Table kind="models" data={filteredCloudModels} columns={columnsWithActions} row={row} defaultSortColumn="Name" />
               </div>
             {/if}
           </div>
@@ -228,7 +229,7 @@ function selectCategory(cat: Category): void {
 
               {#if filteredInHouseModels.length > 0}
                 <div class="flex min-w-full">
-                  <Table kind="models" data={filteredInHouseModels} columns={columns} row={row} defaultSortColumn="Name" />
+                  <Table kind="models" data={filteredInHouseModels} columns={columnsWithActions} row={row} defaultSortColumn="Name" />
                 </div>
               {/if}
             {/if}

--- a/packages/renderer/src/lib/models/columns/ModelActionsColumn.svelte
+++ b/packages/renderer/src/lib/models/columns/ModelActionsColumn.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-import { faEllipsisVertical, faPlay, faRocket, faStop } from '@fortawesome/free-solid-svg-icons';
-
 import type { CatalogModelInfo } from '/@/lib/models/models-utils';
-import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
 import { disabledModels, isModelEnabled, toggleModel } from '/@/stores/model-catalog';
 
@@ -12,38 +9,16 @@ interface Props {
 
 let { object }: Props = $props();
 
+let toggleId: string = $derived(`model-toggle-${object.providerId}-${object.label}`.replace(/[^A-Za-z0-9_-]/g, '-'));
 let enabled: boolean = $derived(isModelEnabled($disabledModels, object.providerId, object.label));
-let isLocal: boolean = $derived(object.type === 'local');
-let isRunning: boolean = $derived(object.connectionStatus === 'started' || object.connectionStatus === 'unknown');
 
 function onChecked(): void {
   toggleModel(object.providerId, object.label);
 }
-
-function handlePlayground(): void {
-  // TODO: open model in playground/chat
-}
-
-function handleRunStop(): void {
-  // TODO: start or stop the model
-}
-
-function handleSettings(): void {
-  // TODO: navigate to model settings/runtime arguments page
-}
 </script>
 
-{#if isLocal}
-  <ListItemButtonIcon title="Open in playground" icon={faRocket} onClick={handlePlayground} />
-  <ListItemButtonIcon
-    title={isRunning ? 'Stop model' : 'Start model'}
-    icon={isRunning ? faStop : faPlay}
-    onClick={handleRunStop} />
-  <ListItemButtonIcon title="Settings" tooltip="Configure runtime arguments" icon={faEllipsisVertical} onClick={handleSettings} />
-{:else}
-  <SlideToggle
-    id="model-toggle-{object.providerId}-{object.label}"
-    checked={enabled}
-    on:checked={onChecked}
-    aria-label={enabled ? `Disable ${object.label}` : `Enable ${object.label}`} />
-{/if}
+<SlideToggle
+  id={toggleId}
+  checked={enabled}
+  on:checked={onChecked}
+  aria-label={enabled ? `Disable ${object.label}` : `Enable ${object.label}`} />


### PR DESCRIPTION
Remove playground, start/stop, and settings buttons from local models
since they had no implementation. Keep the enable/disable toggle for
cloud and corporate models only.

<img width="1162" height="812" alt="Screenshot 2026-05-18 at 10 54 13" src="https://github.com/user-attachments/assets/c80ec1f7-659b-48c9-98d3-0a995fe996b3" />


Fixes #1814