### PR TITLE
feat(claude): add custom baseURL support for Anthropic provider

### DIFF
--- a/extensions/claude/package.json
+++ b/extensions/claude/package.json
@@ -20,6 +20,11 @@
           "scope": "InferenceProviderConnectionFactory",
           "markdownDescription": "Provide a Claude API key\n\n:button[Grab a key]{href=\"https://console.anthropic.com/settings/keys\"}"
         },
+        "claude.factory.baseURL": {
+          "type": "string",
+          "scope": "InferenceProviderConnectionFactory",
+          "description": "Custom base URL (leave empty for https://api.anthropic.com)"
+        },
         "claude.factory.apiKey": {
           "type": "string",
           "scope": "InferenceProviderConnectionFactory",

--- a/extensions/claude/src/manager/claude-inference-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.spec.ts
@@ -25,7 +25,7 @@ import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
-import { ClaudeInferenceManager, TOKENS_KEY } from './claude-inference-manager';
+import { ClaudeInferenceManager, CONNECTION_INFOS_KEY, TOKENS_KEY } from './claude-inference-manager';
 
 vi.mock(import('@ai-sdk/anthropic'));
 
@@ -105,13 +105,30 @@ describe('init', () => {
     });
   });
 
-  test('should restore connections from secret storage', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('existingKey');
+  test('should restore connections from new infos key', async () => {
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockImplementation(async (key: string) => {
+      if (key === CONNECTION_INFOS_KEY) return 'existingKey|https://api.anthropic.com';
+      return undefined;
+    });
 
     const manager = await createManager();
     await manager.init();
 
-    expect(SECRET_STORAGE_MOCK.get).toHaveBeenCalledWith(TOKENS_KEY);
+    expect(SECRET_STORAGE_MOCK.get).toHaveBeenCalledWith(CONNECTION_INFOS_KEY);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+  });
+
+  test('should migrate legacy tokens to new format', async () => {
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockImplementation(async (key: string) => {
+      if (key === TOKENS_KEY) return 'legacyKey';
+      return undefined;
+    });
+
+    const manager = await createManager();
+    await manager.init();
+
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(CONNECTION_INFOS_KEY, 'legacyKey|https://api.anthropic.com');
+    expect(SECRET_STORAGE_MOCK.delete).toHaveBeenCalledWith(TOKENS_KEY);
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
   });
 
@@ -143,16 +160,16 @@ describe('factory', () => {
     }).rejects.toThrowError('invalid apiKey');
   });
 
-  test('calling create with proper params should save token', async () => {
+  test('calling create with only apiKey should use default baseURL', async () => {
     await create({
       'claude.factory.apiKey': 'dummyKey',
     });
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey');
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(CONNECTION_INFOS_KEY, 'dummyKey|https://api.anthropic.com');
   });
 
-  test('calling create with proper params should register inference connection', async () => {
+  test('calling create with apiKey and default baseURL should not pass baseURL to SDK', async () => {
     await create({
       'claude.factory.apiKey': 'dummyKey',
     });
@@ -180,6 +197,54 @@ describe('factory', () => {
       sdk: ANTHROPIC_PROVIDER_MOCK,
       models: [{ label: 'claude-sonnet-4-20250514' }, { label: 'claude-haiku-3.5-20241022' }],
       credentials: expect.any(Function),
+    });
+  });
+
+  test('calling create with custom baseURL should pass it to SDKs', async () => {
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+      'claude.factory.baseURL': 'http://localhost:8080',
+    });
+
+    expect(createAnthropic).toHaveBeenCalledOnce();
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
+      baseURL: 'http://localhost:8080',
+    });
+
+    expect(AnthropicClient).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
+      baseURL: 'http://localhost:8080',
+    });
+
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(CONNECTION_INFOS_KEY, 'dummyKey|http://localhost:8080');
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
+      name: 'http://localhost:8080',
+      type: 'self-hosted',
+      llmMetadata: {
+        name: 'anthropic',
+      },
+      endpoint: 'http://localhost:8080',
+      status: expect.any(Function),
+      lifecycle: {
+        delete: expect.any(Function),
+      },
+      sdk: ANTHROPIC_PROVIDER_MOCK,
+      models: [{ label: 'claude-sonnet-4-20250514' }, { label: 'claude-haiku-3.5-20241022' }],
+      credentials: expect.any(Function),
+    });
+  });
+
+  test('calling create with empty baseURL should use default', async () => {
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+      'claude.factory.baseURL': '  ',
+    });
+
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
     });
   });
 });
