### PR TITLE
feat(mistral): persist connection IDs in secret storage

### DIFF
--- a/extensions/mistral/src/manager/mistral-inference-manager.spec.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { randomUUID } from 'node:crypto';
+
 import { createMistral, type MistralProvider } from '@ai-sdk/mistral';
 import { Mistral } from '@mistralai/mistralai';
 import type { CancellationToken, Disposable, Logger, Provider, SecretStorage } from '@openkaiden/api';
@@ -24,7 +26,15 @@ import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { MistralProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
-import { MistralInferenceManager, TOKENS_KEY } from './mistral-inference-manager';
+import { MistralInferenceManager, type StoredConnection, TOKENS_KEY } from './mistral-inference-manager';
+
+vi.mock(import('node:crypto'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
+  };
+});
 
 vi.mock(import('@ai-sdk/mistral'));
 
@@ -59,6 +69,7 @@ const SECRET_STORAGE_MOCK: SecretStorage = {
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(randomUUID).mockReturnValue('fake-uuid-1' as ReturnType<typeof randomUUID>);
   vi.mocked(createMistral).mockReturnValue(MISTRAL_PROVIDER_MOCK);
 
   vi.mocked(Mistral).mockImplementation(function () {
@@ -98,13 +109,17 @@ describe('init', () => {
   });
 
   test('should restore connections from secret storage', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('existingKey');
+    const stored: StoredConnection[] = [{ id: 'persisted-id', token: 'existingKey' }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     const manager = await createManager();
     await manager.init();
 
     expect(SECRET_STORAGE_MOCK.get).toHaveBeenCalledWith(TOKENS_KEY);
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'persisted-id' }),
+    );
   });
 
   test('should handle empty secret storage', async () => {
@@ -114,6 +129,48 @@ describe('init', () => {
     await manager.init();
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('should migrate legacy comma-separated tokens to JSON format', async () => {
+    vi.mocked(randomUUID)
+      .mockReturnValueOnce('migrated-id-1' as ReturnType<typeof randomUUID>)
+      .mockReturnValueOnce('migrated-id-2' as ReturnType<typeof randomUUID>);
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('tokenA,tokenB');
+
+    const manager = await createManager();
+    await manager.init();
+
+    const expected: StoredConnection[] = [
+      { id: 'migrated-id-1', token: 'tokenA' },
+      { id: 'migrated-id-2', token: 'tokenB' },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-2' }),
+    );
+  });
+
+  test('should restore persisted IDs across restarts', async () => {
+    const stored: StoredConnection[] = [
+      { id: 'stable-id-1', token: 'key1' },
+      { id: 'stable-id-2', token: 'key2' },
+    ];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
+    const manager = await createManager();
+    await manager.init();
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-2' }),
+    );
   });
 });
 
@@ -135,13 +192,14 @@ describe('factory', () => {
     }).rejects.toThrowError('invalid apiKey');
   });
 
