### PR TITLE
refactor(openshell): bundle host-specific binaries and decouple download from electron-builder

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -27,6 +27,10 @@ function getKdnOutputDir(platform, arch) {
   return path.resolve('./kdn-binary', `${platform}-${arch}`);
 }
 
+function getOpenshellOutputDir() {
+  return path.resolve('./openshell-binary');
+}
+
 if (process.env.VITE_APP_VERSION === undefined) {
   const now = new Date();
   process.env.VITE_APP_VERSION = `${now.getUTCFullYear() - 2000}.${now.getUTCMonth() + 1}.${now.getUTCDate()}-${
@@ -151,6 +155,42 @@ async function downloadKdn(context) {
 }
 
 /**
+ * Downloads the OpenShell install script for bundling.
+ * Fetches the latest install.sh from the NVIDIA/OpenShell repo.
+ */
+async function downloadOpenshell(context) {
+  const downloadScript = path.join('extensions', 'openshell', 'dist', 'openshell-download.js');
+  if (!fs.existsSync(downloadScript)) {
+    throw new Error(`${downloadScript} not found. Run "pnpm run build:extensions:openshell" before packaging.`);
+  }
+
+  const outputDir = getOpenshellOutputDir();
+
+  await new Promise((resolve, reject) => {
+    execFile(
+      'node',
+      [downloadScript, `--output=${outputDir}`],
+      { maxBuffer: 10 * 1024 * 1024, timeout: 5 * 60 * 1000 },
+      (error, stdout, stderr) => {
+        if (stdout) console.log(stdout);
+        if (stderr) console.error(stderr);
+        if (error) {
+          reject(new Error(`OpenShell install script download failed: ${stderr || error.message}`));
+        } else {
+          resolve();
+        }
+      },
+    );
+  });
+
+  context.packager.config.extraResources.push({
+    from: outputDir,
+    to: 'openshell',
+    filter: ['!.openshell-version'],
+  });
+}
+
+/**
  * @type {import('electron-builder').Configuration}
  * @see https://www.electron.build/configuration/configuration
  */
@@ -173,6 +213,9 @@ const config = {
 
     // download & bundle kdn CLI binary
     await downloadKdn(context);
+
+    // download & bundle OpenShell install script
+    await downloadOpenshell(context);
 
     // include product.json
     context.packager.config.extraResources.push({

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -27,10 +27,6 @@ function getKdnOutputDir(platform, arch) {
   return path.resolve('./kdn-binary', `${platform}-${arch}`);
 }
 
-function getOpenshellOutputDir() {
-  return path.resolve('./openshell-binary');
-}
-
 if (process.env.VITE_APP_VERSION === undefined) {
   const now = new Date();
   process.env.VITE_APP_VERSION = `${now.getUTCFullYear() - 2000}.${now.getUTCMonth() + 1}.${now.getUTCDate()}-${
@@ -155,42 +151,6 @@ async function downloadKdn(context) {
 }
 
 /**
- * Downloads the OpenShell install script for bundling.
- * Fetches the latest install.sh from the NVIDIA/OpenShell repo.
- */
-async function downloadOpenshell(context) {
-  const downloadScript = path.join('extensions', 'openshell', 'dist', 'openshell-download.js');
-  if (!fs.existsSync(downloadScript)) {
-    throw new Error(`${downloadScript} not found. Run "pnpm run build:extensions:openshell" before packaging.`);
-  }
-
-  const outputDir = getOpenshellOutputDir();
-
-  await new Promise((resolve, reject) => {
-    execFile(
-      'node',
-      [downloadScript, `--output=${outputDir}`],
-      { maxBuffer: 10 * 1024 * 1024, timeout: 5 * 60 * 1000 },
-      (error, stdout, stderr) => {
-        if (stdout) console.log(stdout);
-        if (stderr) console.error(stderr);
-        if (error) {
-          reject(new Error(`OpenShell install script download failed: ${stderr || error.message}`));
-        } else {
-          resolve();
-        }
-      },
-    );
-  });
-
-  context.packager.config.extraResources.push({
-    from: outputDir,
-    to: 'openshell',
-    filter: ['!.openshell-version'],
-  });
-}
-
-/**
  * @type {import('electron-builder').Configuration}
  * @see https://www.electron.build/configuration/configuration
  */
@@ -214,8 +174,27 @@ const config = {
     // download & bundle kdn CLI binary
     await downloadKdn(context);
 
-    // download & bundle OpenShell install script
-    await downloadOpenshell(context);
+    // include pre-downloaded OpenShell binaries (not available on Windows)
+    const openshellArchMap = { [Arch.x64]: 'x64', [Arch.arm64]: 'arm64' };
+    const openshellArch = openshellArchMap[context.arch];
+    if (openshellArch && context.electronPlatformName !== 'win32') {
+      const openshellAssetsDir = path.join(
+        'extensions',
+        'openshell',
+        'assets',
+        `${context.electronPlatformName}-${openshellArch}`,
+      );
+      if (!fs.existsSync(openshellAssetsDir)) {
+        throw new Error(
+          `OpenShell assets not found at ${openshellAssetsDir}. Run "pnpm --filter openshell download" (or "pnpm --filter openshell download:all") before packaging.`,
+        );
+      }
+      context.packager.config.extraResources.push({
+        from: openshellAssetsDir,
+        to: 'openshell',
+        filter: ['!.openshell-version'],
+      });
+    }
 
     // include product.json
     context.packager.config.extraResources.push({

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ yarn.lock
 extensions/podman/assets/
 extensions-extra/
 kdn-binary/
+openshell-binary/
 .claude
 output/
 __mocks__/@openkaiden/api.ts

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ yarn.lock
 extensions/podman/assets/
 extensions-extra/
 kdn-binary/
-openshell-binary/
+extensions/openshell/assets/
 .claude
 output/
 __mocks__/@openkaiden/api.ts

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenShell",
   "description": "Registers the openshell CLI binary for managing sandboxed workspaces.",
   "version": "0.2.0-next",
-  "openshellVersion": "0.0.55",
+  "openshellVersion": "0.0.57",
   "icon": "icon.png",
   "publisher": "kaiden",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "build": "vite build && tsx ./scripts/download.ts",
+    "build": "vite build && tsx ./scripts/download.ts --all",
     "download": "tsx ./scripts/download.ts",
     "download:all": "tsx ./scripts/download.ts --all",
     "test": "vitest run --coverage",

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -26,16 +26,20 @@
     }
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && tsx ./scripts/download.ts",
+    "download": "tsx ./scripts/download.ts",
+    "download:all": "tsx ./scripts/download.ts --all",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "inversify": "^7.10.4"
+    "inversify": "^7.10.4",
+    "tar": "^7.5.3"
   },
   "devDependencies": {
     "@openkaiden/api": "workspace:*",
+    "tsx": "^4.19.4",
     "vite": "^7.1.2",
     "vitest": "^4.0.10"
   }

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -3,6 +3,7 @@
   "displayName": "OpenShell",
   "description": "Registers the openshell CLI binary for managing sandboxed workspaces.",
   "version": "0.2.0-next",
+  "openshellVersion": "0.0.55",
   "icon": "icon.png",
   "publisher": "kaiden",
   "license": "Apache-2.0",

--- a/extensions/openshell/scripts/download.ts
+++ b/extensions/openshell/scripts/download.ts
@@ -17,11 +17,12 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
+import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
-import { getLatestRelease, downloadOpenshellBinaries } from '../src/openshell-download';
+import { getRelease, downloadOpenshellBinaries } from '../src/openshell-download';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ASSETS_DIR = resolve(__dirname, '..', 'assets');
@@ -71,8 +72,16 @@ if (targets.length === 0) {
 }
 
 (async () => {
-  const { version, digests } = await getLatestRelease();
-  console.log(`openshell latest release: v${version}`);
+  const pkgPath = resolve(__dirname, '..', 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { openshellVersion: string };
+  const pinnedVersion = pkg.openshellVersion;
+  if (!pinnedVersion) {
+    console.error('missing "openshellVersion" in package.json');
+    process.exit(1);
+  }
+
+  const { version, digests } = await getRelease(pinnedVersion);
+  console.log(`openshell pinned release: v${version}`);
 
   for (const { platform, arch } of targets) {
     const outputDir = resolve(ASSETS_DIR, `${platform}-${arch}`);

--- a/extensions/openshell/scripts/download.ts
+++ b/extensions/openshell/scripts/download.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env tsx
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+import { getLatestRelease, downloadOpenshellBinaries } from '../src/openshell-download';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ASSETS_DIR = resolve(__dirname, '..', 'assets');
+
+const SUPPORTED_TARGETS: { platform: string; arch: string }[] = [
+  { platform: 'darwin', arch: 'arm64' },
+  { platform: 'linux', arch: 'x64' },
+  { platform: 'linux', arch: 'arm64' },
+];
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    all: { type: 'boolean', default: false },
+    platform: { type: 'string' },
+    arch: { type: 'string' },
+  },
+  strict: true,
+});
+
+let targets: { platform: string; arch: string }[];
+
+if (values.all) {
+  targets = SUPPORTED_TARGETS;
+} else if (values.platform && values.arch) {
+  const requested = { platform: values.platform, arch: values.arch };
+  const isSupported = SUPPORTED_TARGETS.some(t => t.platform === requested.platform && t.arch === requested.arch);
+  if (!isSupported) {
+    console.error(
+      `Unsupported target "${requested.platform}-${requested.arch}". Use --all or one of: ${SUPPORTED_TARGETS.map(t => `${t.platform}-${t.arch}`).join(', ')}`,
+    );
+    process.exit(1);
+  }
+  targets = [requested];
+} else if (values.platform || values.arch) {
+  console.error('--platform and --arch must be specified together');
+  process.exit(1);
+} else {
+  targets = SUPPORTED_TARGETS.filter(t => t.platform === process.platform);
+}
+
+if (targets.length === 0) {
+  console.log(
+    `No supported OpenShell target for host platform "${process.platform}", skipping. Use --all or pass --platform and --arch to download for a specific target.`,
+  );
+  process.exit(0);
+}
+
+(async () => {
+  const { version, digests } = await getLatestRelease();
+  console.log(`openshell latest release: v${version}`);
+
+  for (const { platform, arch } of targets) {
+    const outputDir = resolve(ASSETS_DIR, `${platform}-${arch}`);
+    await downloadOpenshellBinaries(version, platform, arch, outputDir, digests);
+  }
+})();

--- a/extensions/openshell/scripts/download.ts
+++ b/extensions/openshell/scripts/download.ts
@@ -61,7 +61,7 @@ if (values.all) {
   console.error('--platform and --arch must be specified together');
   process.exit(1);
 } else {
-  targets = SUPPORTED_TARGETS.filter(t => t.platform === process.platform);
+  targets = SUPPORTED_TARGETS.filter(t => t.platform === process.platform && t.arch === process.arch);
 }
 
 if (targets.length === 0) {

--- a/extensions/openshell/src/extension.spec.ts
+++ b/extensions/openshell/src/extension.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import type { ExtensionContext } from '@openkaiden/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { activate, deactivate } from './extension';
+import { OpenshellExtension } from './openshell-extension';
+
+let extensionContextMock: ExtensionContext;
+
+vi.mock(import('./openshell-extension'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  extensionContextMock = {} as ExtensionContext;
+});
+
+test('should initialize and activate the OpenshellExtension when activate is called', async () => {
+  await activate(extensionContextMock);
+
+  expect(OpenshellExtension.prototype.activate).toHaveBeenCalled();
+});
+
+test('should call deactivate when deactivate is called', async () => {
+  await activate(extensionContextMock);
+
+  await deactivate();
+
+  expect(OpenshellExtension.prototype.deactivate).toHaveBeenCalled();
+});

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -27,8 +27,8 @@ import { ExtensionContextSymbol } from '/@/inject/symbol';
 import { OpenshellInstaller } from '/@/openshell-installer';
 
 interface BinaryDiscoveryResult {
-  path: string;
-  version: string;
+  path?: string;
+  version?: string;
   installationSource: CliToolInstallationSource;
 }
 
@@ -46,16 +46,13 @@ export class OpenshellCliManager implements Disposable {
   async init(): Promise<void> {
     const packageJsonPath = join(this.extensionContext.extensionUri.fsPath, 'package.json');
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-    const installer = new OpenshellInstaller(packageJson.openshellVersion, this.extensionContext.storagePath);
 
     const cliResult = await this.discoverBinary('openshell', 'openshell.binary.path');
     const registration: BinaryDiscoveryResult = cliResult ?? {
-      path: extensionApi.env.isWindows ? 'openshell.exe' : 'openshell',
-      version: await installer.selectVersion(),
-      installationSource: 'external',
+      installationSource: 'extension',
     };
 
-    if (cliResult) {
+    if (cliResult?.path) {
       this.#registeredPath = cliResult.path;
     } else {
       console.warn('[openshell] CLI not found, registering installer-only entry');
@@ -67,21 +64,10 @@ export class OpenshellCliManager implements Disposable {
       'OpenShell CLI for managing sandboxed workspaces',
       registration,
     );
+    const installer = new OpenshellInstaller(cliTool, packageJson.openshellVersion, this.extensionContext.storagePath);
 
     this.extensionContext.subscriptions.push(cliTool.registerInstaller(installer));
     if (!cliResult) return;
-
-    const gatewayResult = await this.discoverGatewayBinary(cliResult.path);
-    if (gatewayResult) {
-      this.registerCliTool(
-        'openshell-gateway',
-        'OpenShell Gateway',
-        'OpenShell Gateway server for sandbox orchestration',
-        gatewayResult,
-      );
-    } else {
-      console.warn('[openshell-gateway] binary not found, skipping registration');
-    }
   }
 
   dispose(): void {}

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import type { CliToolInstallationSource, Disposable, ExtensionContext } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
@@ -67,7 +67,6 @@ export class OpenshellCliManager implements Disposable {
     const installer = new OpenshellInstaller(cliTool, packageJson.openshellVersion, this.extensionContext.storagePath);
 
     this.extensionContext.subscriptions.push(cliTool.registerInstaller(installer));
-    if (!cliResult) return;
   }
 
   dispose(): void {}
@@ -120,25 +119,6 @@ export class OpenshellCliManager implements Disposable {
     if (systemResult) {
       console.log(`[${binaryBaseName}] binary found in system PATH`);
       return { path: systemResult.path, version: systemResult.version, installationSource: 'external' };
-    }
-
-    return undefined;
-  }
-
-  private async discoverGatewayBinary(cliPath: string): Promise<BinaryDiscoveryResult | undefined> {
-    const result = await this.discoverBinary('openshell-gateway', 'openshell.gateway.binary.path');
-    if (result) {
-      return result;
-    }
-
-    const gatewayName = extensionApi.env.isWindows ? 'openshell-gateway.exe' : 'openshell-gateway';
-    const siblingPath = join(dirname(cliPath), gatewayName);
-    if (existsSync(siblingPath)) {
-      const version = await this.getVersion(siblingPath);
-      if (version) {
-        console.log('[openshell-gateway] binary found alongside openshell CLI');
-        return { path: siblingPath, version, installationSource: 'external' };
-      }
     }
 
     return undefined;

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -24,6 +24,7 @@ import * as extensionApi from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 
 import { ExtensionContextSymbol } from '/@/inject/symbol';
+import { OpenshellInstaller } from '/@/openshell-installer';
 
 interface BinaryDiscoveryResult {
   path: string;
@@ -50,7 +51,10 @@ export class OpenshellCliManager implements Disposable {
     }
 
     this.#registeredPath = cliResult.path;
-    this.registerCliTool('openshell', 'OpenShell', 'OpenShell CLI for managing sandboxed workspaces', cliResult);
+    const cliTool = this.registerCliTool('openshell', 'OpenShell', 'OpenShell CLI for managing sandboxed workspaces', cliResult);
+
+    const installer = new OpenshellInstaller();
+    this.extensionContext.subscriptions.push(cliTool.registerInstaller(installer));
 
     const gatewayResult = await this.discoverGatewayBinary(cliResult.path);
     if (gatewayResult) {
@@ -72,7 +76,7 @@ export class OpenshellCliManager implements Disposable {
     displayName: string,
     markdownDescription: string,
     result: BinaryDiscoveryResult,
-  ): void {
+  ): extensionApi.CliTool {
     const cliTool = extensionApi.cli.createCliTool({
       name,
       displayName,
@@ -84,6 +88,7 @@ export class OpenshellCliManager implements Disposable {
     });
     this.extensionContext.subscriptions.push(cliTool);
     console.log(`[${name}] registered at ${result.path} (v${result.version})`);
+    return cliTool;
   }
 
   private async discoverBinary(binaryBaseName: string, configKey: string): Promise<BinaryDiscoveryResult | undefined> {

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import type { CliToolInstallationSource, Disposable, ExtensionContext } from '@openkaiden/api';
@@ -44,22 +44,32 @@ export class OpenshellCliManager implements Disposable {
   }
 
   async init(): Promise<void> {
+    const packageJsonPath = join(this.extensionContext.extensionUri.fsPath, 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    const installer = new OpenshellInstaller(packageJson.openshellVersion, this.extensionContext.storagePath);
+
     const cliResult = await this.discoverBinary('openshell', 'openshell.binary.path');
-    if (!cliResult) {
-      console.warn('[openshell] CLI not found, skipping registration');
-      return;
+    const registration: BinaryDiscoveryResult = cliResult ?? {
+      path: extensionApi.env.isWindows ? 'openshell.exe' : 'openshell',
+      version: await installer.selectVersion(),
+      installationSource: 'external',
+    };
+
+    if (cliResult) {
+      this.#registeredPath = cliResult.path;
+    } else {
+      console.warn('[openshell] CLI not found, registering installer-only entry');
     }
 
-    this.#registeredPath = cliResult.path;
     const cliTool = this.registerCliTool(
       'openshell',
       'OpenShell',
       'OpenShell CLI for managing sandboxed workspaces',
-      cliResult,
+      registration,
     );
 
-    const installer = new OpenshellInstaller();
     this.extensionContext.subscriptions.push(cliTool.registerInstaller(installer));
+    if (!cliResult) return;
 
     const gatewayResult = await this.discoverGatewayBinary(cliResult.path);
     if (gatewayResult) {

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -51,7 +51,12 @@ export class OpenshellCliManager implements Disposable {
     }
 
     this.#registeredPath = cliResult.path;
-    const cliTool = this.registerCliTool('openshell', 'OpenShell', 'OpenShell CLI for managing sandboxed workspaces', cliResult);
+    const cliTool = this.registerCliTool(
+      'openshell',
+      'OpenShell',
+      'OpenShell CLI for managing sandboxed workspaces',
+      cliResult,
+    );
 
     const installer = new OpenshellInstaller();
     this.extensionContext.subscriptions.push(cliTool.registerInstaller(installer));

--- a/extensions/openshell/src/openshell-download.spec.ts
+++ b/extensions/openshell/src/openshell-download.spec.ts
@@ -151,7 +151,7 @@ describe('downloadOpenshellBinaries', () => {
     );
   });
 
-  test('handles darwin-arm64 with subdir for sandbox', async () => {
+  test('handles darwin-arm64', async () => {
     stubFetch();
     const digests = new Map([
       ['openshell-aarch64-apple-darwin.tar.gz', 'abc123'],
@@ -164,13 +164,12 @@ describe('downloadOpenshellBinaries', () => {
       const cwd = opts.cwd ?? '';
       fileMap.set(normPath(path.join(cwd, 'openshell')), true);
       fileMap.set(normPath(path.join(cwd, 'openshell-gateway')), true);
-      fileMap.set(normPath(path.join(cwd, 'openshell-sandbox')), true);
       fileMap.set(normPath(path.join(cwd, 'openshell-driver-vm')), true);
     });
 
     await downloadOpenshellBinaries('0.0.55', 'darwin', 'arm64', '/output', digests);
 
-    expect(mkdir).toHaveBeenCalledWith(expect.stringContaining('linux-arm64'), { recursive: true });
+    expect(mkdir).toHaveBeenCalledWith('/output', { recursive: true });
   });
 });
 

--- a/extensions/openshell/src/openshell-download.spec.ts
+++ b/extensions/openshell/src/openshell-download.spec.ts
@@ -1,0 +1,214 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import * as tar from 'tar';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { downloadOpenshellBinaries, getRelease } from './openshell-download';
+import { sha256 } from './sha256';
+
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
+vi.mock(import('node:stream/promises'));
+vi.mock(import('tar'));
+vi.mock(import('./sha256'));
+
+let fileMap: Map<string, boolean>;
+
+function normPath(p: string): string {
+  return path.posix.normalize(String(p).replace(/\\/g, '/'));
+}
+
+function stubFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: new PassThrough(),
+      }),
+    ),
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  fileMap = new Map();
+  vi.mocked(existsSync).mockImplementation(p => fileMap.get(normPath(String(p))) ?? false);
+  vi.mocked(sha256).mockResolvedValue('abc123');
+  vi.mocked(writeFile).mockImplementation(async (p: Parameters<typeof writeFile>[0]) => {
+    fileMap.set(normPath(String(p)), true);
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('downloadOpenshellBinaries', () => {
+  test('skips download when cached', async () => {
+    fileMap.set('/output/.openshell-version', true);
+    fileMap.set('/output/openshell', true);
+    fileMap.set('/output/openshell-gateway', true);
+    fileMap.set('/output/openshell-sandbox', true);
+    fileMap.set('/output/openshell-driver-vm', true);
+    vi.mocked(readFile).mockResolvedValue('0.0.55-linux-x64');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        throw new Error('fetch should not be called when cached');
+      }),
+    );
+
+    await downloadOpenshellBinaries('0.0.55', 'linux', 'x64', '/output', new Map());
+  });
+
+  test('re-downloads when binary is missing but version marker exists', async () => {
+    fileMap.set('/output/.openshell-version', true);
+    fileMap.set('/output/openshell', false);
+    vi.mocked(readFile).mockResolvedValue('0.0.55-linux-x64');
+    stubFetch();
+    const digests = new Map([
+      ['openshell-x86_64-unknown-linux-musl.tar.gz', 'abc123'],
+      ['openshell-gateway-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
+      ['openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
+      ['openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
+    ]);
+
+    vi.mocked(tar.extract).mockImplementation(async (opts: { cwd?: string }) => {
+      const cwd = opts.cwd ?? '';
+      fileMap.set(normPath(path.join(cwd, 'openshell')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-gateway')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-sandbox')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-driver-vm')), true);
+    });
+
+    await downloadOpenshellBinaries('0.0.55', 'linux', 'x64', '/output', digests);
+
+    expect(vi.mocked(tar.extract)).toHaveBeenCalled();
+  });
+
+  test('extracts tar.gz and writes version marker', async () => {
+    stubFetch();
+    const digests = new Map([
+      ['openshell-x86_64-unknown-linux-musl.tar.gz', 'abc123'],
+      ['openshell-gateway-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
+      ['openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
+      ['openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz', 'abc123'],
+    ]);
+
+    vi.mocked(tar.extract).mockImplementation(async (opts: { cwd?: string }) => {
+      const cwd = opts.cwd ?? '';
+      fileMap.set(normPath(path.join(cwd, 'openshell')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-gateway')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-sandbox')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-driver-vm')), true);
+    });
+
+    await downloadOpenshellBinaries('0.0.55', 'linux', 'x64', '/output', digests);
+
+    expect(vi.mocked(tar.extract)).toHaveBeenCalledTimes(4);
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('.openshell-version'),
+      '0.0.55-linux-x64',
+      expect.any(Object),
+    );
+    expect(chmod).toHaveBeenCalledTimes(4);
+  });
+
+  test('throws on checksum mismatch', async () => {
+    stubFetch();
+    const digests = new Map([['openshell-x86_64-unknown-linux-musl.tar.gz', 'wrongchecksum']]);
+
+    await expect(downloadOpenshellBinaries('0.0.55', 'linux', 'x64', '/output', digests)).rejects.toThrow(
+      'checksum mismatch',
+    );
+  });
+
+  test('throws on unsupported target', async () => {
+    await expect(downloadOpenshellBinaries('0.0.55', 'win32', 'x64', '/output', new Map())).rejects.toThrow(
+      'unsupported target',
+    );
+  });
+
+  test('handles darwin-arm64 with subdir for sandbox', async () => {
+    stubFetch();
+    const digests = new Map([
+      ['openshell-aarch64-apple-darwin.tar.gz', 'abc123'],
+      ['openshell-gateway-aarch64-apple-darwin.tar.gz', 'abc123'],
+      ['openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz', 'abc123'],
+      ['openshell-driver-vm-aarch64-apple-darwin.tar.gz', 'abc123'],
+    ]);
+
+    vi.mocked(tar.extract).mockImplementation(async (opts: { cwd?: string }) => {
+      const cwd = opts.cwd ?? '';
+      fileMap.set(normPath(path.join(cwd, 'openshell')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-gateway')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-sandbox')), true);
+      fileMap.set(normPath(path.join(cwd, 'openshell-driver-vm')), true);
+    });
+
+    await downloadOpenshellBinaries('0.0.55', 'darwin', 'arm64', '/output', digests);
+
+    expect(mkdir).toHaveBeenCalledWith(expect.stringContaining('linux-arm64'), { recursive: true });
+  });
+});
+
+describe('getRelease', () => {
+  test('strips v prefix and builds digest map', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          tag_name: 'v0.0.55',
+          assets: [
+            { name: 'openshell-x86_64-unknown-linux-musl.tar.gz', digest: 'sha256:abc123' },
+            { name: 'openshell-gateway-x86_64-unknown-linux-gnu.tar.gz', digest: 'sha256:def456' },
+            { name: 'no-digest-asset.txt', digest: null },
+          ],
+        }),
+      }),
+    );
+
+    const release = await getRelease('0.0.55');
+
+    expect(release.version).toBe('0.0.55');
+    expect(release.digests.get('openshell-x86_64-unknown-linux-musl.tar.gz')).toBe('abc123');
+    expect(release.digests.get('openshell-gateway-x86_64-unknown-linux-gnu.tar.gz')).toBe('def456');
+    expect(release.digests.has('no-digest-asset.txt')).toBe(false);
+  });
+
+  test('throws on fetch failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      }),
+    );
+
+    await expect(getRelease('0.0.99')).rejects.toThrow('failed to fetch OpenShell release v0.0.99');
+  });
+});

--- a/extensions/openshell/src/openshell-download.ts
+++ b/extensions/openshell/src/openshell-download.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { createWriteStream, existsSync } from 'node:fs';
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { parseArgs as nodeParseArgs } from 'node:util';
+
+const OPENSHELL_REPO = 'NVIDIA/OpenShell';
+const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${OPENSHELL_REPO}/main/install.sh`;
+
+export async function getLatestVersion(): Promise<string> {
+  const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
+  const token = process.env['GITHUB_TOKEN'];
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`https://api.github.com/repos/${OPENSHELL_REPO}/releases/latest`, {
+    headers,
+    redirect: 'follow',
+  });
+  if (!res.ok) {
+    throw new Error(`failed to fetch latest OpenShell release: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { tag_name: string };
+  return data.tag_name.replace(/^v/, '');
+}
+
+export async function downloadInstallScript(outputDir: string): Promise<void> {
+  const version = await getLatestVersion();
+  const versionFile = join(outputDir, '.openshell-version');
+  const scriptPath = join(outputDir, 'install.sh');
+
+  if (existsSync(versionFile) && existsSync(scriptPath)) {
+    const existing = await readFile(versionFile, { encoding: 'utf-8' });
+    if (existing.trim() === version) {
+      console.log(`OpenShell install.sh (version ${version}) already downloaded`);
+      return;
+    }
+  }
+
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  console.log(`downloading OpenShell install.sh (latest: ${version})...`);
+  const res = await fetch(INSTALL_SCRIPT_URL, { redirect: 'follow' });
+  if (!res.ok || !res.body) {
+    throw new Error(`failed to download install.sh: ${res.status} ${res.statusText}`);
+  }
+  await pipeline(res.body, createWriteStream(scriptPath));
+  await chmod(scriptPath, 0o755);
+
+  await writeFile(versionFile, version, { encoding: 'utf-8' });
+  console.log(`OpenShell install.sh (version ${version}) ready at ${scriptPath}`);
+}
+
+function parseArgs(args: string[]): { output: string } {
+  const { values } = nodeParseArgs({
+    args,
+    options: {
+      output: { type: 'string' },
+    },
+    strict: true,
+  });
+
+  if (!values.output || !isAbsolute(values.output)) throw new Error('--output must be an absolute path');
+
+  return { output: values.output };
+}
+
+if (!process.env['VITEST']) {
+  const { output } = parseArgs(process.argv.slice(2));
+  downloadInstallScript(output).catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/extensions/openshell/src/openshell-download.ts
+++ b/extensions/openshell/src/openshell-download.ts
@@ -18,14 +18,71 @@
 
 import { createWriteStream, existsSync } from 'node:fs';
 import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { isAbsolute, join } from 'node:path';
+import { join, normalize } from 'node:path';
 import { pipeline } from 'node:stream/promises';
-import { parseArgs as nodeParseArgs } from 'node:util';
+
+import * as tar from 'tar';
+
+import { sha256 } from './sha256';
 
 const OPENSHELL_REPO = 'NVIDIA/OpenShell';
-const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${OPENSHELL_REPO}/main/install.sh`;
 
-export async function getLatestVersion(): Promise<string> {
+export interface ReleaseInfo {
+  version: string;
+  digests: Map<string, string>;
+}
+
+interface AssetSpec {
+  component: string;
+  assetName: string;
+  binaryName: string;
+  subdir?: string;
+}
+
+const ASSET_MAP: Record<string, AssetSpec[]> = {
+  'darwin-arm64': [
+    { component: 'openshell', assetName: 'openshell-aarch64-apple-darwin.tar.gz', binaryName: 'openshell' },
+    {
+      component: 'openshell-gateway',
+      assetName: 'openshell-gateway-aarch64-apple-darwin.tar.gz',
+      binaryName: 'openshell-gateway',
+    },
+    {
+      component: 'openshell-sandbox',
+      assetName: 'openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz',
+      binaryName: 'openshell-sandbox',
+      subdir: 'linux-arm64',
+    },
+  ],
+  'linux-x64': [
+    { component: 'openshell', assetName: 'openshell-x86_64-unknown-linux-musl.tar.gz', binaryName: 'openshell' },
+    {
+      component: 'openshell-gateway',
+      assetName: 'openshell-gateway-x86_64-unknown-linux-gnu.tar.gz',
+      binaryName: 'openshell-gateway',
+    },
+    {
+      component: 'openshell-sandbox',
+      assetName: 'openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz',
+      binaryName: 'openshell-sandbox',
+    },
+  ],
+  'linux-arm64': [
+    { component: 'openshell', assetName: 'openshell-aarch64-unknown-linux-musl.tar.gz', binaryName: 'openshell' },
+    {
+      component: 'openshell-gateway',
+      assetName: 'openshell-gateway-aarch64-unknown-linux-gnu.tar.gz',
+      binaryName: 'openshell-gateway',
+    },
+    {
+      component: 'openshell-sandbox',
+      assetName: 'openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz',
+      binaryName: 'openshell-sandbox',
+    },
+  ],
+};
+
+export async function getLatestRelease(): Promise<ReleaseInfo> {
   const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
   const token = process.env['GITHUB_TOKEN'];
   if (token) {
@@ -38,56 +95,110 @@ export async function getLatestVersion(): Promise<string> {
   if (!res.ok) {
     throw new Error(`failed to fetch latest OpenShell release: ${res.status} ${res.statusText}`);
   }
-  const data = (await res.json()) as { tag_name: string };
-  return data.tag_name.replace(/^v/, '');
+  const data = (await res.json()) as { tag_name: string; assets: { name: string; digest: string | null }[] };
+  const version = data.tag_name.replace(/^v/, '');
+  const digests = new Map<string, string>();
+  for (const asset of data.assets) {
+    if (asset.digest) {
+      digests.set(asset.name, asset.digest.replace(/^sha256:/, ''));
+    }
+  }
+  return { version, digests };
 }
 
-export async function downloadInstallScript(outputDir: string): Promise<void> {
-  const version = await getLatestVersion();
-  const versionFile = join(outputDir, '.openshell-version');
-  const scriptPath = join(outputDir, 'install.sh');
+export async function download(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok || !res.body) {
+    throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
+  }
+  await pipeline(res.body, createWriteStream(dest));
+}
 
-  if (existsSync(versionFile) && existsSync(scriptPath)) {
+export async function verifyChecksum(
+  digests: Map<string, string>,
+  assetFileName: string,
+  filePath: string,
+): Promise<void> {
+  const expected = digests.get(assetFileName);
+  if (!expected) {
+    throw new Error(`no digest found for ${assetFileName} in release assets`);
+  }
+
+  const actual = await sha256(filePath);
+  if (actual !== expected) {
+    throw new Error(`checksum mismatch for ${assetFileName}: expected ${expected}, got ${actual}`);
+  }
+  console.log(`checksum verified for ${assetFileName}`);
+}
+
+function isSafePath(entryName: string): boolean {
+  const normalized = normalize(entryName.replace(/\\/g, '/'));
+  return !normalized.startsWith('..') && !normalized.startsWith('/');
+}
+
+export async function extract(archive: string, outDir: string): Promise<void> {
+  await tar.extract({
+    file: archive,
+    cwd: outDir,
+    filter: (path: string) => isSafePath(path),
+  });
+}
+
+export async function downloadOpenshellBinaries(
+  version: string,
+  platform: string,
+  arch: string,
+  outputDir: string,
+  digests: Map<string, string>,
+): Promise<void> {
+  const key = `${platform}-${arch}`;
+  const assets = ASSET_MAP[key];
+  if (!assets) {
+    throw new Error(`unsupported target: ${key}. Supported: ${Object.keys(ASSET_MAP).join(', ')}`);
+  }
+
+  const versionFile = join(outputDir, '.openshell-version');
+  const versionMarker = `${version}-${platform}-${arch}`;
+
+  if (existsSync(versionFile)) {
     const existing = await readFile(versionFile, { encoding: 'utf-8' });
-    if (existing.trim() === version) {
-      console.log(`OpenShell install.sh (version ${version}) already downloaded`);
-      return;
+    if (existing.trim() === versionMarker) {
+      const allPresent = assets.every(a => {
+        const dir = a.subdir ? join(outputDir, a.subdir) : outputDir;
+        return existsSync(join(dir, a.binaryName));
+      });
+      if (allPresent) {
+        console.log(`openshell ${version} for ${platform}/${arch} already downloaded`);
+        return;
+      }
     }
   }
 
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
 
-  console.log(`downloading OpenShell install.sh (latest: ${version})...`);
-  const res = await fetch(INSTALL_SCRIPT_URL, { redirect: 'follow' });
-  if (!res.ok || !res.body) {
-    throw new Error(`failed to download install.sh: ${res.status} ${res.statusText}`);
+  for (const asset of assets) {
+    const extractDir = asset.subdir ? join(outputDir, asset.subdir) : outputDir;
+    await mkdir(extractDir, { recursive: true });
+
+    const url = `https://github.com/${OPENSHELL_REPO}/releases/download/v${version}/${asset.assetName}`;
+    const archivePath = join(extractDir, asset.assetName);
+
+    console.log(`downloading ${asset.component} ${version} for ${platform}/${arch}...`);
+    await download(url, archivePath);
+    await verifyChecksum(digests, asset.assetName, archivePath);
+
+    console.log(`extracting ${asset.component}...`);
+    await extract(archivePath, extractDir);
+    await rm(archivePath);
+
+    const binaryPath = join(extractDir, asset.binaryName);
+    if (!existsSync(binaryPath)) {
+      throw new Error(`expected extracted binary at ${binaryPath}`);
+    }
+    await chmod(binaryPath, 0o755);
   }
-  await pipeline(res.body, createWriteStream(scriptPath));
-  await chmod(scriptPath, 0o755);
 
-  await writeFile(versionFile, version, { encoding: 'utf-8' });
-  console.log(`OpenShell install.sh (version ${version}) ready at ${scriptPath}`);
-}
-
-function parseArgs(args: string[]): { output: string } {
-  const { values } = nodeParseArgs({
-    args,
-    options: {
-      output: { type: 'string' },
-    },
-    strict: true,
-  });
-
-  if (!values.output || !isAbsolute(values.output)) throw new Error('--output must be an absolute path');
-
-  return { output: values.output };
-}
-
-if (!process.env['VITEST']) {
-  const { output } = parseArgs(process.argv.slice(2));
-  downloadInstallScript(output).catch((error: unknown) => {
-    console.error(error);
-    process.exit(1);
-  });
+  await writeFile(versionFile, versionMarker, { encoding: 'utf-8' });
+  console.log(`openshell ${version} for ${platform}/${arch} ready`);
 }

--- a/extensions/openshell/src/openshell-download.ts
+++ b/extensions/openshell/src/openshell-download.ts
@@ -53,6 +53,11 @@ const ASSET_MAP: Record<string, AssetSpec[]> = {
       binaryName: 'openshell-sandbox',
       subdir: 'linux-arm64',
     },
+    {
+      component: 'openshell-driver-vm',
+      assetName: 'openshell-driver-vm-aarch64-apple-darwin.tar.gz',
+      binaryName: 'openshell-driver-vm',
+    },
   ],
   'linux-x64': [
     { component: 'openshell', assetName: 'openshell-x86_64-unknown-linux-musl.tar.gz', binaryName: 'openshell' },
@@ -65,6 +70,11 @@ const ASSET_MAP: Record<string, AssetSpec[]> = {
       component: 'openshell-sandbox',
       assetName: 'openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz',
       binaryName: 'openshell-sandbox',
+    },
+    {
+      component: 'openshell-driver-vm',
+      assetName: 'openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz',
+      binaryName: 'openshell-driver-vm',
     },
   ],
   'linux-arm64': [
@@ -79,31 +89,36 @@ const ASSET_MAP: Record<string, AssetSpec[]> = {
       assetName: 'openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz',
       binaryName: 'openshell-sandbox',
     },
+    {
+      component: 'openshell-driver-vm',
+      assetName: 'openshell-driver-vm-aarch64-unknown-linux-gnu.tar.gz',
+      binaryName: 'openshell-driver-vm',
+    },
   ],
 };
 
-export async function getLatestRelease(): Promise<ReleaseInfo> {
+export async function getRelease(version: string): Promise<ReleaseInfo> {
   const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
   const token = process.env['GITHUB_TOKEN'];
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
   }
-  const res = await fetch(`https://api.github.com/repos/${OPENSHELL_REPO}/releases/latest`, {
+  const res = await fetch(`https://api.github.com/repos/${OPENSHELL_REPO}/releases/tags/v${version}`, {
     headers,
     redirect: 'follow',
   });
   if (!res.ok) {
-    throw new Error(`failed to fetch latest OpenShell release: ${res.status} ${res.statusText}`);
+    throw new Error(`failed to fetch OpenShell release v${version}: ${res.status} ${res.statusText}`);
   }
   const data = (await res.json()) as { tag_name: string; assets: { name: string; digest: string | null }[] };
-  const version = data.tag_name.replace(/^v/, '');
+  const resolvedVersion = data.tag_name.replace(/^v/, '');
   const digests = new Map<string, string>();
   for (const asset of data.assets) {
     if (asset.digest) {
       digests.set(asset.name, asset.digest.replace(/^sha256:/, ''));
     }
   }
-  return { version, digests };
+  return { version: resolvedVersion, digests };
 }
 
 export async function download(url: string, dest: string): Promise<void> {

--- a/extensions/openshell/src/openshell-download.ts
+++ b/extensions/openshell/src/openshell-download.ts
@@ -48,12 +48,6 @@ const ASSET_MAP: Record<string, AssetSpec[]> = {
       binaryName: 'openshell-gateway',
     },
     {
-      component: 'openshell-sandbox',
-      assetName: 'openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz',
-      binaryName: 'openshell-sandbox',
-      subdir: 'linux-arm64',
-    },
-    {
       component: 'openshell-driver-vm',
       assetName: 'openshell-driver-vm-aarch64-apple-darwin.tar.gz',
       binaryName: 'openshell-driver-vm',

--- a/extensions/openshell/src/openshell-extension.spec.ts
+++ b/extensions/openshell/src/openshell-extension.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import type { ExtensionContext } from '@openkaiden/api';
+import type { Container } from 'inversify';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { OpenshellCliManager } from '/@/manager/openshell-cli-manager';
+import { OpenshellExtension } from '/@/openshell-extension';
+
+vi.mock(import('@openkaiden/api'));
+vi.mock(import('/@/manager/openshell-cli-manager'));
+
+class TestOpenshellExtension extends OpenshellExtension {
+  getContainer(): Container | undefined {
+    return super.getContainer();
+  }
+}
+
+describe('OpenshellExtension', () => {
+  let extensionContext: ExtensionContext;
+  let openshellExtension: TestOpenshellExtension;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    extensionContext = { subscriptions: [] } as unknown as ExtensionContext;
+    openshellExtension = new TestOpenshellExtension(extensionContext);
+  });
+
+  test('activate initializes OpenshellCliManager', async () => {
+    await openshellExtension.activate();
+
+    expect(OpenshellCliManager.prototype.init).toHaveBeenCalled();
+  });
+
+  test('deactivate disposes resources', async () => {
+    await openshellExtension.activate();
+
+    await openshellExtension.deactivate();
+  });
+
+  test('deactivate is safe to call without activate', async () => {
+    await openshellExtension.deactivate();
+  });
+});

--- a/extensions/openshell/src/openshell-installer.spec.ts
+++ b/extensions/openshell/src/openshell-installer.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
+import { join } from 'node:path';
+
 import type { Logger } from '@openkaiden/api';
 import { env } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -83,7 +85,7 @@ describe('OpenshellInstaller', () => {
         '0.0.55',
         'linux',
         expect.any(String),
-        '/tmp/storage/bin',
+        join('/tmp/storage', 'bin'),
         expect.any(Map),
       );
       expect(logger.log).toHaveBeenCalledWith('OpenShell installation completed successfully');
@@ -100,7 +102,7 @@ describe('OpenshellInstaller', () => {
         '0.0.55',
         'darwin',
         expect.any(String),
-        '/tmp/storage/bin',
+        join('/tmp/storage', 'bin'),
         expect.any(Map),
       );
     });

--- a/extensions/openshell/src/openshell-installer.spec.ts
+++ b/extensions/openshell/src/openshell-installer.spec.ts
@@ -1,0 +1,137 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import type { Logger } from '@openkaiden/api';
+import { env } from '@openkaiden/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { downloadOpenshellBinaries, getRelease } from './openshell-download';
+import { OpenshellInstaller } from './openshell-installer';
+
+vi.mock(import('./openshell-download'));
+
+const logger: Logger = {
+  log: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getRelease).mockResolvedValue({
+    version: '0.0.55',
+    digests: new Map([['openshell-x86_64-unknown-linux-musl.tar.gz', 'abc123']]),
+  });
+  vi.mocked(downloadOpenshellBinaries).mockResolvedValue();
+});
+
+describe('OpenshellInstaller', () => {
+  describe('selectVersion', () => {
+    test('returns pinned version from release', async () => {
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+
+      const version = await installer.selectVersion();
+
+      expect(version).toBe('0.0.55');
+      expect(getRelease).toHaveBeenCalledWith('0.0.55');
+    });
+
+    test('caches version on subsequent calls', async () => {
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+
+      await installer.selectVersion();
+      await installer.selectVersion();
+
+      expect(getRelease).toHaveBeenCalledTimes(1);
+    });
+
+    test('re-fetches when latest is true', async () => {
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+
+      await installer.selectVersion();
+      await installer.selectVersion(true);
+
+      expect(getRelease).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('doInstall', () => {
+    test('downloads binaries for linux', async () => {
+      vi.mocked(env).isMac = false;
+      vi.mocked(env).isLinux = true;
+
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      await installer.doInstall(logger);
+
+      expect(getRelease).toHaveBeenCalledWith('0.0.55');
+      expect(downloadOpenshellBinaries).toHaveBeenCalledWith(
+        '0.0.55',
+        'linux',
+        expect.any(String),
+        '/tmp/storage/bin',
+        expect.any(Map),
+      );
+      expect(logger.log).toHaveBeenCalledWith('OpenShell installation completed successfully');
+    });
+
+    test('downloads binaries for mac', async () => {
+      vi.mocked(env).isMac = true;
+      vi.mocked(env).isLinux = false;
+
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      await installer.doInstall(logger);
+
+      expect(downloadOpenshellBinaries).toHaveBeenCalledWith(
+        '0.0.55',
+        'darwin',
+        expect.any(String),
+        '/tmp/storage/bin',
+        expect.any(Map),
+      );
+    });
+
+    test('uses selected version when available', async () => {
+      vi.mocked(env).isMac = false;
+      vi.mocked(env).isLinux = true;
+
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      await installer.selectVersion();
+      await installer.doInstall(logger);
+
+      expect(getRelease).toHaveBeenCalledTimes(2);
+    });
+
+    test('throws on unsupported platform', async () => {
+      vi.mocked(env).isMac = false;
+      vi.mocked(env).isLinux = false;
+
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      await expect(installer.doInstall(logger)).rejects.toThrow('not supported on this platform');
+    });
+
+    test('logs error and rethrows on download failure', async () => {
+      vi.mocked(env).isMac = false;
+      vi.mocked(env).isLinux = true;
+      vi.mocked(downloadOpenshellBinaries).mockRejectedValue(new Error('network error'));
+
+      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      await expect(installer.doInstall(logger)).rejects.toThrow('network error');
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('network error'));
+    });
+  });
+});

--- a/extensions/openshell/src/openshell-installer.spec.ts
+++ b/extensions/openshell/src/openshell-installer.spec.ts
@@ -18,7 +18,7 @@
 
 import { join } from 'node:path';
 
-import type { Logger } from '@openkaiden/api';
+import type { CliTool, Logger } from '@openkaiden/api';
 import { env } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -33,6 +33,10 @@ const logger: Logger = {
   warn: vi.fn(),
 };
 
+const cliTool: CliTool = {
+  updateVersion: vi.fn(),
+} as unknown as CliTool;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(getRelease).mockResolvedValue({
@@ -45,7 +49,7 @@ beforeEach(() => {
 describe('OpenshellInstaller', () => {
   describe('selectVersion', () => {
     test('returns pinned version from release', async () => {
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
 
       const version = await installer.selectVersion();
 
@@ -54,7 +58,7 @@ describe('OpenshellInstaller', () => {
     });
 
     test('caches version on subsequent calls', async () => {
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
 
       await installer.selectVersion();
       await installer.selectVersion();
@@ -63,7 +67,7 @@ describe('OpenshellInstaller', () => {
     });
 
     test('re-fetches when latest is true', async () => {
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
 
       await installer.selectVersion();
       await installer.selectVersion(true);
@@ -77,7 +81,7 @@ describe('OpenshellInstaller', () => {
       vi.mocked(env).isMac = false;
       vi.mocked(env).isLinux = true;
 
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
       await installer.doInstall(logger);
 
       expect(getRelease).toHaveBeenCalledWith('0.0.55');
@@ -89,13 +93,17 @@ describe('OpenshellInstaller', () => {
         expect.any(Map),
       );
       expect(logger.log).toHaveBeenCalledWith('OpenShell installation completed successfully');
+      expect(cliTool.updateVersion).toHaveBeenCalledWith({
+        version: '0.0.55',
+        path: join('/tmp/storage', 'bin', 'openshell'),
+      });
     });
 
     test('downloads binaries for mac', async () => {
       vi.mocked(env).isMac = true;
       vi.mocked(env).isLinux = false;
 
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
       await installer.doInstall(logger);
 
       expect(downloadOpenshellBinaries).toHaveBeenCalledWith(
@@ -105,13 +113,17 @@ describe('OpenshellInstaller', () => {
         join('/tmp/storage', 'bin'),
         expect.any(Map),
       );
+      expect(cliTool.updateVersion).toHaveBeenCalledWith({
+        version: '0.0.55',
+        path: join('/tmp/storage', 'bin', 'openshell'),
+      });
     });
 
     test('uses selected version when available', async () => {
       vi.mocked(env).isMac = false;
       vi.mocked(env).isLinux = true;
 
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
       await installer.selectVersion();
       await installer.doInstall(logger);
 
@@ -122,7 +134,7 @@ describe('OpenshellInstaller', () => {
       vi.mocked(env).isMac = false;
       vi.mocked(env).isLinux = false;
 
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
       await expect(installer.doInstall(logger)).rejects.toThrow('not supported on this platform');
     });
 
@@ -131,7 +143,7 @@ describe('OpenshellInstaller', () => {
       vi.mocked(env).isLinux = true;
       vi.mocked(downloadOpenshellBinaries).mockRejectedValue(new Error('network error'));
 
-      const installer = new OpenshellInstaller('0.0.55', '/tmp/storage');
+      const installer = new OpenshellInstaller(cliTool, '0.0.55', '/tmp/storage');
       await expect(installer.doInstall(logger)).rejects.toThrow('network error');
       expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('network error'));
     });

--- a/extensions/openshell/src/openshell-installer.ts
+++ b/extensions/openshell/src/openshell-installer.ts
@@ -16,19 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
+import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { CliToolInstaller, Logger } from '@openkaiden/api';
+import type { CliTool, CliToolInstaller, Logger } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
 
 import { downloadOpenshellBinaries, getRelease } from './openshell-download';
 
 export class OpenshellInstaller implements CliToolInstaller {
   private selectedVersion: string | undefined;
+  readonly #cliTool: CliTool;
   readonly #openshellVersion: string;
   readonly #storagePath: string;
 
-  constructor(openshellVersion: string, storagePath: string) {
+  constructor(cliTool: extensionApi.CliTool, openshellVersion: string, storagePath: string) {
+    this.#cliTool = cliTool;
     this.#openshellVersion = openshellVersion;
     this.#storagePath = storagePath;
   }
@@ -56,6 +59,10 @@ export class OpenshellInstaller implements CliToolInstaller {
       const release = await getRelease(version);
       await downloadOpenshellBinaries(release.version, platform, arch, binDir, release.digests);
       logger.log('OpenShell installation completed successfully');
+      this.#cliTool.updateVersion({
+        version: release.version,
+        path: join(binDir, extensionApi.env.isWindows ? 'openshell.exe' : 'openshell'),
+      });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(`OpenShell installation failed: ${message}`);
@@ -67,12 +74,9 @@ export class OpenshellInstaller implements CliToolInstaller {
     logger.log('Uninstalling OpenShell...');
 
     try {
-      if (extensionApi.env.isMac) {
-        await extensionApi.process.exec('brew', ['uninstall', 'openshell'], { logger });
-      } else if (extensionApi.env.isLinux) {
-        await this.uninstallLinux(logger);
-      } else {
-        throw new Error('OpenShell uninstall is not supported on this platform');
+      if (extensionApi.env.isMac || extensionApi.env.isLinux) {
+        const binDir = join(this.#storagePath, 'bin');
+        await rm(binDir, { recursive: true, force: true });
       }
       logger.log('OpenShell uninstalled successfully');
     } catch (error: unknown) {
@@ -85,34 +89,6 @@ export class OpenshellInstaller implements CliToolInstaller {
   private async fetchPinnedVersion(): Promise<string> {
     const release = await getRelease(this.#openshellVersion);
     return release.version;
-  }
-
-  private async uninstallLinux(logger: Logger): Promise<void> {
-    const hasDnf = await this.hasCommand('dnf');
-    if (hasDnf) {
-      await extensionApi.process.exec('dnf', ['remove', '-y', 'openshell', 'openshell-gateway'], {
-        logger,
-        isAdmin: true,
-      });
-      return;
-    }
-
-    const hasApt = await this.hasCommand('apt-get');
-    if (hasApt) {
-      await extensionApi.process.exec('apt-get', ['remove', '-y', 'openshell', 'openshell-gateway'], {
-        logger,
-        isAdmin: true,
-      });
-      return;
-    }
-
-    const hasRpm = await this.hasCommand('rpm');
-    if (hasRpm) {
-      await extensionApi.process.exec('rpm', ['-e', 'openshell', 'openshell-gateway'], { logger, isAdmin: true });
-      return;
-    }
-
-    throw new Error('no supported package manager found (dnf, apt-get, rpm)');
   }
 
   private async hasCommand(cmd: string): Promise<boolean> {

--- a/extensions/openshell/src/openshell-installer.ts
+++ b/extensions/openshell/src/openshell-installer.ts
@@ -16,15 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
+import { join } from 'node:path';
+
 import type { CliToolInstaller, Logger } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
 
-const OPENSHELL_REPO = 'NVIDIA/OpenShell';
-const OPENSHELL_VERSION = '0.0.55';
-const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${OPENSHELL_REPO}/v${OPENSHELL_VERSION}/install.sh`;
+import { downloadOpenshellBinaries, getRelease } from './openshell-download';
 
 export class OpenshellInstaller implements CliToolInstaller {
   private selectedVersion: string | undefined;
+  readonly #openshellVersion: string;
+  readonly #storagePath: string;
+
+  constructor(openshellVersion: string, storagePath: string) {
+    this.#openshellVersion = openshellVersion;
+    this.#storagePath = storagePath;
+  }
 
   async selectVersion(latest?: boolean): Promise<string> {
     if (latest || !this.selectedVersion) {
@@ -38,10 +45,16 @@ export class OpenshellInstaller implements CliToolInstaller {
       throw new Error('OpenShell install is not supported on this platform');
     }
 
-    logger.log('Installing OpenShell via upstream installer...');
+    const version = this.selectedVersion ?? this.#openshellVersion;
+    const platform = extensionApi.env.isMac ? 'darwin' : 'linux';
+    const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+    const binDir = join(this.#storagePath, 'bin');
+
+    logger.log(`Installing OpenShell ${version} for ${platform}/${arch}...`);
 
     try {
-      await this.installFromUpstream(logger);
+      const release = await getRelease(version);
+      await downloadOpenshellBinaries(release.version, platform, arch, binDir, release.digests);
       logger.log('OpenShell installation completed successfully');
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -70,26 +83,8 @@ export class OpenshellInstaller implements CliToolInstaller {
   }
 
   private async fetchPinnedVersion(): Promise<string> {
-    const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
-    const res = await fetch(`https://api.github.com/repos/${OPENSHELL_REPO}/releases/tags/v${OPENSHELL_VERSION}`, {
-      headers,
-      redirect: 'follow',
-    });
-    if (!res.ok) {
-      throw new Error(`failed to fetch OpenShell release v${OPENSHELL_VERSION}: ${res.status} ${res.statusText}`);
-    }
-    const data = (await res.json()) as { tag_name: string };
-    return data.tag_name.replace(/^v/, '');
-  }
-
-  private async installFromUpstream(logger: Logger): Promise<void> {
-    logger.log(`Downloading install script from ${INSTALL_SCRIPT_URL}`);
-    const res = await fetch(INSTALL_SCRIPT_URL, { redirect: 'follow' });
-    if (!res.ok || !res.body) {
-      throw new Error(`failed to download install.sh: ${res.status} ${res.statusText}`);
-    }
-    const script = await res.text();
-    await extensionApi.process.exec('sh', ['-c', script], { logger, isAdmin: true });
+    const release = await getRelease(this.#openshellVersion);
+    return release.version;
   }
 
   private async uninstallLinux(logger: Logger): Promise<void> {
@@ -104,7 +99,10 @@ export class OpenshellInstaller implements CliToolInstaller {
 
     const hasApt = await this.hasCommand('apt-get');
     if (hasApt) {
-      await extensionApi.process.exec('apt-get', ['remove', '-y', 'openshell'], { logger, isAdmin: true });
+      await extensionApi.process.exec('apt-get', ['remove', '-y', 'openshell', 'openshell-gateway'], {
+        logger,
+        isAdmin: true,
+      });
       return;
     }
 

--- a/extensions/openshell/src/openshell-installer.ts
+++ b/extensions/openshell/src/openshell-installer.ts
@@ -90,13 +90,4 @@ export class OpenshellInstaller implements CliToolInstaller {
     const release = await getRelease(this.#openshellVersion);
     return release.version;
   }
-
-  private async hasCommand(cmd: string): Promise<boolean> {
-    try {
-      await extensionApi.process.exec('which', [cmd]);
-      return true;
-    } catch {
-      return false;
-    }
-  }
 }

--- a/extensions/openshell/src/openshell-installer.ts
+++ b/extensions/openshell/src/openshell-installer.ts
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { CliToolInstaller, Logger } from '@openkaiden/api';
+import * as extensionApi from '@openkaiden/api';
+
+const OPENSHELL_REPO = 'NVIDIA/OpenShell';
+const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${OPENSHELL_REPO}/main/install.sh`;
+
+export class OpenshellInstaller implements CliToolInstaller {
+  private selectedVersion: string | undefined;
+
+  async selectVersion(latest?: boolean): Promise<string> {
+    if (latest || !this.selectedVersion) {
+      this.selectedVersion = await this.fetchLatestVersion();
+    }
+    return this.selectedVersion;
+  }
+
+  async doInstall(logger: Logger): Promise<void> {
+    const scriptPath = this.findInstallScript();
+
+    if (scriptPath) {
+      logger.log(`Using bundled install script: ${scriptPath}`);
+    } else {
+      logger.log('Bundled install script not found, will use upstream installer directly');
+    }
+
+    logger.log('Installing OpenShell...');
+
+    try {
+      if (scriptPath) {
+        await extensionApi.process.exec('sh', [scriptPath], { logger, isAdmin: true });
+      } else {
+        await this.installFromUpstream(logger);
+      }
+      logger.log('OpenShell installation completed successfully');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`OpenShell installation failed: ${message}`);
+      throw error;
+    }
+  }
+
+  async doUninstall(logger: Logger): Promise<void> {
+    logger.log('Uninstalling OpenShell...');
+
+    try {
+      if (extensionApi.env.isMac) {
+        await extensionApi.process.exec('brew', ['uninstall', 'openshell'], { logger });
+      } else if (extensionApi.env.isLinux) {
+        await this.uninstallLinux(logger);
+      } else {
+        throw new Error('OpenShell uninstall is not supported on this platform');
+      }
+      logger.log('OpenShell uninstalled successfully');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`OpenShell uninstall failed: ${message}`);
+      throw error;
+    }
+  }
+
+  private async fetchLatestVersion(): Promise<string> {
+    const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
+    const res = await fetch(`https://api.github.com/repos/${OPENSHELL_REPO}/releases/latest`, {
+      headers,
+      redirect: 'follow',
+    });
+    if (!res.ok) {
+      throw new Error(`failed to fetch latest OpenShell release: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as { tag_name: string };
+    return data.tag_name.replace(/^v/, '');
+  }
+
+  private findInstallScript(): string | undefined {
+    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+    if (resourcesPath) {
+      const bundledPath = join(resourcesPath, 'openshell', 'install.sh');
+      if (existsSync(bundledPath)) {
+        return bundledPath;
+      }
+    }
+    return undefined;
+  }
+
+  private async installFromUpstream(logger: Logger): Promise<void> {
+    logger.log(`Downloading install script from ${INSTALL_SCRIPT_URL}`);
+    const res = await fetch(INSTALL_SCRIPT_URL, { redirect: 'follow' });
+    if (!res.ok || !res.body) {
+      throw new Error(`failed to download install.sh: ${res.status} ${res.statusText}`);
+    }
+    const script = await res.text();
+    await extensionApi.process.exec('sh', ['-c', script], { logger, isAdmin: true });
+  }
+
+  private async uninstallLinux(logger: Logger): Promise<void> {
+    const hasDnf = await this.hasCommand('dnf');
+    if (hasDnf) {
+      await extensionApi.process.exec('dnf', ['remove', '-y', 'openshell', 'openshell-gateway'], {
+        logger,
+        isAdmin: true,
+      });
+      return;
+    }
+
+    const hasApt = await this.hasCommand('apt-get');
+    if (hasApt) {
+      await extensionApi.process.exec('apt-get', ['remove', '-y', 'openshell'], { logger, isAdmin: true });
+      return;
+    }
+
+    const hasRpm = await this.hasCommand('rpm');
+    if (hasRpm) {
+      await extensionApi.process.exec('rpm', ['-e', 'openshell', 'openshell-gateway'], { logger, isAdmin: true });
+      return;
+    }
+
+    throw new Error('no supported package manager found (dnf, apt-get, rpm)');
+  }
+
+  private async hasCommand(cmd: string): Promise<boolean> {
+    try {
+      await extensionApi.process.exec('which', [cmd]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/extensions/openshell/src/openshell-installer.ts
+++ b/extensions/openshell/src/openshell-installer.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
-
 import type { CliToolInstaller, Logger } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
 
@@ -36,22 +33,14 @@ export class OpenshellInstaller implements CliToolInstaller {
   }
 
   async doInstall(logger: Logger): Promise<void> {
-    const scriptPath = this.findInstallScript();
-
-    if (scriptPath) {
-      logger.log(`Using bundled install script: ${scriptPath}`);
-    } else {
-      logger.log('Bundled install script not found, will use upstream installer directly');
+    if (!extensionApi.env.isMac && !extensionApi.env.isLinux) {
+      throw new Error('OpenShell install is not supported on this platform');
     }
 
-    logger.log('Installing OpenShell...');
+    logger.log('Installing OpenShell via upstream installer...');
 
     try {
-      if (scriptPath) {
-        await extensionApi.process.exec('sh', [scriptPath], { logger, isAdmin: true });
-      } else {
-        await this.installFromUpstream(logger);
-      }
+      await this.installFromUpstream(logger);
       logger.log('OpenShell installation completed successfully');
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -90,17 +79,6 @@ export class OpenshellInstaller implements CliToolInstaller {
     }
     const data = (await res.json()) as { tag_name: string };
     return data.tag_name.replace(/^v/, '');
-  }
-
-  private findInstallScript(): string | undefined {
-    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
-    if (resourcesPath) {
-      const bundledPath = join(resourcesPath, 'openshell', 'install.sh');
-      if (existsSync(bundledPath)) {
-        return bundledPath;
-      }
-    }
-    return undefined;
   }
 
   private async installFromUpstream(logger: Logger): Promise<void> {

--- a/extensions/openshell/src/openshell-installer.ts
+++ b/extensions/openshell/src/openshell-installer.ts
@@ -20,14 +20,15 @@ import type { CliToolInstaller, Logger } from '@openkaiden/api';
 import * as extensionApi from '@openkaiden/api';
 
 const OPENSHELL_REPO = 'NVIDIA/OpenShell';
-const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${OPENSHELL_REPO}/main/install.sh`;
+const OPENSHELL_VERSION = '0.0.55';
+const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${OPENSHELL_REPO}/v${OPENSHELL_VERSION}/install.sh`;
 
 export class OpenshellInstaller implements CliToolInstaller {
   private selectedVersion: string | undefined;
 
   async selectVersion(latest?: boolean): Promise<string> {
     if (latest || !this.selectedVersion) {
-      this.selectedVersion = await this.fetchLatestVersion();
+      this.selectedVersion = await this.fetchPinnedVersion();
     }
     return this.selectedVersion;
   }
@@ -68,14 +69,14 @@ export class OpenshellInstaller implements CliToolInstaller {
     }
   }
 
-  private async fetchLatestVersion(): Promise<string> {
+  private async fetchPinnedVersion(): Promise<string> {
     const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
-    const res = await fetch(`https://api.github.com/repos/${OPENSHELL_REPO}/releases/latest`, {
+    const res = await fetch(`https://api.github.com/repos/${OPENSHELL_REPO}/releases/tags/v${OPENSHELL_VERSION}`, {
       headers,
       redirect: 'follow',
     });
     if (!res.ok) {
-      throw new Error(`failed to fetch latest OpenShell release: ${res.status} ${res.statusText}`);
+      throw new Error(`failed to fetch OpenShell release v${OPENSHELL_VERSION}: ${res.status} ${res.statusText}`);
     }
     const data = (await res.json()) as { tag_name: string };
     return data.tag_name.replace(/^v/, '');

--- a/extensions/openshell/src/sha256.ts
+++ b/extensions/openshell/src/sha256.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+
+export async function sha256(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(filePath), hash);
+  return hash.digest('hex');
+}

--- a/extensions/openshell/vite.config.js
+++ b/extensions/openshell/vite.config.js
@@ -41,7 +41,7 @@ const config = {
     assetsDir: '.',
     minify: process.env.MODE === 'production' ? 'esbuild' : false,
     lib: {
-      entry: ['src/extension.ts', 'src/openshell-download.ts'],
+      entry: ['src/extension.ts'],
       formats: ['cjs'],
     },
     rollupOptions: {

--- a/extensions/openshell/vite.config.js
+++ b/extensions/openshell/vite.config.js
@@ -41,7 +41,7 @@ const config = {
     assetsDir: '.',
     minify: process.env.MODE === 'production' ? 'esbuild' : false,
     lib: {
-      entry: ['src/extension.ts'],
+      entry: ['src/extension.ts', 'src/openshell-download.ts'],
       formats: ['cjs'],
     },
     rollupOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,10 +776,16 @@ importers:
       inversify:
         specifier: ^7.10.4
         version: 7.11.0(reflect-metadata@0.2.2)
+      tar:
+        specifier: ^7.5.3
+        version: 7.5.15
     devDependencies:
       '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
+      tsx:
+        specifier: ^4.19.4
+        version: 4.20.3
       vite:
         specifier: ^7.1.2
         version: 7.3.1(@types/node@24.13.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.2)
@@ -12456,7 +12462,6 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-    optional: true
 
   getos@3.2.1:
     dependencies:
@@ -15613,7 +15618,6 @@ snapshots:
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace install.sh bundling with direct platform-specific binary downloads (openshell, openshell-gateway, openshell-sandbox, openshell-driver-vm)
- Pin binary downloads to a tagged release (v0.0.55) via `openshellVersion` in `package.json` instead of fetching `/releases/latest`
- Move binary downloading out of electron-builder's `beforePack` hook into the extension's own `scripts/download.ts`
- Electron-builder now only declares pre-existing asset files as `extraResources`
- On macOS, bundle the Linux arm64 sandbox binary under `linux-arm64/` for future injection into the Podman VM
- Remove bundled install.sh lookup from installer — `doInstall()` always uses upstream installer

Fixes: https://github.com/openkaiden/kaiden/issues/2028

### Bundled binaries per platform

| Platform | openshell | openshell-gateway | openshell-sandbox | openshell-driver-vm |
|----------|-----------|-------------------|-------------------|---------------------|
| darwin-arm64 | host | host | linux-arm64 (for VM injection) | host |
| linux-x64 | host | host | host | host |
| linux-arm64 | host | host | host | host |

`openshell-driver-vm` is the MicroVM compute driver — it enables the gateway to run sandboxes as lightweight VMs in addition to containers (Docker/Podman).

### New files
- `extensions/openshell/scripts/download.ts` — standalone tsx script with `--all`, `--platform/--arch` flags
- `extensions/openshell/src/sha256.ts` — checksum verification utility
- `extensions/openshell/src/openshell-download.ts` — rewritten to download actual binaries with sha256 verification

### Modified files
- `.electron-builder.config.cjs` — replaced `downloadOpenshell()` with static asset inclusion
- `extensions/openshell/package.json` — added `openshellVersion` field, `download`/`download:all` scripts, `tar` and `tsx` deps
- `extensions/openshell/vite.config.js` — removed download entry point from build
- `extensions/openshell/src/openshell-installer.ts` — pin to tagged release, removed bundled install.sh lookup
- `.gitignore` — `openshell-binary/` → `extensions/openshell/assets/`

## Test plan
- [ ] `pnpm --filter openshell download` downloads binaries for host platform to `extensions/openshell/assets/`
- [ ] `pnpm --filter openshell download:all` downloads all 3 platform/arch combos
- [ ] `pnpm compile` packages the app with OpenShell binaries in `resources/openshell/`
- [ ] `pnpm run typecheck:extensions:openshell` passes
- [ ] `pnpm run test:extensions:openshell` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)