### PR TITLE
fix: redact secret values from kdn CLI error logs

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -640,13 +640,13 @@ describe('ensureModelSecret', () => {
     expect(secretManager.create).not.toHaveBeenCalled();
   });
 
-  test('tolerates "already exists" error from secret creation', async () => {
+  test('proceeds normally when secret already exists (handled by KdnCli)', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { 'claude:tokens': 'sk-ant-secret' },
       llmMetadataName: 'anthropic',
       endpoint: undefined,
     });
-    vi.mocked(secretManager.create).mockRejectedValue(new Error('secret already exists: my-workspace-anthropic'));
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-anthropic' });
 
     const options = { ...baseOptions, model: 'anthropic::claude-sonnet-4-20250514::' };
     await manager.ensureModelSecret(options);
@@ -654,7 +654,7 @@ describe('ensureModelSecret', () => {
     expect(options.secrets).toContain('my-workspace-anthropic');
   });
 
-  test('rethrows non-"already exists" errors from secret creation', async () => {
+  test('rethrows errors from secret creation', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { 'claude:tokens': 'sk-ant-secret' },
       llmMetadataName: 'anthropic',

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -149,12 +149,7 @@ export class AgentWorkspaceManager implements Disposable {
     const result = this.buildSecretOptions(connectionInfo, workspaceSecretPrefix);
     if (!result) return;
 
-    try {
-      await this.secretManager.create(result.secret);
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!msg.includes('already exists')) throw err;
-    }
+    await this.secretManager.create(result.secret);
 
     options.secrets = [...new Set([...(options.secrets ?? []), result.secret.name])];
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -864,60 +864,49 @@ describe('createSecret', () => {
   };
 
   test('executes kdn secret create with required flags and returns the secret name', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
     const result = await kdnCli.createSecret(defaultOptions);
 
-    expect(exec.exec).toHaveBeenCalledWith(
-      KAIDEN_CLI_PATH,
-      ['secret', 'create', 'my-secret', '--type', 'github', '--value', 'ghp_abc123', '--output', 'json'],
-      undefined,
-    );
+    expect(exec.exec).toHaveBeenCalledWith(KAIDEN_CLI_PATH, [
+      'secret',
+      'create',
+      'my-secret',
+      '--type',
+      'github',
+      '--value',
+      'ghp_abc123',
+      '--output',
+      'json',
+    ]);
     expect(result).toEqual({ name: 'my-secret' });
   });
 
   test('includes optional description flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
     await kdnCli.createSecret({ ...defaultOptions, description: 'GitHub token' });
 
-    expect(exec.exec).toHaveBeenCalledWith(
-      KAIDEN_CLI_PATH,
-      expect.arrayContaining(['--description', 'GitHub token']),
-      undefined,
-    );
+    expect(exec.exec).toHaveBeenCalledWith(KAIDEN_CLI_PATH, expect.arrayContaining(['--description', 'GitHub token']));
   });
 
   test('includes optional host flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
     await kdnCli.createSecret({ ...defaultOptions, type: 'other', hosts: ['api.example.com'] });
 
-    expect(exec.exec).toHaveBeenCalledWith(
-      KAIDEN_CLI_PATH,
-      expect.arrayContaining(['--host', 'api.example.com']),
-      undefined,
-    );
+    expect(exec.exec).toHaveBeenCalledWith(KAIDEN_CLI_PATH, expect.arrayContaining(['--host', 'api.example.com']));
   });
 
   test('includes optional header flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
     await kdnCli.createSecret({ ...defaultOptions, type: 'other', header: 'Authorization' });
 
-    expect(exec.exec).toHaveBeenCalledWith(
-      KAIDEN_CLI_PATH,
-      expect.arrayContaining(['--header', 'Authorization']),
-      undefined,
-    );
+    expect(exec.exec).toHaveBeenCalledWith(KAIDEN_CLI_PATH, expect.arrayContaining(['--header', 'Authorization']));
   });
 
   test('includes optional headerTemplate flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
     await kdnCli.createSecret({ ...defaultOptions, type: 'other', headerTemplate: 'Bearer ${value}' });
@@ -925,21 +914,18 @@ describe('createSecret', () => {
     expect(exec.exec).toHaveBeenCalledWith(
       KAIDEN_CLI_PATH,
       expect.arrayContaining(['--headerTemplate', 'Bearer ${value}']),
-      undefined,
     );
   });
 
   test('includes optional path flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
     await kdnCli.createSecret({ ...defaultOptions, type: 'other', path: '/api/v1' });
 
-    expect(exec.exec).toHaveBeenCalledWith(KAIDEN_CLI_PATH, expect.arrayContaining(['--path', '/api/v1']), undefined);
+    expect(exec.exec).toHaveBeenCalledWith(KAIDEN_CLI_PATH, expect.arrayContaining(['--path', '/api/v1']));
   });
 
   test('repeats env flag for each entry in the array', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify({ name: 'my-secret' })));
 
     await kdnCli.createSecret({ ...defaultOptions, type: 'other', envs: ['API_KEY', 'SECRET_KEY'] });
@@ -947,25 +933,47 @@ describe('createSecret', () => {
     expect(exec.exec).toHaveBeenCalledWith(
       KAIDEN_CLI_PATH,
       expect.arrayContaining(['--env', 'API_KEY', '--env', 'SECRET_KEY']),
-      undefined,
     );
   });
 
