### PR TITLE
feat(agent-workspaces): add knowledge settings section to workspace details

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -48,6 +48,7 @@ const workspaceSummary: AgentWorkspaceSummary = {
   name: 'api-refactor',
   project: 'backend',
   agent: 'coder-v1',
+  runtime: 'podman',
   state: 'stopped',
   runtime: 'podman',
   paths: {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -48,7 +48,6 @@ const workspaceSummary: AgentWorkspaceSummary = {
   name: 'api-refactor',
   project: 'backend',
   agent: 'coder-v1',
-  runtime: 'podman',
   state: 'stopped',
   runtime: 'podman',
   paths: {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -23,14 +23,17 @@ import { writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import * as ragStore from '/@/stores/rag-environments';
 import * as skillsStore from '/@/stores/skills';
 import type { AgentWorkspaceConfiguration, AgentWorkspaceSummary } from '/@api/agent-workspace-info';
+import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { SkillInfo } from '/@api/skill/skill-info';
 
 import AgentWorkspaceDetailsSettings from './AgentWorkspaceDetailsSettings.svelte';
 
 vi.mock(import('tinro'));
 vi.mock(import('/@/stores/skills'));
+vi.mock(import('/@/stores/rag-environments'));
 vi.mock(import('/@/navigation'));
 
 const routerStore = writable({
@@ -69,6 +72,7 @@ beforeEach(() => {
   vi.mocked(window.updateAgentWorkspaceSummary).mockResolvedValue(undefined);
   vi.mocked(window.updateAgentWorkspaceConfiguration).mockResolvedValue(undefined);
   vi.mocked(skillsStore).skillInfos = writable<readonly SkillInfo[]>([]);
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
 });
 
 test('Expect General section is active by default with workspace info', () => {
@@ -477,4 +481,243 @@ test('Expect browse button calls openDialog and fills host path', async () => {
 
   expect(window.openDialog).toHaveBeenCalledWith({ title: 'Select a directory', selectors: ['openDirectory'] });
   expect(screen.getByRole('textbox', { name: 'Host path 1' })).toHaveValue('/selected/path');
+});
+
+test('Expect Knowledge section shows checklist with available knowledge bases', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'Project Docs',
+      ragConnection: { name: 'ChromaDB', providerId: 'chroma-1' },
+      chunkerId: 'chunker-1',
+      files: [
+        { path: '/docs/api.md', status: 'indexed' },
+        { path: '/docs/guide.md', status: 'indexed' },
+      ],
+      mcpServer: {
+        id: 'rag-1',
+        name: 'Project Docs MCP',
+        description: '',
+        url: 'http://localhost:3100/sse',
+        infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+        tools: {},
+      },
+    },
+  ]);
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  expect(screen.getByText('Project Docs')).toBeInTheDocument();
+  expect(screen.getByText('2 sources · ChromaDB')).toBeInTheDocument();
+});
+
+test('Expect Knowledge section shows empty message when no knowledge bases available', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  expect(screen.getByText('No knowledge bases available yet.')).toBeInTheDocument();
+});
+
+test('Expect Knowledge section pre-selects knowledge matching workspace mcp config', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'Project Docs',
+      ragConnection: { name: 'ChromaDB', providerId: 'chroma-1' },
+      chunkerId: 'chunker-1',
+      files: [{ path: '/docs/api.md', status: 'indexed' }],
+      mcpServer: {
+        id: 'rag-1',
+        name: 'Project Docs MCP',
+        description: '',
+        url: 'http://localhost:3100/sse',
+        infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+        tools: {},
+      },
+    },
+    {
+      name: 'Wiki',
+      ragConnection: { name: 'Weaviate', providerId: 'weav-1' },
+      chunkerId: 'chunker-2',
+      files: [],
+      mcpServer: {
+        id: 'rag-2',
+        name: 'Wiki MCP',
+        description: '',
+        url: 'http://localhost:3200/sse',
+        infos: { internalProviderId: 'p2', serverId: 's2', remoteId: 2 },
+        tools: {},
+      },
+    },
+  ]);
+
+  const configWithKnowledge: AgentWorkspaceConfiguration = {
+    ...configuration,
+    mcp: { servers: [{ name: 'Project Docs MCP', url: 'http://localhost:3100/sse' }] },
+  };
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: configWithKnowledge });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  expect(screen.getByText('1 of 2 selected')).toBeInTheDocument();
+});
+
+test('Expect toggling knowledge base shows unsaved changes', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'Project Docs',
+      ragConnection: { name: 'ChromaDB', providerId: 'chroma-1' },
+      chunkerId: 'chunker-1',
+      files: [],
+      mcpServer: {
+        id: 'rag-1',
+        name: 'Project Docs MCP',
+        description: '',
+        url: 'http://localhost:3100/sse',
+        infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+        tools: {},
+      },
+    },
+  ]);
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  const itemButton = screen.getByRole('button', { name: 'Project Docs' });
+  await fireEvent.click(itemButton);
+
+  expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+});
+
+test('Expect saving knowledge changes calls updateAgentWorkspaceConfiguration', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'Project Docs',
+      ragConnection: { name: 'ChromaDB', providerId: 'chroma-1' },
+      chunkerId: 'chunker-1',
+      files: [],
+      mcpServer: {
+        id: 'rag-1',
+        name: 'Project Docs MCP',
+        description: '',
+        url: 'http://localhost:3100/sse',
+        infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+        tools: {},
+      },
+    },
+  ]);
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  const itemButton = screen.getByRole('button', { name: 'Project Docs' });
+  await fireEvent.click(itemButton);
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.updateAgentWorkspaceConfiguration).toHaveBeenCalledWith('ws-1', {
+    mcp: { servers: [{ name: 'Project Docs MCP', url: 'http://localhost:3100/sse' }] },
+  });
+});
+
+test('Expect saving knowledge preserves non-knowledge MCP servers', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'Project Docs',
+      ragConnection: { name: 'ChromaDB', providerId: 'chroma-1' },
+      chunkerId: 'chunker-1',
+      files: [],
+      mcpServer: {
+        id: 'rag-1',
+        name: 'Project Docs MCP',
+        description: '',
+        url: 'http://localhost:3100/sse',
+        infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+        tools: {},
+      },
+    },
+  ]);
+
+  const configWithExistingMcp: AgentWorkspaceConfiguration = {
+    ...configuration,
+    mcp: {
+      servers: [{ name: 'GitHub MCP', url: 'https://mcp.github.com/sse' }],
+      commands: [{ name: 'Local Tool', command: 'npx', args: ['tool'] }],
+    },
+  };
+
+  render(AgentWorkspaceDetailsSettings, {
+    workspaceId: 'ws-1',
+    workspaceSummary,
+    configuration: configWithExistingMcp,
+  });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  const itemButton = screen.getByRole('button', { name: 'Project Docs' });
+  await fireEvent.click(itemButton);
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.updateAgentWorkspaceConfiguration).toHaveBeenCalledWith('ws-1', {
+    mcp: {
+      servers: [
+        { name: 'GitHub MCP', url: 'https://mcp.github.com/sse' },
+        { name: 'Project Docs MCP', url: 'http://localhost:3100/sse' },
+      ],
+      commands: [{ name: 'Local Tool', command: 'npx', args: ['tool'] }],
+    },
+  });
+});
+
+test('Expect discarding knowledge changes resets selection', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([
+    {
+      name: 'Project Docs',
+      ragConnection: { name: 'ChromaDB', providerId: 'chroma-1' },
+      chunkerId: 'chunker-1',
+      files: [],
+      mcpServer: {
+        id: 'rag-1',
+        name: 'Project Docs MCP',
+        description: '',
+        url: 'http://localhost:3100/sse',
+        infos: { internalProviderId: 'p1', serverId: 's1', remoteId: 1 },
+        tools: {},
+      },
+    },
+  ]);
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  const itemButton = screen.getByRole('button', { name: 'Project Docs' });
+  await fireEvent.click(itemButton);
+  await fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+
+  expect(screen.getByText('No changes to save')).toBeInTheDocument();
+  expect(window.updateAgentWorkspaceConfiguration).not.toHaveBeenCalled();
+});
+
+test('Expect Knowledge section has Manage Knowledges button', async () => {
+  vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const knowledgeNav = screen.getByRole('link', { name: 'Knowledge' });
+  await fireEvent.click(knowledgeNav);
+
+  expect(screen.getByRole('button', { name: 'Manage Knowledges' })).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -186,6 +186,21 @@ async function handleBrowseCustomPath(index: number): Promise<void> {
       buttons: ['OK'],
     });
   }
