### PR TITLE
feat(openshiftai): persist connection IDs in secret storage

### DIFF
--- a/extensions/openshift-ai/src/openshiftai.spec.ts
+++ b/extensions/openshift-ai/src/openshiftai.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { randomUUID } from 'node:crypto';
+
 import { createOpenAICompatible, type OpenAICompatibleProvider } from '@ai-sdk/openai-compatible';
 import { KubeConfig } from '@kubernetes/client-node';
 import type {
@@ -28,7 +30,15 @@ import type {
 } from '@openkaiden/api';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { OpenShiftAI, TOKENS_KEY } from './openshiftai';
+import { OpenShiftAI, type StoredConnection, TOKENS_KEY } from './openshiftai';
+
+vi.mock(import('node:crypto'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('fake-uuid-1'),
+  };
+});
 
 vi.mock('@openkaiden/api', () => ({
   Disposable: {
@@ -78,6 +88,7 @@ global.fetch = fetchMock;
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(randomUUID).mockReturnValue('fake-uuid-1' as ReturnType<typeof randomUUID>);
   vi.mocked(PROVIDER_API_MOCK.createProvider).mockReturnValue(PROVIDER_MOCK as Provider);
   vi.mocked(createOpenAICompatible).mockReturnValue(OPENAI_PROVIDER_MOCK);
   vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(undefined);
@@ -228,16 +239,19 @@ describe('factory', () => {
     expect(call.models).toEqual([{ label: 'llama-3' }]);
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(
-      TOKENS_KEY,
-      'dummyToken|https://api.cluster.example.com:6443',
-    );
+    const expected: StoredConnection[] = [
+      { id: 'fake-uuid-1', token: 'dummyToken', url: 'https://api.cluster.example.com:6443' },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
 });
 
 describe('restoreConnections', () => {
   test('should not crash if restore fails due to no inference services', async () => {
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('savedToken|https://api.cluster.example.com:6443');
+    const stored: StoredConnection[] = [
+      { id: 'persisted-id', token: 'savedToken', url: 'https://api.cluster.example.com:6443' },
+    ];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     listClusterCustomObjectMock.mockResolvedValue({ items: [] });
 
@@ -245,5 +259,64 @@ describe('restoreConnections', () => {
     await openshiftai.init();
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('should migrate legacy pipe/comma-separated format to JSON', async () => {
+    vi.mocked(randomUUID)
+      .mockReturnValueOnce('migrated-id-1' as ReturnType<typeof randomUUID>)
+      .mockReturnValueOnce('migrated-id-2' as ReturnType<typeof randomUUID>);
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(
+      'tokenA|https://cluster-a.com:6443,tokenB|https://cluster-b.com:6443',
+    );
+
+    listClusterCustomObjectMock.mockResolvedValue({ items: [] });
+
+    const openshiftai = new OpenShiftAI(PROVIDER_API_MOCK, SECRET_STORAGE_MOCK);
+    await openshiftai.init();
+
+    const expected: StoredConnection[] = [
+      { id: 'migrated-id-1', token: 'tokenA', url: 'https://cluster-a.com:6443' },
+      { id: 'migrated-id-2', token: 'tokenB', url: 'https://cluster-b.com:6443' },
+    ];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+  });
+
+  test('should restore persisted IDs across restarts', async () => {
+    vi.mocked(randomUUID).mockReturnValue('conn-uuid' as ReturnType<typeof randomUUID>);
+    const stored: StoredConnection[] = [{ id: 'stable-id-1', token: 'key1', url: 'https://cluster1.example.com:6443' }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
+    listClusterCustomObjectMock.mockResolvedValue({
+      items: [{ metadata: { name: 'test-project' } }],
+    });
+    listNamespacedCustomObjectMock.mockResolvedValue({
+      items: [
+        {
+          metadata: { name: 'my-model' },
+          spec: { predictor: { model: { runtime: 'vllm' } } },
+          status: { url: 'https://my-model.example.com' },
+        },
+      ],
+    });
+    listNamespacedSecretMock.mockResolvedValue({
+      items: [
+        {
+          metadata: { annotations: { 'kubernetes.io/service-account.name': 'vllm-sa' } },
+          data: { token: Buffer.from('serviceToken').toString('base64') },
+        },
+      ],
+    });
+    fetchMock.mockResolvedValue({
+      status: 200,
+      json: async () => ({ data: [{ id: 'llama-3' }] }),
+    });
+
+    const openshiftai = new OpenShiftAI(PROVIDER_API_MOCK, SECRET_STORAGE_MOCK);
+    await openshiftai.init();
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'https://cluster1.example.com:6443' }),
+    );
   });
 });

--- a/extensions/openshift-ai/src/openshiftai.spec.ts
+++ b/extensions/openshift-ai/src/openshiftai.spec.ts
@@ -232,6 +232,7 @@ describe('factory', () => {
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     const call = vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mock.calls[0][0];
+    expect(call.id).toBe('fake-uuid-1');
     expect(call.name).toBe('https://api.cluster.example.com:6443');
     expect(call.type).toBe('self-hosted');
     expect(call.endpoint).toBe('https://my-model.example.com/v1');
@@ -240,7 +241,12 @@ describe('factory', () => {
 
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledOnce();
     const expected: StoredConnection[] = [
-      { id: 'fake-uuid-1', token: 'dummyToken', url: 'https://api.cluster.example.com:6443' },
+      {
+        id: 'fake-uuid-1',
+        url: 'https://api.cluster.example.com:6443',
+        token: 'dummyToken',
+        baseURL: 'https://my-model.example.com/v1',
+      },
     ];
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
@@ -249,7 +255,12 @@ describe('factory', () => {
 describe('restoreConnections', () => {
   test('should not crash if restore fails due to no inference services', async () => {
     const stored: StoredConnection[] = [
-      { id: 'persisted-id', token: 'savedToken', url: 'https://api.cluster.example.com:6443' },
+      {
+        id: 'persisted-id',
+        url: 'https://api.cluster.example.com:6443',
+        token: 'savedToken',
+        baseURL: 'https://my-model.example.com/v1',
+      },
     ];
     vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
@@ -261,29 +272,73 @@ describe('restoreConnections', () => {
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).not.toHaveBeenCalled();
   });
 
-  test('should migrate legacy pipe/comma-separated format to JSON', async () => {
-    vi.mocked(randomUUID)
-      .mockReturnValueOnce('migrated-id-1' as ReturnType<typeof randomUUID>)
-      .mockReturnValueOnce('migrated-id-2' as ReturnType<typeof randomUUID>);
-    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(
-      'tokenA|https://cluster-a.com:6443,tokenB|https://cluster-b.com:6443',
-    );
+  test('should migrate legacy pipe/comma-separated format by discovering services', async () => {
+    vi.mocked(randomUUID).mockReturnValue('migrated-id-1' as ReturnType<typeof randomUUID>);
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue('tokenA|https://cluster-a.com:6443');
 
-    listClusterCustomObjectMock.mockResolvedValue({ items: [] });
+    const coreAPI = {
+      listClusterCustomObject: listClusterCustomObjectMock,
+      listNamespacedSecret: listNamespacedSecretMock,
+    };
+    const genericAPI = {
+      listNamespacedCustomObject: listNamespacedCustomObjectMock,
+      listClusterCustomObject: listClusterCustomObjectMock,
+    };
+    vi.mocked(KubeConfig.prototype.makeApiClient)
+      .mockReturnValueOnce(coreAPI)
+      .mockReturnValueOnce(genericAPI)
+      .mockReturnValueOnce(coreAPI)
+      .mockReturnValueOnce(genericAPI);
+
+    listClusterCustomObjectMock.mockResolvedValue({
+      items: [{ metadata: { name: 'test-project' } }],
+    });
+    listNamespacedCustomObjectMock.mockResolvedValue({
+      items: [
+        {
+          metadata: { name: 'my-model' },
+          spec: { predictor: { model: { runtime: 'vllm' } } },
+          status: { url: 'https://my-model.example.com' },
+        },
+      ],
+    });
+    listNamespacedSecretMock.mockResolvedValue({
+      items: [
+        {
+          metadata: { annotations: { 'kubernetes.io/service-account.name': 'vllm-sa' } },
+          data: { token: Buffer.from('serviceToken').toString('base64') },
+        },
+      ],
+    });
+    fetchMock.mockResolvedValue({
+      status: 200,
+      json: async () => ({ data: [{ id: 'llama-3' }] }),
+    });
 
     const openshiftai = new OpenShiftAI(PROVIDER_API_MOCK, SECRET_STORAGE_MOCK);
     await openshiftai.init();
 
     const expected: StoredConnection[] = [
-      { id: 'migrated-id-1', token: 'tokenA', url: 'https://cluster-a.com:6443' },
-      { id: 'migrated-id-2', token: 'tokenB', url: 'https://cluster-b.com:6443' },
+      {
+        id: 'migrated-id-1',
+        url: 'https://cluster-a.com:6443',
+        token: 'tokenA',
+        baseURL: 'https://my-model.example.com/v1',
+      },
     ];
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
   });
 
   test('should restore persisted IDs across restarts', async () => {
-    vi.mocked(randomUUID).mockReturnValue('conn-uuid' as ReturnType<typeof randomUUID>);
-    const stored: StoredConnection[] = [{ id: 'stable-id-1', token: 'key1', url: 'https://cluster1.example.com:6443' }];
+    const stored: StoredConnection[] = [
+      {
+        id: 'stable-id-1',
+        url: 'https://cluster1.example.com:6443',
+        token: 'key1',
+        baseURL: 'https://my-model.example.com/v1',
+      },
+    ];
     vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
 
     listClusterCustomObjectMock.mockResolvedValue({
@@ -316,7 +371,7 @@ describe('restoreConnections', () => {
 
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'https://cluster1.example.com:6443' }),
+      expect.objectContaining({ id: 'stable-id-1', name: 'https://cluster1.example.com:6443' }),
     );
   });
 });

--- a/extensions/openshift-ai/src/openshiftai.ts
+++ b/extensions/openshift-ai/src/openshiftai.ts
@@ -15,6 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { randomUUID } from 'node:crypto';
+
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { CoreV1Api, CustomObjectsApi, KubeConfig } from '@kubernetes/client-node';
 import type {
@@ -27,8 +29,12 @@ import type {
 } from '@openkaiden/api';
 
 export const TOKENS_KEY = 'openshiftai:infos';
-export const TOKEN_SEPARATOR = ',';
-const INFO_SEPARATOR = '|';
+
+export interface StoredConnection {
+  id: string;
+  token: string;
+  url: string;
+}
 
 interface ConnectionInfo {
   token: string;
@@ -38,7 +44,6 @@ interface ConnectionInfo {
 export class OpenShiftAI implements Disposable {
   private provider: Provider | undefined = undefined;
   private connections: Map<ConnectionInfo, Disposable> = new Map();
-  private connectionIdCounter = 0;
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -73,69 +78,49 @@ export class OpenShiftAI implements Disposable {
   }
 
   private async restoreConnections(): Promise<void> {
-    const connectionInfos = await this.getConnectionInfos();
-    for (const connectionInfo of connectionInfos) {
+    const stored = await this.getStoredConnections();
+    for (const entry of stored) {
       try {
-        await this.registerInferenceProviderConnection({
-          token: connectionInfo.token,
-          baseURL: connectionInfo.baseURL,
-        });
+        await this.registerInferenceProviderConnection(entry);
       } catch (err: unknown) {
-        console.error(`OpenShift AI: failed to restore connection for baseURL ${connectionInfo.baseURL}`, err);
+        console.error(`OpenShift AI: failed to restore connection for baseURL ${entry.url}`, err);
       }
     }
   }
 
-  private async getTokens(): Promise<string[]> {
-    // get raw string from secret storage
+  private async getStoredConnections(): Promise<StoredConnection[]> {
     let raw: string | undefined;
     try {
       raw = await this.secrets.get(TOKENS_KEY);
     } catch (err: unknown) {
       console.error('OpenShift AI: something went wrong while trying to get tokens from secret storage', err);
     }
-    // if undefined return empty array
     if (!raw) return [];
-    // split raw string by token separator
-    return raw.split(TOKEN_SEPARATOR);
+
+    try {
+      return JSON.parse(raw) as StoredConnection[];
+    } catch {
+      // Migrate legacy pipe/comma-separated format: token|url,token|url
+      const entries = raw.split(',');
+      const migrated: StoredConnection[] = entries.map(entry => {
+        const [token, url] = entry.split('|');
+        return { id: randomUUID(), token, url };
+      });
+      await this.secrets.store(TOKENS_KEY, JSON.stringify(migrated));
+      return migrated;
+    }
   }
 
-  /**
-   * Get all connection infos from secret storage
-   * @private
-   */
-  private async getConnectionInfos(): Promise<ConnectionInfo[]> {
-    return (await this.getTokens()).map(str => {
-      const [token, baseURL] = str.split(INFO_SEPARATOR);
-      return {
-        token,
-        baseURL,
-      };
-    });
+  private async saveConnection(connection: StoredConnection): Promise<void> {
+    const stored = await this.getStoredConnections();
+    stored.push(connection);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(stored));
   }
 
-  /**
-   * Save connection info to secret storage
-   * @param token
-   * @param baseURL
-   * @private
-   */
-  private async saveConnectionInfo(token: string, baseURL: string): Promise<void> {
-    // get existing tokens
-    const tokens = await this.getTokens();
-    // concat new token with existing tokens
-    const raw = [...tokens, `${token}${INFO_SEPARATOR}${baseURL}`].join(TOKEN_SEPARATOR);
-    // save to secret storage
-    await this.secrets.store(TOKENS_KEY, raw);
-  }
-
-  private async removeConnectionInfo(token: string, baseURL: string): Promise<void> {
-    // get existing tokens
-    const tokens = await this.getConnectionInfos();
-    // filter out the token
-    const raw = tokens.filter(t => t.token !== token || t.baseURL !== baseURL).join(TOKEN_SEPARATOR);
-    // save to secret storage
-    await this.secrets.store(TOKENS_KEY, raw);
+  private async removeConnection(id: string): Promise<void> {
+    const stored = await this.getStoredConnections();
+    const filtered = stored.filter(entry => entry.id !== id);
+    await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
   protected async listModels({ baseURL, token }: ConnectionInfo): Promise<Array<InferenceModel>> {
@@ -229,48 +214,42 @@ export class OpenShiftAI implements Disposable {
     return urls;
   }
 
-  private async registerInferenceProviderConnection({ token, baseURL }: ConnectionInfo): Promise<void> {
+  private async registerInferenceProviderConnection({ id, token, url }: StoredConnection): Promise<void> {
     if (!this.provider) throw new Error('cannot create MCP provider connection: provider is not initialized');
 
-    const connectionInfos = await this.getInferenceServices(baseURL, token);
+    const connectionInfos = await this.getInferenceServices(url, token);
 
     if (connectionInfos.length === 0) {
       throw new Error('no inference services found on the cluster');
     }
 
     for (const connectionInfo of connectionInfos) {
-      // get hash of the token (used for Map)
       if (this.connections.has(connectionInfo)) {
-        throw new Error(`connection already exists for token (hidden) baseURL ${baseURL}`);
+        throw new Error(`connection already exists for token (hidden) baseURL ${url}`);
       }
 
       const models = await this.listModels(connectionInfo);
 
-      // create ProviderV2
       const openai = createOpenAICompatible({
         baseURL: connectionInfo.baseURL,
         apiKey: connectionInfo.token,
         name: connectionInfo.baseURL,
       });
 
-      // create a clean method
       const clean = async (): Promise<void> => {
-        // dispose inference provider connection
         this.connections.get(connectionInfo)?.dispose();
-        // delete map entry
         this.connections.delete(connectionInfo);
-        // remove token from secret storage
-        await this.removeConnectionInfo(token, baseURL);
+        await this.removeConnection(id);
       };
 
       const connectionDisposable = this.provider.registerInferenceProviderConnection({
-        id: String(this.connectionIdCounter++),
-        name: baseURL,
+        id: randomUUID(),
+        name: url,
         type: 'self-hosted',
         endpoint: connectionInfo.baseURL,
         sdk: openai,
         status(): ProviderConnectionStatus {
-          return 'unknown'; // if status is not unknown we cannot delete the connection
+          return 'unknown';
         },
         lifecycle: {
           delete: clean.bind(this),
@@ -287,20 +266,15 @@ export class OpenShiftAI implements Disposable {
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {
-    // extract token from params
     const url = params['openshiftai.factory.url'];
     if (!url || typeof url !== 'string') throw new Error('invalid OpenShift AI URL');
 
     const token = params['openshiftai.factory.token'];
     if (!token || typeof token !== 'string') throw new Error('invalid token');
 
-    // use dedicated method to register connection
-    await this.registerInferenceProviderConnection({
-      token,
-      baseURL: url,
-    });
-
-    await this.saveConnectionInfo(token, url);
+    const connection: StoredConnection = { id: randomUUID(), token, url };
+    await this.registerInferenceProviderConnection(connection);
+    await this.saveConnection(connection);
   }
 
   dispose(): void {

--- a/extensions/openshift-ai/src/openshiftai.ts
+++ b/extensions/openshift-ai/src/openshiftai.ts
@@ -32,8 +32,9 @@ export const TOKENS_KEY = 'openshiftai:infos';
 
 export interface StoredConnection {
   id: string;
-  token: string;
   url: string;
+  token: string;
+  baseURL: string;
 }
 
 interface ConnectionInfo {
@@ -43,7 +44,7 @@ interface ConnectionInfo {
 
 export class OpenShiftAI implements Disposable {
   private provider: Provider | undefined = undefined;
-  private connections: Map<ConnectionInfo, Disposable> = new Map();
+  private connections: Map<string, Disposable> = new Map();
 
   constructor(
     private readonly providerAPI: typeof ProviderAPI,
@@ -81,9 +82,15 @@ export class OpenShiftAI implements Disposable {
     const stored = await this.getStoredConnections();
     for (const entry of stored) {
       try {
-        await this.registerInferenceProviderConnection(entry);
+        const services = await this.getInferenceServices(entry.url, entry.token);
+        const matching = services.find(s => s.baseURL === entry.baseURL);
+        if (!matching) {
+          console.error(`OpenShift AI: inference service at ${entry.baseURL} no longer available`);
+          continue;
+        }
+        await this.registerSingleConnection(entry, matching);
       } catch (err: unknown) {
-        console.error(`OpenShift AI: failed to restore connection for baseURL ${entry.url}`, err);
+        console.error(`OpenShift AI: failed to restore connection for ${entry.url}`, err);
       }
     }
   }
@@ -102,10 +109,14 @@ export class OpenShiftAI implements Disposable {
     } catch {
       // Migrate legacy pipe/comma-separated format: token|url,token|url
       const entries = raw.split(',');
-      const migrated: StoredConnection[] = entries.map(entry => {
+      const migrated: StoredConnection[] = [];
+      for (const entry of entries) {
         const [token, url] = entry.split('|');
-        return { id: randomUUID(), token, url };
-      });
+        const services = await this.getInferenceServices(url, token);
+        for (const service of services) {
+          migrated.push({ id: randomUUID(), url, token, baseURL: service.baseURL });
+        }
+      }
       await this.secrets.store(TOKENS_KEY, JSON.stringify(migrated));
       return migrated;
     }
@@ -214,55 +225,47 @@ export class OpenShiftAI implements Disposable {
     return urls;
   }
 
-  private async registerInferenceProviderConnection({ id, token, url }: StoredConnection): Promise<void> {
+  private async registerSingleConnection(stored: StoredConnection, serviceInfo: ConnectionInfo): Promise<void> {
     if (!this.provider) throw new Error('cannot create MCP provider connection: provider is not initialized');
 
-    const connectionInfos = await this.getInferenceServices(url, token);
-
-    if (connectionInfos.length === 0) {
-      throw new Error('no inference services found on the cluster');
+    if (this.connections.has(stored.id)) {
+      throw new Error(`connection already exists for baseURL ${serviceInfo.baseURL}`);
     }
 
-    for (const connectionInfo of connectionInfos) {
-      if (this.connections.has(connectionInfo)) {
-        throw new Error(`connection already exists for token (hidden) baseURL ${url}`);
-      }
+    const models = await this.listModels(serviceInfo);
 
-      const models = await this.listModels(connectionInfo);
+    const openai = createOpenAICompatible({
+      baseURL: serviceInfo.baseURL,
+      apiKey: serviceInfo.token,
+      name: serviceInfo.baseURL,
+    });
 
-      const openai = createOpenAICompatible({
-        baseURL: connectionInfo.baseURL,
-        apiKey: connectionInfo.token,
-        name: connectionInfo.baseURL,
-      });
+    const clean = async (): Promise<void> => {
+      this.connections.get(stored.id)?.dispose();
+      this.connections.delete(stored.id);
+      await this.removeConnection(stored.id);
+    };
 
-      const clean = async (): Promise<void> => {
-        this.connections.get(connectionInfo)?.dispose();
-        this.connections.delete(connectionInfo);
-        await this.removeConnection(id);
-      };
-
-      const connectionDisposable = this.provider.registerInferenceProviderConnection({
-        id: randomUUID(),
-        name: url,
-        type: 'self-hosted',
-        endpoint: connectionInfo.baseURL,
-        sdk: openai,
-        status(): ProviderConnectionStatus {
-          return 'unknown';
-        },
-        lifecycle: {
-          delete: clean.bind(this),
-        },
-        models: models,
-        credentials(): Record<string, string> {
-          return {
-            'openshiftai:tokens': token,
-          };
-        },
-      });
-      this.connections.set(connectionInfo, connectionDisposable);
-    }
+    const connectionDisposable = this.provider.registerInferenceProviderConnection({
+      id: stored.id,
+      name: stored.url,
+      type: 'self-hosted',
+      endpoint: serviceInfo.baseURL,
+      sdk: openai,
+      status(): ProviderConnectionStatus {
+        return 'unknown';
+      },
+      lifecycle: {
+        delete: clean.bind(this),
+      },
+      models: models,
+      credentials(): Record<string, string> {
+        return {
+          'openshiftai:tokens': stored.token,
+        };
+      },
+    });
+    this.connections.set(stored.id, connectionDisposable);
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {
@@ -272,9 +275,16 @@ export class OpenShiftAI implements Disposable {
     const token = params['openshiftai.factory.token'];
     if (!token || typeof token !== 'string') throw new Error('invalid token');
 
-    const connection: StoredConnection = { id: randomUUID(), token, url };
-    await this.registerInferenceProviderConnection(connection);
-    await this.saveConnection(connection);
+    const services = await this.getInferenceServices(url, token);
+    if (services.length === 0) {
+      throw new Error('no inference services found on the cluster');
+    }
+
+    for (const service of services) {
+      const connection: StoredConnection = { id: randomUUID(), url, token, baseURL: service.baseURL };
+      await this.registerSingleConnection(connection, service);
+      await this.saveConnection(connection);
+    }
   }
 
   dispose(): void {


### PR DESCRIPTION
Replace the transient counter-based IDs with stable UUIDs stored as a JSON array alongside tokens, so connections keep their identity across restarts. Legacy comma-separated format is auto-migrated on first read.

Fixes #1941