### PR TITLE
feat(claude): register Claude Code as agent via extension point

### DIFF
--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -91,6 +91,23 @@ describe('ClaudeExtension', () => {
     await expect(claudeExtension.activate()).rejects.toThrow('Container creation failed');
   });
 
+  test('activate cleans up all resources on failure', async () => {
+    const agentDisposeMock = vi.fn();
+    vi.mocked(agents.registerAgent).mockReturnValue({ dispose: agentDisposeMock });
+
+    const faultyGetAsync = vi
+      .fn()
+      .mockResolvedValueOnce(new ClaudeSkillsManager())
+      .mockRejectedValueOnce(new Error('Container creation failed'));
+    vi.spyOn(claudeExtension, 'getContainer').mockReturnValue({
+      getAsync: faultyGetAsync,
+    } as unknown as Container);
+
+    await expect(claudeExtension.activate()).rejects.toThrow('Container creation failed');
+    expect(agentDisposeMock).toHaveBeenCalled();
+    expect(ClaudeSkillsManager.prototype.dispose).toHaveBeenCalled();
+  });
+
   test('deactivate disposes agent registration', async () => {
     const disposeMock = vi.fn();
     vi.mocked(agents.registerAgent).mockReturnValue({ dispose: disposeMock });

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -89,23 +89,6 @@ describe('ClaudeExtension', () => {
     await expect(claudeExtension.activate()).rejects.toThrow('Container creation failed');
   });
 
-  test('activate cleans up all resources on failure', async () => {
-    const agentDisposeMock = vi.fn();
-    vi.mocked(agents.registerAgent).mockReturnValue({ dispose: agentDisposeMock });
-
-    const faultyGetAsync = vi
-      .fn()
-      .mockResolvedValueOnce(new ClaudeSkillsManager())
-      .mockRejectedValueOnce(new Error('Container creation failed'));
-    vi.spyOn(claudeExtension, 'getContainer').mockReturnValue({
-      getAsync: faultyGetAsync,
-    } as unknown as Container);
-
-    await expect(claudeExtension.activate()).rejects.toThrow('Container creation failed');
-    expect(agentDisposeMock).toHaveBeenCalled();
-    expect(ClaudeSkillsManager.prototype.dispose).toHaveBeenCalled();
-  });
-
   test('deactivate disposes agent registration', async () => {
     const disposeMock = vi.fn();
     vi.mocked(agents.registerAgent).mockReturnValue({ dispose: disposeMock });

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -62,7 +62,6 @@ describe('ClaudeExtension', () => {
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
         isSupportedModelType: expect.any(Function),
-        isSupportedRuntime: expect.any(Function),
       }),
     );
   });
@@ -75,12 +74,11 @@ describe('ClaudeExtension', () => {
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(false);
   });
 
-  test('registered agent supports all runtimes', async () => {
+  test('registered agent does not restrict runtimes', async () => {
     await claudeExtension.activate();
 
     const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-    expect(agent.isSupportedRuntime!('podman')).toBe(true);
-    expect(agent.isSupportedRuntime!('openshell')).toBe(true);
+    expect(agent.isSupportedRuntime).toBeUndefined();
   });
 
   test('activate handles error during container creation', async () => {

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { ExtensionContext } from '@openkaiden/api';
+import { agents } from '@openkaiden/api';
 import type { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -50,12 +51,54 @@ describe('ClaudeExtension', () => {
     expect(ClaudeInferenceManager.prototype.init).toHaveBeenCalled();
   });
 
+  test('activate registers agent', async () => {
+    await claudeExtension.activate();
+
+    expect(agents.registerAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'claude',
+        name: 'Claude Code',
+        description: expect.any(String),
+        icon: expect.objectContaining({ icon: './icon.png' }),
+        tags: ['Cloud'],
+        isSupportedModelType: expect.any(Function),
+        isSupportedRuntime: expect.any(Function),
+      }),
+    );
+  });
+
+  test('registered agent supports anthropic model type', async () => {
+    await claudeExtension.activate();
+
+    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    expect(agent.isSupportedModelType!({ name: 'anthropic' })).toBe(true);
+    expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(false);
+  });
+
+  test('registered agent supports all runtimes', async () => {
+    await claudeExtension.activate();
+
+    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    expect(agent.isSupportedRuntime!('podman')).toBe(true);
+    expect(agent.isSupportedRuntime!('openshell')).toBe(true);
+  });
+
   test('activate handles error during container creation', async () => {
     const faultyGetAsync = vi.fn().mockRejectedValue(new Error('Container creation failed'));
     vi.spyOn(claudeExtension, 'getContainer').mockReturnValue({
       getAsync: faultyGetAsync,
     } as unknown as Container);
     await expect(claudeExtension.activate()).rejects.toThrow('Container creation failed');
+  });
+
+  test('deactivate disposes agent registration', async () => {
+    const disposeMock = vi.fn();
+    vi.mocked(agents.registerAgent).mockReturnValue({ dispose: disposeMock });
+
+    await claudeExtension.activate();
+    await claudeExtension.deactivate();
+
+    expect(disposeMock).toHaveBeenCalled();
   });
 
   test('deactivate disposes subscriptions', async () => {

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -60,7 +60,6 @@ export class ClaudeExtension {
       icon: providerImages,
       tags: ['Cloud'],
       isSupportedModelType: (type): boolean => type.name === 'anthropic',
-      isSupportedRuntime: (): boolean => true,
     });
 
     try {

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -63,25 +63,19 @@ export class ClaudeExtension {
       isSupportedRuntime: (): boolean => true,
     });
 
-    this.#inversifyBinding = new InversifyBinding(claudeProvider, this.#extensionContext);
-    this.#container = await this.#inversifyBinding.initBindings();
-
     try {
+      this.#inversifyBinding = new InversifyBinding(claudeProvider, this.#extensionContext);
+      this.#container = await this.#inversifyBinding.initBindings();
+
       this.#claudeSkillsManager = await this.getContainer()?.getAsync(ClaudeSkillsManager);
-    } catch (e) {
-      console.error('Error while creating the Claude skills manager', e);
-      throw e;
-    }
-
-    try {
       this.#claudeInferenceManager = await this.getContainer()?.getAsync(ClaudeInferenceManager);
+
+      await this.#claudeSkillsManager?.init();
+      await this.#claudeInferenceManager?.init();
     } catch (e) {
-      console.error('Error while creating the Claude inference manager', e);
+      await this.deactivate();
       throw e;
     }
-
-    await this.#claudeSkillsManager?.init();
-    await this.#claudeInferenceManager?.init();
   }
 
   protected getContainer(): Container | undefined {

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -62,19 +62,25 @@ export class ClaudeExtension {
       isSupportedModelType: (type): boolean => type.name === 'anthropic',
     });
 
+    this.#inversifyBinding = new InversifyBinding(claudeProvider, this.#extensionContext);
+    this.#container = await this.#inversifyBinding.initBindings();
+
     try {
-      this.#inversifyBinding = new InversifyBinding(claudeProvider, this.#extensionContext);
-      this.#container = await this.#inversifyBinding.initBindings();
-
       this.#claudeSkillsManager = await this.getContainer()?.getAsync(ClaudeSkillsManager);
-      this.#claudeInferenceManager = await this.getContainer()?.getAsync(ClaudeInferenceManager);
-
-      await this.#claudeSkillsManager?.init();
-      await this.#claudeInferenceManager?.init();
     } catch (e) {
-      await this.deactivate();
+      console.error('Error while creating the Claude skills manager', e);
       throw e;
     }
+
+    try {
+      this.#claudeInferenceManager = await this.getContainer()?.getAsync(ClaudeInferenceManager);
+    } catch (e) {
+      console.error('Error while creating the Claude inference manager', e);
+      throw e;
+    }
+
+    await this.#claudeSkillsManager?.init();
+    await this.#claudeInferenceManager?.init();
   }
 
   protected getContainer(): Container | undefined {

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@openkaiden/api';
-import { provider } from '@openkaiden/api';
+import type { Disposable, ExtensionContext } from '@openkaiden/api';
+import { agents, provider } from '@openkaiden/api';
 import type { Container } from 'inversify';
 
 import { InversifyBinding } from '/@/inject/inversify-binding';
@@ -31,23 +31,36 @@ export class ClaudeExtension {
   #container: Container | undefined;
   #claudeSkillsManager: ClaudeSkillsManager | undefined;
   #claudeInferenceManager: ClaudeInferenceManager | undefined;
+  #agentDisposable: Disposable | undefined;
 
   constructor(extensionContext: ExtensionContext) {
     this.#extensionContext = extensionContext;
   }
 
   async activate(): Promise<void> {
+    const providerImages = {
+      icon: './icon.png',
+      logo: {
+        dark: './icon.png',
+        light: './icon.png',
+      },
+    };
+
     const claudeProvider = provider.createProvider({
       name: 'Claude',
       status: 'unknown',
       id: 'claude',
-      images: {
-        icon: './icon.png',
-        logo: {
-          dark: './icon.png',
-          light: './icon.png',
-        },
-      },
+      images: providerImages,
+    });
+
+    this.#agentDisposable = agents.registerAgent({
+      id: 'claude',
+      name: 'Claude Code',
+      description: 'Anthropic cloud agent — connect with an API key to access Claude models.',
+      icon: providerImages,
+      tags: ['Cloud'],
+      isSupportedModelType: (type): boolean => type.name === 'anthropic',
+      isSupportedRuntime: (): boolean => true,
     });
 
     this.#inversifyBinding = new InversifyBinding(claudeProvider, this.#extensionContext);
@@ -76,6 +89,8 @@ export class ClaudeExtension {
   }
 
   async deactivate(): Promise<void> {
+    this.#agentDisposable?.dispose();
+    this.#agentDisposable = undefined;
     await this.#inversifyBinding?.dispose();
     this.#claudeSkillsManager?.dispose();
     this.#claudeSkillsManager = undefined;


### PR DESCRIPTION
Use the new agents.registerAgent() API introduced in #1912 to register Claude Code from the extension instead of relying on core-only definitions.

Closes #1835