### PR TITLE
fix: persist navigation route across page reloads

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,8 @@ vi.mock('./lib/welcome/WelcomePage.svelte', () => ({
   default: vi.fn(),
 }));
 
+vi.mock(import('./PreferencesNavigation.svelte'));
+
 vi.mock('./lib/context/ContextKey.svelte', () => ({
   default: vi.fn(),
 }));
@@ -88,6 +90,7 @@ const messages = new Map<string, (args: unknown) => void>();
 
 beforeEach(() => {
   vi.resetAllMocks();
+  sessionStorage.clear();
   showChatWindow.set(true);
   router.goto('/');
   (window.events as unknown) = {
@@ -240,6 +243,59 @@ test('leaving Chat Page saves it in lastPage storage', async () => {
   router.goto('/pods');
   await tick();
   expect(get(lastPage).name).equals('Chat');
+});
+
+describe('route persistence across reloads', () => {
+  const LAST_ROUTE_KEY = 'last-route';
+  const SETTINGS_PAGE_KEY = 'settings-page';
+
+  test('navigating to a regular page saves it in sessionStorage', async () => {
+    render(App);
+    router.goto('/images');
+    await tick();
+    expect(sessionStorage.getItem(LAST_ROUTE_KEY)).toBe('/images');
+    expect(sessionStorage.getItem(SETTINGS_PAGE_KEY)).toBeNull();
+  });
+
+  test('navigating to Dashboard clears sessionStorage', async () => {
+    render(App);
+    router.goto('/images');
+    await tick();
+    router.goto('/');
+    await tick();
+    expect(sessionStorage.getItem(LAST_ROUTE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(SETTINGS_PAGE_KEY)).toBeNull();
+  });
+
+  test('navigating to a preferences page saves it without overwriting last regular page', async () => {
+    render(App);
+    router.goto('/images');
+    await tick();
+    router.goto('/preferences/resources');
+    await tick();
+    expect(sessionStorage.getItem(LAST_ROUTE_KEY)).toBe('/images');
+    expect(sessionStorage.getItem(SETTINGS_PAGE_KEY)).toBe('/preferences/resources');
+  });
+
+  test('navigating directly to a preferences page (no prior regular page) saves only SETTINGS_PAGE_KEY', async () => {
+    render(App);
+    router.goto('/preferences/onboarding/podman');
+    await tick();
+    expect(sessionStorage.getItem(SETTINGS_PAGE_KEY)).toBe('/preferences/onboarding/podman');
+    expect(sessionStorage.getItem(LAST_ROUTE_KEY)).toBeNull();
+  });
+
+  test('navigating away from preferences clears SETTINGS_PAGE_KEY', async () => {
+    render(App);
+    router.goto('/images');
+    await tick();
+    router.goto('/preferences/resources');
+    await tick();
+    router.goto('/containers');
+    await tick();
+    expect(sessionStorage.getItem(LAST_ROUTE_KEY)).toBe('/containers');
+    expect(sessionStorage.getItem(SETTINGS_PAGE_KEY)).toBeNull();
+  });
 });
 
 describe('Table persistence functionality', () => {

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -116,8 +116,8 @@ router.mode.memory();
 const LAST_ROUTE_KEY = 'last-route';
 const SETTINGS_PAGE_KEY = 'settings-page';
 
-const savedRoute = sessionStorage.getItem(LAST_ROUTE_KEY);
-const savedSettingsPage = sessionStorage.getItem(SETTINGS_PAGE_KEY);
+let savedRoute: string | undefined = sessionStorage.getItem(LAST_ROUTE_KEY) ?? undefined;
+let savedSettingsPage: string | undefined = sessionStorage.getItem(SETTINGS_PAGE_KEY) ?? undefined;
 
 //remember from where we come to preference pages
 let nonSettingsPage = savedRoute ?? '/';
@@ -156,9 +156,15 @@ router.subscribe(function (navigation) {
 
   currentUrl = navigation.url;
 
-  if ((savedRoute !== null || savedSettingsPage !== null) && navigation.url === '/') {
-    if (savedRoute) router.goto(savedRoute);
-    if (savedSettingsPage) router.goto(savedSettingsPage);
+  if ((savedRoute !== undefined || savedSettingsPage !== undefined) && navigation.url === '/') {
+    if (savedRoute) {
+      router.goto(savedRoute);
+      savedRoute = undefined;
+    }
+    if (savedSettingsPage) {
+      router.goto(savedSettingsPage);
+      savedSettingsPage = undefined;
+    }
     return;
   }
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -113,8 +113,14 @@ import SubmenuNavigation from './SubmenuNavigation.svelte';
 
 router.mode.memory();
 
+const LAST_ROUTE_KEY = 'last-route';
+const SETTINGS_PAGE_KEY = 'settings-page';
+
+const savedRoute = sessionStorage.getItem(LAST_ROUTE_KEY);
+const savedSettingsPage = sessionStorage.getItem(SETTINGS_PAGE_KEY);
+
 //remember from where we come to preference pages
-let nonSettingsPage = '/';
+let nonSettingsPage = savedRoute ?? '/';
 
 function isChatRoute(url: string): boolean {
   return url === '/' || url.startsWith('/chat');
@@ -137,18 +143,43 @@ const unsubscribeShowChatWindow = showChatWindow.subscribe(value => {
 
 onDestroy(unsubscribeShowChatWindow);
 
+// tinro fires router.subscribe synchronously with the current state on setup,
+// and WelcomePage always calls router.goto('/') in its onMount (even on reload).
+// We use that guaranteed '/' event as the trigger to restore the pre-reload
+// route on top of Dashboard.  subscribeReady skips the synchronous initial
+// fire so savedRoute is still available when the real '/' event arrives.
+let subscribeReady = false;
 router.subscribe(function (navigation) {
-  if (navigation.url !== undefined) {
-    currentUrl = navigation.url;
-    if (!navigation.url.startsWith('/preferences')) {
-      nonSettingsPage = navigation.url;
-    }
+  if (!subscribeReady) return;
+  if (navigation.url === undefined || navigation.url.includes('.html')) return;
+  if (!navigation.url.startsWith('/')) return;
+
+  currentUrl = navigation.url;
+
+  if ((savedRoute !== null || savedSettingsPage !== null) && navigation.url === '/') {
+    if (savedRoute) router.goto(savedRoute);
+    if (savedSettingsPage) router.goto(savedSettingsPage);
+    return;
   }
+
+  if (navigation.url === '/') {
+    sessionStorage.removeItem(LAST_ROUTE_KEY);
+    sessionStorage.removeItem(SETTINGS_PAGE_KEY);
+    nonSettingsPage = '/';
+  } else if (navigation.url.startsWith('/preferences')) {
+    sessionStorage.setItem(SETTINGS_PAGE_KEY, navigation.url);
+  } else {
+    sessionStorage.setItem(LAST_ROUTE_KEY, navigation.url);
+    sessionStorage.removeItem(SETTINGS_PAGE_KEY);
+    nonSettingsPage = navigation.url;
+  }
+
   // Guard: redirect away from chat routes when chat is disabled
-  if (navigation.url !== undefined && $showChatWindow === false && isChatRoute(navigation.url)) {
+  if ($showChatWindow === false && isChatRoute(navigation.url)) {
     router.goto('/agent-workspaces');
   }
 });
+subscribeReady = true;
 
 window.events?.receive('context-menu:visible', visible => {
   if (visible) {


### PR DESCRIPTION
The fix saves current page and preference page (if visible) paths in
session storage and restore it after UI reloaded.

Cherry-picked from https://github.com/podman-desktop/podman-desktop/commit/04919f8566e and
adapted for kaiden's chat routing logic.

Fixes #1881
