### PR TITLE
refactor(agent-workspaces): replace hardcoded agent registry with dynamic agentInfos store

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -24,6 +24,7 @@ import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { resetDraft, wizard } from '/@/stores/agent-workspace-create-draft.svelte';
+import * as agentsStore from '/@/stores/agents';
 import * as agentWorkspaceRuntimeStore from '/@/stores/agentworkspace-runtime';
 import * as mcpStore from '/@/stores/mcp-remote-servers';
 import * as modelCatalogStore from '/@/stores/model-catalog';
@@ -32,6 +33,7 @@ import * as providerStore from '/@/stores/providers';
 import * as ragStore from '/@/stores/rag-environments';
 import * as secretVaultStore from '/@/stores/secret-vault';
 import * as skillsStore from '/@/stores/skills';
+import type { AgentInfo } from '/@api/agent-info';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 import type { CatalogModelInfo } from '/@api/model-registry-info';
 import type { ProviderInfo } from '/@api/provider-info';
@@ -42,6 +44,7 @@ import type { SkillInfo } from '/@api/skill/skill-info';
 import AgentWorkspaceCreate from './AgentWorkspaceCreate.svelte';
 
 vi.mock(import('/@/navigation'));
+vi.mock(import('/@/stores/agents'));
 vi.mock(import('/@/stores/agentworkspace-runtime'));
 vi.mock(import('/@/stores/skills'));
 vi.mock(import('/@/stores/mcp-remote-servers'));
@@ -86,6 +89,29 @@ beforeEach(() => {
     cancel: vi.fn(),
     onfinish: null,
   });
+  vi.mocked(agentsStore).agentInfos = writable<AgentInfo[]>([
+    {
+      id: 'opencode',
+      name: 'OpenCode',
+      description: 'Open-source agent.',
+      tags: ['Recommended'],
+      supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
+    },
+    {
+      id: 'claude',
+      name: 'Claude Code',
+      description: 'Anthropic Claude.',
+      tags: ['Cloud'],
+      supportedModelTypes: [{ name: 'anthropic' }],
+    },
+    {
+      id: 'goose',
+      name: 'Goose',
+      description: 'Autonomous coding agent.',
+      supportedRuntimes: ['podman'],
+      supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
+    },
+  ]);
   vi.mocked(agentWorkspaceRuntimeStore).agentWorkspaceRuntime = writable<string>('podman');
   vi.mocked(skillsStore).skillInfos = writable<SkillInfo[]>([]);
   vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([]);
@@ -1214,9 +1240,9 @@ test('Expect workspaceConfiguration undefined when no settings for selected agen
   );
 });
 
-test('Expect workspaceConfiguration resolved via cliAgent for variant agents like claude-vertex', async () => {
+test('Expect workspaceConfiguration looked up by agent id directly', async () => {
   vi.mocked(window.getConfigurationValue).mockResolvedValue({
-    defaultAgent: 'claude-vertex',
+    defaultAgent: 'claude',
     defaultAgentSettings: {
       claude: {
         workspaceConfiguration: {
@@ -1225,6 +1251,7 @@ test('Expect workspaceConfiguration resolved via cliAgent for variant agents lik
       },
     },
   });
+  setProviders([mockAnthropicProvider]);
 
   render(AgentWorkspaceCreate);
 
@@ -1238,49 +1265,6 @@ test('Expect workspaceConfiguration resolved via cliAgent for variant agents lik
       agent: 'claude',
       workspaceConfiguration: {
         environment: [{ name: 'CLAUDE_CODE_USE_VERTEX', value: '1' }],
-      },
-    }),
-  );
-});
-
-test('Expect workspaceConfiguration falls back to raw agent key when resolved key has no config', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue({
-    defaultAgent: 'claude-vertex',
-    defaultAgentSettings: {
-      'claude-vertex': {
-        workspaceConfiguration: {
-          environment: [{ name: 'CLOUD_ML_REGION', value: 'us-east5' }],
-          mounts: [
-            {
-              host: '$HOME/.config/gcloud/application_default_credentials.json',
-              target: '$HOME/.config/gcloud/application_default_credentials.json',
-              ro: true,
-            },
-          ],
-        },
-      },
-    },
-  });
-
-  render(AgentWorkspaceCreate);
-
-  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
-    target: { value: '/home/user/my-repo' },
-  });
-  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
-
-  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
-    expect.objectContaining({
-      agent: 'claude',
-      workspaceConfiguration: {
-        environment: [{ name: 'CLOUD_ML_REGION', value: 'us-east5' }],
-        mounts: [
-          {
-            host: '$HOME/.config/gcloud/application_default_credentials.json',
-            target: '$HOME/.config/gcloud/application_default_credentials.json',
-            ro: true,
-          },
-        ],
       },
     }),
   );

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -6,13 +6,13 @@ import { onMount } from 'svelte';
 import { toast } from 'svelte-sonner';
 
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
-import { agentDefinitions, matchesModelFilter } from '/@/lib/guided-setup/agent-registry';
 import { getModelId } from '/@/lib/models/models-utils';
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { resetDraft, wizard } from '/@/stores/agent-workspace-create-draft.svelte';
+import { agentInfos } from '/@/stores/agents';
 import { agentWorkspaceRuntime } from '/@/stores/agentworkspace-runtime';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
