### PR TITLE
fix: guard terminal webContents.send against destroyed state

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -110,6 +110,7 @@ const filesystemMonitoring = {
 const webContents = {
   send: vi.fn(),
   receive: vi.fn(),
+  isDestroyed: vi.fn().mockReturnValue(false),
 } as unknown as WebContents;
 
 const configurationRegistry = {
@@ -1164,5 +1165,44 @@ describe('dispose', () => {
     await expect(terminalHandler({}, 'unknown-id', 1)).rejects.toThrow(
       'workspace "unknown-id" not found. Use "workspace list" to see available workspaces.',
     );
+  });
+
+  test('does not send terminal data when webContents is destroyed', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
+
+    let onDataCallback: ((data: string) => void) | undefined;
+    let onExitCallback: (() => void) | undefined;
+    const mockPty = {
+      onData: vi.fn((cb: (data: string) => void) => {
+        onDataCallback = cb;
+        return { dispose: vi.fn() };
+      }),
+      onExit: vi.fn((cb: () => void) => {
+        onExitCallback = cb;
+        return { dispose: vi.fn() };
+      }),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      pid: 123,
+    } as unknown as IPty;
+    vi.mocked(spawn).mockReturnValue(mockPty);
+
+    const terminalHandler = vi
+      .mocked(ipcHandle)
+      .mock.calls.find(call => call[0] === 'agent-workspace:terminal')?.[1] as (
+      _listener: unknown,
+      id: string,
+      onDataId: number,
+    ) => Promise<number>;
+
+    await terminalHandler({}, 'ws-1', 1);
+
+    vi.mocked(webContents.isDestroyed).mockReturnValue(true);
+
+    onDataCallback!('some output');
+    onExitCallback!();
+
+    expect(webContents.send).not.toHaveBeenCalled();
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -453,13 +453,19 @@ export class AgentWorkspaceManager implements Disposable {
         const invocation = this.shellInAgentWorkspace(
           workspace.name,
           (content: string) => {
-            this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
+            if (!this.webContents.isDestroyed()) {
+              this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
+            }
           },
           (error: string) => {
-            this.webContents.send('agent-workspace:terminal-onError', onDataId, error);
+            if (!this.webContents.isDestroyed()) {
+              this.webContents.send('agent-workspace:terminal-onError', onDataId, error);
+            }
           },
           () => {
-            this.webContents.send('agent-workspace:terminal-onEnd', onDataId);
+            if (!this.webContents.isDestroyed()) {
+              this.webContents.send('agent-workspace:terminal-onEnd', onDataId);
+            }
             this.terminalCallbacks.delete(onDataId);
             this.terminalProcesses.delete(onDataId);
           },


### PR DESCRIPTION
## Summary

Fixes #1931

- Guard all `webContents.send()` calls in the workspace terminal IPC handler with `webContents.isDestroyed()` checks to prevent a JavaScript error crash when the app is closed during an active terminal prompt session.

## Root Cause

When closing the application while a workspace terminal session is waiting for a prompt response, the pty `onData`/`onExit` callbacks could fire after the Electron `webContents` was already destroyed. Calling `.send()` on a destroyed `webContents` throws an unhandled error that surfaces as a crash dialog.

## Test plan

- [x] Unit test added: verifies no `webContents.send()` calls occur when `isDestroyed()` returns `true`
- [x] Manual: enable "exit on close", create a workspace, open terminal, send a prompt, close the app while waiting for response — no crash dialog should appear


Made with [Cursor](https://cursor.com)