+  if (hasNameChanges) {
+    await window.updateAgentWorkspaceSummary(workspaceId, { name: workspaceName.trim() });
+  }
+  if (hasSkillChanges) {
+    const selectedPaths = pendingSkillIds
+      .map(name => $skillInfos.find(s => s.name === name)?.path)
+      .filter((path): path is string => path !== undefined);
+    const newSkills = selectedPaths.length > 0 ? selectedPaths : undefined;
+    configuration = { ...configuration, skills: newSkills };
+    await window.updateAgentWorkspaceConfiguration(workspaceId, { skills: newSkills });
+  }
+}
+
+function navigateToSkills(): void {
+  handleNavigation({ page: NavigationPage.SKILLS });
 }
 
 function navigateToSkills(): void {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -186,17 +186,6 @@ async function handleBrowseCustomPath(index: number): Promise<void> {
       buttons: ['OK'],
     });
   }
-  if (hasNameChanges) {
-    await window.updateAgentWorkspaceSummary(workspaceId, { name: workspaceName.trim() });
-  }
-  if (hasSkillChanges) {
-    const selectedPaths = pendingSkillIds
-      .map(name => $skillInfos.find(s => s.name === name)?.path)
-      .filter((path): path is string => path !== undefined);
-    const newSkills = selectedPaths.length > 0 ? selectedPaths : undefined;
-    configuration = { ...configuration, skills: newSkills };
-    await window.updateAgentWorkspaceConfiguration(workspaceId, { skills: newSkills });
-  }
 }
 
 function navigateToSkills(): void {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faWrench } from '@fortawesome/free-solid-svg-icons';