@@ -93,7 +93,7 @@ onMount(async () => {
 
   if (!wizard.draft.initialized) {
     const defaultAgent = defaultSettings?.defaultAgent;
-    if (defaultAgent && agentDefinitions.some(d => d.cliName === defaultAgent)) {
+    if (defaultAgent && $agentInfos.some(a => a.id === defaultAgent)) {
       wizard.draft.selectedAgent = defaultAgent;
     }
 
@@ -257,10 +257,7 @@ function normalizeTildeToHome(p: string): string {
 }
 
 function getAgentWorkspaceConfiguration(agent: string): AgentWorkspaceConfiguration | undefined {
-  const resolvedAgent = agentDefinitions.find(d => d.cliName === agent)?.cliAgent ?? agent;
-  const config =
-    defaultSettings?.defaultAgentSettings?.[resolvedAgent]?.workspaceConfiguration ??
-    defaultSettings?.defaultAgentSettings?.[agent]?.workspaceConfiguration;
+  const config = defaultSettings?.defaultAgentSettings?.[agent]?.workspaceConfiguration;
   if (!config) return undefined;
   const snapshot = $state.snapshot(config);
   if (snapshot.mounts) {
@@ -274,7 +271,7 @@ function getAgentWorkspaceConfiguration(agent: string): AgentWorkspaceConfigurat
 }
 
 function getFirstCompatibleModel(): ModelInfo | undefined {
-  const agentDef = agentDefinitions.find(d => d.cliName === wizard.draft.selectedAgent);
+  const agentInfo = $agentInfos.find(a => a.id === wizard.draft.selectedAgent);
   const enabled = $catalogModels.filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   const seen = new Set<string>();
@@ -284,10 +281,9 @@ function getFirstCompatibleModel(): ModelInfo | undefined {
     seen.add(key);
     return true;
   });
-  const compatible = agentDef?.modelFilter
-    ? unique.filter(m => matchesModelFilter(agentDef.modelFilter!, m.llmMetadata?.name))
-    : unique;
-  return compatible[0];
+  if (!agentInfo?.supportedModelTypes || agentInfo.supportedModelTypes.length === 0) return unique[0];
+  const typeNames = new Set(agentInfo.supportedModelTypes.map(t => t.name));
+  return unique.filter(m => m.llmMetadata?.name !== undefined && typeNames.has(m.llmMetadata.name))[0];
 }
 
 function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorkspaceMount[] | undefined {
@@ -318,11 +314,10 @@ async function startAsIs(): Promise<void> {
   const draftSnapshot = $state.snapshot(wizard.draft);
 
   try {
-    const agentDef = agentDefinitions.find(d => d.cliName === draftSnapshot.selectedAgent);
     await window.createAgentWorkspace({
       sourcePath: draftSnapshot.sourcePath,
       runtime: $agentWorkspaceRuntime,
-      agent: agentDef?.cliAgent ?? draftSnapshot.selectedAgent,
+      agent: draftSnapshot.selectedAgent,
       name: draftSnapshot.sessionName || getDefaultSessionName(draftSnapshot.sourcePath),
     });
     resetDraft();
@@ -356,8 +351,6 @@ async function startWorkspace(): Promise<void> {
     );
     const mounts = buildMountsFrom(draftSnapshot.selectedFileAccess, draftSnapshot.customMounts);
 
-    const agentDef = agentDefinitions.find(d => d.cliName === draftSnapshot.selectedAgent);
-
     const selected = $mcpRemoteServerInfos.filter(m => draftSnapshot.selectedMcpIds.includes(m.id));
     const remoteServers = selected
       .filter(m => m.setupType === 'remote' || (!m.setupType && m.url))
@@ -375,7 +368,7 @@ async function startWorkspace(): Promise<void> {
     await window.createAgentWorkspace({
       sourcePath: draftSnapshot.sourcePath,
       runtime: $agentWorkspaceRuntime,
-      agent: agentDef?.cliAgent ?? draftSnapshot.selectedAgent,
+      agent: draftSnapshot.selectedAgent,
       model: draftSnapshot.selectedModel ? getModelId(draftSnapshot.selectedModel) : undefined,
       name: draftSnapshot.sessionName,
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
@@ -22,16 +22,19 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
+import * as agentsStore from '/@/stores/agents';
 import * as agentWorkspaceRuntimeStore from '/@/stores/agentworkspace-runtime';
 import * as modelCatalogStore from '/@/stores/model-catalog';
 import * as modelsStore from '/@/stores/models';
 import * as providersStore from '/@/stores/providers';
+import type { AgentInfo } from '/@api/agent-info';
 import type { CatalogModelInfo } from '/@api/model-registry-info';
 import type { ProviderInfo } from '/@api/provider-info';
 
 import AgentWorkspaceCreateStepAgentModel from './AgentWorkspaceCreateStepAgentModel.svelte';
 
 vi.mock(import('/@/navigation'));
+vi.mock(import('/@/stores/agents'));
 vi.mock(import('/@/stores/providers'));
 vi.mock(import('/@/stores/model-catalog'));
 vi.mock(import('/@/stores/models'));
@@ -63,42 +66,41 @@ function setProviders(providers: ProviderInfo[]): void {
   vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>(providers);
   vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(buildCatalogModels(providers));
 }
-vi.mock(import('/@/lib/guided-setup/agent-registry'), async importOriginal => {
-  const actual = await importOriginal();
-  return {
-    matchesModelFilter: actual.matchesModelFilter,
-    agentDefinitions: [
-      {
-        cliName: 'opencode',
-        title: 'OpenCode',
-        description: 'Open-source agent.',
-        badge: 'Recommended',
-        modelFilter: '!vertexai',
-      },
-      {
-        cliName: 'claude',
-        title: 'Claude Code',
-        description: 'Anthropic Claude.',
-        badge: 'Cloud',
-        modelFilter: 'anthropic',
-      },
-      {
-        cliName: 'claude-vertex',
-        title: 'Claude on Vertex AI',
-        description: 'Claude via Vertex AI.',
-        modelFilter: 'vertexai',
-      },
-      { cliName: 'cursor', title: 'Cursor', description: 'AI code editor.', modelFilter: '!vertexai' },
-      {
-        cliName: 'goose',
-        title: 'Goose',
-        description: 'Autonomous coding agent.',
-        runtimes: ['podman'],
-        modelFilter: '!vertexai',
-      },
-    ] as unknown as typeof actual.agentDefinitions,
-  };
-});
+const mockAgentInfos: AgentInfo[] = [
+  {
+    id: 'opencode',
+    name: 'OpenCode',
+    description: 'Open-source agent.',
+    tags: ['Recommended'],
+    supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
+  },
+  {
+    id: 'claude',
+    name: 'Claude Code',
+    description: 'Anthropic Claude.',
+    tags: ['Cloud'],
+    supportedModelTypes: [{ name: 'anthropic' }],
+  },
+  {
+    id: 'claude-vertex',
+    name: 'Claude on Vertex AI',
+    description: 'Claude via Vertex AI.',
+    supportedModelTypes: [{ name: 'vertexai' }],
+  },
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    description: 'AI code editor.',
+    supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
+  },
+  {
+    id: 'goose',
+    name: 'Goose',
+    description: 'Autonomous coding agent.',
+    supportedRuntimes: ['podman'],
+    supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
+  },
+];
 
 const mockAnthropicProvider: ProviderInfo = {
   id: 'claude',
@@ -157,6 +159,7 @@ const mockOllamaProvider: ProviderInfo = {
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
+  vi.mocked(agentsStore).agentInfos = writable<AgentInfo[]>(mockAgentInfos);
   vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([]);
   vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([]);
   vi.mocked(agentWorkspaceRuntimeStore).agentWorkspaceRuntime = writable<string>('podman');
@@ -381,6 +384,22 @@ test('Claude on Vertex AI shows only Vertex AI models', async () => {
   expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
   expect(screen.queryByText('llama3.2:3b')).not.toBeInTheDocument();
   expect(screen.queryByText('claude-opus-4')).not.toBeInTheDocument();
+});
+
+test('recommended agent is sorted first regardless of other tags', () => {
+  const agents: AgentInfo[] = [
+    { id: 'cloud', name: 'Cloud Agent', description: 'Cloud tag.', tags: ['Cloud'] },
+    { id: 'no-tag', name: 'No Tag Agent', description: 'No tags.' },
+    { id: 'recommended', name: 'Recommended Agent', description: 'Recommended.', tags: ['Recommended'] },
+  ];
+  vi.mocked(agentsStore).agentInfos = writable<AgentInfo[]>(agents);
+
+  render(AgentWorkspaceCreateStepAgentModel);
+
+  const options = screen.getAllByRole('option');
+  expect(options[0]).toHaveTextContent('Recommended Agent');
+  expect(options[1]).toHaveTextContent('Cloud Agent');
+  expect(options[2]).toHaveTextContent('No Tag Agent');
 });
 
 test('agent with non-matching runtime is hidden', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+import { faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { untrack } from 'svelte';
 
+import IconImage from '/@/lib/appearance/IconImage.svelte';
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
-import { agentDefinitions, matchesModelFilter } from '/@/lib/guided-setup/agent-registry';
 import type { CatalogModelInfo } from '/@/lib/models/models-utils';
 import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
+import { agentInfos } from '/@/stores/agents';
 import { agentWorkspaceRuntime } from '/@/stores/agentworkspace-runtime';
 import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
 import { catalogModels } from '/@/stores/models';
@@ -16,7 +19,16 @@ interface Props {
 
 let { selectedAgent = $bindable(''), selectedModel = $bindable() }: Props = $props();
 
-let filteredAgents = $derived(agentDefinitions.filter(a => !a.runtimes || a.runtimes.includes($agentWorkspaceRuntime)));
+let filteredAgents = $derived(
+  $agentInfos
+    .filter(a => !a.supportedRuntimes || a.supportedRuntimes.some(r => r === $agentWorkspaceRuntime))
+    .toSorted((a, b) => {
+      const aRec = a.tags?.includes('Recommended') ? 1 : 0;
+      const bRec = b.tags?.includes('Recommended') ? 1 : 0;
+      if (aRec !== bRec) return bRec - aRec;
+      return a.name.localeCompare(b.name);
+    }),
+);
 
 let allModels: CatalogModelInfo[] = $derived.by(() => {
   const enabled = $catalogModels.filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
@@ -31,17 +43,16 @@ let allModels: CatalogModelInfo[] = $derived.by(() => {
 
 let agentFilteredModels: CatalogModelInfo[] = $derived(filterByAgent(allModels, selectedAgent));
 
-let selectedAgentLabel: string = $derived(
-  agentDefinitions.find(a => a.cliName === selectedAgent)?.title ?? 'the selected agent',
-);
+let selectedAgentLabel: string = $derived($agentInfos.find(a => a.id === selectedAgent)?.name ?? 'the selected agent');
 
 let selectedKey: string = $derived(selectedModel ? modelKey(selectedModel.providerId, selectedModel.label) : '');
 
 function filterByAgent(models: CatalogModelInfo[], agent: string): CatalogModelInfo[] {
   if (!agent) return models;
-  const def = agentDefinitions.find(d => d.cliName === agent);
-  if (!def?.modelFilter) return models;
-  return models.filter(m => matchesModelFilter(def.modelFilter!, m.llmMetadata?.name));
+  const info = $agentInfos.find(a => a.id === agent);
+  if (!info?.supportedModelTypes || info.supportedModelTypes.length === 0) return models;
+  const typeNames = new Set(info.supportedModelTypes.map(t => t.name));
+  return models.filter(m => m.llmMetadata?.name !== undefined && typeNames.has(m.llmMetadata.name));
 }
 
 function handleModelSelect(model: CatalogModelInfo): void {
@@ -81,8 +92,8 @@ $effect(() => {
     </p>
 
     <div class="grid grid-cols-4 gap-3" role="listbox" aria-label="Coding agent">
-      {#each filteredAgents as agent (agent.cliName)}
-        {@const isSelected = selectedAgent === agent.cliName}
+      {#each filteredAgents as agent (agent.id)}
+        {@const isSelected = selectedAgent === agent.id}
         <button
           type="button"
           role="option"
@@ -91,18 +102,24 @@ $effect(() => {
             {isSelected
               ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
               : 'border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-inset-bg)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
-          onclick={(): void => selectAgent(agent.cliName)}>
-          {#if agent.iconComponent}
-            <agent.iconComponent size={44} />
-          {/if}
-          <span class="font-bold text-sm text-[var(--pd-modal-text)]">{agent.title}</span>
+          onclick={(): void => selectAgent(agent.id)}>
+          <div class="w-11 h-11 flex items-center justify-center">
+            <IconImage image={agent.icon?.logo ?? agent.icon?.icon} alt={agent.name} class="w-11 h-11">
+              <Icon icon={faTerminal} size="2x" />
+            </IconImage>
+          </div>
+          <span class="font-bold text-sm text-[var(--pd-modal-text)]">{agent.name}</span>
           <p class="text-xs text-[var(--pd-content-card-text)] opacity-70 leading-relaxed grow">
             {agent.description}
           </p>
-          {#if agent.badge}
-            <span class="self-start text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full border border-[var(--pd-status-running)] text-[var(--pd-status-running)]">
-              {agent.badge}
-            </span>
+          {#if agent.tags?.length}
+            <div class="flex flex-wrap gap-1 self-start">
+              {#each agent.tags as tag (tag)}
+                <span class="text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full border border-[var(--pd-status-running)] text-[var(--pd-status-running)]">
+                  {tag}
+                </span>
+              {/each}
+            </div>
           {/if}
         </button>
       {/each}

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -183,8 +183,11 @@ export const CODING_AGENT = {
   OPENCODE: 'OpenCode',
   OPENCLAW: 'OpenClaw',
   CLAUDE: 'Claude Code',
-  CLAUDE_VERTEX: 'Claude on Vertex AI',
   GOOSE: 'Goose',
+  CODEX: 'Codex',
+  CURSOR: 'Cursor CLI',
+  COPILOT: 'GitHub Copilot',
+  GEMINI: 'Gemini CLI',
 } as const;
 export const CODING_AGENTS = Object.values(CODING_AGENT);
 export type CodingAgent = (typeof CODING_AGENT)[keyof typeof CODING_AGENT];


### PR DESCRIPTION
Use the extension-provided agentInfos store instead of the static agent-registry for agent selection, model filtering, and icon rendering in the workspace creation flow. This removes the cliAgent indirection and simplifies workspace configuration lookup.

Closes https://github.com/openkaiden/kaiden/issues/1846


https://github.com/user-attachments/assets/ac94153d-c56d-492e-832f-7b8cd97db613

