### PR TITLE
fix: force Node 24.15.0 as 24.16.0 as issues with electron unpackaking

### DIFF
--- a/.github/workflows/e2e-test-job.yaml
+++ b/.github/workflows/e2e-test-job.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Execute pnpm

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -110,7 +110,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/npmjs-publish.yaml
+++ b/.github/workflows/npmjs-publish.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24 # 24.x for npm publish with OIDC
+          node-version: 24.15.0 # 24.x for npm publish with OIDC
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Execute pnpm
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Execute pnpm
@@ -145,7 +145,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Execute pnpm
@@ -177,7 +177,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Execute pnpm
@@ -211,7 +211,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Execute pnpm
@@ -241,7 +241,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Execute pnpm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,7 +160,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
See https://github.com/vitejs/vite-ecosystem-ci/pull/472