-  test('calling create with proper params should save token', async () => {
+  test('calling create with proper params should save connection as JSON', async () => {
     await create({
       'mistral.factory.apiKey': 'dummyKey',
     });
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey');
+    const expected: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
 
   test('calling create with proper params should register inference connection', async () => {
@@ -160,7 +218,7 @@ describe('factory', () => {
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
-      id: '0',
+      id: 'fake-uuid-1',
       name: 'dum*****',
       type: 'cloud',
       llmMetadata: { name: 'mistral' },
@@ -202,16 +260,15 @@ describe('connection delete lifecycle', () => {
     mDelete = lifecycle.delete;
   });
 
-  test('calling delete should delete the token', async () => {
+  test('calling delete should remove the connection from storage', async () => {
     await mDelete();
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
 
-    // first time when registering the connection
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, 'dummyKey');
+    const saved: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, JSON.stringify(saved));
 
-    // second time when unregistering the connection
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, '');
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, JSON.stringify([]));
   });
 
   test('calling delete should dispose provider inference connection', async () => {

--- a/extensions/mistral/src/manager/mistral-inference-manager.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
 import { createMistral } from '@ai-sdk/mistral';
 import { Mistral } from '@mistralai/mistralai';

--- a/extensions/mistral/src/manager/mistral-inference-manager.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { createMistral } from '@ai-sdk/mistral';
 import { Mistral } from '@mistralai/mistralai';
@@ -26,7 +26,11 @@ import { inject, injectable } from 'inversify';
 import { MistralProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
 export const TOKENS_KEY = 'mistral:tokens';
-export const TOKEN_SEPARATOR = ',';
+
+export interface StoredConnection {
+  id: string;
+  token: string;
+}
 
 @injectable()
 export class MistralInferenceManager {
@@ -37,7 +41,6 @@ export class MistralInferenceManager {
   private secrets: SecretStorage;
 
   private connections: Map<string, Disposable> = new Map();
-  private connectionIdCounter = 0;
 
   async init(): Promise<void> {
     this.mistralProvider.setInferenceProviderConnectionFactory({
@@ -48,13 +51,13 @@ export class MistralInferenceManager {
   }
 
   private async restoreConnections(): Promise<void> {
-    const tokens = await this.getTokens();
-    for (const token of tokens) {
-      await this.registerInferenceProviderConnection({ token });
+    const stored = await this.getStoredConnections();
+    for (const entry of stored) {
+      await this.registerInferenceProviderConnection({ id: entry.id, token: entry.token });
     }
   }
 
-  private async getTokens(): Promise<string[]> {
+  private async getStoredConnections(): Promise<StoredConnection[]> {
     let raw: string | undefined;
     try {
       raw = await this.secrets.get(TOKENS_KEY);
@@ -62,13 +65,21 @@ export class MistralInferenceManager {
       console.error('Mistral: something went wrong while trying to get tokens from secret storage', err);
     }
     if (!raw) return [];
-    return raw.split(TOKEN_SEPARATOR);
+
+    try {
+      return JSON.parse(raw) as StoredConnection[];
+    } catch {
+      const tokens = raw.split(',');
+      const migrated: StoredConnection[] = tokens.map(token => ({ id: randomUUID(), token }));
+      await this.secrets.store(TOKENS_KEY, JSON.stringify(migrated));
+      return migrated;
+    }
   }
 
-  private async saveToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = [...tokens, token].join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async saveConnection(connection: StoredConnection): Promise<void> {
+    const stored = await this.getStoredConnections();
+    stored.push(connection);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(stored));
   }
 
   private getTokenHash(token: string): string {
@@ -76,13 +87,13 @@ export class MistralInferenceManager {
     return sha256.update(token).digest('hex');
   }
 
-  private async removeToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = tokens.filter(t => t !== token).join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async removeConnection(token: string): Promise<void> {
+    const stored = await this.getStoredConnections();
+    const filtered = stored.filter(entry => entry.token !== token);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
-  private async registerInferenceProviderConnection({ token }: { token: string }): Promise<void> {
+  private async registerInferenceProviderConnection({ id, token }: { id: string; token: string }): Promise<void> {
     const key = this.maskKey(token);
     const tokenHash = this.getTokenHash(token);
 
@@ -97,7 +108,7 @@ export class MistralInferenceManager {
     const clean = async (): Promise<void> => {
       this.connections.get(tokenHash)?.dispose();
       this.connections.delete(tokenHash);
-      await this.removeToken(token);
+      await this.removeConnection(token);
     };
 
     let status: ProviderConnectionStatus = 'unknown';
@@ -110,7 +121,7 @@ export class MistralInferenceManager {
     }
 
     const connectionDisposable = this.mistralProvider.registerInferenceProviderConnection({
-      id: String(this.connectionIdCounter++),
+      id,
       name: this.maskKey(token),
       type: 'cloud',
       llmMetadata: { name: 'mistral' },
@@ -152,8 +163,9 @@ export class MistralInferenceManager {
     const apiKey = params['mistral.factory.apiKey'];
     if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
 
-    await this.saveToken(apiKey);
-    await this.registerInferenceProviderConnection({ token: apiKey });
+    const id = randomUUID();
+    await this.saveConnection({ id, token: apiKey });
+    await this.registerInferenceProviderConnection({ id, token: apiKey });
   }
 
   dispose(): void {

--- a/extensions/mistral/src/manager/mistral-inference-manager.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.ts
@@ -82,23 +82,15 @@ export class MistralInferenceManager {
     await this.secrets.store(TOKENS_KEY, JSON.stringify(stored));
   }
 
-  private getTokenHash(token: string): string {
-    const sha256 = createHash('sha256');
-    return sha256.update(token).digest('hex');
-  }
-
-  private async removeConnection(token: string): Promise<void> {
+  private async removeConnection(id: string): Promise<void> {
     const stored = await this.getStoredConnections();
-    const filtered = stored.filter(entry => entry.token !== token);
+    const filtered = stored.filter(entry => entry.id !== id);
     await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
   private async registerInferenceProviderConnection({ id, token }: { id: string; token: string }): Promise<void> {
-    const key = this.maskKey(token);
-    const tokenHash = this.getTokenHash(token);
-
-    if (this.connections.has(tokenHash)) {
-      throw new Error(`connection already exists for token ${key}`);
+    if (this.connections.has(id)) {
+      throw new Error(`connection already exists for id ${id}`);
     }
 
     const mistral = createMistral({
@@ -106,9 +98,9 @@ export class MistralInferenceManager {
     });
 
     const clean = async (): Promise<void> => {
-      this.connections.get(tokenHash)?.dispose();
-      this.connections.delete(tokenHash);
-      await this.removeConnection(token);
+      this.connections.get(id)?.dispose();
+      this.connections.delete(id);
+      await this.removeConnection(id);
     };
 
     let status: ProviderConnectionStatus = 'unknown';
@@ -139,7 +131,7 @@ export class MistralInferenceManager {
         };
       },
     });
-    this.connections.set(tokenHash, connectionDisposable);
+    this.connections.set(id, connectionDisposable);
   }
 
   private async getMistralModels(token: string): Promise<Array<{ label: string }>> {


### PR DESCRIPTION
Replace the transient counter-based IDs with stable UUIDs stored as a JSON array alongside tokens, so connections keep their identity across restarts. Legacy comma-separated format is auto-migrated on first read.

Fixes #1939