@@ -211,16 +276,20 @@ describe('connection delete lifecycle', () => {
     mDelete = lifecycle.delete;
   });
 
-  test('calling delete should delete the token', async () => {
+  test('calling delete should remove connection info', async () => {
     await mDelete();
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
 
-    // first time when registering the connection
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, 'dummyKey');
+    // first time when saving the connection
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(
+      1,
+      CONNECTION_INFOS_KEY,
+      'dummyKey|https://api.anthropic.com',
+    );
 
-    // second time when unregistering the connection
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, '');
+    // second time when removing the connection
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, CONNECTION_INFOS_KEY, '');
   });
 
   test('calling delete should dispose provider inference connection', async () => {

--- a/extensions/claude/src/manager/claude-inference-manager.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.ts
@@ -26,7 +26,16 @@ import { inject, injectable } from 'inversify';
 import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
 export const TOKENS_KEY = 'claude:tokens';
+export const CONNECTION_INFOS_KEY = 'claude:infos';
 export const TOKEN_SEPARATOR = ',';
+const INFO_SEPARATOR = '|';
+
+const DEFAULT_BASE_URL = 'https://api.anthropic.com';
+
+interface ConnectionInfo {
+  apiKey: string;
+  baseURL: string;
+}
 
 @injectable()
 export class ClaudeInferenceManager {
@@ -47,27 +56,58 @@ export class ClaudeInferenceManager {
   }
 
   private async restoreConnections(): Promise<void> {
-    const tokens = await this.getTokens();
-    for (const token of tokens) {
-      await this.registerInferenceProviderConnection({ token });
+    const connectionInfos = await this.getConnectionInfos();
+    for (const info of connectionInfos) {
+      try {
+        await this.registerInferenceProviderConnection({ token: info.apiKey, baseURL: info.baseURL });
+      } catch (err: unknown) {
+        console.error(`Claude: failed to restore connection for baseURL ${info.baseURL}`, err);
+      }
     }
   }
 
-  private async getTokens(): Promise<string[]> {
+  /**
+   * Reads connection infos from the new `claude:infos` key.
+   * Falls back to the legacy `claude:tokens` key (API-key-only entries default to the Anthropic API).
+   */
+  private async getConnectionInfos(): Promise<ConnectionInfo[]> {
     let raw: string | undefined;
+    try {
+      raw = await this.secrets.get(CONNECTION_INFOS_KEY);
+    } catch (err: unknown) {
+      console.error('Claude: something went wrong while trying to get connection infos from secret storage', err);
+    }
+
+    if (raw) {
+      return raw.split(TOKEN_SEPARATOR).map(entry => {
+        const [apiKey, baseURL] = entry.split(INFO_SEPARATOR);
+        return { apiKey, baseURL: baseURL || DEFAULT_BASE_URL };
+      });
+    }
+
+    // Migrate legacy token-only storage
     try {
       raw = await this.secrets.get(TOKENS_KEY);
     } catch (err: unknown) {
       console.error('Claude: something went wrong while trying to get tokens from secret storage', err);
     }
     if (!raw) return [];
-    return raw.split(TOKEN_SEPARATOR);
+
+    const infos = raw.split(TOKEN_SEPARATOR).map(apiKey => ({ apiKey, baseURL: DEFAULT_BASE_URL }));
+    // Persist in the new format and clean up legacy key
+    await this.saveConnectionInfos(infos);
+    await this.secrets.delete(TOKENS_KEY);
+    return infos;
   }
 
-  private async saveToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = [...tokens, token].join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async saveConnectionInfos(infos: ConnectionInfo[]): Promise<void> {
+    const raw = infos.map(i => `${i.apiKey}${INFO_SEPARATOR}${i.baseURL}`).join(TOKEN_SEPARATOR);
+    await this.secrets.store(CONNECTION_INFOS_KEY, raw);
+  }
+
+  private async saveConnectionInfo(apiKey: string, baseURL: string): Promise<void> {
+    const existing = await this.getConnectionInfos();
+    await this.saveConnectionInfos([...existing, { apiKey, baseURL }]);
   }
 
   private getTokenHash(token: string): string {
@@ -75,45 +115,56 @@ export class ClaudeInferenceManager {
     return sha256.update(token).digest('hex');
   }
 
-  private async removeToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = tokens.filter(t => t !== token).join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async removeConnectionInfo(apiKey: string, baseURL: string): Promise<void> {
+    const infos = await this.getConnectionInfos();
+    const filtered = infos.filter(i => i.apiKey !== apiKey || i.baseURL !== baseURL);
+    await this.saveConnectionInfos(filtered);
   }
 
-  private async registerInferenceProviderConnection({ token }: { token: string }): Promise<void> {
-    const key = this.maskKey(token);
+  private async registerInferenceProviderConnection({
+    token,
+    baseURL,
+  }: {
+    token: string;
+    baseURL: string;
+  }): Promise<void> {
     const tokenHash = this.getTokenHash(token);
 
     if (this.connections.has(tokenHash)) {
-      throw new Error(`connection already exists for token ${key}`);
+      throw new Error(`connection already exists for token ${this.maskKey(token)}`);
     }
+
+    const isCustomBaseURL = baseURL !== DEFAULT_BASE_URL;
 
     const anthropic = createAnthropic({
       apiKey: token,
+      ...(isCustomBaseURL && { baseURL }),
     });
 
     const clean = async (): Promise<void> => {
       this.connections.get(tokenHash)?.dispose();
       this.connections.delete(tokenHash);
-      await this.removeToken(token);
+      await this.removeConnectionInfo(token, baseURL);
     };
 
     let status: ProviderConnectionStatus = 'unknown';
     let models: InferenceModel[] = [];
 
     try {
-      models = await this.getAnthropicModels(token);
+      models = await this.getAnthropicModels(token, baseURL);
     } catch (err: unknown) {
       status = 'stopped';
     }
 
+    const connectionName = isCustomBaseURL ? baseURL : this.maskKey(token);
+
     const connectionDisposable = this.claudeProvider.registerInferenceProviderConnection({
-      name: this.maskKey(token),
-      type: 'cloud',
+      name: connectionName,
+      type: isCustomBaseURL ? 'self-hosted' : 'cloud',
       llmMetadata: {
         name: 'anthropic',
       },
+      ...(isCustomBaseURL && { endpoint: baseURL }),
       sdk: anthropic,
       status(): ProviderConnectionStatus {
         return status;
@@ -131,8 +182,12 @@ export class ClaudeInferenceManager {
     this.connections.set(tokenHash, connectionDisposable);
   }
 
-  private async getAnthropicModels(token: string): Promise<Array<{ label: string }>> {
-    const client = new AnthropicClient({ apiKey: token });
+  private async getAnthropicModels(token: string, baseURL: string): Promise<Array<{ label: string }>> {
+    const isCustomBaseURL = baseURL !== DEFAULT_BASE_URL;
+    const client = new AnthropicClient({
+      apiKey: token,
+      ...(isCustomBaseURL && { baseURL }),
+    });
     const models: InferenceModel[] = [];
     for await (const model of client.models.list()) {
       if (model.id) {
@@ -151,8 +206,11 @@ export class ClaudeInferenceManager {
     const apiKey = params['claude.factory.apiKey'];
     if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
 
-    await this.saveToken(apiKey);
-    await this.registerInferenceProviderConnection({ token: apiKey });
+    const rawBaseURL = params['claude.factory.baseURL'];
+    const baseURL = typeof rawBaseURL === 'string' && rawBaseURL.trim() ? rawBaseURL.trim() : DEFAULT_BASE_URL;
+
+    await this.saveConnectionInfo(apiKey, baseURL);
+    await this.registerInferenceProviderConnection({ token: apiKey, baseURL });
   }
 
   dispose(): void {


### PR DESCRIPTION
Allow users to configure a custom base URL when creating a Claude provider connection, enabling local inference engines (e.g. llama-server) and API proxies. Connections with a custom URL are registered as self-hosted with the endpoint exposed in the model ID.

<img width="1508" height="948" alt="Captura de pantalla 2026-05-18 a las 13 30 47" src="https://github.com/user-attachments/assets/a462fdc0-931d-4516-b5dc-4436c41699a6" />

Not merge until https://github.com/openkaiden/kdn/pull/543 is merged.
Close #1855