### PR TITLE
chore(ci): enable dependabot for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      # check at 3am UTC
+      time: "03:00"
+    open-pull-requests-limit: 20
+
   - package-ecosystem: "npm"
     directory: "/" # adjust if your package.json is in a subfolder
     schedule:


### PR DESCRIPTION
## Summary
- Add `github-actions` package ecosystem to dependabot config so CI action versions are kept up to date automatically.
- Configuration matches podman-desktop's dependabot setup (daily at 3am UTC, limit 20 PRs).

Once merged, dependabot will automatically open PRs to bump outdated actions (checkout, pnpm/action-setup, setup-node, upload-artifact, etc.) to their latest versions.

## Test plan
- [ ] Verify dependabot starts creating PRs for outdated github-actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)