### PR TITLE
feat(openai): persist connection IDs in secret storage

### DIFF
--- a/extensions/openai-compatible/src/openAI.spec.ts
+++ b/extensions/openai-compatible/src/openAI.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { randomUUID } from 'node:crypto';
+
 import { createOpenAICompatible, type OpenAICompatibleProvider } from '@ai-sdk/openai-compatible';
 import type {
   CancellationToken,
@@ -27,7 +29,15 @@ import type {
 } from '@openkaiden/api';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { OpenAI, TOKENS_KEY } from './openAI';
+import { OpenAI, type StoredConnection, TOKENS_KEY } from './openAI';
+
+vi.mock(import('node:crypto'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
+  };
+});
 
 vi.mock('@openkaiden/api', () => ({
   Disposable: {
@@ -71,6 +81,7 @@ global.fetch = fetchMock;
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(randomUUID).mockReturnValue('fake-uuid-1' as ReturnType<typeof randomUUID>);
   vi.mocked(PROVIDER_API_MOCK.createProvider).mockReturnValue(PROVIDER_MOCK as Provider);
   vi.mocked(createOpenAICompatible).mockReturnValue(OPENAI_PROVIDER_MOCK);
   vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(undefined);
@@ -143,15 +154,17 @@ describe('factory', () => {
     }).rejects.toThrowError('invalid baseURL');
   });
 
-  test('calling create with proper params should save connection info', async () => {
+  test('calling create with proper params should save connection as JSON', async () => {
     await create({
       'openai.factory.apiKey': 'dummyKey',
       'openai.factory.baseURL': 'http://localhost:11434/v1',
     });
 
-    // ensure store has been updated with combined key|baseURL format
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey|http://localhost:11434/v1');
+    const expected: StoredConnection[] = [
+      { id: 'fake-uuid-1', apiKey: 'dummyKey', baseURL: 'http://localhost:11434/v1' },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
 
   test('calling create should fetch models, create SDK and register inference connection', async () => {
@@ -230,16 +243,24 @@ describe('connection delete lifecycle', () => {
 });
 
 describe('restoreConnections', () => {
-  test('should restore multiple connections from secret storage on init', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('key1|http://a/v1,key2|http://b/v1');
+  test('should restore multiple connections from JSON storage on init', async () => {
+    const stored: StoredConnection[] = [
+      { id: 'id-1', apiKey: 'key1', baseURL: 'http://a/v1' },
+      { id: 'id-2', apiKey: 'key2', baseURL: 'http://b/v1' },
+    ];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     const openai = new OpenAI(PROVIDER_API_MOCK, SECRET_STORAGE_MOCK);
     await openai.init();
 
-    // two connections should be attempted
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'id-2' }),
+    );
 
-    // Also ensure models listing was requested twice
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://a/v1/models', {
       headers: { Authorization: 'Bearer key1' },
@@ -249,17 +270,19 @@ describe('restoreConnections', () => {
     });
   });
 
-  test('should restore a single connection from secret storage on init', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('key1|http://a/v1,key2|http://b/v1');
+  test('should restore connections even when one fails model listing', async () => {
+    const stored: StoredConnection[] = [
+      { id: 'id-1', apiKey: 'key1', baseURL: 'http://a/v1' },
+      { id: 'id-2', apiKey: 'key2', baseURL: 'http://b/v1' },
+    ];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
     fetchMock.mockResolvedValueOnce({ status: 500, json: async () => ({}) });
 
     const openai = new OpenAI(PROVIDER_API_MOCK, SECRET_STORAGE_MOCK);
     await openai.init();
 
-    // two connections should be attempted
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
 
-    // Also ensure models listing was requested twice
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://a/v1/models', {
       headers: { Authorization: 'Bearer key1' },
@@ -267,6 +290,29 @@ describe('restoreConnections', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://b/v1/models', {
       headers: { Authorization: 'Bearer key2' },
     });
+  });
+
+  test('should migrate legacy pipe+comma-separated format to JSON', async () => {
+    vi.mocked(randomUUID)
+      .mockReturnValueOnce('migrated-id-1' as ReturnType<typeof randomUUID>)
+      .mockReturnValueOnce('migrated-id-2' as ReturnType<typeof randomUUID>);
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('key1|http://a/v1,key2|http://b/v1');
+
+    const openai = new OpenAI(PROVIDER_API_MOCK, SECRET_STORAGE_MOCK);
+    await openai.init();
+
+    const expected: StoredConnection[] = [
+      { id: 'migrated-id-1', apiKey: 'key1', baseURL: 'http://a/v1' },
+      { id: 'migrated-id-2', apiKey: 'key2', baseURL: 'http://b/v1' },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-2' }),
+    );
   });
 });
 

--- a/extensions/openai-compatible/src/openAI.spec.ts
+++ b/extensions/openai-compatible/src/openAI.spec.ts
@@ -31,13 +31,7 @@ import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { OpenAI, type StoredConnection, TOKENS_KEY } from './openAI';
 
-vi.mock(import('node:crypto'), async importOriginal => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
-  };
-});
+vi.mock(import('node:crypto'));
 
 vi.mock('@openkaiden/api', () => ({
   Disposable: {
@@ -370,8 +364,11 @@ describe('duplicate connection prevention', () => {
 
     await create({ 'openai.factory.apiKey': 'dup', 'openai.factory.baseURL': 'http://dup/v1' });
 
+    const stored: StoredConnection[] = [{ id: 'fake-uuid-1', apiKey: 'dup', baseURL: 'http://dup/v1' }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
     await expect(
       create({ 'openai.factory.apiKey': 'dup', 'openai.factory.baseURL': 'http://dup/v1' }),
-    ).rejects.toThrowError('connection already exists for token (hidden) baseURL http://dup/v1');
+    ).rejects.toThrowError('connection already exists for baseURL http://dup/v1');
   });
 });

--- a/extensions/openai-compatible/src/openAI.ts
+++ b/extensions/openai-compatible/src/openAI.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type {
@@ -38,7 +38,6 @@ export interface StoredConnection {
 export class OpenAI implements Disposable {
   private provider: Provider | undefined = undefined;
   private connections: Map<string, Disposable> = new Map();
-  private activeTokenHashes: Set<string> = new Set();
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -107,11 +106,6 @@ export class OpenAI implements Disposable {
     await this.secrets.store(TOKENS_KEY, JSON.stringify(stored));
   }
 
-  private getTokenHash(token: string): string {
-    const sha256 = createHash('sha256');
-    return sha256.update(token).digest('hex');
-  }
-
   private async removeConnection(id: string): Promise<void> {
     const stored = await this.getStoredConnections();
     const filtered = stored.filter(entry => entry.id !== id);
@@ -144,12 +138,6 @@ export class OpenAI implements Disposable {
   }): Promise<void> {
     if (!this.provider) throw new Error('cannot create MCP provider connection: provider is not initialized');
 
-    const tokenHash = this.getTokenHash(token);
-
-    if (this.activeTokenHashes.has(tokenHash)) {
-      throw new Error(`connection already exists for token (hidden) baseURL ${baseURL}`);
-    }
-
     let models: InferenceModel[] = [];
     let status: ProviderConnectionStatus = 'unknown';
 
@@ -168,7 +156,6 @@ export class OpenAI implements Disposable {
     const clean = async (): Promise<void> => {
       this.connections.get(id)?.dispose();
       this.connections.delete(id);
-      this.activeTokenHashes.delete(tokenHash);
       await this.removeConnection(id);
     };
 
@@ -192,7 +179,6 @@ export class OpenAI implements Disposable {
         };
       },
     });
-    this.activeTokenHashes.add(tokenHash);
     this.connections.set(id, connectionDisposable);
   }
 
@@ -203,6 +189,11 @@ export class OpenAI implements Disposable {
     const baseURL = params['openai.factory.baseURL'];
     if (!baseURL || typeof baseURL !== 'string') throw new Error('invalid baseURL');
 
+    const stored = await this.getStoredConnections();
+    if (stored.some(c => c.apiKey === apiKey && c.baseURL === baseURL)) {
+      throw new Error(`connection already exists for baseURL ${baseURL}`);
+    }
+
     const id = randomUUID();
     await this.saveConnection({ id, apiKey, baseURL });
     await this.registerInferenceProviderConnection({ id, token: apiKey, baseURL });
@@ -212,6 +203,5 @@ export class OpenAI implements Disposable {
     this.provider?.dispose();
     this.connections.forEach(disposable => disposable.dispose());
     this.connections.clear();
-    this.activeTokenHashes.clear();
   }
 }

--- a/extensions/openai-compatible/src/openAI.ts
+++ b/extensions/openai-compatible/src/openAI.ts
@@ -38,6 +38,7 @@ export interface StoredConnection {
 export class OpenAI implements Disposable {
   private provider: Provider | undefined = undefined;
   private connections: Map<string, Disposable> = new Map();
+  private activeTokenHashes: Set<string> = new Set();
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -111,9 +112,9 @@ export class OpenAI implements Disposable {
     return sha256.update(token).digest('hex');
   }
 
-  private async removeConnection(token: string, baseURL: string): Promise<void> {
+  private async removeConnection(id: string): Promise<void> {
     const stored = await this.getStoredConnections();
-    const filtered = stored.filter(entry => entry.apiKey !== token || entry.baseURL !== baseURL);
+    const filtered = stored.filter(entry => entry.id !== id);
     await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
@@ -143,10 +144,9 @@ export class OpenAI implements Disposable {
   }): Promise<void> {
     if (!this.provider) throw new Error('cannot create MCP provider connection: provider is not initialized');
 
-    // get hash of the token (used for Map)
     const tokenHash = this.getTokenHash(token);
 
-    if (this.connections.has(tokenHash)) {
+    if (this.activeTokenHashes.has(tokenHash)) {
       throw new Error(`connection already exists for token (hidden) baseURL ${baseURL}`);
     }
 
@@ -159,21 +159,17 @@ export class OpenAI implements Disposable {
       status = 'stopped';
     }
 
-    // create ProviderV2
     const openai = createOpenAICompatible({
       baseURL: baseURL,
       apiKey: token,
       name: baseURL,
     });
 
-    // create a clean method
     const clean = async (): Promise<void> => {
-      // dispose inference provider connection
-      this.connections.get(tokenHash)?.dispose();
-      // delete map entry
-      this.connections.delete(tokenHash);
-      // remove token from secret storage
-      await this.removeConnection(token, baseURL);
+      this.connections.get(id)?.dispose();
+      this.connections.delete(id);
+      this.activeTokenHashes.delete(tokenHash);
+      await this.removeConnection(id);
     };
 
     const connectionDisposable = this.provider.registerInferenceProviderConnection({
@@ -196,7 +192,8 @@ export class OpenAI implements Disposable {
         };
       },
     });
-    this.connections.set(tokenHash, connectionDisposable);
+    this.activeTokenHashes.add(tokenHash);
+    this.connections.set(id, connectionDisposable);
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {
@@ -215,5 +212,6 @@ export class OpenAI implements Disposable {
     this.provider?.dispose();
     this.connections.forEach(disposable => disposable.dispose());
     this.connections.clear();
+    this.activeTokenHashes.clear();
   }
 }

--- a/extensions/openai-compatible/src/openAI.ts
+++ b/extensions/openai-compatible/src/openAI.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type {
@@ -28,10 +28,9 @@ import type {
 } from '@openkaiden/api';
 
 export const TOKENS_KEY = 'openai:infos';
-export const TOKEN_SEPARATOR = ',';
-const INFO_SEPARATOR = '|';
 
-interface ConnectionInfo {
+export interface StoredConnection {
+  id: string;
   apiKey: string;
   baseURL: string;
 }
@@ -39,7 +38,6 @@ interface ConnectionInfo {
 export class OpenAI implements Disposable {
   private provider: Provider | undefined = undefined;
   private connections: Map<string, Disposable> = new Map();
-  private connectionIdCounter = 0;
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -65,56 +63,47 @@ export class OpenAI implements Disposable {
   }
 
   private async restoreConnections(): Promise<void> {
-    const connectionInfos = await this.getConnectionInfos();
-    for (const connectionInfo of connectionInfos) {
+    const stored = await this.getStoredConnections();
+    for (const entry of stored) {
       try {
         await this.registerInferenceProviderConnection({
-          token: connectionInfo.apiKey,
-          baseURL: connectionInfo.baseURL,
+          id: entry.id,
+          token: entry.apiKey,
+          baseURL: entry.baseURL,
         });
       } catch (err: unknown) {
-        console.error(`openai: failed to restore connection for baseURL ${connectionInfo.baseURL}`, err);
+        console.error(`openai: failed to restore connection for baseURL ${entry.baseURL}`, err);
       }
     }
   }
 
-  /**
-   * Get all connection infos from secret storage
-   * @private
-   */
-  private async getConnectionInfos(): Promise<ConnectionInfo[]> {
-    // get raw string from secret storage
+  private async getStoredConnections(): Promise<StoredConnection[]> {
     let raw: string | undefined;
     try {
       raw = await this.secrets.get(TOKENS_KEY);
     } catch (err: unknown) {
       console.error('openai: something went wrong while trying to get tokens from secret storage', err);
     }
-    // if undefined return empty array
     if (!raw) return [];
-    // split raw string by token separator
-    return raw.split(TOKEN_SEPARATOR).map(str => {
-      const [apiKey, baseURL] = str.split(INFO_SEPARATOR);
-      return {
-        apiKey,
-        baseURL,
-      };
-    });
+
+    try {
+      return JSON.parse(raw) as StoredConnection[];
+    } catch {
+      // Migrate legacy pipe+comma-separated format (apiKey|baseURL,apiKey|baseURL)
+      const entries = raw.split(',');
+      const migrated: StoredConnection[] = entries.map(str => {
+        const [apiKey, baseURL] = str.split('|');
+        return { id: randomUUID(), apiKey, baseURL };
+      });
+      await this.secrets.store(TOKENS_KEY, JSON.stringify(migrated));
+      return migrated;
+    }
   }
 
-  /**
-   * Save connection info to secret storage
-   * @param apiKey
-   * @param baseURL
-   * @private
-   */
-  private async saveConnectionInfo(apiKey: string, baseURL: string): Promise<void> {
-    // get existing tokens
-    const tokens = (await this.getConnectionInfos()).map(t => `${t.apiKey}|${t.baseURL}`);
-    // concat new token with existing tokens
-    const raw = [...tokens, `${apiKey}${INFO_SEPARATOR}${baseURL}`].join(TOKEN_SEPARATOR);
-    // save to secret storage
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async saveConnection(connection: StoredConnection): Promise<void> {
+    const stored = await this.getStoredConnections();
+    stored.push(connection);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(stored));
   }
 
   private getTokenHash(token: string): string {
@@ -122,13 +111,10 @@ export class OpenAI implements Disposable {
     return sha256.update(token).digest('hex');
   }
 
-  private async removeConnectionInfo(token: string, baseURL: string): Promise<void> {
-    // get existing tokens
-    const tokens = await this.getConnectionInfos();
-    // filter out the token
-    const raw = tokens.filter(t => t.apiKey !== token || t.baseURL !== baseURL).join(TOKEN_SEPARATOR);
-    // save to secret storage
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async removeConnection(token: string, baseURL: string): Promise<void> {
+    const stored = await this.getStoredConnections();
+    const filtered = stored.filter(entry => entry.apiKey !== token || entry.baseURL !== baseURL);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
   protected async listModels(baseURL: string, token: string): Promise<Array<{ label: string }>> {
@@ -147,9 +133,11 @@ export class OpenAI implements Disposable {
   }
 
   private async registerInferenceProviderConnection({
+    id,
     token,
     baseURL,
   }: {
+    id: string;
     token: string;
     baseURL: string;
   }): Promise<void> {
@@ -185,11 +173,11 @@ export class OpenAI implements Disposable {
       // delete map entry
       this.connections.delete(tokenHash);
       // remove token from secret storage
-      await this.removeConnectionInfo(token, baseURL);
+      await this.removeConnection(token, baseURL);
     };
 
     const connectionDisposable = this.provider.registerInferenceProviderConnection({
-      id: String(this.connectionIdCounter++),
+      id,
       name: baseURL,
       type: 'cloud',
       llmMetadata: { name: 'openai' },
@@ -212,21 +200,15 @@ export class OpenAI implements Disposable {
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {
-    // extract key from params
     const apiKey = params['openai.factory.apiKey'];
     if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
 
     const baseURL = params['openai.factory.baseURL'];
     if (!baseURL || typeof baseURL !== 'string') throw new Error('invalid baseURL');
 
-    // save the connection info in secret storage
-    await this.saveConnectionInfo(apiKey, baseURL);
-
-    // use dedicated method to register connection
-    await this.registerInferenceProviderConnection({
-      token: apiKey,
-      baseURL: baseURL,
-    });
+    const id = randomUUID();
+    await this.saveConnection({ id, apiKey, baseURL });
+    await this.registerInferenceProviderConnection({ id, token: apiKey, baseURL });
   }
 
   dispose(): void {


### PR DESCRIPTION
Replace the transient counter-based IDs in OpenAI extension with stable UUIDs stored as a JSON array alongside API keys and base URLs, so connections keep their identity across restarts. Legacy pipe+comma-separated format is auto-migrated on first read.

Closes #1940