### PR TITLE
feat(claude): persist connection IDs in secret storage

### DIFF
--- a/extensions/claude/src/manager/claude-inference-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { randomUUID } from 'node:crypto';
+
 import { type AnthropicProvider, createAnthropic } from '@ai-sdk/anthropic';
 import AnthropicClient from '@anthropic-ai/sdk';
 import type { ModelInfo } from '@anthropic-ai/sdk/resources';
@@ -25,7 +27,15 @@ import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
-import { ClaudeInferenceManager, TOKENS_KEY } from './claude-inference-manager';
+import { ClaudeInferenceManager, type StoredConnection, TOKENS_KEY } from './claude-inference-manager';
+
+vi.mock(import('node:crypto'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
+  };
+});
 
 vi.mock(import('@ai-sdk/anthropic'));
 
@@ -48,6 +58,7 @@ const SECRET_STORAGE_MOCK: SecretStorage = {
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(randomUUID).mockReturnValue('fake-uuid-1' as ReturnType<typeof randomUUID>);
   vi.mocked(createAnthropic).mockReturnValue(ANTHROPIC_PROVIDER_MOCK);
 
   const mockModels: ModelInfo[] = [
@@ -106,13 +117,17 @@ describe('init', () => {
   });
 
   test('should restore connections from secret storage', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('existingKey');
+    const stored: StoredConnection[] = [{ id: 'persisted-id', token: 'existingKey' }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     const manager = await createManager();
     await manager.init();
 
     expect(SECRET_STORAGE_MOCK.get).toHaveBeenCalledWith(TOKENS_KEY);
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'persisted-id' }),
+    );
   });
 
   test('should handle empty secret storage', async () => {
@@ -122,6 +137,48 @@ describe('init', () => {
     await manager.init();
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('should migrate legacy comma-separated tokens to JSON format', async () => {
+    vi.mocked(randomUUID)
+      .mockReturnValueOnce('migrated-id-1' as ReturnType<typeof randomUUID>)
+      .mockReturnValueOnce('migrated-id-2' as ReturnType<typeof randomUUID>);
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('tokenA,tokenB');
+
+    const manager = await createManager();
+    await manager.init();
+
+    const expected: StoredConnection[] = [
+      { id: 'migrated-id-1', token: 'tokenA' },
+      { id: 'migrated-id-2', token: 'tokenB' },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-2' }),
+    );
+  });
+
+  test('should restore persisted IDs across restarts', async () => {
+    const stored: StoredConnection[] = [
+      { id: 'stable-id-1', token: 'key1' },
+      { id: 'stable-id-2', token: 'key2' },
+    ];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
+    const manager = await createManager();
+    await manager.init();
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-2' }),
+    );
   });
 });
 
@@ -143,13 +200,14 @@ describe('factory', () => {
     }).rejects.toThrowError('invalid apiKey');
   });
 
