### PR TITLE
feat(openshell): add OpenshellCli wrapper for sandbox and gateway operations

### DIFF
--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import type { CliToolInstallationSource, Disposable, ExtensionContext } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
@@ -25,76 +25,117 @@ import { inject, injectable } from 'inversify';
 
 import { ExtensionContextSymbol } from '/@/inject/symbol';
 
+interface BinaryDiscoveryResult {
+  path: string;
+  version: string;
+  installationSource: CliToolInstallationSource;
+}
+
 @injectable()
 export class OpenshellCliManager implements Disposable {
   @inject(ExtensionContextSymbol)
   private extensionContext!: ExtensionContext;
 
+  #registeredPath: string | undefined;
+
+  getRegisteredPath(): string | undefined {
+    return this.#registeredPath;
+  }
+
   async init(): Promise<void> {
-    const binDir = join(this.extensionContext.storagePath, 'bin');
-    const binaryName = 'openshell';
-    const localBinaryPath = join(binDir, binaryName);
-
-    let binaryPath: string | undefined;
-    let version: string | undefined;
-    let installationSource: CliToolInstallationSource = 'external';
-
-    const customPath = this.getCustomBinaryPath();
-    if (customPath && existsSync(customPath)) {
-      version = await this.getVersion(customPath);
-      if (version) {
-        binaryPath = customPath;
-        installationSource = 'external';
-        console.log(`[openshell] using custom binary path: ${customPath}`);
-      } else {
-        console.warn(`[openshell] custom binary at ${customPath} failed to report a version`);
-      }
-    }
-
-    if (!binaryPath && existsSync(localBinaryPath)) {
-      version = await this.getVersion(localBinaryPath);
-      if (version) {
-        binaryPath = localBinaryPath;
-        installationSource = 'extension';
-        console.log('[openshell] binary found in extension storage');
-      } else {
-        console.warn(`[openshell] binary exists at ${localBinaryPath} but failed to report a version`);
-      }
-    }
-
-    if (!binaryPath) {
-      const systemResult = await this.findOnPath();
-      if (systemResult) {
-        binaryPath = systemResult.path;
-        version = systemResult.version;
-        installationSource = 'external';
-        console.log('[openshell] binary found in system PATH');
-      } else {
-        console.warn('[openshell] not found in system PATH');
-      }
-    }
-
-    if (!binaryPath) {
+    const cliResult = await this.discoverBinary('openshell', 'openshell.binary.path');
+    if (!cliResult) {
       console.warn('[openshell] CLI not found, skipping registration');
       return;
     }
 
-    const cliTool = extensionApi.cli.createCliTool({
-      name: 'openshell',
-      displayName: 'OpenShell',
-      markdownDescription: 'OpenShell CLI for managing sandboxed workspaces',
-      images: {},
-      version,
-      path: binaryPath,
-      installationSource,
-    });
-    this.extensionContext.subscriptions.push(cliTool);
+    this.#registeredPath = cliResult.path;
+    this.registerCliTool('openshell', 'OpenShell', 'OpenShell CLI for managing sandboxed workspaces', cliResult);
+
+    const gatewayResult = await this.discoverGatewayBinary(cliResult.path);
+    if (gatewayResult) {
+      this.registerCliTool(
+        'openshell-gateway',
+        'OpenShell Gateway',
+        'OpenShell Gateway server for sandbox orchestration',
+        gatewayResult,
+      );
+    } else {
+      console.warn('[openshell-gateway] binary not found, skipping registration');
+    }
   }
 
   dispose(): void {}
 
-  private getCustomBinaryPath(): string | undefined {
-    return extensionApi.configuration.getConfiguration('openshell').get<string>('binary.path') ?? undefined;
+  private registerCliTool(
+    name: string,
+    displayName: string,
+    markdownDescription: string,
+    result: BinaryDiscoveryResult,
+  ): void {
+    const cliTool = extensionApi.cli.createCliTool({
+      name,
+      displayName,
+      markdownDescription,
+      images: {},
+      version: result.version,
+      path: result.path,
+      installationSource: result.installationSource,
+    });
+    this.extensionContext.subscriptions.push(cliTool);
+    console.log(`[${name}] registered at ${result.path} (v${result.version})`);
+  }
+
+  private async discoverBinary(binaryBaseName: string, configKey: string): Promise<BinaryDiscoveryResult | undefined> {
+    const binDir = join(this.extensionContext.storagePath, 'bin');
+    const binaryName = extensionApi.env.isWindows ? `${binaryBaseName}.exe` : binaryBaseName;
+    const localBinaryPath = join(binDir, binaryName);
+
+    const customPath = extensionApi.configuration.getConfiguration('openshell').get<string>(configKey) ?? undefined;
+    if (customPath && existsSync(customPath)) {
+      const version = await this.getVersion(customPath);
+      if (version) {
+        console.log(`[${binaryBaseName}] using custom binary path: ${customPath}`);
+        return { path: customPath, version, installationSource: 'external' };
+      }
+      console.warn(`[${binaryBaseName}] custom binary at ${customPath} failed to report a version`);
+    }
+
+    if (existsSync(localBinaryPath)) {
+      const version = await this.getVersion(localBinaryPath);
+      if (version) {
+        console.log(`[${binaryBaseName}] binary found in extension storage`);
+        return { path: localBinaryPath, version, installationSource: 'extension' };
+      }
+      console.warn(`[${binaryBaseName}] binary exists at ${localBinaryPath} but failed to report a version`);
+    }
+
+    const systemResult = await this.findOnPath(binaryBaseName);
+    if (systemResult) {
+      console.log(`[${binaryBaseName}] binary found in system PATH`);
+      return { path: systemResult.path, version: systemResult.version, installationSource: 'external' };
+    }
+
+    return undefined;
+  }
+
+  private async discoverGatewayBinary(cliPath: string): Promise<BinaryDiscoveryResult | undefined> {
+    const result = await this.discoverBinary('openshell-gateway', 'openshell.gateway.binary.path');
+    if (result) {
+      return result;
+    }
+
+    const gatewayName = extensionApi.env.isWindows ? 'openshell-gateway.exe' : 'openshell-gateway';
+    const siblingPath = join(dirname(cliPath), gatewayName);
+    if (existsSync(siblingPath)) {
+      const version = await this.getVersion(siblingPath);
+      if (version) {
+        console.log('[openshell-gateway] binary found alongside openshell CLI');
+        return { path: siblingPath, version, installationSource: 'external' };
+      }
+    }
+
+    return undefined;
   }
 
   private parseVersion(output: string): string | undefined {
@@ -112,12 +153,12 @@ export class OpenshellCliManager implements Disposable {
     }
   }
 
-  private async findOnPath(): Promise<{ version: string; path: string } | undefined> {
+  private async findOnPath(binaryName: string): Promise<{ version: string; path: string } | undefined> {
     try {
-      const result = await extensionApi.process.exec('openshell', ['--version']);
+      const result = await extensionApi.process.exec(binaryName, ['--version']);
       const version = this.parseVersion(result.stdout || result.stderr);
       if (version) {
-        const resolvedPath = await this.resolveFromPath();
+        const resolvedPath = await this.resolveFromPath(binaryName);
         return { version, path: resolvedPath };
       }
     } catch {
@@ -126,9 +167,9 @@ export class OpenshellCliManager implements Disposable {
     return undefined;
   }
 
-  private async resolveFromPath(): Promise<string> {
+  private async resolveFromPath(binaryName: string): Promise<string> {
     const cmd = extensionApi.env.isWindows ? 'where' : 'which';
-    const result = await extensionApi.process.exec(cmd, ['openshell']);
+    const result = await extensionApi.process.exec(cmd, [binaryName]);
     return result.stdout.trim().split(/\r?\n/)[0];
   }
 }

--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import z from 'zod';
+
+export const GatewayInfoSchema = z.object({
+  name: z.string(),
+  endpoint: z.string(),
+  active: z.boolean().optional(),
+  auth: z.string().optional(),
+  type: z.string().optional(),
+});
+
+export type GatewayInfo = z.output<typeof GatewayInfoSchema>;
+
+export const SandboxInfoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  phase: z.string(),
+  created_at: z.string().optional(),
+  current_policy_version: z.number().optional(),
+  labels: z.record(z.string(), z.string()).optional(),
+  resource_version: z.number().optional(),
+});
+
+export type SandboxInfo = z.output<typeof SandboxInfoSchema>;
+
+export interface CreateSandboxOptions {
+  name?: string;
+  gateway?: string;
+  from?: string;
+  gpu?: boolean;
+  gpuDevice?: string;
+  cpu?: string;
+  memory?: string;
+  providers?: string[];
+  labels?: Record<string, string>;
+  command?: string[];
+}
+
+export interface GatewayAddOptions {
+  endpoint: string;
+  name?: string;
+  /** SSH destination for remote mTLS gateway (conflicts with `local`). */
+  remote?: string;
+  /** Use local mTLS gateway in Docker (conflicts with `remote`). */
+  local?: boolean;
+}
+
+export interface OpenshellGatewayStartOptions {
+  port?: number;
+  bindAddress?: string;
+  disableTls?: boolean;
+}
+
+export interface GatewaySandboxes {
+  gateway: GatewayInfo;
+  sandboxes: SandboxInfo[];
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -70,6 +70,8 @@ import { MCPIPCHandler } from '/@/plugin/mcp/mcp-ipc-handler.js';
 import { MCPManager } from '/@/plugin/mcp/mcp-manager.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
+import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
@@ -588,6 +590,8 @@ export class PluginSystem {
     container.bind<CliToolRegistry>(CliToolRegistry).toSelf().inSingletonScope();
     container.bind<AgentRegistry>(AgentRegistry).toSelf().inSingletonScope();
     container.bind<KdnCli>(KdnCli).toSelf().inSingletonScope();
+    container.bind<OpenshellCli>(OpenshellCli).toSelf().inSingletonScope();
+    container.bind<OpenshellGateway>(OpenshellGateway).toSelf().inSingletonScope();
     container.bind<AgentWorkspaceManager>(AgentWorkspaceManager).toSelf().inSingletonScope();
     container.bind<SecretManager>(SecretManager).toSelf().inSingletonScope();
     container.bind<FlowManager>(FlowManager).toSelf().inSingletonScope();
@@ -3744,6 +3748,9 @@ export class PluginSystem {
       apiSender.send('extensions-started');
       this.markAsExtensionsStarted();
     }
+    const openshellGateway = container.get<OpenshellGateway>(OpenshellGateway);
+    openshellGateway.init().catch((err: unknown) => console.error('Unable to initialize openshell gateway', err));
+
     extensionsUpdater.init().catch((err: unknown) => console.error('Unable to perform extension updates', err));
     autoStartEngine.start().catch((err: unknown) => console.error('Unable to perform autostart', err));
     await exploreFeatures.init();

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -1,0 +1,558 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RunError, RunResult } from '@openkaiden/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { Proxy } from '/@/plugin/proxy.js';
+import { Exec } from '/@/plugin/util/exec.js';
+import type { CliToolInfo } from '/@api/cli-tool-info.js';
+
+import { OpenshellCli } from './openshell-cli.js';
+
+vi.mock(import('/@/plugin/util/exec.js'));
+
+const OPENSHELL_CLI_PATH = '/usr/local/bin/openshell';
+
+let openshellCli: OpenshellCli;
+
+const exec = new Exec({} as Proxy);
+const cliToolRegistry = {
+  getCliToolInfos: vi.fn().mockReturnValue([{ name: 'openshell', path: OPENSHELL_CLI_PATH }]),
+} as unknown as CliToolRegistry;
+
+function mockExecResult(stdout: string): RunResult {
+  return { command: OPENSHELL_CLI_PATH, stdout, stderr: '' };
+}
+
+function mockRunError(overrides: Partial<RunError> = {}): RunError {
+  const err = new Error(overrides.message ?? 'Command execution failed with exit code 1') as RunError;
+  err.exitCode = overrides.exitCode ?? 1;
+  err.command = overrides.command ?? OPENSHELL_CLI_PATH;
+  err.stdout = overrides.stdout ?? '';
+  err.stderr = overrides.stderr ?? '';
+  err.cancelled = overrides.cancelled ?? false;
+  err.killed = overrides.killed ?? false;
+  return err;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
+    { name: 'openshell', path: OPENSHELL_CLI_PATH },
+  ] as unknown as CliToolInfo[]);
+  openshellCli = new OpenshellCli(exec, cliToolRegistry);
+});
+
+describe('getCliPath', () => {
+  test('returns path from CLI tool registry', () => {
+    expect(openshellCli.getCliPath()).toBe(OPENSHELL_CLI_PATH);
+  });
+
+  test('falls back to openshell when no CLI tool is registered', () => {
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([]);
+    expect(openshellCli.getCliPath()).toBe('openshell');
+  });
+
+  test('falls back to openshell when tool has no path', () => {
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([{ name: 'openshell' }] as unknown as CliToolInfo[]);
+    expect(openshellCli.getCliPath()).toBe('openshell');
+  });
+});
+
+describe('getVersion', () => {
+  test('executes openshell --version and returns trimmed output', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell 0.0.52\n'));
+
+    const result = await openshellCli.getVersion();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['--version']);
+    expect(result).toBe('openshell 0.0.52');
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('command not found'));
+
+    await expect(openshellCli.getVersion()).rejects.toThrow('command not found');
+  });
+});
+
+describe('createSandbox', () => {
+  test('executes openshell sandbox create with defaults', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'create']);
+  });
+
+  test('includes --name flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ name: 'my-sandbox' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'create', '--name', 'my-sandbox']);
+  });
+
+  test('includes --from flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ from: 'python' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'create', '--from', 'python']);
+  });
+
+  test('includes -g flag and gateway label when gateway is provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ gateway: 'my-gw' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'sandbox',
+      'create',
+      '-g',
+      'my-gw',
+      '--label',
+      'gateway=my-gw',
+    ]);
+  });
+
+  test('includes resource flags when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ gpu: true, cpu: '2', memory: '4Gi' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'sandbox',
+      'create',
+      '--gpu',
+      '--cpu',
+      '2',
+      '--memory',
+      '4Gi',
+    ]);
+  });
+
+  test('includes --provider flags when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ providers: ['openai', 'anthropic'] });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'sandbox',
+      'create',
+      '--provider',
+      'openai',
+      '--provider',
+      'anthropic',
+    ]);
+  });
+
+  test('includes --label flags when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ labels: { env: 'dev', team: 'platform' } });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'sandbox',
+      'create',
+      '--label',
+      'env=dev',
+      '--label',
+      'team=platform',
+    ]);
+  });
+
+  test('appends command after -- separator', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ command: ['bash', '-c', 'echo hello'] });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'create', '--', 'bash', '-c', 'echo hello']);
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('no active gateway'));
+
+    await expect(openshellCli.createSandbox()).rejects.toThrow('no active gateway');
+  });
+
+  test('extracts JSON error from stdout on failure', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'gateway connection refused' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(openshellCli.createSandbox()).rejects.toThrow('gateway connection refused');
+  });
+});
+
+describe('listSandboxes', () => {
+  test('executes openshell sandbox list with json output', async () => {
+    const payload = [{ id: 'sb-1', name: 'sb-1', phase: 'Running' }];
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(payload)));
+
+    const result = await openshellCli.listSandboxes();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'list', '-o', 'json'], undefined);
+    expect(result).toEqual(payload);
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('command not found'));
+
+    await expect(openshellCli.listSandboxes()).rejects.toThrow('command not found');
+  });
+});
+
+describe('startSandbox', () => {
+  test('executes openshell sandbox start with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.startSandbox('my-sandbox');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'start', 'my-sandbox']);
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('sandbox not found: unknown'));
+
+    await expect(openshellCli.startSandbox('unknown')).rejects.toThrow('sandbox not found: unknown');
+  });
+});
+
+describe('stopSandbox', () => {
+  test('executes openshell sandbox stop with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.stopSandbox('my-sandbox');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'stop', 'my-sandbox']);
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('sandbox not found: unknown'));
+
+    await expect(openshellCli.stopSandbox('unknown')).rejects.toThrow('sandbox not found: unknown');
+  });
+});
+
+describe('deleteSandbox', () => {
+  test('executes openshell sandbox delete with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.deleteSandbox('my-sandbox');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'delete', 'my-sandbox']);
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('sandbox not found: unknown'));
+
+    await expect(openshellCli.deleteSandbox('unknown')).rejects.toThrow('sandbox not found: unknown');
+  });
+});
+
+describe('deleteAllSandboxes', () => {
+  test('executes openshell sandbox delete --all', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.deleteAllSandboxes();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'delete', '--all']);
+  });
+
+  test('includes -g flag when gateway is provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.deleteAllSandboxes('my-gw');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'delete', '--all', '-g', 'my-gw']);
+  });
+});
+
+describe('connectSandbox', () => {
+  test('executes openshell sandbox connect with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.connectSandbox('my-sandbox');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'connect', 'my-sandbox']);
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('sandbox not found: unknown'));
+
+    await expect(openshellCli.connectSandbox('unknown')).rejects.toThrow('sandbox not found: unknown');
+  });
+});
+
+describe('addGateway', () => {
+  test('executes gateway add with endpoint', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.addGateway({ endpoint: 'https://gw.example.com' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'add', 'https://gw.example.com']);
+  });
+
+  test('includes --name flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.addGateway({ endpoint: 'https://gw.example.com', name: 'my-gw' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'gateway',
+      'add',
+      'https://gw.example.com',
+      '--name',
+      'my-gw',
+    ]);
+  });
+
+  test('includes --remote flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.addGateway({ endpoint: 'https://gw.example.com', remote: 'user@host' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'gateway',
+      'add',
+      'https://gw.example.com',
+      '--remote',
+      'user@host',
+    ]);
+  });
+
+  test('includes --local flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.addGateway({ endpoint: 'https://127.0.0.1', local: true });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'add', 'https://127.0.0.1', '--local']);
+  });
+
+  test('extracts JSON error from stdout on failure', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'invalid endpoint' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(openshellCli.addGateway({ endpoint: 'bad' })).rejects.toThrow('invalid endpoint');
+  });
+});
+
+describe('removeGateway', () => {
+  test('executes gateway remove with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.removeGateway('my-gw');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'remove', 'my-gw']);
+  });
+
+  test('executes gateway remove without name for active gateway', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.removeGateway();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'remove']);
+  });
+});
+
+describe('selectGateway', () => {
+  test('executes gateway select with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.selectGateway('my-gw');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'select', 'my-gw']);
+  });
+
+  test('executes gateway select without name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.selectGateway();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'select']);
+  });
+});
+
+describe('listGateways', () => {
+  test('executes gateway list with json output and returns parsed result', async () => {
+    const payload = [
+      { name: 'gw-1', endpoint: 'https://gw1.example.com' },
+      { name: 'gw-2', endpoint: 'https://gw2.example.com' },
+    ];
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(payload)));
+
+    const result = await openshellCli.listGateways();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'list', '-o', 'json'], undefined);
+    expect(result).toEqual(payload);
+  });
+});
+
+describe('listSandboxesForGateway', () => {
+  test('lists sandboxes for a specific gateway using -g flag', async () => {
+    const gateways = [
+      { name: 'gw-1', endpoint: 'https://gw1.example.com', active: true },
+      { name: 'gw-2', endpoint: 'https://gw2.example.com', active: false },
+    ];
+    const sandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Running' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes)));
+
+    const result = await openshellCli.listSandboxesForGateway('gw-2');
+
+    expect(result.gateway.name).toBe('gw-2');
+    expect(result.sandboxes).toEqual(sandboxes);
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['sandbox', 'list', '-g', 'gw-2', '--selector', 'gateway=gw-2', '-o', 'json'],
+      undefined,
+    );
+    expect(exec.exec).not.toHaveBeenCalledWith(OPENSHELL_CLI_PATH, expect.arrayContaining(['gateway', 'select']));
+  });
+
+  test('throws when gateway is not found', async () => {
+    const gateways = [{ name: 'gw-1', endpoint: 'https://gw1.example.com', active: true }];
+    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)));
+
+    await expect(openshellCli.listSandboxesForGateway('unknown')).rejects.toThrow('Gateway not found: unknown');
+  });
+});
+
+describe('listSandboxesPerGateway', () => {
+  test('returns sandboxes for each gateway using -g flag', async () => {
+    const gateways = [
+      { name: 'gw-1', endpoint: 'https://gw1.example.com', active: true },
+      { name: 'gw-2', endpoint: 'https://gw2.example.com', active: false },
+    ];
+    const sandboxes1 = [{ id: 'sb-1', name: 'sb-1', phase: 'Running' }];
+    const sandboxes2 = [{ id: 'sb-2', name: 'sb-2', phase: 'Stopped' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes1)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes2)));
+
+    const results = await openshellCli.listSandboxesPerGateway();
+
+    expect(results).toHaveLength(2);
+    const [first, second] = results;
+    expect(first?.gateway.name).toBe('gw-1');
+    expect(first?.sandboxes).toEqual(sandboxes1);
+    expect(second?.gateway.name).toBe('gw-2');
+    expect(second?.sandboxes).toEqual(sandboxes2);
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['sandbox', 'list', '-g', 'gw-1', '--selector', 'gateway=gw-1', '-o', 'json'],
+      undefined,
+    );
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['sandbox', 'list', '-g', 'gw-2', '--selector', 'gateway=gw-2', '-o', 'json'],
+      undefined,
+    );
+    expect(exec.exec).not.toHaveBeenCalledWith(OPENSHELL_CLI_PATH, expect.arrayContaining(['gateway', 'select']));
+  });
+
+  test('returns empty array when no gateways exist', async () => {
+    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify([])));
+
+    const results = await openshellCli.listSandboxesPerGateway();
+
+    expect(results).toEqual([]);
+  });
+
+  test('returns empty sandboxes for a gateway that fails to list', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const gateways = [{ name: 'gw-1', endpoint: 'https://gw1.example.com', active: true }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockRejectedValueOnce(new Error('connection refused'));
+
+    const results = await openshellCli.listSandboxesPerGateway();
+
+    expect(results).toHaveLength(1);
+    expect(results.at(0)?.sandboxes).toEqual([]);
+  });
+});
+
+describe('getGatewayStatus', () => {
+  test('executes status and returns trimmed output', async () => {
+    const statusText = 'Server Status\n\n  Gateway: openshell\n  Status: Connected\n';
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(statusText));
+
+    const result = await openshellCli.getGatewayStatus();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['status']);
+    expect(result).toBe(statusText.trim());
+  });
+
+  test('rejects when no gateway is configured', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('no gateway configured'));
+
+    await expect(openshellCli.getGatewayStatus()).rejects.toThrow('no gateway configured');
+  });
+});

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -1,0 +1,283 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RunError, RunOptions } from '@openkaiden/api';
+import { inject, injectable } from 'inversify';
+import z from 'zod';
+
+import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { Exec } from '/@/plugin/util/exec.js';
+import type {
+  CreateSandboxOptions,
+  GatewayAddOptions,
+  GatewayInfo,
+  GatewaySandboxes,
+  SandboxInfo,
+} from '/@api/openshell-gateway-info.js';
+import { GatewayInfoSchema, SandboxInfoSchema } from '/@api/openshell-gateway-info.js';
+
+/**
+ * Low-level wrapper around the `openshell` CLI binary.
+ *
+ * Sandbox commands:
+ *   - `openshell sandbox create`
+ *   - `openshell sandbox list`
+ *   - `openshell sandbox start`
+ *   - `openshell sandbox stop`
+ *   - `openshell sandbox delete`
+ *   - `openshell sandbox connect`
+ *   - `openshell --version`
+ *
+ * Gateway registration commands:
+ *   - `openshell gateway add <endpoint>`
+ *   - `openshell gateway remove [name]`
+ *   - `openshell gateway select [name]`
+ *   - `openshell gateway list`
+ *   - `openshell status`
+ */
+@injectable()
+export class OpenshellCli {
+  constructor(
+    @inject(Exec)
+    private readonly exec: Exec,
+    @inject(CliToolRegistry)
+    private readonly cliToolRegistry: CliToolRegistry,
+  ) {}
+
+  getCliPath(): string {
+    const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
+    if (tool?.path) {
+      return tool.path;
+    }
+    return 'openshell';
+  }
+
+  private extractCliError(err: unknown): string {
+    if (err instanceof Error && 'stdout' in err && typeof (err as RunError).stdout === 'string') {
+      try {
+        const parsed: unknown = JSON.parse((err as RunError).stdout);
+        if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
+          const errorField = (parsed as { error: unknown }).error;
+          if (typeof errorField === 'string' && errorField) {
+            return errorField;
+          }
+        }
+      } catch {
+        // not JSON – fall through
+      }
+    }
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  async getVersion(): Promise<string> {
+    const cliPath = this.getCliPath();
+    try {
+      const result = await this.exec.exec(cliPath, ['--version']);
+      return result.stdout.trim();
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      console.error(`openshell failed: ${cliPath} --version — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+
+  // ── sandbox commands ──────────────────────────────────────────────
+
+  async createSandbox(options: CreateSandboxOptions = {}): Promise<void> {
+    const args = ['sandbox', 'create'];
+    if (options.name) {
+      args.push('--name', options.name);
+    }
+    if (options.from) {
+      args.push('--from', options.from);
+    }
+    if (options.gateway) {
+      args.push('-g', options.gateway);
+      args.push('--label', `gateway=${options.gateway}`);
+    }
+    if (options.gpu) {
+      args.push('--gpu');
+    }
+    if (options.gpuDevice) {
+      args.push('--gpu-device', options.gpuDevice);
+    }
+    if (options.cpu) {
+      args.push('--cpu', options.cpu);
+    }
+    if (options.memory) {
+      args.push('--memory', options.memory);
+    }
+    if (options.providers) {
+      for (const provider of options.providers) {
+        args.push('--provider', provider);
+      }
+    }
+    if (options.labels) {
+      for (const [key, value] of Object.entries(options.labels)) {
+        args.push('--label', `${key}=${value}`);
+      }
+    }
+    if (options.command?.length) {
+      args.push('--', ...options.command);
+    }
+    await this.runCli(args);
+  }
+
+  async listSandboxes(gatewayName?: string): Promise<SandboxInfo[]> {
+    const args = ['sandbox', 'list'];
+    if (gatewayName) {
+      args.push('-g', gatewayName);
+      args.push('--selector', `gateway=${gatewayName}`);
+    }
+    const data = await this.execCLI<unknown>(args);
+    return z.array(SandboxInfoSchema).parse(data);
+  }
+
+  async startSandbox(name: string): Promise<void> {
+    await this.runCli(['sandbox', 'start', name]);
+  }
+
+  async stopSandbox(name: string): Promise<void> {
+    await this.runCli(['sandbox', 'stop', name]);
+  }
+
+  async deleteSandbox(name: string): Promise<void> {
+    await this.runCli(['sandbox', 'delete', name]);
+  }
+
+  async deleteAllSandboxes(gatewayName?: string): Promise<void> {
+    const args = ['sandbox', 'delete', '--all'];
+    if (gatewayName) {
+      args.push('-g', gatewayName);
+    }
+    await this.runCli(args);
+  }
+
+  async connectSandbox(name: string): Promise<void> {
+    await this.runCli(['sandbox', 'connect', name]);
+  }
+
+  async listSandboxesForGateway(gatewayName: string): Promise<GatewaySandboxes> {
+    const gateways = await this.listGateways();
+    const targetGateway = gateways.find(g => g.name === gatewayName);
+    if (!targetGateway) {
+      throw new Error(`Gateway not found: ${gatewayName}`);
+    }
+
+    const sandboxes = await this.listSandboxes(gatewayName);
+    return { gateway: targetGateway, sandboxes };
+  }
+
+  async listSandboxesPerGateway(): Promise<GatewaySandboxes[]> {
+    const gateways = await this.listGateways();
+    if (gateways.length === 0) {
+      return [];
+    }
+
+    const results: GatewaySandboxes[] = [];
+    for (const gateway of gateways) {
+      try {
+        const sandboxes = await this.listSandboxes(gateway.name);
+        results.push({ gateway, sandboxes });
+      } catch (err: unknown) {
+        console.warn(
+          `[openshell] failed to list sandboxes for gateway ${gateway.name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        results.push({ gateway, sandboxes: [] });
+      }
+    }
+
+    return results;
+  }
+
+  // ── gateway registration commands ─────────────────────────────────
+
+  async addGateway(options: GatewayAddOptions): Promise<void> {
+    const args = ['gateway', 'add', options.endpoint];
+    if (options.name) {
+      args.push('--name', options.name);
+    }
+    if (options.remote) {
+      args.push('--remote', options.remote);
+    }
+    if (options.local) {
+      args.push('--local');
+    }
+    await this.runCli(args);
+  }
+
+  async removeGateway(name?: string): Promise<void> {
+    const args = ['gateway', 'remove'];
+    if (name) {
+      args.push(name);
+    }
+    await this.runCli(args);
+  }
+
+  async selectGateway(name?: string): Promise<void> {
+    const args = ['gateway', 'select'];
+    if (name) {
+      args.push(name);
+    }
+    await this.runCli(args);
+  }
+
+  async listGateways(): Promise<GatewayInfo[]> {
+    const data = await this.execCLI<unknown>(['gateway', 'list']);
+    return z.array(GatewayInfoSchema).parse(data);
+  }
+
+  async getGatewayStatus(): Promise<string> {
+    const cliPath = this.getCliPath();
+    try {
+      const result = await this.exec.exec(cliPath, ['status']);
+      return result.stdout.trim();
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      console.error(`openshell failed: ${cliPath} status — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────
+
+  private async runCli(args: string[]): Promise<void> {
+    const cliPath = this.getCliPath();
+    console.log(`Executing: ${cliPath} ${args.join(' ')}`);
+    try {
+      await this.exec.exec(cliPath, args);
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      console.error(`openshell failed: ${cliPath} ${args.join(' ')} — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+
+  private async execCLI<T>(args: string[], options?: RunOptions): Promise<T> {
+    const cliPath = this.getCliPath();
+    const fullArgs = [...args, '-o', 'json'];
+    try {
+      const result = await this.exec.exec(cliPath, fullArgs, options);
+      return JSON.parse(result.stdout) as T;
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      console.error(`openshell failed: ${cliPath} ${fullArgs.join(' ')} — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+}

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -1,0 +1,320 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+import type { RunResult } from '@openkaiden/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { Proxy } from '/@/plugin/proxy.js';
+import { Exec } from '/@/plugin/util/exec.js';
+import type { CliToolInfo } from '/@api/cli-tool-info.js';
+import type { GatewayInfo } from '/@api/openshell-gateway-info.js';
+
+import { OpenshellGateway } from './openshell-gateway.js';
+
+vi.mock(import('node:child_process'));
+vi.mock(import('/@/plugin/util/exec.js'));
+
+const { spawn } = await import('node:child_process');
+
+const GATEWAY_BINARY = '/usr/local/bin/openshell-gateway';
+const CLI_BINARY = '/usr/local/bin/openshell';
+
+function createMockChildProcess(): ChildProcess & { _stdout: EventEmitter; _stderr: EventEmitter } {
+  const proc = new EventEmitter() as ChildProcess & { _stdout: EventEmitter; _stderr: EventEmitter };
+  proc._stdout = new EventEmitter();
+  proc._stderr = new EventEmitter();
+  Object.defineProperty(proc, 'stdout', { get: (): EventEmitter => proc._stdout });
+  Object.defineProperty(proc, 'stderr', { get: (): EventEmitter => proc._stderr });
+  proc.kill = vi.fn().mockReturnValue(true);
+  Object.defineProperty(proc, 'exitCode', { value: undefined, writable: true, configurable: true });
+  return proc;
+}
+
+function mockExecResult(stdout = ''): RunResult {
+  return { command: CLI_BINARY, stdout, stderr: '' };
+}
+
+let gateway: OpenshellGateway;
+
+const exec = new Exec({} as Proxy);
+const cliToolRegistry = {
+  getCliToolInfos: vi.fn(),
+} as unknown as CliToolRegistry;
+
+const openshellCli = {
+  listGateways: vi.fn(),
+} as unknown as OpenshellCli;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
+    { name: 'openshell-gateway', path: GATEWAY_BINARY },
+    { name: 'openshell', path: CLI_BINARY },
+  ] as unknown as CliToolInfo[]);
+  gateway = new OpenshellGateway(exec, cliToolRegistry, openshellCli);
+});
+
+describe('init', () => {
+  test('skips auto-start when existing gateways are discovered', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const existingGateways: GatewayInfo[] = [{ name: 'remote-gw', endpoint: 'https://gw.example.com', active: true }];
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
+
+    await gateway.init();
+
+    expect(openshellCli.listGateways).toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('auto-starts local gateway when no gateways exist and port is free', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(spawn).toHaveBeenCalledWith(
+      GATEWAY_BINARY,
+      expect.arrayContaining(['--port', '17670']),
+      expect.objectContaining({ detached: false }),
+    );
+  });
+
+  test('reuses orphan gateway when port is already healthy', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
+      'gateway',
+      'add',
+      'http://127.0.0.1:17670',
+      '--local',
+      '--name',
+      'kaiden-local',
+    ]);
+  });
+
+  test('skips auto-start when discovery fails and binary is not registered', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('CLI not found'));
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
+      { name: 'openshell', path: CLI_BINARY },
+    ] as unknown as CliToolInfo[]);
+
+    await gateway.init();
+
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('auto-starts when discovery fails but binary is available and port is free', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('no gateway configured'));
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(spawn).toHaveBeenCalledWith(
+      GATEWAY_BINARY,
+      expect.arrayContaining(['--port', '17670']),
+      expect.objectContaining({ detached: false }),
+    );
+  });
+});
+
+describe('getGatewayBinaryPath', () => {
+  test('returns path from CLI tool registry', () => {
+    expect(gateway.getGatewayBinaryPath()).toBe(GATEWAY_BINARY);
+  });
+
+  test('returns undefined when openshell-gateway is not registered', () => {
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
+      { name: 'openshell', path: CLI_BINARY },
+    ] as unknown as CliToolInfo[]);
+    expect(gateway.getGatewayBinaryPath()).toBeUndefined();
+  });
+});
+
+describe('start', () => {
+  test('spawns the gateway process with default args', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+
+    await gateway.start();
+
+    expect(spawn).toHaveBeenCalledWith(
+      GATEWAY_BINARY,
+      ['--port', '17670', '--bind-address', '127.0.0.1', '--disable-tls'],
+      expect.objectContaining({ detached: false }),
+    );
+  });
+
+  test('spawns with custom port and address', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+
+    await gateway.start({ port: 9999, bindAddress: '0.0.0.0' });
+
+    expect(spawn).toHaveBeenCalledWith(
+      GATEWAY_BINARY,
+      ['--port', '9999', '--bind-address', '0.0.0.0', '--disable-tls'],
+      expect.objectContaining({ detached: false }),
+    );
+  });
+
+  test('skips --disable-tls when disableTls is false', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+
+    await gateway.start({ disableTls: false });
+
+    expect(spawn).toHaveBeenCalledWith(
+      GATEWAY_BINARY,
+      ['--port', '17670', '--bind-address', '127.0.0.1'],
+      expect.objectContaining({ detached: false }),
+    );
+  });
+
+  test('skips if already running', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+
+    await gateway.start();
+    await gateway.start();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws when gateway binary is not registered', async () => {
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
+      { name: 'openshell', path: CLI_BINARY },
+    ] as unknown as CliToolInfo[]);
+
+    await expect(gateway.start()).rejects.toThrow('openshell-gateway binary not registered');
+  });
+
+  test('performs health check with openshell status', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.start();
+
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
+      'status',
+      '--gateway-endpoint',
+      'http://127.0.0.1:17670',
+      '--gateway-insecure',
+    ]);
+  });
+
+  test('registers gateway with CLI after health check passes', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.start();
+
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
+      'gateway',
+      'add',
+      'http://127.0.0.1:17670',
+      '--local',
+      '--name',
+      'kaiden-local',
+    ]);
+  });
+});
+
+describe('stop', () => {
+  test('sends SIGTERM to running process', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.start();
+
+    const stopPromise = gateway.stop();
+    proc.emit('exit', 0, undefined);
+    await stopPromise;
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  test('is a no-op when not running', async () => {
+    await gateway.stop();
+  });
+});
+
+describe('isRunning', () => {
+  test('returns false when no process is spawned', () => {
+    expect(gateway.isRunning()).toBe(false);
+  });
+
+  test('returns true when process is running', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.start();
+
+    expect(gateway.isRunning()).toBe(true);
+  });
+});
+
+describe('dispose', () => {
+  test('stops the gateway process', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.start();
+
+    gateway.dispose();
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+});

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -1,0 +1,236 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
+
+import type { Disposable } from '@openkaiden/api';
+import { inject, injectable, preDestroy } from 'inversify';
+
+import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import { Exec } from '/@/plugin/util/exec.js';
+import type { OpenshellGatewayStartOptions } from '/@api/openshell-gateway-info.js';
+
+const DEFAULT_PORT = 17670;
+const DEFAULT_BIND_ADDRESS = '127.0.0.1';
+const HEALTH_CHECK_INTERVAL_MS = 1000;
+const MAX_HEALTH_CHECK_ATTEMPTS = 30;
+const STOP_TIMEOUT_MS = 5000;
+
+/**
+ * Manages the `openshell-gateway` server binary lifecycle.
+ *
+ * On {@link init}, discovers existing gateways via the CLI. If none are found,
+ * auto-starts a local gateway by spawning the `openshell-gateway` binary,
+ * waiting for it to become healthy, and registering it with the CLI.
+ */
+@injectable()
+export class OpenshellGateway implements Disposable {
+  #gatewayProcess: ChildProcess | undefined;
+  #port: number = DEFAULT_PORT;
+  #bindAddress: string = DEFAULT_BIND_ADDRESS;
+
+  constructor(
+    @inject(Exec)
+    private readonly exec: Exec,
+    @inject(CliToolRegistry)
+    private readonly cliToolRegistry: CliToolRegistry,
+    @inject(OpenshellCli)
+    private readonly openshellCli: OpenshellCli,
+  ) {}
+
+  async init(): Promise<void> {
+    try {
+      const gateways = await this.openshellCli.listGateways();
+      if (gateways.length > 0) {
+        console.log(`[openshell-gateway] discovered ${gateways.length} existing gateway(s)`);
+        return;
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[openshell-gateway] failed to discover gateways: ${message}`);
+    }
+
+    const binaryPath = this.getGatewayBinaryPath();
+    if (!binaryPath) {
+      console.warn('[openshell-gateway] no existing gateways and binary not registered, skipping auto-start');
+      return;
+    }
+
+    if (await this.isEndpointHealthy()) {
+      console.log('[openshell-gateway] found healthy gateway on default port, registering');
+      await this.registerWithCli();
+      return;
+    }
+
+    console.log('[openshell-gateway] no existing gateways found, auto-starting local gateway');
+    await this.start();
+  }
+
+  private async isEndpointHealthy(): Promise<boolean> {
+    const endpoint = `http://${this.#bindAddress}:${this.#port}`;
+    const cliPath = this.getCliPath();
+    try {
+      await this.exec.exec(cliPath, ['status', '--gateway-endpoint', endpoint, '--gateway-insecure']);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  getGatewayBinaryPath(): string | undefined {
+    const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell-gateway');
+    return tool?.path;
+  }
+
+  private getCliPath(): string {
+    const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
+    return tool?.path ?? 'openshell';
+  }
+
+  async start(options?: OpenshellGatewayStartOptions): Promise<void> {
+    if (this.#gatewayProcess) {
+      console.log('[openshell-gateway] already running, skipping start');
+      return;
+    }
+
+    const binaryPath = this.getGatewayBinaryPath();
+    if (!binaryPath) {
+      throw new Error('openshell-gateway binary not registered in CLI tool registry');
+    }
+
+    if (options?.port !== undefined) {
+      this.#port = options.port;
+    }
+    if (options?.bindAddress !== undefined) {
+      this.#bindAddress = options.bindAddress;
+    }
+
+    const args = this.buildArgs(options?.disableTls ?? true);
+    console.log(`[openshell-gateway] starting: ${binaryPath} ${args.join(' ')}`);
+
+    this.#gatewayProcess = spawn(binaryPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: false,
+    });
+
+    this.#gatewayProcess.stdout?.on('data', (data: Buffer) => {
+      console.log(`[openshell-gateway] ${data.toString().trimEnd()}`);
+    });
+
+    this.#gatewayProcess.stderr?.on('data', (data: Buffer) => {
+      console.error(`[openshell-gateway] ${data.toString().trimEnd()}`);
+    });
+
+    this.#gatewayProcess.on('exit', (code, signal) => {
+      console.log(`[openshell-gateway] exited with code=${code ?? 'none'} signal=${signal ?? 'none'}`);
+      this.#gatewayProcess = undefined;
+    });
+
+    this.#gatewayProcess.on('error', (err: Error) => {
+      console.error(`[openshell-gateway] failed to start: ${err.message}`);
+      this.#gatewayProcess = undefined;
+    });
+
+    await this.waitForReady();
+    await this.registerWithCli();
+  }
+
+  async stop(): Promise<void> {
+    const proc = this.#gatewayProcess;
+    if (!proc) {
+      return;
+    }
+
+    console.log('[openshell-gateway] stopping');
+    proc.kill('SIGTERM');
+
+    await new Promise<void>(resolve => {
+      const timeout = setTimeout(() => {
+        if (proc.exitCode === undefined || proc.exitCode === null) {
+          console.warn('[openshell-gateway] did not exit after SIGTERM, sending SIGKILL');
+          proc.kill('SIGKILL');
+        }
+        resolve();
+      }, STOP_TIMEOUT_MS);
+
+      proc.once('exit', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    this.#gatewayProcess = undefined;
+  }
+
+  isRunning(): boolean {
+    return this.#gatewayProcess !== undefined && this.#gatewayProcess.exitCode === undefined;
+  }
+
+  @preDestroy()
+  dispose(): void {
+    this.stop().catch((err: unknown) => console.error('[openshell-gateway] failed to stop: ', err));
+  }
+
+  private buildArgs(disableTls: boolean): string[] {
+    const args: string[] = [];
+    args.push('--port', String(this.#port));
+    args.push('--bind-address', this.#bindAddress);
+    if (disableTls) {
+      args.push('--disable-tls');
+    }
+    return args;
+  }
+
+  private async waitForReady(): Promise<void> {
+    const endpoint = `http://${this.#bindAddress}:${this.#port}`;
+    console.log(`[openshell-gateway] waiting for server at ${endpoint}`);
+
+    const cliPath = this.getCliPath();
+    for (let attempt = 0; attempt < MAX_HEALTH_CHECK_ATTEMPTS; attempt++) {
+      if (!this.isRunning()) {
+        throw new Error('Gateway process exited before becoming ready');
+      }
+
+      try {
+        await this.exec.exec(cliPath, ['status', '--gateway-endpoint', endpoint, '--gateway-insecure']);
+        console.log('[openshell-gateway] server is ready');
+        return;
+      } catch {
+        // not ready yet
+      }
+
+      await new Promise<void>(resolve => setTimeout(resolve, HEALTH_CHECK_INTERVAL_MS));
+    }
+
+    throw new Error(`Gateway did not become ready within ${MAX_HEALTH_CHECK_ATTEMPTS}s`);
+  }
+
+  private async registerWithCli(): Promise<void> {
+    const endpoint = `http://${this.#bindAddress}:${this.#port}`;
+    const cliPath = this.getCliPath();
+    try {
+      await this.exec.exec(cliPath, ['gateway', 'add', endpoint, '--local', '--name', 'kaiden-local']);
+      console.log(`[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[openshell-gateway] failed to register with CLI: ${message}`);
+    }
+  }
+}


### PR DESCRIPTION
Introduces a low-level CLI wrapper that maps Kaiden sandbox/gateway operations to openshell commands (create, list, start, stop, delete, connect) and registers it as a singleton in the plugin DI container. 

Closes https://github.com/openkaiden/kaiden/issues/1923