### PR TITLE
fix(ci): remove playwright postinstall and fix e2e browser setup

### DIFF
--- a/.github/workflows/e2e-test-job.yaml
+++ b/.github/workflows/e2e-test-job.yaml
@@ -95,6 +95,32 @@ jobs:
       - name: Execute pnpm
         run: pnpm install
 
+      - name: Get Playwright version and cache path
+        id: playwright-info
+        shell: bash
+        run: |
+          echo "version=$(npx --yes playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "path=$USERPROFILE/AppData/Local/ms-playwright" >> "$GITHUB_OUTPUT"
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "path=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=$HOME/.cache/ms-playwright" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: playwright-cache
+        with:
+          path: ${{ steps.playwright-info.outputs.path }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-info.outputs.version }}
+
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: tests/playwright
+        timeout-minutes: 3
+        run: npx playwright install chromium
+
       - name: Enable Podman socket
         if: runner.os == 'Linux'
         run: |

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -9,8 +9,7 @@
     "test:debug": "playwright test --debug",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
-    "report": "playwright show-report ./output/tests",
-    "postinstall": "playwright install chromium"
+    "report": "playwright show-report ./output/tests"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",


### PR DESCRIPTION
## Summary
- Remove `postinstall: playwright install chromium` from `tests/playwright/package.json` — stops all non-e2e jobs (typecheck, lint, unit tests, builds) from downloading a browser they never use
- For e2e jobs:
  - Bump `pnpm/action-setup` v4.1.0 → v6.0.8 (Node.js 20 → 24) to fix `playwright install` hanging on some runners
  - Cache Playwright browsers (`~/.cache/ms-playwright`) so downloads are skipped on cache hit
  - Install Chromium as a dedicated step, only on cache miss

## Problem
`pnpm install` was hanging for 40+ minutes on some CI jobs because the `postinstall` hook triggered `playwright install chromium` on **every** job. The Chromium zip extraction would stall on runners with I/O contention (noisy neighbor), causing non-deterministic cancellations. The old `pnpm/action-setup` v4.1.0 running on deprecated Node.js 20 exacerbated the issue.

## Test plan
- [ ] Verify `typecheck` and `linter` jobs complete without hanging at `Execute pnpm`
- [ ] Verify `smoke-e2e-tests` install Chromium and run successfully
- [ ] Verify Playwright browser cache is populated on first run and reused on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)