### PR TITLE
feat: add Projects page with sidebar navigation

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -71,4 +71,5 @@ export enum NavigationPage {
   SECRET_VAULT_CREATE = 'secret-vault-create',
   SECRET_VAULT_DETAILS = 'secret-vault-details',
   MODELS = 'models',
+  PROJECTS = 'projects',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -93,6 +93,7 @@ export interface NavigationParameters {
     id: string;
   };
   [NavigationPage.MODELS]: never;
+  [NavigationPage.PROJECTS]: never;
 }
 
 // the parameters property is optional when the NavigationParameters say it is

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -15,6 +15,7 @@ import FlowDetails from '/@/lib/flows/FlowDetails.svelte';
 import FlowList from '/@/lib/flows/FlowList.svelte';
 import KubernetesRoot from '/@/lib/kube/KubernetesRoot.svelte';
 import MCPDetails from '/@/lib/mcp/MCPDetails.svelte';
+import ProjectList from '/@/lib/projects/ProjectList.svelte';
 import RAGEnvironmentDetails from '/@/lib/rag/RAGEnvironmentDetails.svelte';
 import RAGEnvironmentList from '/@/lib/rag/RAGEnvironmentList.svelte';
 import PinActions from '/@/lib/statusbar/PinActions.svelte';
@@ -227,6 +228,10 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
           <Route path="/:id/*" breadcrumb="Workspace Details" let:meta navigationHint="details">
             <AgentWorkspaceDetails workspaceId={decodeURIComponent(meta.params.id)} />
           </Route>
+        </Route>
+
+        <Route path="/projects" breadcrumb="Projects" navigationHint="root">
+          <ProjectList />
         </Route>
 
         <Route path="/flows/*" breadcrumb="Flows" navigationHint="root" firstmatch>

--- a/packages/renderer/src/lib/projects/ProjectEmptyScreen.svelte
+++ b/packages/renderer/src/lib/projects/ProjectEmptyScreen.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+</script>
+
+<EmptyScreen title="No projects" icon={faFolderOpen}>
+  <span class="text-(--pd-content-text)">
+    Projects will appear here once created.
+  </span>
+</EmptyScreen>

