### PR TITLE
feat(gemini): persist connection IDs in secret storage

### DIFF
--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { randomUUID } from 'node:crypto';
+
 import { createGoogleGenerativeAI, type GoogleGenerativeAIProvider } from '@ai-sdk/google';
 import type { Model, Pager } from '@google/genai';
 import { GoogleGenAI } from '@google/genai';
@@ -29,7 +31,15 @@ import type {
 } from '@openkaiden/api';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { Gemini, TOKENS_KEY } from './gemini';
+import { Gemini, type StoredConnection, TOKENS_KEY } from './gemini';
+
+vi.mock(import('node:crypto'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
+  };
+});
 
 vi.mock('@openkaiden/api', () => ({
   Disposable: {
@@ -71,6 +81,7 @@ const SAFE_STORAGE_MOCK: SecretStorage = {
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(randomUUID).mockReturnValue('fake-uuid-1' as ReturnType<typeof randomUUID>);
   vi.mocked(PROVIDER_API_MOCK.createProvider).mockReturnValue(PROVIDER_MOCK as Provider);
   vi.mocked(createGoogleGenerativeAI).mockReturnValue(GOOGLE_AI_PROVIDER_MOCK);
 
@@ -148,6 +159,71 @@ describe('init', () => {
       create: expect.any(Function),
     });
   });
+
+  test('should restore connections from secret storage', async () => {
+    const stored: StoredConnection[] = [{ id: 'persisted-id', token: 'existingKey' }];
+    vi.mocked(SAFE_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
+    const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    expect(SAFE_STORAGE_MOCK.get).toHaveBeenCalledWith(TOKENS_KEY);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'persisted-id' }),
+    );
+  });
+
+  test('should handle empty secret storage', async () => {
+    vi.mocked(SAFE_STORAGE_MOCK.get).mockResolvedValue(undefined);
+
+    const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('should migrate legacy comma-separated tokens to JSON format', async () => {
+    vi.mocked(randomUUID)
+      .mockReturnValueOnce('migrated-id-1' as ReturnType<typeof randomUUID>)
+      .mockReturnValueOnce('migrated-id-2' as ReturnType<typeof randomUUID>);
+    vi.mocked(SAFE_STORAGE_MOCK.get).mockResolvedValue('tokenA,tokenB');
+
+    const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    const expected: StoredConnection[] = [
+      { id: 'migrated-id-1', token: 'tokenA' },
+      { id: 'migrated-id-2', token: 'tokenB' },
+    ];
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-2' }),
+    );
+  });
+
+  test('should restore persisted IDs across restarts', async () => {
+    const stored: StoredConnection[] = [
+      { id: 'stable-id-1', token: 'key1' },
+      { id: 'stable-id-2', token: 'key2' },
+    ];
+    vi.mocked(SAFE_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
+    const gemini = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini.init();
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-2' }),
+    );
+  });
 });
 
 describe('factory', () => {
@@ -167,14 +243,14 @@ describe('factory', () => {
     }).rejects.toThrowError('invalid apiKey');
   });
 