+import { faBook, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { Button, Input, SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
@@ -10,8 +10,13 @@ import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import ChecklistPanel from '/@/lib/ui/ChecklistPanel.svelte';
 import { handleNavigation } from '/@/navigation';
 import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
+import { ragEnvironments } from '/@/stores/rag-environments';
 import { skillInfos } from '/@/stores/skills';
-import type { AgentWorkspaceConfiguration, AgentWorkspaceMount } from '/@api/agent-workspace-info';
+import type {
+  AgentWorkspaceConfiguration,
+  AgentWorkspaceMcpConfig,
+  AgentWorkspaceMount,
+} from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
 
 type SettingsSection = 'general' | 'skills' | 'mcp' | 'knowledge' | 'file-access' | 'network' | 'advanced';
@@ -120,7 +125,40 @@ const hasMountChanges: boolean = $derived(
         ))),
 );
 
-const hasChanges = $derived(hasNameChanges || hasMountChanges || hasSkillChanges);
+// --- Knowledge section state ---
+let knowledgeItems: ChecklistItem[] = $derived(
+  $ragEnvironments
+    .filter(r => r.mcpServer)
+    .map(r => {
+      const sourceCount = r.files.length;
+      const sourcesLabel = sourceCount > 0 ? `${sourceCount} source${sourceCount !== 1 ? 's' : ''}` : '';
+      return {
+        id: r.name,
+        name: r.name,
+        description: [sourcesLabel, r.ragConnection.name].filter(Boolean).join(' · '),
+      };
+    }),
+);
+
+const originalKnowledgeIds: string[] = $derived(
+  $ragEnvironments
+    .filter(r => r.mcpServer && (configuration.mcp?.servers ?? []).some(s => s.url === r.mcpServer?.url))
+    .map(r => r.name),
+);
+
+let pendingKnowledgeIds: string[] = $state([...originalKnowledgeIds]);
+
+const hasKnowledgeChanges: boolean = $derived(
+  pendingKnowledgeIds.length !== originalKnowledgeIds.length ||
+    pendingKnowledgeIds.some(id => !originalKnowledgeIds.includes(id)),
+);
+
+function onKnowledgeSelectionChange(selected: string[]): void {
+  pendingKnowledgeIds = selected;
+}
+
+// --- Combined dirty state ---
+const hasChanges = $derived(hasNameChanges || hasMountChanges || hasSkillChanges || hasKnowledgeChanges);
 
 // --- Save / Discard ---
 async function saveChanges(): Promise<void> {
@@ -143,6 +181,11 @@ async function saveChanges(): Promise<void> {
       await window.updateAgentWorkspaceConfiguration(workspaceId, { skills: newSkills });
       configuration = { ...configuration, skills: newSkills };
     }
+    if (hasKnowledgeChanges) {
+      const mcpConfig = buildMcpConfigWithKnowledge(pendingKnowledgeIds);
+      await window.updateAgentWorkspaceConfiguration(workspaceId, { mcp: mcpConfig });
+      configuration = { ...configuration, mcp: mcpConfig };
+    }
   } catch (err: unknown) {
     await window.showMessageBox({
       title: 'Agent Workspace',
@@ -154,11 +197,27 @@ async function saveChanges(): Promise<void> {
   }
 }
 
+function buildMcpConfigWithKnowledge(selectedIds: string[]): AgentWorkspaceMcpConfig {
+  const knowledgeUrls = new Set($ragEnvironments.filter(r => r.mcpServer).map(r => r.mcpServer!.url));
+  const nonKnowledgeServers = (configuration.mcp?.servers ?? []).filter(s => !knowledgeUrls.has(s.url));
+  const selectedServers = selectedIds
+    .map(name => $ragEnvironments.find(r => r.name === name)?.mcpServer)
+    .filter((s): s is NonNullable<typeof s> => s !== undefined)
+    .map(s => ({ name: s.name, url: s.url }));
+
+  const servers = [...nonKnowledgeServers, ...selectedServers];
+  return {
+    ...(configuration.mcp?.commands ? { commands: configuration.mcp.commands } : {}),
+    ...(servers.length > 0 ? { servers } : {}),
+  };
+}
+
 function discardChanges(): void {
   workspaceName = originalName;
   pendingFileAccess = originalFileAccess;
   pendingCustomMounts = originalCustomMounts.map(m => ({ ...m }));
   pendingSkillIds = [...originalSkillIds];
+  pendingKnowledgeIds = [...originalKnowledgeIds];
 }
 
 function addCustomMount(): void {
@@ -188,8 +247,8 @@ async function handleBrowseCustomPath(index: number): Promise<void> {
   }
 }
 
-function navigateToSkills(): void {
-  handleNavigation({ page: NavigationPage.SKILLS });
+function navigateToKnowledges(): void {
+  handleNavigation({ page: NavigationPage.RAG_ENVIRONMENTS });
 }
 
 function navigateToSkills(): void {
@@ -287,6 +346,24 @@ function navigateToSkills(): void {
               <Button type="secondary" onclick={navigateToSkills}>Manage Skills</Button>
             {/snippet}
           </ChecklistPanel>
+        {:else if activeSection === 'knowledge'}
+          <p class="text-sm text-[var(--pd-content-text)] mb-7">
+            Select which knowledge bases are available in this workspace.
+          </p>
+
+          <ChecklistPanel
+            title="Knowledge Bases"
+            subtitle="Optional retrieval context for the agent"
+            icon={faBook}
+            items={knowledgeItems}
+            selected={pendingKnowledgeIds}
+            onchange={onKnowledgeSelectionChange}
+            emptyMessage="No knowledge bases available yet.">
+            {#snippet headerAction()}
+              <Button type="secondary" onclick={navigateToKnowledges}>Manage Knowledges</Button>
+            {/snippet}
+          </ChecklistPanel>
+
         {:else}
           <p class="text-sm text-[var(--pd-content-text)] mb-7">
             Configure {activeLabel.toLowerCase()} settings for this workspace.

--- a/packages/renderer/src/lib/ui/ChecklistPanel.svelte
+++ b/packages/renderer/src/lib/ui/ChecklistPanel.svelte
@@ -18,9 +18,9 @@ interface Props {
   icon?: IconDefinition;
   items: readonly ChecklistItem[];
   selected?: string[];
+  onchange?: (selected: string[]) => void;
   emptyMessage?: string;
   headerAction?: Snippet;
-  onchange?: (selected: string[]) => void;
 }
 
 let {
@@ -29,9 +29,9 @@ let {
   icon,
   items,
   selected = $bindable<string[]>([]),
+  onchange,
   emptyMessage = 'No items available.',
   headerAction,
-  onchange,
 }: Props = $props();
 
 interface GroupedItems {


### PR DESCRIPTION

Allow users to select which RAG knowledge bases are available in a workspace. Knowledge bases are mapped to MCP servers in the workspace configuration while preserving non-knowledge MCP entries.

Closes https://github.com/openkaiden/kaiden/issues/1620

Needs rebase after https://github.com/openkaiden/kaiden/pull/1867