-  test('calling create with proper params should save token', async () => {
+  test('calling create with proper params should save connection as JSON', async () => {
     await create({
       'claude.factory.apiKey': 'dummyKey',
     });
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey');
+    const expected: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
 
   test('calling create with proper params should register inference connection', async () => {
@@ -168,7 +226,7 @@ describe('factory', () => {
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
-      id: '0',
+      id: 'fake-uuid-1',
       name: 'dum*****',
       type: 'cloud',
       llmMetadata: {
@@ -212,16 +270,15 @@ describe('connection delete lifecycle', () => {
     mDelete = lifecycle.delete;
   });
 
-  test('calling delete should delete the token', async () => {
+  test('calling delete should remove the connection from storage', async () => {
     await mDelete();
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
 
-    // first time when registering the connection
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, 'dummyKey');
+    const saved: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, JSON.stringify(saved));
 
-    // second time when unregistering the connection
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, '');
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, JSON.stringify([]));
   });
 
   test('calling delete should dispose provider inference connection', async () => {

--- a/extensions/claude/src/manager/claude-inference-manager.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { createAnthropic } from '@ai-sdk/anthropic';
 import AnthropicClient from '@anthropic-ai/sdk';
@@ -26,7 +26,11 @@ import { inject, injectable } from 'inversify';
 import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
 export const TOKENS_KEY = 'claude:tokens';
-export const TOKEN_SEPARATOR = ',';
+
+export interface StoredConnection {
+  id: string;
+  token: string;
+}
 
 @injectable()
 export class ClaudeInferenceManager {
@@ -37,7 +41,6 @@ export class ClaudeInferenceManager {
   private secrets: SecretStorage;
 
   private connections: Map<string, Disposable> = new Map();
-  private connectionIdCounter = 0;
 
   async init(): Promise<void> {
     this.claudeProvider.setInferenceProviderConnectionFactory({
@@ -48,13 +51,13 @@ export class ClaudeInferenceManager {
   }
 
   private async restoreConnections(): Promise<void> {
-    const tokens = await this.getTokens();
-    for (const token of tokens) {
-      await this.registerInferenceProviderConnection({ token });
+    const stored = await this.getStoredConnections();
+    for (const entry of stored) {
+      await this.registerInferenceProviderConnection({ id: entry.id, token: entry.token });
     }
   }
 
-  private async getTokens(): Promise<string[]> {
+  private async getStoredConnections(): Promise<StoredConnection[]> {
     let raw: string | undefined;
     try {
       raw = await this.secrets.get(TOKENS_KEY);
@@ -62,13 +65,22 @@ export class ClaudeInferenceManager {
       console.error('Claude: something went wrong while trying to get tokens from secret storage', err);
     }
     if (!raw) return [];
-    return raw.split(TOKEN_SEPARATOR);
+
+    try {
+      return JSON.parse(raw) as StoredConnection[];
+    } catch {
+      // Migrate legacy comma-separated token format
+      const tokens = raw.split(',');
+      const migrated: StoredConnection[] = tokens.map(token => ({ id: randomUUID(), token }));
+      await this.secrets.store(TOKENS_KEY, JSON.stringify(migrated));
+      return migrated;
+    }
   }
 
-  private async saveToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = [...tokens, token].join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async saveConnection(connection: StoredConnection): Promise<void> {
+    const stored = await this.getStoredConnections();
+    stored.push(connection);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(stored));
   }
 
   private getTokenHash(token: string): string {
@@ -76,13 +88,13 @@ export class ClaudeInferenceManager {
     return sha256.update(token).digest('hex');
   }
 
-  private async removeToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = tokens.filter(t => t !== token).join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async removeConnection(token: string): Promise<void> {
+    const stored = await this.getStoredConnections();
+    const filtered = stored.filter(entry => entry.token !== token);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
-  private async registerInferenceProviderConnection({ token }: { token: string }): Promise<void> {
+  private async registerInferenceProviderConnection({ id, token }: { id: string; token: string }): Promise<void> {
     const key = this.maskKey(token);
     const tokenHash = this.getTokenHash(token);
 
@@ -97,7 +109,7 @@ export class ClaudeInferenceManager {
     const clean = async (): Promise<void> => {
       this.connections.get(tokenHash)?.dispose();
       this.connections.delete(tokenHash);
-      await this.removeToken(token);
+      await this.removeConnection(token);
     };
 
     let status: ProviderConnectionStatus = 'unknown';
@@ -110,7 +122,7 @@ export class ClaudeInferenceManager {
     }
 
     const connectionDisposable = this.claudeProvider.registerInferenceProviderConnection({
-      id: String(this.connectionIdCounter++),
+      id,
       name: this.maskKey(token),
       type: 'cloud',
       llmMetadata: {
@@ -153,8 +165,9 @@ export class ClaudeInferenceManager {
     const apiKey = params['claude.factory.apiKey'];
     if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
 
-    await this.saveToken(apiKey);
-    await this.registerInferenceProviderConnection({ token: apiKey });
+    const id = randomUUID();
+    await this.saveConnection({ id, token: apiKey });
+    await this.registerInferenceProviderConnection({ id, token: apiKey });
   }
 
   dispose(): void {


### PR DESCRIPTION
Replace the transient counter-based IDs with stable UUIDs stored as a JSON array alongside tokens, so connections keep their identity across restarts. Legacy comma-separated format is auto-migrated on first read.

Closes #1936