### PR TITLE
feat(vertex-ai): persist connection IDs in secret storage

### DIFF
--- a/extensions/vertex-ai/src/vertex-ai.spec.ts
+++ b/extensions/vertex-ai/src/vertex-ai.spec.ts
@@ -33,13 +33,7 @@ import {
   type VertexAiConnectionConfig,
 } from './vertex-ai';
 
-vi.mock(import('node:crypto'), async importOriginal => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
-  };
-});
+vi.mock(import('node:crypto'));
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('node:os'));
@@ -501,6 +495,16 @@ describe('factory', () => {
       'vertex-ai.factory.region': 'us-east5',
       'vertex-ai.factory.credentialsFile': '/home/user/.config/gcloud/application_default_credentials.json',
     });
+
+    const stored: StoredConnection[] = [
+      {
+        id: 'fake-uuid-1',
+        projectId: 'my-project',
+        region: 'us-east5',
+        credentialsFile: '/home/user/.config/gcloud/application_default_credentials.json',
+      },
+    ];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     await expect(
       create({

--- a/extensions/vertex-ai/src/vertex-ai.spec.ts
+++ b/extensions/vertex-ai/src/vertex-ai.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { randomUUID } from 'node:crypto';
 import { access, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -24,7 +25,21 @@ import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import type { Disposable, Logger, Provider, provider as ProviderAPI, SecretStorage } from '@openkaiden/api';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { CONNECTIONS_KEY, FALLBACK_MODELS, VertexAi, type VertexAiConnectionConfig } from './vertex-ai';
+import {
+  CONNECTIONS_KEY,
+  FALLBACK_MODELS,
+  type StoredConnection,
+  VertexAi,
+  type VertexAiConnectionConfig,
+} from './vertex-ai';
+
+vi.mock(import('node:crypto'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
+  };
+});
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('node:os'));
@@ -92,6 +107,7 @@ function mockFetchResponses(): void {
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(randomUUID).mockReturnValue('fake-uuid-1' as ReturnType<typeof randomUUID>);
   vi.mocked(PROVIDER_API_MOCK.createProvider).mockReturnValue(PROVIDER_MOCK);
   vi.mocked(createVertexAnthropic).mockReturnValue(VERTEX_ANTHROPIC_MOCK);
   vi.mocked(homedir).mockReturnValue('/home/testuser');
@@ -122,14 +138,18 @@ describe('init', () => {
     });
   });
 
-  test('should restore connections from secret storage', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify([VALID_CONFIG]));
+  test('should restore connections from secret storage with persisted IDs', async () => {
+    const stored: StoredConnection[] = [{ id: 'persisted-id', ...VALID_CONFIG }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     const vertexAi = createVertexAi();
     await vertexAi.init();
 
     expect(SECRET_STORAGE_MOCK.get).toHaveBeenCalledWith(CONNECTIONS_KEY);
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'persisted-id' }),
+    );
   });
 
   test('should handle empty secret storage', async () => {
@@ -142,7 +162,8 @@ describe('init', () => {
   });
 
   test('should restore connections with fallback models when fetch fails', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify([VALID_CONFIG]));
+    const stored: StoredConnection[] = [{ id: 'persisted-id', ...VALID_CONFIG }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network error'));
 
     const vertexAi = createVertexAi();
@@ -162,6 +183,20 @@ describe('init', () => {
     await vertexAi.init();
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('should migrate legacy JSON without id field', async () => {
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify([VALID_CONFIG]));
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    const expected: StoredConnection[] = [{ ...VALID_CONFIG, id: 'fake-uuid-1' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(CONNECTIONS_KEY, JSON.stringify(expected));
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'fake-uuid-1' }),
+    );
   });
 });
 
@@ -476,7 +511,7 @@ describe('factory', () => {
     ).rejects.toThrow('Connection already exists for project my-project in us-east5');
   });
 