--- a/packages/renderer/src/lib/projects/ProjectList.svelte
+++ b/packages/renderer/src/lib/projects/ProjectList.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+import { FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { workspaceProjectInfos } from '/@/stores/workspace-projects';
+import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
+
+import ProjectActions from './columns/ProjectActions.svelte';
+import ProjectFolder from './columns/ProjectFolder.svelte';
+import ProjectName from './columns/ProjectName.svelte';
+import ProjectResources from './columns/ProjectResources.svelte';
+import ProjectEmptyScreen from './ProjectEmptyScreen.svelte';
+
+type ProjectSelectable = WorkspaceProjectInfo & { selected: boolean };
+
+let searchTerm = $state('');
+
+const filteredProjects: ProjectSelectable[] = $derived.by(() => {
+  const term = searchTerm.trim().toLowerCase();
+  return $workspaceProjectInfos
+    .filter(p => !term || p.name.toLowerCase().includes(term) || p.folder.toLowerCase().includes(term))
+    .map(p => ({ ...p, selected: false }));
+});
+
+const row = new TableRow<ProjectSelectable>({});
+
+const nameColumn = new TableColumn<ProjectSelectable>('Name', {
+  width: '2fr',
+  renderer: ProjectName,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+const folderColumn = new TableColumn<ProjectSelectable>('Folder', {
+  width: '2fr',
+  renderer: ProjectFolder,
+  comparator: (a, b): number => a.folder.localeCompare(b.folder),
+});
+
+const resourcesColumn = new TableColumn<ProjectSelectable>('Resources', {
+  width: '2fr',
+  renderer: ProjectResources,
+});
+
+const actionsColumn = new TableColumn<ProjectSelectable>('', {
+  align: 'right',
+  width: '40px',
+  renderer: ProjectActions,
+  overflow: true,
+});
+
+const columns = [nameColumn, folderColumn, resourcesColumn, actionsColumn];
+</script>
+
+<NavPage bind:searchTerm={searchTerm} title="Projects">
+  {#snippet content()}
+    <div class="flex min-w-full h-full">
+      {#if filteredProjects.length === 0}
+        {#if searchTerm}
+          <FilteredEmptyScreen icon={NoLogIcon} kind="projects" bind:searchTerm={searchTerm} />
+        {:else}
+          <ProjectEmptyScreen />
+        {/if}
+      {:else}
+        <Table
+          kind="projects"
+          data={filteredProjects}
+          columns={columns}
+          row={row}
+          defaultSortColumn="Name"
+        />
+      {/if}
+    </div>
+  {/snippet}
+</NavPage>

--- a/packages/renderer/src/lib/projects/columns/ProjectActions.svelte
+++ b/packages/renderer/src/lib/projects/columns/ProjectActions.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
+import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
+
+interface Props {
+  object: WorkspaceProjectInfo;
+}
+
+let { object }: Props = $props();
+
+function handleRemove(): void {
+  withConfirmation(
+    () => window.removeWorkspaceProject(object.id).catch(console.error),
+    `remove project ${object.name}`,
+  );
+}
+</script>
+
+<ListItemButtonIcon
+  title="Remove project"
+  icon={faTrash}
+  onClick={handleRemove} />

--- a/packages/renderer/src/lib/projects/columns/ProjectFolder.svelte
+++ b/packages/renderer/src/lib/projects/columns/ProjectFolder.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
+
+interface Props {
+  object: WorkspaceProjectInfo;
+}
+
+let { object }: Props = $props();
+</script>
+
+<span
+  class="text-(--pd-table-body-text) text-sm overflow-hidden text-ellipsis whitespace-nowrap"
+  title={object.folder}>
+  {object.folder}
+</span>

--- a/packages/renderer/src/lib/projects/columns/ProjectName.svelte
+++ b/packages/renderer/src/lib/projects/columns/ProjectName.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { router } from 'tinro';
+
+import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
+
+interface Props {
+  object: WorkspaceProjectInfo;
+}
+
+let { object }: Props = $props();
+
+function openDetails(): void {
+  router.goto(`/projects/${encodeURIComponent(object.id)}`);
+}
+</script>
+
+<div class="flex items-center overflow-hidden max-w-full">
+  <button class="flex items-start" onclick={openDetails}>
+    <span
+      class="text-(--pd-table-body-text-highlight) text-[14px] font-semibold leading-normal overflow-hidden text-ellipsis whitespace-nowrap"
+      title={object.name}>
+      {object.name}
+    </span>
+  </button>
+</div>

--- a/packages/renderer/src/lib/projects/columns/ProjectResources.svelte
+++ b/packages/renderer/src/lib/projects/columns/ProjectResources.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
+
+interface Props {
+  object: WorkspaceProjectInfo;
+}
+
+let { object }: Props = $props();
+
+const parts = $derived.by(() => {
+  const items: string[] = [];
+  if (object.skills.length > 0) items.push(`${object.skills.length} skill${object.skills.length !== 1 ? 's' : ''}`);
+  if (object.mcpServers.length > 0) items.push(`${object.mcpServers.length} MCP`);
+  if (object.knowledges.length > 0) items.push(`${object.knowledges.length} KB`);
+  if (object.secrets.length > 0) items.push(`${object.secrets.length} secret${object.secrets.length !== 1 ? 's' : ''}`);
+  return items;
+});
+</script>
+
+<div class="flex items-center gap-2 flex-wrap">
+  {#each parts as part (part)}
+    <span class="text-(--pd-table-body-text) text-xs px-1.5 py-0.5 rounded bg-(--pd-label-bg)">{part}</span>
+  {/each}
+  {#if parts.length === 0}
+    <span class="text-(--pd-table-body-text-secondary) text-xs italic">None</span>
+  {/if}
+</div>

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -206,5 +206,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.SECRET_VAULT_DETAILS:
       router.goto(`/secret-vault/${encodeURIComponent(request.parameters.id)}/summary`);
       break;
+    case NavigationPage.PROJECTS:
+      router.goto('/projects');
+      break;
   }
 };

--- a/packages/renderer/src/stores/navigation/navigation-registry-projects.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-projects.svelte.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
+
+import { workspaceProjectInfos } from '/@/stores/workspace-projects';
+
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationProjectsEntry(): NavigationRegistryEntry {
+  workspaceProjectInfos.subscribe(projects => {
+    count = projects.length;
+  });
+
+  const registry: NavigationRegistryEntry = {
+    name: 'Projects',
+    icon: { faIcon: { definition: faFolderOpen, size: 'lg' } },
+    link: '/projects',
+    tooltip: 'Projects',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -29,6 +29,7 @@ import { createNavigationCodingAgentsEntry } from './navigation-registry-coding-
 import { createNavigationExtensionEntry, createNavigationExtensionGroup } from './navigation-registry-extension.svelte';
 import { createNavigationMcpEntry } from './navigation-registry-mcp.svelte';
 import { createNavigationModelsEntry } from './navigation-registry-models.svelte';
+import { createNavigationProjectsEntry } from './navigation-registry-projects.svelte';
 import { createNavigationRagEntry } from './navigation-registry-rag.svelte';
 import { createNavigationSecretVaultEntry } from './navigation-registry-secret-vault.svelte';
 import { createNavigationSkillsEntry } from './navigation-registry-skills.svelte';
@@ -65,6 +66,7 @@ let values: NavigationRegistryEntry[] = [];
 let initialized = false;
 const init = (): void => {
   values.push(createNavigationAgentWorkspacesEntry());
+  values.push(createNavigationProjectsEntry());
   values.push(createNavigationCodingAgentsEntry());
   values.push(createNavigationModelsEntry());
   values.push(createNavigationMcpEntry());


### PR DESCRIPTION
## Summary
- Add a new Projects page that displays workspace projects in a searchable table with Name, Folder, Resources, and Actions columns
- Register a Projects navigation entry (folder icon) in the sidebar, positioned after Workspaces
- Wire up routing, navigation enum, and navigation handler for the `/projects` route

Fixes: https://github.com/openkaiden/kaiden/issues/1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)