### PR TITLE
feat(cursor): persist connection IDs in secret storage

### DIFF
--- a/extensions/cursor/src/manager/cursor-inference-manager.spec.ts
+++ b/extensions/cursor/src/manager/cursor-inference-manager.spec.ts
@@ -16,13 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { randomUUID } from 'node:crypto';
+
 import type { CancellationToken, Disposable, Logger, Provider, SecretStorage } from '@openkaiden/api';
 import { Container } from 'inversify';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { CursorProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
-import { CursorInferenceManager, TOKENS_KEY } from './cursor-inference-manager';
+import { CursorInferenceManager, type StoredConnection, TOKENS_KEY } from './cursor-inference-manager';
 import { CursorRestHelper } from './cursor-rest-helper';
 
 const PROVIDER_MOCK: Provider = {
@@ -37,11 +39,20 @@ const SECRET_STORAGE_MOCK: SecretStorage = {
   onDidChange: vi.fn(),
 };
 
+vi.mock(import('node:crypto'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
+  };
+});
+
 vi.mock(import('./cursor-rest-helper'));
 
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(randomUUID).mockReturnValue('fake-uuid-1' as ReturnType<typeof randomUUID>);
   vi.mocked(CursorRestHelper.prototype.listModels).mockResolvedValue([{ id: 'composer-2' }, { id: 'gpt-5.5' }]);
 });
 
@@ -67,13 +78,17 @@ describe('init', () => {
   });
 
   test('should restore connections from secret storage', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('existingKey');
+    const stored: StoredConnection[] = [{ id: 'persisted-id', token: 'existingKey' }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     const manager = await createManager();
     await manager.init();
 
     expect(SECRET_STORAGE_MOCK.get).toHaveBeenCalledWith(TOKENS_KEY);
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'persisted-id' }),
+    );
   });
 
   test('should handle empty secret storage', async () => {
@@ -83,6 +98,48 @@ describe('init', () => {
     await manager.init();
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('should migrate legacy comma-separated tokens to JSON format', async () => {
+    vi.mocked(randomUUID)
+      .mockReturnValueOnce('migrated-id-1' as ReturnType<typeof randomUUID>)
+      .mockReturnValueOnce('migrated-id-2' as ReturnType<typeof randomUUID>);
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('tokenA,tokenB');
+
+    const manager = await createManager();
+    await manager.init();
+
+    const expected: StoredConnection[] = [
+      { id: 'migrated-id-1', token: 'tokenA' },
+      { id: 'migrated-id-2', token: 'tokenB' },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'migrated-id-2' }),
+    );
+  });
+
+  test('should restore persisted IDs across restarts', async () => {
+    const stored: StoredConnection[] = [
+      { id: 'stable-id-1', token: 'key1' },
+      { id: 'stable-id-2', token: 'key2' },
+    ];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
+    const manager = await createManager();
+    await manager.init();
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledTimes(2);
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-1' }),
+    );
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'stable-id-2' }),
+    );
   });
 });
 
@@ -104,13 +161,14 @@ describe('factory', () => {
     }).rejects.toThrowError('invalid apiKey');
   });
 
