### PR TITLE
Coding agents page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -62,6 +62,7 @@ export enum NavigationPage {
   MCP_DETAILS = 'mcp-details',
   AGENT_WORKSPACES = 'agent-workspaces',
   AGENT_WORKSPACE_CREATE = 'agent-workspace-create',
+  CODING_AGENTS = 'coding-agents',
   SKILLS = 'skills',
   SKILL_DETAILS = 'skill-details',
   RAG_ENVIRONMENTS = 'rag-environments',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -78,6 +78,7 @@ export interface NavigationParameters {
   };
   [NavigationPage.AGENT_WORKSPACES]: never;
   [NavigationPage.AGENT_WORKSPACE_CREATE]: never;
+  [NavigationPage.CODING_AGENTS]: never;
   [NavigationPage.SKILLS]: never;
   [NavigationPage.SKILL_DETAILS]: {
     name: string;

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -28,6 +28,7 @@ import AppNavigation from './AppNavigation.svelte';
 import { navigateTo } from './kubernetesNavigation';
 import Appearance from './lib/appearance/Appearance.svelte';
 import CustomChat from './lib/chat/route/CustomChat.svelte';
+import CodingAgentsPage from './lib/coding-agents/CodingAgentsPage.svelte';
 import ComposeDetails from './lib/compose/ComposeDetails.svelte';
 import ConfigMapDetails from './lib/configmaps-secrets/ConfigMapDetails.svelte';
 import ConfigMapSecretList from './lib/configmaps-secrets/ConfigMapSecretList.svelte';
@@ -255,6 +256,11 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
         <Route path="/mcp-install-from-registry/:serverId/*" breadcrumb="Install MCP Server from Registry" let:meta>
           <McpRegistryCreateFromRegistryForm serverId={decodeURIComponent(meta.params.serverId)} />
+        </Route>
+
+        <!-- Coding agents -->
+        <Route path="/coding-agents" breadcrumb="Coding agents" navigationHint="root">
+          <CodingAgentsPage />
         </Route>
 
         <!-- Models -->

--- a/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
@@ -3,10 +3,10 @@ import { faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
+import IconImage from '/@/lib/appearance/IconImage.svelte';
 import type { CatalogModelInfo, InferenceConnectionSummary } from '/@/lib/models/models-utils';
 import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
 import ProviderConnectionTiles from '/@/lib/models/ProviderConnectionTiles.svelte';
-import { isDark } from '/@/stores/appearance';
 import { inferenceConnectionSummariesData } from '/@/stores/inference-connection-summaries';
 import { modelKey } from '/@/stores/model-catalog';
 import { catalogModels } from '/@/stores/models';
@@ -31,9 +31,10 @@ let hasModels = $derived(compatibleModels.length > 0);
 
 let configurableConnections: InferenceConnectionSummary[] = $derived.by(() => {
   const all: InferenceConnectionSummary[] = $inferenceConnectionSummariesData.slice();
-  const ownProvider = all.filter(c => c.providerId === agentInfo.id);
-  if (ownProvider.length > 0) return ownProvider;
-  return all;
+  if (agentInfo.supportedModelTypes === undefined) return all;
+  const compatibleProviderIds = new Set(compatibleModels.map(m => m.providerId));
+  if (compatibleProviderIds.size === 0) return all;
+  return all.filter(c => compatibleProviderIds.has(c.providerId));
 });
 
 let savedModelKey = $state('');
@@ -106,28 +107,17 @@ async function saveSelection(): Promise<void> {
   }
 }
 
-let agentIconSrc = $derived(getAgentIconSrc(agentInfo));
-
 function getAgentSubtitle(agent: AgentInfo): string {
   return agent.tags?.join(' · ') ?? '';
-}
-
-function getAgentIconSrc(agent: AgentInfo): string | undefined {
-  const image = agent.icon?.logo ?? agent.icon?.icon;
-  if (!image) return undefined;
-  if (typeof image === 'string') return image;
-  return $isDark ? image.dark : image.light;
 }
 </script>
 
 <div class="flex flex-col h-full overflow-y-auto">
   <div class="pt-6 px-8">
     <div class="flex items-center gap-3 mb-1">
-      {#if agentIconSrc}
-        <Icon icon={agentIconSrc} size={32} />
-      {:else}
+      <IconImage image={agentInfo.icon?.logo ?? agentInfo.icon?.icon} alt={agentInfo.name} class="w-8 h-8">
         <Icon icon={faTerminal} size="2x" />
-      {/if}
+      </IconImage>
       <h1 class="text-2xl font-bold text-(--pd-content-header)">{agentInfo.name}</h1>
     </div>
     {#if getAgentSubtitle(agentInfo)}

--- a/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
@@ -176,6 +176,17 @@ function getAgentIconSrc(agent: AgentInfo): string | undefined {
           </p>
         </div>
       </div>
+    {:else}
+      <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+        <div class="flex flex-col items-center text-center py-6">
+          <Icon icon={faTerminal} size="2em" class="text-(--pd-content-card-text) opacity-40 mb-4" />
+          <h2 class="text-base font-semibold text-(--pd-content-card-text) mb-2">No compatible models found</h2>
+          <p class="text-sm text-(--pd-content-card-text) opacity-60 max-w-md">
+            Your providers are connected but no compatible models are available yet.
+            Check the provider settings above or install a model that supports this agent.
+          </p>
+        </div>
+      </div>
     {/if}
   </div>
 </div>

--- a/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+import { faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import type { CatalogModelInfo, InferenceConnectionSummary } from '/@/lib/models/models-utils';
+import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
+import ProviderConnectionTiles from '/@/lib/models/ProviderConnectionTiles.svelte';
+import { isDark } from '/@/stores/appearance';
+import { inferenceConnectionSummariesData } from '/@/stores/inference-connection-summaries';
+import { modelKey } from '/@/stores/model-catalog';
+import { catalogModels } from '/@/stores/models';
+import type { AgentInfo } from '/@api/agent-info';
+import type { DefaultPerAgentWorkspaceSettings, DefaultWorkspaceSettings } from '/@api/onboarding-settings-info';
+
+interface Props {
+  agentInfo: AgentInfo;
+}
+
+let { agentInfo }: Props = $props();
+
+let compatibleModels: CatalogModelInfo[] = $derived.by(() => {
+  const types = agentInfo.supportedModelTypes;
+  if (types === undefined) return $catalogModels.slice();
+  if (types.length === 0) return [];
+  const typeNames = new Set(types.map(t => t.name));
+  return $catalogModels.filter(m => m.llmMetadata?.name !== undefined && typeNames.has(m.llmMetadata.name));
+});
+
+let hasModels = $derived(compatibleModels.length > 0);
+
+let configurableConnections: InferenceConnectionSummary[] = $derived.by(() => {
+  const all: InferenceConnectionSummary[] = $inferenceConnectionSummariesData.slice();
+  const ownProvider = all.filter(c => c.providerId === agentInfo.id);
+  if (ownProvider.length > 0) return ownProvider;
+  return all;
+});
+
+let savedModelKey = $state('');
+let selectedModelKey = $state('');
+let saving = $state(false);
+
+let hasChanges = $derived(selectedModelKey !== '' && selectedModelKey !== savedModelKey);
+let selectedModel: CatalogModelInfo | undefined = $derived(
+  compatibleModels.find(m => modelKey(m.providerId, m.label) === selectedModelKey),
+);
+
+async function loadSavedModel(): Promise<void> {
+  try {
+    const existing = await window.getConfigurationValue<DefaultWorkspaceSettings>(
+      'onboarding.defaultWorkspaceSettings',
+    );
+    const agentSettings = existing?.defaultAgentSettings?.[agentInfo.id];
+    if (agentSettings?.defaultModel) {
+      const key = modelKey(agentSettings.defaultModel.providerId, agentSettings.defaultModel.label);
+      savedModelKey = key;
+      selectedModelKey = key;
+    }
+  } catch {
+    // ignore — no saved model
+  }
+}
+
+$effect(() => {
+  loadSavedModel().catch(() => {});
+});
+
+function selectModel(model: CatalogModelInfo): void {
+  selectedModelKey = modelKey(model.providerId, model.label);
+}
+
+function discardChanges(): void {
+  selectedModelKey = savedModelKey;
+}
+
+async function saveSelection(): Promise<void> {
+  if (!selectedModel) return;
+  saving = true;
+  try {
+    const existing = await window.getConfigurationValue<DefaultWorkspaceSettings>(
+      'onboarding.defaultWorkspaceSettings',
+    );
+    const settings: DefaultWorkspaceSettings = existing ?? {};
+    settings.defaultAgentSettings ??= {};
+
+    const agentSettings: DefaultPerAgentWorkspaceSettings = settings.defaultAgentSettings[agentInfo.id] ?? {};
+    agentSettings.defaultModel = {
+      providerId: selectedModel.providerId,
+      connectionName: selectedModel.connectionName,
+      label: selectedModel.label,
+    };
+    settings.defaultAgentSettings[agentInfo.id] = agentSettings;
+
+    await window.updateConfigurationValue('onboarding.defaultWorkspaceSettings', settings);
+    savedModelKey = selectedModelKey;
+  } catch (err: unknown) {
+    console.error('Failed to save agent model selection', err);
+    await window.showMessageBox({
+      title: 'Coding agents',
+      type: 'error',
+      message: `Failed to save default model: ${err instanceof Error ? err.message : String(err)}`,
+      buttons: ['OK'],
+    });
+  } finally {
+    saving = false;
+  }
+}
+
+let agentIconSrc = $derived(getAgentIconSrc(agentInfo));
+
+function getAgentSubtitle(agent: AgentInfo): string {
+  return agent.tags?.join(' · ') ?? '';
+}
+
+function getAgentIconSrc(agent: AgentInfo): string | undefined {
+  const image = agent.icon?.logo ?? agent.icon?.icon;
+  if (!image) return undefined;
+  if (typeof image === 'string') return image;
+  return $isDark ? image.dark : image.light;
+}
+</script>
+
+<div class="flex flex-col h-full overflow-y-auto">
+  <div class="pt-6 px-8">
+    <div class="flex items-center gap-3 mb-1">
+      {#if agentIconSrc}
+        <Icon icon={agentIconSrc} size={32} />
+      {:else}
+        <Icon icon={faTerminal} size="2x" />
+      {/if}
+      <h1 class="text-2xl font-bold text-(--pd-content-header)">{agentInfo.name}</h1>
+    </div>
+    {#if getAgentSubtitle(agentInfo)}
+      <p class="text-sm text-(--pd-link) mb-2">{getAgentSubtitle(agentInfo)}</p>
+    {/if}
+    {#if agentInfo.description}
+      <p class="text-sm text-(--pd-content-text) opacity-70 mb-6">{agentInfo.description}</p>
+    {/if}
+  </div>
+
+  <div class="px-8 pb-8 flex-1">
+    {#if configurableConnections.length > 0}
+      <div class="mb-4">
+        <ProviderConnectionTiles connections={configurableConnections} />
+      </div>
+    {/if}
+
+    {#if hasModels}
+      <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+        <h2 class="text-sm font-semibold text-(--pd-content-card-text) mb-1">Default model</h2>
+        <p class="text-xs text-(--pd-content-card-text) opacity-60 mb-4">
+          Select the default model for this agent. You can override per workspace later.
+        </p>
+        <ModelSelectionTable
+          models={compatibleModels}
+          selectedKey={selectedModelKey}
+          onselect={selectModel} />
+
+        <div class="flex items-center justify-end gap-3 mt-6 pt-4 border-t border-(--pd-content-divider)">
+          <span class="text-xs text-(--pd-content-card-text) opacity-60 mr-auto">
+            {hasChanges ? 'You have unsaved changes' : ''}
+          </span>
+          <Button type="secondary" onclick={discardChanges} disabled={!hasChanges}>Discard</Button>
+          <Button onclick={saveSelection} disabled={!hasChanges || saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    {:else if configurableConnections.length === 0}
+      <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+        <div class="flex flex-col items-center text-center py-6">
+          <Icon icon={faTerminal} size="2em" class="text-(--pd-content-card-text) opacity-40 mb-4" />
+          <h2 class="text-base font-semibold text-(--pd-content-card-text) mb-2">No models or providers available</h2>
+          <p class="text-sm text-(--pd-content-card-text) opacity-60 max-w-md">
+            Install a compatible provider extension, then return here to select a model.
+          </p>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/packages/renderer/src/lib/coding-agents/CodingAgentsPage.svelte
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentsPage.svelte
@@ -2,20 +2,19 @@
 import { faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
+import IconImage from '/@/lib/appearance/IconImage.svelte';
 import { agentInfos } from '/@/stores/agents';
-import { isDark } from '/@/stores/appearance';
 import type { AgentInfo } from '/@api/agent-info';
 
 import CodingAgentDetail from './CodingAgentDetail.svelte';
 
-let agents: readonly AgentInfo[] = $derived($agentInfos);
 let activeAgentId: string | undefined = $state(undefined);
 
-let activeAgent: AgentInfo | undefined = $derived(agents.find(a => a.id === activeAgentId) ?? agents[0]);
+let activeAgent: AgentInfo | undefined = $derived($agentInfos.find(a => a.id === activeAgentId) ?? $agentInfos[0]);
 
 $effect(() => {
-  if (agents.length > 0 && (!activeAgentId || !agents.some(a => a.id === activeAgentId))) {
-    activeAgentId = agents[0]?.id;
+  if ($agentInfos.length > 0 && (!activeAgentId || !$agentInfos.some(a => a.id === activeAgentId))) {
+    activeAgentId = $agentInfos[0]?.id;
   }
 });
 
@@ -25,13 +24,6 @@ function selectAgent(agentId: string): void {
 
 function getAgentSubtitle(agent: AgentInfo): string {
   return agent.tags?.join(' · ') ?? '';
-}
-
-function getAgentIconSrc(agent: AgentInfo): string | undefined {
-  const image = agent.icon?.logo ?? agent.icon?.icon;
-  if (!image) return undefined;
-  if (typeof image === 'string') return image;
-  return $isDark ? image.dark : image.light;
 }
 </script>
 
@@ -47,9 +39,8 @@ function getAgentIconSrc(agent: AgentInfo): string | undefined {
       </div>
     </div>
     <div class="h-full overflow-y-auto" style="margin-bottom:auto">
-      {#each agents as agent (agent.id)}
+      {#each $agentInfos as agent (agent.id)}
         {@const isSelected = activeAgent?.id === agent.id}
-        {@const iconSrc = getAgentIconSrc(agent)}
         <button
           type="button"
           class="flex w-full px-3 py-2.5 items-center gap-3 cursor-pointer border-l-4 text-left
@@ -59,11 +50,9 @@ function getAgentIconSrc(agent: AgentInfo): string | undefined {
           aria-label={agent.name}
           onclick={selectAgent.bind(undefined, agent.id)}>
           <div class="shrink-0 w-6 h-6 flex items-center justify-center">
-            {#if iconSrc}
-              <Icon icon={iconSrc} size={20} />
-            {:else}
+            <IconImage image={agent.icon?.logo ?? agent.icon?.icon} alt={agent.name} class="w-5 h-5">
               <Icon icon={faTerminal} size="lg" />
-            {/if}
+            </IconImage>
           </div>
           <div class="flex-1 min-w-0">
             <span class="text-sm font-medium truncate block">{agent.name}</span>
@@ -78,7 +67,7 @@ function getAgentIconSrc(agent: AgentInfo): string | undefined {
     <div class="px-3 py-4 border-t border-(--pd-content-divider)">
       <p class="text-xs font-semibold text-(--pd-content-card-text) opacity-80 uppercase tracking-wide mb-2">About</p>
       <p class="text-[11px] text-(--pd-content-card-text) opacity-60 leading-relaxed">
-        Pick a runtime to edit its defaults for <strong class="text-(--pd-modal-text)">kdn</strong>.
+        Pick an agent to configure its defaults for <strong class="text-(--pd-modal-text)">kdn</strong>.
         Session creation still chooses which agent a workspace uses.
       </p>
     </div>
@@ -89,7 +78,7 @@ function getAgentIconSrc(agent: AgentInfo): string | undefined {
       {#key activeAgent.id}
       <CodingAgentDetail agentInfo={activeAgent} />
       {/key}
-    {:else if agents.length === 0}
+    {:else if $agentInfos.length === 0}
       <div class="flex items-center justify-center h-full">
         <div class="text-center text-(--pd-content-text)">
           <Icon icon={faTerminal} class="mb-3 opacity-40" size="2.5em" />

--- a/packages/renderer/src/lib/coding-agents/CodingAgentsPage.svelte
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentsPage.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+import { faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import { agentInfos } from '/@/stores/agents';
+import { isDark } from '/@/stores/appearance';
+import type { AgentInfo } from '/@api/agent-info';
+
+import CodingAgentDetail from './CodingAgentDetail.svelte';
+
+let agents: readonly AgentInfo[] = $derived($agentInfos);
+let activeAgentId: string | undefined = $state(undefined);
+
+let activeAgent: AgentInfo | undefined = $derived(activeAgentId ? agents.find(a => a.id === activeAgentId) : agents[0]);
+
+$effect(() => {
+  if (agents.length > 0 && !activeAgentId) {
+    activeAgentId = agents[0]?.id;
+  }
+});
+
+function selectAgent(agentId: string): void {
+  activeAgentId = agentId;
+}
+
+function getAgentSubtitle(agent: AgentInfo): string {
+  return agent.tags?.join(' · ') ?? '';
+}
+
+function getAgentIconSrc(agent: AgentInfo): string | undefined {
+  const image = agent.icon?.logo ?? agent.icon?.icon;
+  if (!image) return undefined;
+  if (typeof image === 'string') return image;
+  return $isDark ? image.dark : image.light;
+}
+</script>
+
+<div class="flex flex-row w-full h-full">
+  <nav
+    class="z-1 w-leftsidebar min-w-leftsidebar flex flex-col transition-all duration-500 ease-in-out bg-(--pd-secondary-nav-bg) border-(--pd-global-nav-bg-border) border-r"
+    aria-label="Coding agents">
+    <div class="flex items-center">
+      <div class="pt-4 px-3 mb-5">
+        <p class="text-xl font-semibold text-(--pd-secondary-nav-header-text) border-l-4 border-transparent">
+          Coding agents
+        </p>
+      </div>
+    </div>
+    <div class="h-full overflow-y-auto" style="margin-bottom:auto">
+      {#each agents as agent (agent.id)}
+        {@const isSelected = activeAgent?.id === agent.id}
+        {@const iconSrc = getAgentIconSrc(agent)}
+        <button
+          type="button"
+          class="flex w-full px-3 py-2.5 items-center gap-3 cursor-pointer border-l-4 text-left
+            {isSelected
+              ? 'bg-(--pd-secondary-nav-selected-bg) border-(--pd-secondary-nav-selected-highlight) text-(--pd-secondary-nav-text-selected)'
+              : 'border-(--pd-secondary-nav-bg) text-(--pd-secondary-nav-text) hover:text-(--pd-secondary-nav-text-hover) hover:bg-(--pd-secondary-nav-text-hover-bg)'}"
+          aria-label={agent.name}
+          onclick={selectAgent.bind(undefined, agent.id)}>
+          <div class="shrink-0 w-6 h-6 flex items-center justify-center">
+            {#if iconSrc}
+              <Icon icon={iconSrc} size={20} />
+            {:else}
+              <Icon icon={faTerminal} size="lg" />
+            {/if}
+          </div>
+          <div class="flex-1 min-w-0">
+            <span class="text-sm font-medium truncate block">{agent.name}</span>
+            {#if getAgentSubtitle(agent)}
+              <span class="text-[10px] opacity-60 truncate block">{getAgentSubtitle(agent)}</span>
+            {/if}
+          </div>
+        </button>
+      {/each}
+    </div>
+
+    <div class="px-3 py-4 border-t border-(--pd-content-divider)">
+      <p class="text-xs font-semibold text-(--pd-content-card-text) opacity-80 uppercase tracking-wide mb-2">About</p>
+      <p class="text-[11px] text-(--pd-content-card-text) opacity-60 leading-relaxed">
+        Pick a runtime to edit its defaults for <strong class="text-(--pd-modal-text)">kdn</strong>.
+        Session creation still chooses which agent a workspace uses.
+      </p>
+    </div>
+  </nav>
+
+  <div class="flex flex-col flex-1 min-w-0 h-full bg-(--pd-content-bg)">
+    {#if activeAgent}
+      {#key activeAgent.id}
+      <CodingAgentDetail agentInfo={activeAgent} />
+      {/key}
+    {:else if agents.length === 0}
+      <div class="flex items-center justify-center h-full">
+        <div class="text-center text-(--pd-content-text)">
+          <Icon icon={faTerminal} class="mb-3 opacity-40" size="2.5em" />
+          <p class="text-sm">No coding agents registered</p>
+          <p class="text-xs mt-1 opacity-60">Install an agent extension to see agents here</p>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/packages/renderer/src/lib/coding-agents/CodingAgentsPage.svelte
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentsPage.svelte
@@ -11,10 +11,10 @@ import CodingAgentDetail from './CodingAgentDetail.svelte';
 let agents: readonly AgentInfo[] = $derived($agentInfos);
 let activeAgentId: string | undefined = $state(undefined);
 
-let activeAgent: AgentInfo | undefined = $derived(activeAgentId ? agents.find(a => a.id === activeAgentId) : agents[0]);
+let activeAgent: AgentInfo | undefined = $derived(agents.find(a => a.id === activeAgentId) ?? agents[0]);
 
 $effect(() => {
-  if (agents.length > 0 && !activeAgentId) {
+  if (agents.length > 0 && (!activeAgentId || !agents.some(a => a.id === activeAgentId))) {
     activeAgentId = agents[0]?.id;
   }
 });

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -182,6 +182,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.AGENT_WORKSPACE_CREATE:
       router.goto('/agent-workspaces/create');
       break;
+    case NavigationPage.CODING_AGENTS:
+      router.goto('/coding-agents');
+      break;
     case NavigationPage.SKILL_DETAILS:
       router.goto(`/skills/${encodeURIComponent(request.parameters.name)}/summary`);
       break;

--- a/packages/renderer/src/stores/navigation/navigation-registry-coding-agents.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-coding-agents.svelte.ts
@@ -20,8 +20,6 @@ import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
 
 import type { NavigationRegistryEntry } from './navigation-registry';
 
-const count = $state(0);
-
 export function createNavigationCodingAgentsEntry(): NavigationRegistryEntry {
   const registry: NavigationRegistryEntry = {
     name: 'Coding agents',
@@ -31,7 +29,7 @@ export function createNavigationCodingAgentsEntry(): NavigationRegistryEntry {
     type: 'entry',
 
     get counter() {
-      return count;
+      return 0;
     },
   };
   return registry;

--- a/packages/renderer/src/stores/navigation/navigation-registry-coding-agents.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-coding-agents.svelte.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
+
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+const count = $state(0);
+
+export function createNavigationCodingAgentsEntry(): NavigationRegistryEntry {
+  const registry: NavigationRegistryEntry = {
+    name: 'Coding agents',
+    icon: { faIcon: { definition: faTerminal, size: 'lg' } },
+    link: '/coding-agents',
+    tooltip: 'Coding agents',
+    type: 'entry',
+
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -25,6 +25,7 @@ import { configurationProperties } from '/@/stores/configurationProperties';
 import { EventStore } from '/@/stores/event-store';
 
 import { createNavigationAgentWorkspacesEntry } from './navigation-registry-agent-workspaces.svelte';
+import { createNavigationCodingAgentsEntry } from './navigation-registry-coding-agents.svelte';
 import { createNavigationExtensionEntry, createNavigationExtensionGroup } from './navigation-registry-extension.svelte';
 import { createNavigationMcpEntry } from './navigation-registry-mcp.svelte';
 import { createNavigationModelsEntry } from './navigation-registry-models.svelte';
@@ -64,6 +65,7 @@ let values: NavigationRegistryEntry[] = [];
 let initialized = false;
 const init = (): void => {
   values.push(createNavigationAgentWorkspacesEntry());
+  values.push(createNavigationCodingAgentsEntry());
   values.push(createNavigationModelsEntry());
   values.push(createNavigationMcpEntry());
   values.push(createNavigationSecretVaultEntry());


### PR DESCRIPTION
add coding agents page for per-agent model selection
Allow users to view all registered coding agents and configure the
default model for each one, reusing the same ProviderConnectionTiles
and ModelSelectionTable patterns from the Models catalog.

https://github.com/user-attachments/assets/99038dbe-0fe8-4151-891e-2d4f2c2b7b65

Closes #1839 