-  test('extracts kdn JSON error from stdout on failure', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  test('returns secret name silently when secret already exists', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const runError = mockRunError({
-      stdout: JSON.stringify({ error: 'Error: secret already exists: my-secret' }),
+      stdout: JSON.stringify({ error: 'secret "my-secret": secret already exists' }),
     });
-    vi.spyOn(exec, 'exec').mockRejectedValue(runError);
+    vi.mocked(exec.exec).mockRejectedValue(runError);
 
-    await expect(kdnCli.createSecret(defaultOptions)).rejects.toThrow('Error: secret already exists: my-secret');
+    const result = await kdnCli.createSecret(defaultOptions);
+
+    expect(result).toEqual({ name: 'my-secret' });
   });
 
-  test('redacts secret value from error logs', async () => {
+  test('does not log error when secret already exists', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const runError = mockRunError({
-      stdout: JSON.stringify({ error: 'secret already exists' }),
+      stdout: JSON.stringify({ error: 'secret "my-secret": secret already exists' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await kdnCli.createSecret(defaultOptions);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test('rethrows non-"already exists" errors', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'keychain unavailable' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(kdnCli.createSecret(defaultOptions)).rejects.toThrow('keychain unavailable');
+  });
+
+  test('redacts secret value from error logs on non-"already exists" failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'keychain unavailable' }),
     });
     vi.mocked(exec.exec).mockRejectedValue(runError);
 

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.spec.ts
@@ -961,6 +961,20 @@ describe('createSecret', () => {
 
     await expect(kdnCli.createSecret(defaultOptions)).rejects.toThrow('Error: secret already exists: my-secret');
   });
+
+  test('redacts secret value from error logs', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'secret already exists' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(kdnCli.createSecret(defaultOptions)).rejects.toThrow();
+
+    const loggedMessage = errorSpy.mock.calls[0]![0] as string;
+    expect(loggedMessage).toContain('--value ***');
+    expect(loggedMessage).not.toContain(defaultOptions.value);
+  });
 });
 
 describe('listSecrets', () => {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -335,6 +335,7 @@ export class KdnCli {
   }
 
   async createSecret(options: SecretCreateOptions): Promise<SecretName> {
+    const cliPath = this.getCliPath();
     const args = ['secret', 'create', options.name, '--type', options.type, '--value', options.value];
     if (options.description) {
       args.push('--description', options.description);
@@ -358,7 +359,19 @@ export class KdnCli {
         args.push('--env', e);
       }
     }
-    return this.execCLI<SecretName>(args);
+    const fullArgs = [...args, '--output', 'json'];
+    try {
+      const result = await this.exec.exec(cliPath, fullArgs);
+      return JSON.parse(result.stdout) as SecretName;
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      if (detail.includes('already exists')) {
+        return { name: options.name };
+      }
+      const safeArgs = this.redactSensitiveArgs(fullArgs);
+      console.error(`kdn failed: ${cliPath} ${safeArgs.join(' ')} — ${detail}`);
+      throw new Error(detail);
+    }
   }
 
   async listSecrets(): Promise<SecretInfo[]> {

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -304,6 +304,22 @@ export class KdnCli {
     return this.execCLI<AgentWorkspaceId>(['workspace', 'stop', id]);
   }
 
+  /**
+   * Redact values of sensitive CLI flags so they are never printed to logs.
+   */
+  private redactSensitiveArgs(args: readonly string[]): string[] {
+    const sensitiveFlags = new Set(['--value']);
+    const redacted: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+      redacted.push(args[i]!);
+      if (sensitiveFlags.has(args[i]!) && i + 1 < args.length) {
+        redacted.push('***');
+        i++;
+      }
+    }
+    return redacted;
+  }
+
   private async execCLI<T>(args: string[], options?: RunOptions): Promise<T> {
     const cliPath = this.getCliPath();
     const fullArgs = [...args, '--output', 'json'];
@@ -312,7 +328,8 @@ export class KdnCli {
       return JSON.parse(result.stdout) as T;
     } catch (err: unknown) {
       const detail = this.extractCliError(err);
-      console.error(`kdn failed: ${cliPath} ${fullArgs.join(' ')} — ${detail}`);
+      const safeArgs = this.redactSensitiveArgs(fullArgs);
+      console.error(`kdn failed: ${cliPath} ${safeArgs.join(' ')} — ${detail}`);
       throw new Error(detail);
     }
   }


### PR DESCRIPTION
## Summary

- Redacts `--value` (API key/secret) from `console.error` output when `kdn secret create` fails, replacing it with `***`
- Handles the "secret already exists" case silently in `KdnCli.createSecret` — returns `{ name }` instead of logging an error and forcing callers to catch-and-ignore
- Simplifies `AgentWorkspaceManager.ensureModelSecret` by removing its now-unnecessary try/catch for duplicate secrets

## Test plan

- [x] New tests: `returns secret name silently when secret already exists`, `does not log error when secret already exists`, `rethrows non-"already exists" errors`, `redacts secret value from error logs on non-"already exists" failure`
- [x] All 72 `kdn-cli.spec.ts` tests pass
- [x] All 89 `agent-workspace-manager.spec.ts` tests pass
- [x] All 16 `secret-manager.spec.ts` tests pass
- [x] Typecheck passes

Closes #1944

Made with [Cursor](https://cursor.com)