-  test('calling create with proper params should save token', async () => {
+  test('calling create with proper params should save connection as JSON', async () => {
     await create({
       'gemini.factory.apiKey': 'dummyKey',
     });
 
-    // ensure store has been updated
     expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledOnce();
-    expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey');
+    const expected: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
 
   test('calling create with proper params should register inference connection', async () => {
@@ -193,10 +269,9 @@ describe('factory', () => {
       apiKey: 'dummyKey',
     });
 
-    // ensure the connection has been registered
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
-      id: '0',
+      id: 'fake-uuid-1',
       name: 'dum*****',
       type: 'cloud',
       llmMetadata: { name: 'gemini' },
@@ -239,22 +314,46 @@ describe('connection delete lifecycle', () => {
     mDelete = lifecycle.delete;
   });
 
-  test('calling delete should delete the token', async () => {
+  test('calling delete should remove the connection from storage', async () => {
     await mDelete();
 
-    // should have been called twice
     expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
 
-    // first time when registering the connection
-    expect(SAFE_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, 'dummyKey');
+    const saved: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, JSON.stringify(saved));
 
-    // second time when unregistering the connection
-    expect(SAFE_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, '');
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, JSON.stringify([]));
   });
 
   test('calling delete should dispose provider inference connection', async () => {
     await mDelete();
 
     expect(disposeMock).toHaveBeenCalledOnce();
+  });
+
+  test('calling delete should remove connection by ID, not by token value', async () => {
+    // Setup: simulate two connections with same token but different IDs
+    const multipleConnections: StoredConnection[] = [
+      { id: 'id-1', token: 'sharedToken' },
+      { id: 'id-2', token: 'sharedToken' },
+    ];
+    vi.mocked(SAFE_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(multipleConnections));
+
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockClear();
+    vi.mocked(SAFE_STORAGE_MOCK.store).mockClear();
+    const gemini2 = new Gemini(PROVIDER_API_MOCK, SAFE_STORAGE_MOCK);
+    await gemini2.init();
+
+    // Get the delete function for the restored id-1 connection
+    const registerMock2 = vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection);
+    expect(registerMock2).toHaveBeenCalledTimes(2);
+    const lifecycle2 = registerMock2.mock.calls[0][0].lifecycle;
+    assert(lifecycle2?.delete, 'delete method must be defined');
+
+    await lifecycle2.delete();
+
+    // Verify only the connection with id-1 was removed, id-2 remains
+    const expectedAfterDelete: StoredConnection[] = [{ id: 'id-2', token: 'sharedToken' }];
+    expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expectedAfterDelete));
   });
 });

--- a/extensions/gemini/src/gemini.ts
+++ b/extensions/gemini/src/gemini.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { createHash } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { GoogleGenAI } from '@google/genai';
@@ -29,12 +29,16 @@ import type {
 } from '@openkaiden/api';
 
 export const TOKENS_KEY = 'gemini:tokens';
-export const TOKEN_SEPARATOR = ',';
+
+export interface StoredConnection {
+  id: string;
+  token: string;
+}
 
 export class Gemini implements Disposable {
   private provider: Provider | undefined = undefined;
   private connections: Map<string, Disposable> = new Map();
-  private connectionIdCounter = 0;
+  private storageUpdateQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -67,87 +71,68 @@ export class Gemini implements Disposable {
   }
 
   private async restoreConnections(): Promise<void> {
-    const tokens = await this.getTokens();
-    for (const token of tokens) {
-      await this.registerInferenceProviderConnection({ token });
+    const stored = await this.getStoredConnections();
+    for (const entry of stored) {
+      await this.registerInferenceProviderConnection({ id: entry.id, token: entry.token });
     }
   }
 
-  /**
-   * Get all tokens from secret storage
-   * @private
-   */
-  private async getTokens(): Promise<string[]> {
-    // get raw string from secret storage
+  private async getStoredConnections(): Promise<StoredConnection[]> {
     let raw: string | undefined;
     try {
       raw = await this.secrets.get(TOKENS_KEY);
     } catch (err: unknown) {
       console.error('Gemini: something went wrong while trying to get tokens from secret storage', err);
     }
-    // if undefined return empty array
     if (!raw) return [];
-    // split raw string by token separator
-    return raw.split(TOKEN_SEPARATOR);
+
+    try {
+      return JSON.parse(raw) as StoredConnection[];
+    } catch {
+      // Migrate legacy comma-separated token format
+      const tokens = raw.split(',');
+      const migrated: StoredConnection[] = tokens.map(token => ({ id: randomUUID(), token }));
+      await this.secrets.store(TOKENS_KEY, JSON.stringify(migrated));
+      return migrated;
+    }
   }
 
-  /**
-   * Save token to secret storage
-   * @param token
-   * @private
-   */
-  private async saveToken(token: string): Promise<void> {
-    // get existing tokens
-    const tokens: Array<string> = await this.getTokens();
-    // concat new token with existing tokens
-    const raw = [...tokens, token].join(TOKEN_SEPARATOR);
-    // save to secret storage
-    await this.secrets.store(TOKENS_KEY, raw);
+  private updateStoredConnections(mutate: (stored: StoredConnection[]) => StoredConnection[]): Promise<void> {
+    this.storageUpdateQueue = this.storageUpdateQueue.then(async () => {
+      const stored = await this.getStoredConnections();
+      await this.secrets.store(TOKENS_KEY, JSON.stringify(mutate(stored)));
+    });
+    return this.storageUpdateQueue;
   }
 
-  private getTokenHash(token: string): string {
-    const sha256 = createHash('sha256');
-    return sha256.update(token).digest('hex');
+  private async saveConnection(connection: StoredConnection): Promise<void> {
+    await this.updateStoredConnections(stored => [...stored, connection]);
   }
 
-  private async removeToken(token: string): Promise<void> {
-    // get existing tokens
-    const tokens: Array<string> = await this.getTokens();
-    // filter out the token
-    const raw = tokens.filter(t => t !== token).join(TOKEN_SEPARATOR);
-    // save to secret storage
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async removeConnection(id: string): Promise<void> {
+    await this.updateStoredConnections(stored => stored.filter(entry => entry.id !== id));
   }
 
-  private async registerInferenceProviderConnection({ token }: { token: string }): Promise<void> {
+  private async registerInferenceProviderConnection({ id, token }: { id: string; token: string }): Promise<void> {
     if (!this.provider) throw new Error('cannot create MCP provider connection: provider is not initialized');
 
-    // create masked version of token
     const key = this.maskKey(token);
 
-    // get hash of the token (used for Map)
-    const tokenHash = this.getTokenHash(token);
-
-    if (this.connections.has(tokenHash)) {
+    if (this.connections.has(id)) {
       throw new Error(`connection already exists for token ${key}`);
     }
 
-    // create ProviderV2
     const google = createGoogleGenerativeAI({
       apiKey: token,
     });
 
-    // create a clean method
     const clean = async (): Promise<void> => {
-      // dispose inference provider connection
-      this.connections.get(tokenHash)?.dispose();
-      // delete map entry
-      this.connections.delete(tokenHash);
-      // remove token from secret storage
-      await this.removeToken(token);
+      this.connections.get(id)?.dispose();
+      this.connections.delete(id);
+      await this.removeConnection(id);
     };
 
-    let status: ProviderConnectionStatus = 'unknown'; // if status is not unknown we cannot delete the connection
+    let status: ProviderConnectionStatus = 'unknown';
     let models: InferenceModel[] = [];
 
     try {
@@ -157,7 +142,7 @@ export class Gemini implements Disposable {
     }
 
     const connectionDisposable = this.provider.registerInferenceProviderConnection({
-      id: String(this.connectionIdCounter++),
+      id,
       name: this.maskKey(token),
       type: 'cloud',
       llmMetadata: { name: 'gemini' },
@@ -175,7 +160,7 @@ export class Gemini implements Disposable {
         };
       },
     });
-    this.connections.set(tokenHash, connectionDisposable);
+    this.connections.set(id, connectionDisposable);
   }
 
   private async getGeminiModels(token: string): Promise<Array<{ label: string }>> {
@@ -197,15 +182,12 @@ export class Gemini implements Disposable {
   }
 
   private async mcpFactory(params: { [p: string]: unknown }): Promise<void> {
-    // extract key from params
     const apiKey = params['gemini.factory.apiKey'];
     if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
 
-    // save the key in secret storage
-    await this.saveToken(apiKey);
-
-    // use dedicated method to register connection
-    await this.registerInferenceProviderConnection({ token: apiKey });
+    const id = randomUUID();
+    await this.saveConnection({ id, token: apiKey });
+    await this.registerInferenceProviderConnection({ id, token: apiKey });
   }
 
   dispose(): void {


### PR DESCRIPTION
Replace the transient counter-based IDs with stable UUIDs stored as a
JSON array alongside tokens, so connections keep their identity across
restarts. Legacy comma-separated format is auto-migrated on first read.

Closes #1938

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