-  test('calling create with proper params should save token', async () => {
+  test('calling create with proper params should save connection as JSON', async () => {
     await create({
       'cursor.factory.apiKey': 'dummyKey',
     });
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, 'dummyKey');
+    const expected: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
 
   test('calling create with proper params should register inference connection', async () => {
@@ -123,7 +181,7 @@ describe('factory', () => {
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
-      id: '0',
+      id: 'fake-uuid-1',
       name: 'dum*****',
       type: 'cloud',
       llmMetadata: {
@@ -167,14 +225,15 @@ describe('connection delete lifecycle', () => {
     mDelete = lifecycle.delete;
   });
 
-  test('calling delete should delete the token', async () => {
+  test('calling delete should remove the connection from storage', async () => {
     await mDelete();
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
 
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, 'dummyKey');
+    const saved: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(1, TOKENS_KEY, JSON.stringify(saved));
 
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, '');
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, TOKENS_KEY, JSON.stringify([]));
   });
 
   test('calling delete should dispose provider inference connection', async () => {

--- a/extensions/cursor/src/manager/cursor-inference-manager.ts
+++ b/extensions/cursor/src/manager/cursor-inference-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import type { Disposable, InferenceModel, Provider, ProviderConnectionStatus, SecretStorage } from '@openkaiden/api';
 import { MockProviderV3 } from 'ai/test';
@@ -27,7 +27,11 @@ import { CursorProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 import { CursorRestHelper } from './cursor-rest-helper';
 
 export const TOKENS_KEY = 'cursor:tokens';
-export const TOKEN_SEPARATOR = ',';
+
+export interface StoredConnection {
+  id: string;
+  token: string;
+}
 
 @injectable()
 export class CursorInferenceManager {
@@ -41,7 +45,6 @@ export class CursorInferenceManager {
   private cursorRestHelper: CursorRestHelper;
 
   private connections: Map<string, Disposable> = new Map();
-  private connectionIdCounter = 0;
 
   async init(): Promise<void> {
     this.cursorProvider.setInferenceProviderConnectionFactory({
@@ -52,17 +55,17 @@ export class CursorInferenceManager {
   }
 
   private async restoreConnections(): Promise<void> {
-    const tokens = await this.getTokens();
-    for (const token of tokens) {
+    const stored = await this.getStoredConnections();
+    for (const entry of stored) {
       try {
-        await this.registerInferenceProviderConnection({ token });
+        await this.registerInferenceProviderConnection({ id: entry.id, token: entry.token });
       } catch (err: unknown) {
         console.error('cursor: failed to restore connection', err);
       }
     }
   }
 
-  private async getTokens(): Promise<string[]> {
+  private async getStoredConnections(): Promise<StoredConnection[]> {
     let raw: string | undefined;
     try {
       raw = await this.secrets.get(TOKENS_KEY);
@@ -70,32 +73,33 @@ export class CursorInferenceManager {
       console.error('cursor: something went wrong while trying to get tokens from secret storage', err);
     }
     if (!raw) return [];
-    return raw.split(TOKEN_SEPARATOR);
+
+    try {
+      return JSON.parse(raw) as StoredConnection[];
+    } catch {
+      // Migrate legacy comma-separated token format
+      const tokens = raw.split(',');
+      const migrated: StoredConnection[] = tokens.map(token => ({ id: randomUUID(), token }));
+      await this.secrets.store(TOKENS_KEY, JSON.stringify(migrated));
+      return migrated;
+    }
   }
 
-  private async saveToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = [...tokens, token].join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async saveConnection(connection: StoredConnection): Promise<void> {
+    const stored = await this.getStoredConnections();
+    stored.push(connection);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(stored));
   }
 
-  private getTokenHash(token: string): string {
-    const sha256 = createHash('sha256');
-    return sha256.update(token).digest('hex');
+  private async removeConnection(id: string): Promise<void> {
+    const stored = await this.getStoredConnections();
+    const filtered = stored.filter(entry => entry.id !== id);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
-  private async removeToken(token: string): Promise<void> {
-    const tokens: Array<string> = await this.getTokens();
-    const raw = tokens.filter(t => t !== token).join(TOKEN_SEPARATOR);
-    await this.secrets.store(TOKENS_KEY, raw);
-  }
-
-  private async registerInferenceProviderConnection({ token }: { token: string }): Promise<void> {
-    const key = this.maskKey(token);
-    const tokenHash = this.getTokenHash(token);
-
-    if (this.connections.has(tokenHash)) {
-      throw new Error(`connection already exists for token ${key}`);
+  private async registerInferenceProviderConnection({ id, token }: { id: string; token: string }): Promise<void> {
+    if (this.connections.has(id)) {
+      throw new Error(`connection already exists for id ${id}`);
     }
 
     let status: ProviderConnectionStatus = 'unknown';
@@ -111,13 +115,13 @@ export class CursorInferenceManager {
     const cursorSdk = new MockProviderV3();
 
     const clean = async (): Promise<void> => {
-      this.connections.get(tokenHash)?.dispose();
-      this.connections.delete(tokenHash);
-      await this.removeToken(token);
+      this.connections.get(id)?.dispose();
+      this.connections.delete(id);
+      await this.removeConnection(id);
     };
 
     const connectionDisposable = this.cursorProvider.registerInferenceProviderConnection({
-      id: String(this.connectionIdCounter++),
+      id,
       name: this.maskKey(token),
       type: 'cloud',
       llmMetadata: {
@@ -137,7 +141,7 @@ export class CursorInferenceManager {
         };
       },
     });
-    this.connections.set(tokenHash, connectionDisposable);
+    this.connections.set(id, connectionDisposable);
   }
 
   private async getCursorModels(token: string): Promise<Array<{ label: string }>> {
@@ -154,8 +158,9 @@ export class CursorInferenceManager {
     const apiKey = params['cursor.factory.apiKey'];
     if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
 
-    await this.saveToken(apiKey);
-    await this.registerInferenceProviderConnection({ token: apiKey });
+    const id = randomUUID();
+    await this.saveConnection({ id, token: apiKey });
+    await this.registerInferenceProviderConnection({ id, token: apiKey });
   }
 
   dispose(): void {

--- a/extensions/cursor/src/manager/cursor-inference-manager.ts
+++ b/extensions/cursor/src/manager/cursor-inference-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
 import type { Disposable, InferenceModel, Provider, ProviderConnectionStatus, SecretStorage } from '@openkaiden/api';
 import { MockProviderV3 } from 'ai/test';


### PR DESCRIPTION
Replace the transient counter-based IDs with stable UUIDs stored as a JSON array alongside tokens, so connections keep their identity across restarts. Legacy comma-separated format is auto-migrated on first read.

Fixes #1937