### PR TITLE
fix: set HOME env var for child processes on Windows

### DIFF
--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -559,6 +559,40 @@ describe('exec', () => {
     expect(stdout).toContain('Hello, World!');
     expect(setEncodingMock).toBeCalledWith('utf16le');
   });
+
+  test('should set HOME to homedir on Windows when HOME is not set', async () => {
+    const command = 'echo';
+    const args = ['test'];
+
+    const originalHome = process.env['HOME'];
+    delete process.env['HOME'];
+
+    (util.isWindows as Mock).mockReturnValue(true);
+
+    const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
+      if (event === 'data') {
+        cb('test');
+      }
+    }) as unknown as Readable;
+    const spawnMock = vi.mocked(spawn).mockReturnValue({
+      stdout: { on, setEncoding: setEncodingMock },
+      stderr: { on, setEncoding: setEncodingMock },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(0);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    await exec.exec(command, args);
+
+    const spawnEnv = spawnMock.mock.calls[0]![2]!.env as Record<string, string>;
+    expect(spawnEnv['HOME']).toBe(homedir());
+
+    if (originalHome !== undefined) {
+      process.env['HOME'] = originalHome;
+    }
+  });
 });
 
 vi.mock('./util', () => {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -71,6 +71,10 @@ export class Exec {
       env['PATH'] = getInstallationPath(env['PATH']);
     }
 
+    if (isWindows() && !env['HOME']) {
+      env['HOME'] = homedir();
+    }
+
     // do we have an admin task ?
     // if yes, will use sudo-prompt on windows and osascript on mac and pkexec on linux
     if (options?.isAdmin) {


### PR DESCRIPTION
## Summary
- On Windows, `$HOME` is not a standard environment variable (`USERPROFILE` is used instead). The `kdn` CLI relies on `$HOME` to expand mount paths in `workspace.json` (e.g. when "Home Directory" file access is selected), causing workspace creation to fail with `crun: executable file not found in $PATH` errors.
- Ensures `HOME` is set to `os.homedir()` in the child process environment on Windows, matching the existing pattern for `PATH` adjustments.

Fixes: https://github.com/openkaiden/kdn/issues/528

## Test plan
- [x] Existing `exec.spec.ts` tests pass (23/23)
- [x] Existing `kdn-cli.spec.ts` tests pass (72/72)
- [x] New test verifies `HOME` is injected on Windows when not already set
- [ ] Manual: On Windows, create a workspace with "Home Directory" file access and verify the terminal launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)