### PR TITLE
feat(renderer): add file access settings to workspace details

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -6,8 +6,9 @@ import { onMount } from 'svelte';
 import { toast } from 'svelte-sonner';
 
 import AgentWorkspaceCreateStepAgentModel from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte';
-import type { CustomMount, FileAccessOption } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
-import AgentWorkspaceCreateStepFileSystem from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
+import AgentWorkspaceCreateStepFileSystem, {
+  type CustomMount,
+} from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
 import type { NetworkAccessOption } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte';
 import AgentWorkspaceCreateStepNetworking from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte';
 import AgentWorkspaceCreateStepToolsSecrets from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte';
@@ -34,38 +35,6 @@ import type {
 } from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
 import type { DefaultWorkspaceSettings } from '/@api/onboarding-settings-info';
-
-const fileAccessOptions: FileAccessOption[] = [
-  {
-    value: 'workspace',
-    name: 'No host filesystem access',
-    description: 'The agent cannot read or write files on your host. Use for API-only or fully remote workflows.',
-    access: 'None',
-    notes: 'Strict isolation',
-    badge: 'Recommended',
-  },
-  {
-    value: 'home',
-    name: 'Home Directory',
-    description: 'Agent can access your entire home directory (~/) and all subdirectories.',
-    access: 'Home (~)',
-    notes: 'Local development',
-  },
-  {
-    value: 'custom',
-    name: 'Custom Paths',
-    description: 'Specify exact directories the agent can access.',
-    access: 'Listed paths',
-    notes: 'Set path below',
-  },
-  {
-    value: 'full',
-    name: 'Full System Access',
-    description: 'Agent can access the entire filesystem. Use with caution.',
-    access: 'Full host',
-    notes: 'High privilege',
-  },
-];
 
 const baseNetworkOptions: NetworkAccessOption[] = [
   {
@@ -529,7 +498,6 @@ async function startWorkspace(): Promise<void> {
                 bind:selectedKnowledgeIds={wizard.draft.selectedKnowledgeIds} />
             {:else if currentStepId === 'filesystem'}
               <AgentWorkspaceCreateStepFileSystem
-                {fileAccessOptions}
                 bind:selectedFileAccess={wizard.draft.selectedFileAccess}
                 customMounts={wizard.draft.customMounts}
                 onBrowseCustomPath={handleBrowseCustomPath}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte
@@ -18,28 +18,61 @@ export interface CustomMount {
   ro: boolean;
 }
 
+export const fileAccessOptions: FileAccessOption[] = [
+  {
+    value: 'workspace',
+    name: 'No host filesystem access',
+    description: 'The agent cannot read or write files on your host. Use for API-only or fully remote workflows.',
+    access: 'None',
+    notes: 'Strict isolation',
+    badge: 'Recommended',
+  },
+  {
+    value: 'home',
+    name: 'Home Directory',
+    description: 'Agent can access your entire home directory (~/) and all subdirectories.',
+    access: 'Home (~)',
+    notes: 'Local development',
+  },
+  {
+    value: 'custom',
+    name: 'Custom Paths',
+    description: 'Specify exact directories the agent can access.',
+    access: 'Listed paths',
+    notes: 'Set path below',
+  },
+  {
+    value: 'full',
+    name: 'Full System Access',
+    description: 'Agent can access the entire filesystem. Use with caution.',
+    access: 'Full host',
+    notes: 'High privilege',
+  },
+];
+
 interface Props {
-  fileAccessOptions: FileAccessOption[];
   selectedFileAccess: string;
   customMounts: CustomMount[];
   onBrowseCustomPath: (index: number) => Promise<void>;
   onAddCustomMount: () => void;
   onRemoveCustomMount: (index: number) => void;
   onUpdateCustomMount: (index: number, field: keyof CustomMount, value: string | boolean) => void;
+  onchange?: (selected: string) => void;
 }
 
 let {
-  fileAccessOptions,
   selectedFileAccess = $bindable(),
   customMounts,
   onBrowseCustomPath,
   onAddCustomMount,
   onRemoveCustomMount,
   onUpdateCustomMount,
+  onchange,
 }: Props = $props();
 
 function selectOption(value: string): void {
   selectedFileAccess = value;
+  onchange?.(value);
 }
 </script>
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -150,7 +150,7 @@ function handleRemove(): void {
       <AgentWorkspaceDetailsFiles />
     </Route> -->
     <Route path="/settings" breadcrumb="Settings" navigationHint="tab">
-      <AgentWorkspaceDetailsSettings {workspaceId} {workspaceSummary} {configuration} />
+      <AgentWorkspaceDetailsSettings {workspaceId} {workspaceSummary} bind:configuration />
     </Route>
   {/snippet}
 </DetailsPage>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -62,6 +62,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(router).subscribe.mockImplementation(routerStore.subscribe);
   vi.mocked(window.updateAgentWorkspaceSummary).mockResolvedValue(undefined);
+  vi.mocked(window.updateAgentWorkspaceConfiguration).mockResolvedValue(undefined);
 });
 
 test('Expect General section is active by default with workspace info', () => {
@@ -195,4 +196,130 @@ test('Expect error dialog shown when save fails', async () => {
       message: expect.stringContaining('network timeout'),
     }),
   );
+});
+
+// --- File Access section tests ---
+
+test('Expect File Access section shows Custom Paths selected for existing custom mounts', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  const customRadio = screen.getByRole('radio', { name: 'Use Custom Paths' });
+  expect(customRadio).toBeChecked();
+  const hostInput = screen.getByRole('textbox', { name: 'Host path 1' });
+  expect(hostInput).toHaveValue('$SOURCES/../shared-lib');
+  const targetInput = screen.getByRole('textbox', { name: 'Target path 1' });
+  expect(targetInput).toHaveValue('/workspace/shared-lib');
+});
+
+test('Expect File Access section defaults to No host filesystem access when no mounts', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  const workspaceRadio = screen.getByRole('radio', { name: 'Use No host filesystem access' });
+  expect(workspaceRadio).toBeChecked();
+  expect(screen.queryByRole('textbox', { name: 'Host path 1' })).not.toBeInTheDocument();
+});
+
+test('Expect selecting Custom Paths shows mount editor with empty mount', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Custom Paths' }));
+
+  expect(screen.getByRole('textbox', { name: 'Host path 1' })).toBeInTheDocument();
+  expect(screen.getByRole('textbox', { name: 'Target path 1' })).toBeInTheDocument();
+});
+
+test('Expect switching file access mode shows unsaved changes', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Home Directory' }));
+
+  expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+});
+
+test('Expect toggling read-only updates the button text', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  const toggleBtn = screen.getByRole('button', { name: 'Toggle read-only for mount 1' });
+  expect(toggleBtn).toHaveTextContent('read-write');
+
+  await fireEvent.click(toggleBtn);
+
+  expect(screen.getByRole('button', { name: 'Toggle read-only for mount 1' })).toHaveTextContent('read-only');
+});
+
+test('Expect saving Home Directory mode calls updateAgentWorkspaceConfiguration', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Home Directory' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.updateAgentWorkspaceConfiguration).toHaveBeenCalledWith('ws-1', {
+    mounts: [{ host: '$HOME', target: '$HOME', ro: false }],
+  });
+});
+
+test('Expect saving custom mounts calls updateAgentWorkspaceConfiguration', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Custom Paths' }));
+  const hostInput = screen.getByRole('textbox', { name: 'Host path 1' });
+  await fireEvent.input(hostInput, { target: { value: '/home/user/data' } });
+  const targetInput = screen.getByRole('textbox', { name: 'Target path 1' });
+  await fireEvent.input(targetInput, { target: { value: '/workspace/data' } });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.updateAgentWorkspaceConfiguration).toHaveBeenCalledWith('ws-1', {
+    mounts: [{ host: '/home/user/data', target: '/workspace/data', ro: false }],
+  });
+});
+
+test('Expect discarding file access changes resets to original mode', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Home Directory' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+
+  const customRadio = screen.getByRole('radio', { name: 'Use Custom Paths' });
+  expect(customRadio).toBeChecked();
+  expect(screen.getByRole('textbox', { name: 'Host path 1' })).toHaveValue('$SOURCES/../shared-lib');
+  expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+});
+
+test('Expect browse button calls openDialog and fills host path', async () => {
+  vi.mocked(window.openDialog).mockResolvedValue(['/selected/path']);
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Browse for directory' }));
+
+  expect(window.openDialog).toHaveBeenCalledWith({ title: 'Select a directory', selectors: ['openDirectory'] });
+  expect(screen.getByRole('textbox', { name: 'Host path 1' })).toHaveValue('/selected/path');
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -3,7 +3,9 @@ import { Button, Input, SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
-import type { AgentWorkspaceConfiguration } from '/@api/agent-workspace-info';
+import type { AgentWorkspaceConfiguration, AgentWorkspaceMount } from '/@api/agent-workspace-info';
+
+import AgentWorkspaceCreateStepFileSystem, { type CustomMount } from './AgentWorkspaceCreateStepFileSystem.svelte';
 
 type SettingsSection = 'general' | 'skills' | 'mcp' | 'knowledge' | 'file-access' | 'network' | 'advanced';
 
@@ -35,13 +37,73 @@ const activeLabel = $derived(sections.find(s => s.id === activeSection)?.label ?
 
 const originalName = $derived(workspaceSummary?.name ?? '');
 let workspaceName = $state(originalName);
-const hasChanges = $derived(workspaceName.trim() !== originalName && workspaceName.trim().length > 0);
+const hasNameChanges = $derived(workspaceName.trim() !== originalName && workspaceName.trim().length > 0);
 
+// --- File Access section state ---
+
+function deriveFileAccessSelection(mounts: AgentWorkspaceMount[] | undefined): string {
+  if (!mounts || mounts.length === 0) return 'workspace';
+  if (mounts.length === 1 && mounts[0].host === '$HOME' && mounts[0].target === '$HOME') return 'home';
+  if (mounts.length === 1 && mounts[0].host === '/' && mounts[0].target === '/') return 'full';
+  return 'custom';
+}
+
+function deriveMountsFromMounts(mounts: AgentWorkspaceMount[] | undefined): CustomMount[] {
+  if (!mounts || mounts.length === 0) return [{ host: '', target: '', ro: false }];
+  return mounts.map(m => ({ host: m.host, target: m.target, ro: m.ro }));
+}
+
+const originalFileAccess = $derived(deriveFileAccessSelection(configuration.mounts));
+const originalCustomMounts = $derived(deriveMountsFromMounts(configuration.mounts));
+
+let pendingFileAccess: string = $state(originalFileAccess);
+let pendingCustomMounts: CustomMount[] = $state(originalCustomMounts.map(m => ({ ...m })));
+
+function buildMountsFromSelection(fileAccess: string, mounts: CustomMount[]): AgentWorkspaceMount[] | undefined {
+  switch (fileAccess) {
+    case 'home':
+      return [{ host: '$HOME', target: '$HOME', ro: false }];
+    case 'full':
+      return [{ host: '/', target: '/', ro: false }];
+    case 'custom': {
+      const filtered = mounts
+        .filter(m => m.host.trim() !== '')
+        .map(m => ({ host: m.host.trim(), target: m.target.trim() ?? m.host.trim(), ro: m.ro }));
+      return filtered.length > 0 ? filtered : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+const hasMountChanges: boolean = $derived(
+  pendingFileAccess !== originalFileAccess ||
+    (pendingFileAccess === 'custom' &&
+      (pendingCustomMounts.length !== originalCustomMounts.length ||
+        pendingCustomMounts.some(
+          (m, i) =>
+            m.host !== originalCustomMounts[i]?.host ||
+            m.target !== originalCustomMounts[i]?.target ||
+            m.ro !== originalCustomMounts[i]?.ro,
+        ))),
+);
+
+// --- Combined dirty state ---
+const hasChanges = $derived(hasNameChanges || hasMountChanges);
+
+// --- Save / Discard ---
 async function saveChanges(): Promise<void> {
-  const trimmed = workspaceName.trim();
-  if (!trimmed || trimmed === originalName) return;
   try {
-    await window.updateAgentWorkspaceSummary(workspaceId, { name: trimmed });
+    if (hasNameChanges) {
+      await window.updateAgentWorkspaceSummary(workspaceId, { name: workspaceName.trim() });
+    }
+    if (hasMountChanges) {
+      const newMounts = buildMountsFromSelection(pendingFileAccess, pendingCustomMounts);
+      await window.updateAgentWorkspaceConfiguration(workspaceId, { mounts: newMounts });
+      configuration = { ...configuration, mounts: newMounts };
+      pendingFileAccess = deriveFileAccessSelection(configuration.mounts);
+      pendingCustomMounts = deriveMountsFromMounts(configuration.mounts).map(m => ({ ...m }));
+    }
   } catch (err: unknown) {
     await window.showMessageBox({
       title: 'Agent Workspace',
@@ -54,6 +116,35 @@ async function saveChanges(): Promise<void> {
 
 function discardChanges(): void {
   workspaceName = originalName;
+  pendingFileAccess = originalFileAccess;
+  pendingCustomMounts = originalCustomMounts.map(m => ({ ...m }));
+}
+
+function addCustomMount(): void {
+  pendingCustomMounts = [...pendingCustomMounts, { host: '', target: '', ro: false }];
+}
+
+function removeCustomMount(index: number): void {
+  pendingCustomMounts = pendingCustomMounts.filter((_, i) => i !== index);
+}
+
+function updateCustomMount(index: number, field: keyof CustomMount, value: string | boolean): void {
+  pendingCustomMounts = pendingCustomMounts.map((m, i) => (i === index ? { ...m, [field]: value } : m));
+}
+
+async function handleBrowseCustomPath(index: number): Promise<void> {
+  try {
+    const result = await window.openDialog({ title: 'Select a directory', selectors: ['openDirectory'] });
+    const selected = result?.[0];
+    if (selected) updateCustomMount(index, 'host', selected);
+  } catch (err: unknown) {
+    await window.showMessageBox({
+      title: 'Agent Workspace',
+      type: 'error',
+      message: `Failed to browse for directory: ${err instanceof Error ? err.message : String(err)}`,
+      buttons: ['OK'],
+    });
+  }
 }
 </script>
 
@@ -122,6 +213,15 @@ function discardChanges(): void {
               </div>
             </div>
           </div>
+
+        {:else if activeSection === 'file-access'}
+          <AgentWorkspaceCreateStepFileSystem
+            bind:selectedFileAccess={pendingFileAccess}
+            customMounts={pendingCustomMounts}
+            onBrowseCustomPath={handleBrowseCustomPath}
+            onAddCustomMount={addCustomMount}
+            onRemoveCustomMount={removeCustomMount}
+            onUpdateCustomMount={updateCustomMount} />
 
         {:else}
           <p class="text-sm text-[var(--pd-content-text)] mb-7">


### PR DESCRIPTION
Reuse the AgentWorkspaceCreateStepFileSystem component in the workspace settings page so users can view and edit mount configuration after creation. Includes save/discard logic and unit tests.


https://github.com/user-attachments/assets/2172b3fd-9e36-4649-94ee-675e0b2a1cd1

Closes https://github.com/openkaiden/kaiden/issues/1621