-  test('should save config and register connection', async () => {
+  test('should save config as JSON with persisted ID and register connection', async () => {
     await create({
       'vertex-ai.factory.projectId': 'my-project',
       'vertex-ai.factory.region': 'us-east5',
@@ -484,9 +519,19 @@ describe('factory', () => {
     });
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
+    const expected: StoredConnection[] = [
+      {
+        id: 'fake-uuid-1',
+        projectId: 'my-project',
+        region: 'us-east5',
+        credentialsFile: '/home/user/.config/gcloud/application_default_credentials.json',
+      },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(CONNECTIONS_KEY, JSON.stringify(expected));
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
       expect.objectContaining({
+        id: 'fake-uuid-1',
         name: 'my-project (us-east5)',
         type: 'cloud',
         llmMetadata: { name: 'vertexai' },

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { access, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -97,7 +97,6 @@ export const FALLBACK_MODELS: InferenceModel[] = [
 export class VertexAi implements Disposable {
   private provider: Provider | undefined;
   private connections: Map<string, Disposable> = new Map();
-  private activeConfigHashes: Set<string> = new Set();
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -168,11 +167,6 @@ export class VertexAi implements Disposable {
     const stored = await this.getStoredConnections();
     const filtered = stored.filter(c => c.id !== id);
     await this.secrets.store(CONNECTIONS_KEY, JSON.stringify(filtered));
-  }
-
-  private getConfigHash(config: VertexAiConnectionConfig): string {
-    const sha256 = createHash('sha256');
-    return sha256.update(`${config.projectId}:${config.region}:${config.credentialsFile}`).digest('hex');
   }
 
   private resolveCredentialsPath(credentialsFile: string): string {
@@ -285,12 +279,6 @@ export class VertexAi implements Disposable {
   ): Promise<void> {
     if (!this.provider) throw new Error('Vertex AI provider is not initialized');
 
-    const configHash = this.getConfigHash(config);
-
-    if (this.activeConfigHashes.has(configHash)) {
-      throw new Error(`Connection already exists for project ${config.projectId} in ${config.region}`);
-    }
-
     const credFile = this.resolveCredentialsPath(config.credentialsFile);
 
     const vertexAnthropic = createVertexAnthropic({
@@ -304,7 +292,6 @@ export class VertexAi implements Disposable {
     const clean = async (): Promise<void> => {
       this.connections.get(id)?.dispose();
       this.connections.delete(id);
-      this.activeConfigHashes.delete(configHash);
       await this.removeConnection(id);
     };
 
@@ -354,7 +341,6 @@ export class VertexAi implements Disposable {
         };
       },
     });
-    this.activeConfigHashes.add(configHash);
     this.connections.set(id, connectionDisposable);
   }
 
@@ -422,7 +408,8 @@ export class VertexAi implements Disposable {
       credentialsFile: credentialsFile.trim(),
     };
 
-    if (this.activeConfigHashes.has(this.getConfigHash(config))) {
+    const stored = await this.getStoredConnections();
+    if (stored.some(c => c.projectId === config.projectId && c.region === config.region)) {
       throw new Error(`Connection already exists for project ${config.projectId} in ${config.region}`);
     }
 
@@ -444,6 +431,5 @@ export class VertexAi implements Disposable {
       disposable.dispose();
     }
     this.connections.clear();
-    this.activeConfigHashes.clear();
   }
 }

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -97,6 +97,7 @@ export const FALLBACK_MODELS: InferenceModel[] = [
 export class VertexAi implements Disposable {
   private provider: Provider | undefined;
   private connections: Map<string, Disposable> = new Map();
+  private activeConfigHashes: Set<string> = new Set();
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -163,10 +164,9 @@ export class VertexAi implements Disposable {
     await this.secrets.store(CONNECTIONS_KEY, JSON.stringify(stored));
   }
 
-  private async removeConnection(config: VertexAiConnectionConfig): Promise<void> {
+  private async removeConnection(id: string): Promise<void> {
     const stored = await this.getStoredConnections();
-    const key = this.getConfigHash(config);
-    const filtered = stored.filter(c => this.getConfigHash(c) !== key);
+    const filtered = stored.filter(c => c.id !== id);
     await this.secrets.store(CONNECTIONS_KEY, JSON.stringify(filtered));
   }
 
@@ -287,7 +287,7 @@ export class VertexAi implements Disposable {
 
     const configHash = this.getConfigHash(config);
 
-    if (this.connections.has(configHash)) {
+    if (this.activeConfigHashes.has(configHash)) {
       throw new Error(`Connection already exists for project ${config.projectId} in ${config.region}`);
     }
 
@@ -302,9 +302,10 @@ export class VertexAi implements Disposable {
     });
 
     const clean = async (): Promise<void> => {
-      this.connections.get(configHash)?.dispose();
-      this.connections.delete(configHash);
-      await this.removeConnection(config);
+      this.connections.get(id)?.dispose();
+      this.connections.delete(id);
+      this.activeConfigHashes.delete(configHash);
+      await this.removeConnection(id);
     };
 
     const status: ProviderConnectionStatus = 'unknown';
@@ -353,7 +354,8 @@ export class VertexAi implements Disposable {
         };
       },
     });
-    this.connections.set(configHash, connectionDisposable);
+    this.activeConfigHashes.add(configHash);
+    this.connections.set(id, connectionDisposable);
   }
 
   /**
@@ -420,7 +422,7 @@ export class VertexAi implements Disposable {
       credentialsFile: credentialsFile.trim(),
     };
 
-    if (this.connections.has(this.getConfigHash(config))) {
+    if (this.activeConfigHashes.has(this.getConfigHash(config))) {
       throw new Error(`Connection already exists for project ${config.projectId} in ${config.region}`);
     }
 
@@ -431,7 +433,7 @@ export class VertexAi implements Disposable {
     try {
       await this.registerInferenceProviderConnection(id, config, models);
     } catch (err) {
-      await this.removeConnection(config);
+      await this.removeConnection(id);
       throw err;
     }
   }
@@ -442,5 +444,6 @@ export class VertexAi implements Disposable {
       disposable.dispose();
     }
     this.connections.clear();
+    this.activeConfigHashes.clear();
   }
 }

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { access, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -38,6 +38,10 @@ export interface VertexAiConnectionConfig {
   projectId: string;
   region: string;
   credentialsFile: string;
+}
+
+export interface StoredConnection extends VertexAiConnectionConfig {
+  id: string;
 }
 
 interface AdcCredentials {
@@ -93,7 +97,6 @@ export const FALLBACK_MODELS: InferenceModel[] = [
 export class VertexAi implements Disposable {
   private provider: Provider | undefined;
   private connections: Map<string, Disposable> = new Map();
-  private connectionIdCounter = 0;
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -123,17 +126,17 @@ export class VertexAi implements Disposable {
   }
 
   private async restoreConnections(): Promise<void> {
-    const configs = await this.getConnectionConfigs();
-    for (const config of configs) {
+    const stored = await this.getStoredConnections();
+    for (const entry of stored) {
       try {
-        await this.registerInferenceProviderConnection(config);
+        await this.registerInferenceProviderConnection(entry.id, entry);
       } catch (err: unknown) {
-        console.error(`Vertex AI: failed to restore connection for project ${config.projectId}`, err);
+        console.error(`Vertex AI: failed to restore connection for project ${entry.projectId}`, err);
       }
     }
   }
 
-  private async getConnectionConfigs(): Promise<VertexAiConnectionConfig[]> {
+  private async getStoredConnections(): Promise<StoredConnection[]> {
     let raw: string | undefined;
     try {
       raw = await this.secrets.get(CONNECTIONS_KEY);
@@ -142,22 +145,28 @@ export class VertexAi implements Disposable {
     }
     if (!raw) return [];
     try {
-      return JSON.parse(raw) as VertexAiConnectionConfig[];
+      const parsed = JSON.parse(raw) as Array<VertexAiConnectionConfig & { id?: string }>;
+      if (parsed.some(entry => !entry.id)) {
+        const migrated: StoredConnection[] = parsed.map(entry => ({ ...entry, id: entry.id ?? randomUUID() }));
+        await this.secrets.store(CONNECTIONS_KEY, JSON.stringify(migrated));
+        return migrated;
+      }
+      return parsed as StoredConnection[];
     } catch {
       return [];
     }
   }
 
-  private async saveConnectionConfig(config: VertexAiConnectionConfig): Promise<void> {
-    const configs = await this.getConnectionConfigs();
-    configs.push(config);
-    await this.secrets.store(CONNECTIONS_KEY, JSON.stringify(configs));
+  private async saveConnection(connection: StoredConnection): Promise<void> {
+    const stored = await this.getStoredConnections();
+    stored.push(connection);
+    await this.secrets.store(CONNECTIONS_KEY, JSON.stringify(stored));
   }
 
-  private async removeConnectionConfig(config: VertexAiConnectionConfig): Promise<void> {
-    const configs = await this.getConnectionConfigs();
+  private async removeConnection(config: VertexAiConnectionConfig): Promise<void> {
+    const stored = await this.getStoredConnections();
     const key = this.getConfigHash(config);
-    const filtered = configs.filter(c => this.getConfigHash(c) !== key);
+    const filtered = stored.filter(c => this.getConfigHash(c) !== key);
     await this.secrets.store(CONNECTIONS_KEY, JSON.stringify(filtered));
   }
 
@@ -270,6 +279,7 @@ export class VertexAi implements Disposable {
    * or by fetching them fresh with graceful degradation (restore path).
    */
   private async registerInferenceProviderConnection(
+    id: string,
     config: VertexAiConnectionConfig,
     validatedModels?: InferenceModel[],
   ): Promise<void> {
@@ -294,7 +304,7 @@ export class VertexAi implements Disposable {
     const clean = async (): Promise<void> => {
       this.connections.get(configHash)?.dispose();
       this.connections.delete(configHash);
-      await this.removeConnectionConfig(config);
+      await this.removeConnection(config);
     };
 
     const status: ProviderConnectionStatus = 'unknown';
@@ -321,7 +331,7 @@ export class VertexAi implements Disposable {
     }
 
     const connectionDisposable = this.provider.registerInferenceProviderConnection({
-      id: String(this.connectionIdCounter++),
+      id,
       name: `${config.projectId} (${config.region})`,
       type: 'cloud',
       llmMetadata: {
@@ -416,11 +426,12 @@ export class VertexAi implements Disposable {
 
     const models = await this.validateConnection(config);
 
-    await this.saveConnectionConfig(config);
+    const id = randomUUID();
+    await this.saveConnection({ id, ...config });
     try {
-      await this.registerInferenceProviderConnection(config, models);
+      await this.registerInferenceProviderConnection(id, config, models);
     } catch (err) {
-      await this.removeConnectionConfig(config);
+      await this.removeConnection(config);
       throw err;
     }
   }


### PR DESCRIPTION
Replace the transient counter-based IDs for vertex extension with stable UUIDs stored alongside connection configs in the existing JSON array. Legacy entries without an id field are auto-migrated on first read.

Closes #1942