### PR TITLE
refactor(renderer): extract reusable Card component with gradient background

### DIFF
--- a/packages/renderer/src/app.css
+++ b/packages/renderer/src/app.css
@@ -130,3 +130,18 @@ a {
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 }
+
+/* Card component styles */
+.content-card {
+  background: linear-gradient(180deg, var(--pd-content-card-bg) 0%, var(--pd-content-card-inset-bg) 100%);
+  border: 1px solid var(--pd-content-table-border);
+  border-radius: 0.5rem;
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--pd-content-bg) 6%, transparent),
+    0 8px 24px color-mix(in srgb, var(--pd-content-bg) 7%, transparent);
+}
+
+.dark .content-card {
+  background: linear-gradient(160deg, var(--pd-content-card-bg) 0%, var(--pd-content-bg) 100%);
+  box-shadow: none;
+}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.svelte
@@ -3,6 +3,7 @@ import { faCirclePlay, faRobot, faTableCells } from '@fortawesome/free-solid-svg
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { SvelteSet } from 'svelte/reactivity';
 
+import Card from '/@/lib/components/Card.svelte';
 import type { AgentWorkspaceSummaryUI } from '/@/stores/agent-workspaces.svelte';
 
 import { isActiveWorkspace } from './workspace-utils';
@@ -19,7 +20,7 @@ const agentCount = $derived(new SvelteSet(workspaces.map(ws => ws.agent)).size);
 </script>
 
 <div class="grid grid-cols-3 gap-3.5 mb-5">
-  <div class="flex items-center gap-3.5 py-[18px] px-5 bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-table-border)] rounded-xl">
+  <Card class="flex items-center gap-3.5 py-[18px] px-5">
     <div class="w-10 h-10 rounded-[10px] flex items-center justify-center shrink-0 bg-[color-mix(in_srgb,var(--pd-status-running)_15%,transparent)] text-[var(--pd-status-running)]">
       <Icon icon={faCirclePlay} size="1.1x" />
     </div>
@@ -27,9 +28,9 @@ const agentCount = $derived(new SvelteSet(workspaces.map(ws => ws.agent)).size);
       <span class="text-4xl font-bold text-[var(--pd-content-text)]">{activeCount}</span>
       <span class="text-base text-[var(--pd-content-text)] opacity-60">Active Sessions</span>
     </div>
-  </div>
+  </Card>
 
-  <div class="flex items-center gap-3.5 py-[18px] px-5 bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-table-border)] rounded-xl">
+  <Card class="flex items-center gap-3.5 py-[18px] px-5">
     <div class="w-10 h-10 rounded-[10px] flex items-center justify-center shrink-0 bg-[color-mix(in_srgb,var(--pd-status-waiting)_15%,transparent)] text-[var(--pd-status-waiting)]">
       <Icon icon={faTableCells} size="1.1x" />
     </div>
@@ -37,9 +38,9 @@ const agentCount = $derived(new SvelteSet(workspaces.map(ws => ws.agent)).size);
       <span class="text-4xl font-bold text-[var(--pd-content-text)]">{totalCount}</span>
       <span class="text-base text-[var(--pd-content-text)] opacity-60">Total Sessions</span>
     </div>
-  </div>
+  </Card>
 
-  <div class="flex items-center gap-3.5 py-[18px] px-5 bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-table-border)] rounded-xl">
+  <Card class="flex items-center gap-3.5 py-[18px] px-5">
     <div class="w-10 h-10 rounded-[10px] flex items-center justify-center shrink-0 bg-[color-mix(in_srgb,var(--pd-link)_15%,transparent)] text-[var(--pd-link)]">
       <Icon icon={faRobot} size="1.1x" />
     </div>
@@ -47,5 +48,5 @@ const agentCount = $derived(new SvelteSet(workspaces.map(ws => ws.agent)).size);
       <span class="text-4xl font-bold text-[var(--pd-content-text)]">{agentCount}</span>
       <span class="text-base text-[var(--pd-content-text)] opacity-60">Configured Agents</span>
     </div>
-  </div>
+  </Card>
 </div>

--- a/packages/renderer/src/lib/components/Card.svelte
+++ b/packages/renderer/src/lib/components/Card.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import type { Snippet } from 'svelte';
+import type { HTMLAttributes } from 'svelte/elements';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  class?: string;
+  children: Snippet;
+}
+
+let { class: className, children, ...restProps }: Props = $props();
+</script>
+
+<div class="content-card {className}" {...restProps}>
+  {@render children()}
+</div>

--- a/packages/renderer/src/lib/models/ProviderConnectionTiles.svelte
+++ b/packages/renderer/src/lib/models/ProviderConnectionTiles.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { router } from 'tinro';
 
+import Card from '/@/lib/components/Card.svelte';
 import type { InferenceConnectionSummary } from '/@/lib/models/models-utils';
 
 interface Props {
@@ -79,8 +80,7 @@ function getSecondBadge(status: string): BadgeInfo | undefined {
     {@const status = effectiveStatus(connection)}
     {@const primaryBadge = getStatusBadge(status)}
     {@const secondaryBadge = getSecondBadge(status)}
-    <div
-      class="provider-tile flex flex-col gap-2 p-4 rounded-lg border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] flex-1 min-w-40 max-w-48">
+    <Card class="provider-tile flex flex-col gap-2 p-4 flex-1 min-w-40 max-w-48">
       <span class="text-base font-semibold text-[var(--pd-content-card-header-text)]">
         {connection.providerName}
       </span>
@@ -102,19 +102,7 @@ function getSecondBadge(status: string): BadgeInfo | undefined {
           Configure
         </button>
       {/if}
-    </div>
+    </Card>
   {/each}
 </div>
 
-<style>
-  .provider-tile {
-    box-shadow:
-      0 1px 2px color-mix(in srgb, var(--pd-content-bg) 6%, transparent),
-      0 8px 24px color-mix(in srgb, var(--pd-content-bg) 7%, transparent);
-  }
-
-  :global(.dark) .provider-tile {
-    background: linear-gradient(145deg, var(--pd-content-card-bg) 0%, var(--pd-content-bg) 100%);
-    box-shadow: none;
-  }
-</style>


### PR DESCRIPTION
Centralize card styling (background, border, shadow, gradient) into a single Card component so all surfaces share the same visual treatment and dark/light theming is defined once.

Makes the Agent workspaces page look closer to the mockups:

<img width="1354" height="1102" alt="Screenshot 2026-05-29 at 12 31 10" src="https://github.com/user-attachments/assets/a9fa2d41-7f10-4268-8073-d7dacd8a163f" />
<img width="1354" height="1102" alt="Screenshot 2026-05-29 at 12 31 34" src="https://github.com/user-attachments/assets/a3549bd6-0e04-4877-95be-5e59a40f1b81" />
