### PR TITLE
feat(projects): add create project wizard with local and git source flows

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -73,4 +73,5 @@ export enum NavigationPage {
   MODELS = 'models',
   PROJECTS = 'projects',
   PROJECT_DETAILS = 'project-details',
+  PROJECT_CREATE = 'project-create',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -97,6 +97,7 @@ export interface NavigationParameters {
   [NavigationPage.PROJECT_DETAILS]: {
     id: string;
   };
+  [NavigationPage.PROJECT_CREATE]: never;
 }
 
 // the parameters property is optional when the NavigationParameters say it is

--- a/packages/api/src/workspace-project-info.ts
+++ b/packages/api/src/workspace-project-info.ts
@@ -26,6 +26,7 @@ export interface FilesystemConfiguration {
 export interface WorkspaceProjectInfo {
   id: string;
   name: string;
+  description?: string;
   folder: string;
   skills: string[];
   mcpServers: string[];
@@ -38,3 +39,11 @@ export interface WorkspaceProjectInfo {
 export type WorkspaceProjectCreateOptions = Omit<WorkspaceProjectInfo, 'id'>;
 
 export type WorkspaceProjectUpdateOptions = Partial<Omit<WorkspaceProjectInfo, 'id'>>;
+
+export interface WorkspaceProjectAnalysis {
+  name: string;
+  description: string;
+  folder: string;
+  gitRepository?: string;
+  gitBranch?: string;
+}

--- a/packages/main/src/plugin/util/resolve-home-path.ts
+++ b/packages/main/src/plugin/util/resolve-home-path.ts
@@ -16,24 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-function normalizeGitRepoPath(url: string): string {
-  return url
-    .trim()
-    .replace(/\/+$/, '')
-    .replace(/\.git$/, '');
-}
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
-export function formatGitUrl(url: string): string {
-  return normalizeGitRepoPath(url).replace(/^https?:\/\//, '');
-}
-
-export function extractRepoName(url: string): string {
-  const cleaned = normalizeGitRepoPath(url);
-  const lastSegment = cleaned.split('/').at(-1) ?? '';
-  return lastSegment.charAt(0).toUpperCase() + lastSegment.slice(1);
-}
-
-export function extractRepoSlug(url: string): string {
-  const cleaned = normalizeGitRepoPath(url);
-  return cleaned.split('/').at(-1) ?? 'project';
+export function resolveHomePath(inputPath: string): string {
+  if (inputPath.startsWith('~/')) {
+    return join(homedir(), inputPath.slice(2));
+  }
+  return inputPath;
 }

--- a/packages/main/src/plugin/workspace-project/workspace-project-manager.spec.ts
+++ b/packages/main/src/plugin/workspace-project/workspace-project-manager.spec.ts
@@ -28,6 +28,7 @@ import type { MCPManager } from '/@/plugin/mcp/mcp-manager.js';
 import type { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import type { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import type { SkillManager } from '/@/plugin/skill/skill-manager.js';
+import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { WorkspaceProjectCreateOptions, WorkspaceProjectInfo } from '/@api/workspace-project-info.js';
 
@@ -79,6 +80,10 @@ const ragEnvironmentRegistry = {
   getAllRagEnvironments: vi.fn().mockResolvedValue([{ name: 'knowledge-a' }, { name: 'knowledge-b' }]),
 } as unknown as RagEnvironmentRegistry;
 
+const taskManager = {
+  createTask: vi.fn().mockReturnValue({ state: 'running', status: 'in-progress', progress: undefined, error: '' }),
+} as unknown as TaskManager;
+
 function createManager(): WorkspaceProjectManager {
   return new WorkspaceProjectManager(
     apiSender,
@@ -88,6 +93,7 @@ function createManager(): WorkspaceProjectManager {
     mcpManager,
     secretManager,
     ragEnvironmentRegistry,
+    taskManager,
   );
 }
 

--- a/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
+++ b/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
@@ -40,7 +40,7 @@ import type {
   WorkspaceProjectUpdateOptions,
 } from '/@api/workspace-project-info.js';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 @injectable()
 export class WorkspaceProjectManager {
@@ -194,7 +194,7 @@ export class WorkspaceProjectManager {
     }
 
     try {
-      await execAsync(`git clone ${gitUrl} ${resolvedPath}`);
+      await execFileAsync('git', ['clone', gitUrl, resolvedPath]);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       if (message.includes('Authentication') || message.includes('could not read Username')) {
@@ -213,8 +213,8 @@ export class WorkspaceProjectManager {
 
     try {
       const [remoteResult, branchResult] = await Promise.all([
-        execAsync('git remote get-url origin', { cwd: folderPath }).catch(() => undefined),
-        execAsync('git rev-parse --abbrev-ref HEAD', { cwd: folderPath }).catch(() => undefined),
+        execFileAsync('git', ['remote', 'get-url', 'origin'], { cwd: folderPath }).catch(() => undefined),
+        execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: folderPath }).catch(() => undefined),
       ]);
 
       const remote = remoteResult?.stdout.trim();

--- a/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
+++ b/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
@@ -19,7 +19,6 @@
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -31,6 +30,8 @@ import { MCPManager } from '/@/plugin/mcp/mcp-manager.js';
 import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import { SkillManager } from '/@/plugin/skill/skill-manager.js';
+import { TaskManager } from '/@/plugin/tasks/task-manager.js';
+import { resolveHomePath } from '/@/plugin/util/resolve-home-path.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IDisposable } from '/@api/disposable.js';
 import type {
@@ -55,6 +56,7 @@ export class WorkspaceProjectManager {
     @inject(MCPManager) private readonly mcpManager: MCPManager,
     @inject(SecretManager) private readonly secretManager: SecretManager,
     @inject(RagEnvironmentRegistry) private readonly ragEnvironmentRegistry: RagEnvironmentRegistry,
+    @inject(TaskManager) private readonly taskManager: TaskManager,
   ) {}
 
   async init(): Promise<void> {
@@ -165,24 +167,26 @@ export class WorkspaceProjectManager {
   }
 
   async analyze(folderPath: string): Promise<WorkspaceProjectAnalysis> {
-    if (!existsSync(folderPath)) {
-      throw new Error(`Path "${folderPath}" does not exist`);
+    const resolvedPath = resolveHomePath(folderPath);
+
+    if (!existsSync(resolvedPath)) {
+      throw new Error(`Path "${resolvedPath}" does not exist`);
     }
 
-    const name = basename(folderPath) || folderPath;
-    const gitInfo = await this.detectGitInfo(folderPath);
+    const name = basename(resolvedPath) || resolvedPath;
+    const gitInfo = await this.detectGitInfo(resolvedPath);
 
     return {
       name: name.charAt(0).toUpperCase() + name.slice(1),
       description: 'Auto-detected project from local working directory.',
-      folder: folderPath,
+      folder: resolvedPath,
       gitRepository: gitInfo?.remote,
       gitBranch: gitInfo?.branch,
     };
   }
 
   async cloneAndAnalyze(gitUrl: string, targetPath: string): Promise<WorkspaceProjectAnalysis> {
-    const resolvedPath = this.resolveHomePath(targetPath);
+    const resolvedPath = resolveHomePath(targetPath);
 
     if (existsSync(resolvedPath)) {
       throw new Error(`Target path "${resolvedPath}" already exists`);
@@ -193,14 +197,23 @@ export class WorkspaceProjectManager {
       throw new Error(`Parent directory "${parentDir}" does not exist`);
     }
 
+    const task = this.taskManager.createTask({ title: `Cloning repository ${gitUrl}` });
+
     try {
       await execFileAsync('git', ['clone', gitUrl, resolvedPath]);
+      task.status = 'success';
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       if (message.includes('Authentication') || message.includes('could not read Username')) {
+        task.error = 'Authentication failed';
+        task.status = 'failure';
         throw new Error('Authentication failed. Make sure you can clone this repository from your terminal.');
       }
+      task.error = `Failed to clone repository: ${message}`;
+      task.status = 'failure';
       throw new Error(`Failed to clone repository: ${message}`);
+    } finally {
+      task.state = 'completed';
     }
 
     return this.analyze(resolvedPath);
@@ -212,18 +225,37 @@ export class WorkspaceProjectManager {
     }
 
     try {
-      const [remoteResult, branchResult] = await Promise.all([
-        execFileAsync('git', ['remote', 'get-url', 'origin'], { cwd: folderPath }).catch(() => undefined),
+      const [remoteUrl, branchResult] = await Promise.all([
+        this.getGitRemoteUrl(folderPath),
         execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: folderPath }).catch(() => undefined),
       ]);
 
-      const remote = remoteResult?.stdout.trim();
       const branch = branchResult?.stdout.trim();
 
-      return { remote: remote ?? undefined, branch: branch ?? undefined };
+      return { remote: remoteUrl ?? undefined, branch: branch ?? undefined };
     } catch {
       return undefined;
     }
+  }
+
+  private async getGitRemoteUrl(folderPath: string): Promise<string | undefined> {
+    const originResult = await execFileAsync('git', ['remote', 'get-url', 'origin'], { cwd: folderPath }).catch(
+      () => undefined,
+    );
+    if (originResult?.stdout.trim()) {
+      return originResult.stdout.trim();
+    }
+
+    const remotesResult = await execFileAsync('git', ['remote'], { cwd: folderPath }).catch(() => undefined);
+    const firstRemote = remotesResult?.stdout.trim().split('\n')[0];
+    if (!firstRemote) {
+      return undefined;
+    }
+
+    const result = await execFileAsync('git', ['remote', 'get-url', firstRemote], { cwd: folderPath }).catch(
+      () => undefined,
+    );
+    return result?.stdout.trim() ?? undefined;
   }
 
   private async validateReferences(options: WorkspaceProjectCreateOptions | WorkspaceProjectInfo): Promise<void> {
@@ -337,13 +369,6 @@ export class WorkspaceProjectManager {
       throw new Error('Invalid workspace project id');
     }
     return normalized;
-  }
-
-  private resolveHomePath(inputPath: string): string {
-    if (inputPath.startsWith('~/')) {
-      return join(homedir(), inputPath.slice(2));
-    }
-    return inputPath;
   }
 
   private getFilePath(id: string): string {

--- a/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
+++ b/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
@@ -16,9 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { exec } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
+import { promisify } from 'node:util';
 
 import { inject, injectable, preDestroy } from 'inversify';
 
@@ -31,10 +34,13 @@ import { SkillManager } from '/@/plugin/skill/skill-manager.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IDisposable } from '/@api/disposable.js';
 import type {
+  WorkspaceProjectAnalysis,
   WorkspaceProjectCreateOptions,
   WorkspaceProjectInfo,
   WorkspaceProjectUpdateOptions,
 } from '/@api/workspace-project-info.js';
+
+const execAsync = promisify(exec);
 
 @injectable()
 export class WorkspaceProjectManager {
@@ -85,6 +91,20 @@ export class WorkspaceProjectManager {
       'workspace-project-manager:update',
       async (_listener: unknown, id: string, options: WorkspaceProjectUpdateOptions): Promise<WorkspaceProjectInfo> => {
         return this.update(id, options);
+      },
+    );
+
+    this.ipcHandle(
+      'workspace-project-manager:analyze',
+      async (_listener: unknown, folderPath: string): Promise<WorkspaceProjectAnalysis> => {
+        return this.analyze(folderPath);
+      },
+    );
+
+    this.ipcHandle(
+      'workspace-project-manager:clone-and-analyze',
+      async (_listener: unknown, gitUrl: string, targetPath: string): Promise<WorkspaceProjectAnalysis> => {
+        return this.cloneAndAnalyze(gitUrl, targetPath);
       },
     );
 
@@ -142,6 +162,68 @@ export class WorkspaceProjectManager {
     this.projects.set(id, updated);
     this.apiSender.send('workspace-project-update');
     return updated;
+  }
+
+  async analyze(folderPath: string): Promise<WorkspaceProjectAnalysis> {
+    if (!existsSync(folderPath)) {
+      throw new Error(`Path "${folderPath}" does not exist`);
+    }
+
+    const name = basename(folderPath) || folderPath;
+    const gitInfo = await this.detectGitInfo(folderPath);
+
+    return {
+      name: name.charAt(0).toUpperCase() + name.slice(1),
+      description: 'Auto-detected project from local working directory.',
+      folder: folderPath,
+      gitRepository: gitInfo?.remote,
+      gitBranch: gitInfo?.branch,
+    };
+  }
+
+  async cloneAndAnalyze(gitUrl: string, targetPath: string): Promise<WorkspaceProjectAnalysis> {
+    const resolvedPath = this.resolveHomePath(targetPath);
+
+    if (existsSync(resolvedPath)) {
+      throw new Error(`Target path "${resolvedPath}" already exists`);
+    }
+
+    const parentDir = join(resolvedPath, '..');
+    if (!existsSync(parentDir)) {
+      throw new Error(`Parent directory "${parentDir}" does not exist`);
+    }
+
+    try {
+      await execAsync(`git clone ${gitUrl} ${resolvedPath}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('Authentication') || message.includes('could not read Username')) {
+        throw new Error('Authentication failed. Make sure you can clone this repository from your terminal.');
+      }
+      throw new Error(`Failed to clone repository: ${message}`);
+    }
+
+    return this.analyze(resolvedPath);
+  }
+
+  private async detectGitInfo(folderPath: string): Promise<{ remote?: string; branch?: string } | undefined> {
+    if (!existsSync(join(folderPath, '.git'))) {
+      return undefined;
+    }
+
+    try {
+      const [remoteResult, branchResult] = await Promise.all([
+        execAsync('git remote get-url origin', { cwd: folderPath }).catch(() => undefined),
+        execAsync('git rev-parse --abbrev-ref HEAD', { cwd: folderPath }).catch(() => undefined),
+      ]);
+
+      const remote = remoteResult?.stdout.trim();
+      const branch = branchResult?.stdout.trim();
+
+      return { remote: remote ?? undefined, branch: branch ?? undefined };
+    } catch {
+      return undefined;
+    }
   }
 
   private async validateReferences(options: WorkspaceProjectCreateOptions | WorkspaceProjectInfo): Promise<void> {
@@ -255,6 +337,13 @@ export class WorkspaceProjectManager {
       throw new Error('Invalid workspace project id');
     }
     return normalized;
+  }
+
+  private resolveHomePath(inputPath: string): string {
+    if (inputPath.startsWith('~/')) {
+      return join(homedir(), inputPath.slice(2));
+    }
+    return inputPath;
   }
 
   private getFilePath(id: string): string {

--- a/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
+++ b/packages/main/src/plugin/workspace-project/workspace-project-manager.ts
@@ -197,7 +197,7 @@ export class WorkspaceProjectManager {
       throw new Error(`Parent directory "${parentDir}" does not exist`);
     }
 
-    const task = this.taskManager.createTask({ title: `Cloning repository ${gitUrl}` });
+    const task = this.taskManager.createTask({ title: 'Cloning repository' });
 
     try {
       await execFileAsync('git', ['clone', gitUrl, resolvedPath]);
@@ -247,7 +247,7 @@ export class WorkspaceProjectManager {
     }
 
     const remotesResult = await execFileAsync('git', ['remote'], { cwd: folderPath }).catch(() => undefined);
-    const firstRemote = remotesResult?.stdout.trim().split('\n')[0];
+    const firstRemote = remotesResult?.stdout.trim().split(/\r?\n/)[0];
     if (!firstRemote) {
       return undefined;
     }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -154,6 +154,7 @@ import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info';
 import type { WebviewInfo } from '/@api/webview-info';
 import type { WelcomeMessages } from '/@api/welcome-info';
 import type {
+  WorkspaceProjectAnalysis,
   WorkspaceProjectCreateOptions,
   WorkspaceProjectInfo,
   WorkspaceProjectUpdateOptions,
@@ -558,6 +559,20 @@ export function initExposure(): void {
     'updateWorkspaceProject',
     async (id: string, options: WorkspaceProjectUpdateOptions): Promise<WorkspaceProjectInfo> => {
       return ipcInvoke('workspace-project-manager:update', id, options);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'analyzeWorkspaceProject',
+    async (folderPath: string): Promise<WorkspaceProjectAnalysis> => {
+      return ipcInvoke('workspace-project-manager:analyze', folderPath);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'cloneAndAnalyzeWorkspaceProject',
+    async (gitUrl: string, targetPath: string): Promise<WorkspaceProjectAnalysis> => {
+      return ipcInvoke('workspace-project-manager:clone-and-analyze', gitUrl, targetPath);
     },
   );
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -15,6 +15,7 @@ import FlowDetails from '/@/lib/flows/FlowDetails.svelte';
 import FlowList from '/@/lib/flows/FlowList.svelte';
 import KubernetesRoot from '/@/lib/kube/KubernetesRoot.svelte';
 import MCPDetails from '/@/lib/mcp/MCPDetails.svelte';
+import ProjectCreate from '/@/lib/projects/ProjectCreate.svelte';
 import ProjectDetails from '/@/lib/projects/ProjectDetails.svelte';
 import ProjectList from '/@/lib/projects/ProjectList.svelte';
 import RAGEnvironmentDetails from '/@/lib/rag/RAGEnvironmentDetails.svelte';
@@ -271,6 +272,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/projects/*" breadcrumb="Projects" navigationHint="root" firstmatch>
           <Route path="/" breadcrumb="Projects" navigationHint="root">
             <ProjectList />
+          </Route>
+          <Route path="/create" breadcrumb="New Project">
+            <ProjectCreate />
           </Route>
           <Route path="/:id/*" breadcrumb="Project Details" let:meta navigationHint="details">
             <ProjectDetails projectId={decodeURIComponent(meta.params.id)} />

--- a/packages/renderer/src/lib/projects/ProjectCreate.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreate.svelte
@@ -1,0 +1,238 @@
+<script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+import { toast } from 'svelte-sonner';
+
+import FormPage from '/@/lib/ui/FormPage.svelte';
+import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
+import type { WorkspaceProjectAnalysis } from '/@api/workspace-project-info';
+
+import ProjectCreateStepReview from './ProjectCreateStepReview.svelte';
+import ProjectCreateStepSource from './ProjectCreateStepSource.svelte';
+
+const wizardSteps = [
+  { id: 'source', title: 'Source' },
+  { id: 'review', title: 'Review' },
+];
+
+let currentStepIndex = $state(0);
+let currentStepId = $derived(wizardSteps[currentStepIndex]?.id ?? '');
+let isLastStep = $derived(currentStepIndex === wizardSteps.length - 1);
+
+let sourcePath = $state('');
+let gitUrl = $state('');
+let analyzing = $state(false);
+let creating = $state(false);
+let analysis = $state<WorkspaceProjectAnalysis | undefined>(undefined);
+
+let projectName = $state('');
+let projectDescription = $state('');
+let cloneTo = $state('');
+let error = $state('');
+
+let isGitSource = $derived(gitUrl.trim() !== '' && sourcePath.trim() === '');
+let gitRepoDisplay = $derived(formatGitUrl(gitUrl));
+
+let isSourceStepComplete = $derived(sourcePath.trim() !== '' || gitUrl.trim() !== '');
+let isReviewStepComplete = $derived.by(() => {
+  if (isGitSource) {
+    return projectName.trim() !== '' && cloneTo.trim() !== '';
+  }
+  return projectName.trim() !== '';
+});
+
+function formatGitUrl(url: string): string {
+  return url
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\.git$/, '');
+}
+
+function extractRepoName(url: string): string {
+  const cleaned = url
+    .trim()
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '');
+  const lastSegment = cleaned.split('/').at(-1) ?? '';
+  return lastSegment.charAt(0).toUpperCase() + lastSegment.slice(1);
+}
+
+function extractRepoSlug(url: string): string {
+  const cleaned = url
+    .trim()
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '');
+  return cleaned.split('/').at(-1) ?? 'project';
+}
+
+function goBack(): void {
+  if (currentStepIndex > 0) currentStepIndex--;
+}
+
+function handleStepClick(index: number): void {
+  currentStepIndex = index;
+}
+
+async function handleBrowseSource(): Promise<void> {
+  try {
+    const result = await window.openDialog({ title: 'Select a working directory', selectors: ['openDirectory'] });
+    const selected = result?.[0];
+    if (selected) {
+      sourcePath = selected;
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    toast.error(`Failed to browse for directory: ${message}`);
+  }
+}
+
+async function handleBrowseCloneTo(): Promise<void> {
+  try {
+    const result = await window.openDialog({ title: 'Select parent directory', selectors: ['openDirectory'] });
+    const selected = result?.[0];
+    if (selected) {
+      const repoSlug = extractRepoSlug(gitUrl);
+      cloneTo = `${selected}/${repoSlug}`;
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    toast.error(`Failed to browse for directory: ${message}`);
+  }
+}
+
+async function handleAnalyze(): Promise<void> {
+  if (isGitSource) {
+    projectName = extractRepoName(gitUrl);
+    projectDescription = 'Cloned from remote repository.';
+    cloneTo = '';
+    analysis = undefined;
+    currentStepIndex = 1;
+    return;
+  }
+
+  const path = sourcePath.trim();
+  if (!path) return;
+
+  analyzing = true;
+  try {
+    const result = await window.analyzeWorkspaceProject(path);
+    analysis = result;
+    projectName = result.name;
+    projectDescription = result.description;
+    currentStepIndex = 1;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    toast.error(`Failed to analyze project: ${message}`);
+  } finally {
+    analyzing = false;
+  }
+}
+
+function cancel(): void {
+  handleNavigation({ page: NavigationPage.PROJECTS });
+}
+
+async function createProject(): Promise<void> {
+  if (!projectName.trim()) return;
+
+  error = '';
+  creating = true;
+  try {
+    let folder: string;
+
+    if (isGitSource) {
+      const result = await window.cloneAndAnalyzeWorkspaceProject(gitUrl.trim(), cloneTo.trim());
+      folder = result.folder;
+    } else {
+      folder = analysis?.folder ?? sourcePath.trim();
+    }
+
+    await window.createWorkspaceProject({
+      name: projectName.trim(),
+      description: projectDescription.trim() || undefined,
+      folder,
+      skills: [],
+      mcpServers: [],
+      knowledges: [],
+      secrets: [],
+      filesystem: { mode: 'project', mounts: [] },
+      network: { mode: 'allow' },
+    });
+    toast.success(`Project "${projectName}" created successfully`);
+    handleNavigation({ page: NavigationPage.PROJECTS });
+  } catch (err: unknown) {
+    console.error('Failed to create project', err);
+    error = err instanceof Error ? err.message : String(err);
+  } finally {
+    creating = false;
+  }
+}
+</script>
+
+<FormPage title="New Project">
+  {#snippet content()}
+    <div class="px-5 pb-5 min-w-full">
+      <div class="bg-(--pd-content-card-bg) py-6">
+        <div class="flex flex-col px-6 max-w-4xl mx-auto space-y-5">
+
+          <!-- Page header -->
+          <div class="mb-2">
+            <h1 class="text-2xl font-bold text-(--pd-modal-text) mb-1">New Project</h1>
+            <p class="text-sm text-(--pd-content-card-text) opacity-70 max-w-2xl leading-relaxed">
+              Point Kaiden to a local working directory or a git repository, and we'll analyze your project automatically.
+            </p>
+          </div>
+
+          <!-- Stepper -->
+          <WizardStepper steps={wizardSteps} currentIndex={currentStepIndex} onStepClick={handleStepClick} />
+
+          <!-- Step content -->
+          <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+            {#if currentStepId === 'source'}
+              <ProjectCreateStepSource
+                bind:sourcePath={sourcePath}
+                bind:gitUrl={gitUrl}
+                onBrowseSource={handleBrowseSource}
+              />
+            {:else if currentStepId === 'review'}
+              <ProjectCreateStepReview
+                {analysis}
+                bind:projectName={projectName}
+                bind:projectDescription={projectDescription}
+                {isGitSource}
+                {gitRepoDisplay}
+                bind:cloneTo={cloneTo}
+                onBrowseCloneTo={handleBrowseCloneTo}
+                {error}
+              />
+            {/if}
+          </div>
+
+          <!-- Footer actions -->
+          <div class="flex items-center justify-between pt-4 border-t border-(--pd-content-card-border)">
+            <div class="flex items-center gap-3 text-sm text-(--pd-content-card-text) opacity-70">
+              <span>Step {currentStepIndex + 1} of {wizardSteps.length}</span>
+            </div>
+            <div class="flex flex-wrap items-center justify-end gap-3">
+              {#if currentStepIndex > 0}
+                <Button onclick={goBack}>Back</Button>
+              {/if}
+              <Button onclick={cancel}>Cancel</Button>
+              {#if currentStepId === 'source'}
+                <Button disabled={!isSourceStepComplete || analyzing} onclick={handleAnalyze}>
+                  {analyzing ? 'Analyzing...' : 'Analyze'}
+                </Button>
+              {:else if isLastStep}
+                <Button disabled={!isReviewStepComplete || creating} onclick={createProject}>
+                  {creating ? 'Creating...' : 'Create Project'}
+                </Button>
+              {/if}
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  {/snippet}
+</FormPage>

--- a/packages/renderer/src/lib/projects/ProjectCreate.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreate.svelte
@@ -8,6 +8,7 @@ import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
 import type { WorkspaceProjectAnalysis } from '/@api/workspace-project-info';
 
+import { extractRepoName, extractRepoSlug, formatGitUrl } from './git-url-utils';
 import ProjectCreateStepReview from './ProjectCreateStepReview.svelte';
 import ProjectCreateStepSource from './ProjectCreateStepSource.svelte';
 
@@ -41,30 +42,6 @@ let isReviewStepComplete = $derived.by(() => {
   }
   return projectName.trim() !== '';
 });
-
-function formatGitUrl(url: string): string {
-  return url
-    .trim()
-    .replace(/^https?:\/\//, '')
-    .replace(/\.git$/, '');
-}
-
-function extractRepoName(url: string): string {
-  const cleaned = url
-    .trim()
-    .replace(/\.git$/, '')
-    .replace(/\/$/, '');
-  const lastSegment = cleaned.split('/').at(-1) ?? '';
-  return lastSegment.charAt(0).toUpperCase() + lastSegment.slice(1);
-}
-
-function extractRepoSlug(url: string): string {
-  const cleaned = url
-    .trim()
-    .replace(/\.git$/, '')
-    .replace(/\/$/, '');
-  return cleaned.split('/').at(-1) ?? 'project';
-}
 
 function goBack(): void {
   if (currentStepIndex > 0) currentStepIndex--;
@@ -119,7 +96,7 @@ async function handleAnalyze(): Promise<void> {
     const result = await window.analyzeWorkspaceProject(path);
     analysis = result;
     projectName = result.name;
-    projectDescription = result.description;
+    projectDescription = result.description ?? '';
     currentStepIndex = 1;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/renderer/src/lib/projects/ProjectCreate.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreate.svelte
@@ -60,6 +60,9 @@ async function handleBrowseSource(): Promise<void> {
     const selected = result?.[0];
     if (selected) {
       sourcePath = selected;
+      analysis = undefined;
+      projectName = '';
+      projectDescription = '';
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/renderer/src/lib/projects/ProjectCreate.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreate.svelte
@@ -48,6 +48,9 @@ function goBack(): void {
 }
 
 function handleStepClick(index: number): void {
+  if (index > currentStepIndex && !isGitSource && !analysis) {
+    return;
+  }
   currentStepIndex = index;
 }
 
@@ -122,7 +125,10 @@ async function createProject(): Promise<void> {
       const result = await window.cloneAndAnalyzeWorkspaceProject(gitUrl.trim(), cloneTo.trim());
       folder = result.folder;
     } else {
-      folder = analysis?.folder ?? sourcePath.trim();
+      if (!analysis) {
+        throw new Error('Please analyze the selected working directory before creating the project.');
+      }
+      folder = analysis.folder;
     }
 
     await window.createWorkspaceProject({
@@ -202,7 +208,11 @@ async function createProject(): Promise<void> {
                 </Button>
               {:else if isLastStep}
                 <Button disabled={!isReviewStepComplete || creating} onclick={createProject}>
-                  {creating ? 'Creating...' : 'Create Project'}
+                  {#if creating}
+                    {isGitSource ? 'Cloning & Creating...' : 'Creating...'}
+                  {:else}
+                    Create Project
+                  {/if}
                 </Button>
               {/if}
             </div>

--- a/packages/renderer/src/lib/projects/ProjectCreateStepReview.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepReview.svelte
@@ -6,6 +6,8 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { Textarea } from '/@/lib/chat/components/ui/textarea';
 import type { WorkspaceProjectAnalysis } from '/@api/workspace-project-info';
 
+import { formatGitUrl } from './git-url-utils';
+
 interface Props {
   analysis: WorkspaceProjectAnalysis | undefined;
   projectName: string;
@@ -88,7 +90,7 @@ let displayFolder = $derived(analysis?.folder ?? '');
         </span>
         <div class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) px-3 py-2.5">
           <Icon icon={faCodeBranch} class="text-(--pd-content-card-text) opacity-50" size="sm" />
-          <span class="text-sm font-mono text-(--pd-content-card-text)">{analysis.gitRepository.replace(/^https?:\/\//, '').replace(/\.git$/, '')}</span>
+          <span class="text-sm font-mono text-(--pd-content-card-text)">{formatGitUrl(analysis.gitRepository)}</span>
           {#if analysis.gitBranch}
             <span class="ml-auto text-xs font-medium bg-(--pd-label-quaternary-bg) text-(--pd-label-quaternary-text) px-2 py-0.5 rounded">
               {analysis.gitBranch}

--- a/packages/renderer/src/lib/projects/ProjectCreateStepReview.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepReview.svelte
@@ -108,9 +108,6 @@ let displayFolder = $derived(analysis?.folder ?? '');
       <div class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) px-3 py-2.5">
         <Icon icon={faCodeBranch} class="text-(--pd-content-card-text) opacity-50" size="sm" />
         <span class="text-sm font-mono text-(--pd-content-card-text)">{gitRepoDisplay}</span>
-        <span class="ml-auto text-xs font-medium bg-(--pd-label-quaternary-bg) text-(--pd-label-quaternary-text) px-2 py-0.5 rounded">
-          default
-        </span>
       </div>
     </div>
 

--- a/packages/renderer/src/lib/projects/ProjectCreateStepReview.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepReview.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+import { faCheckCircle, faCodeBranch, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { Button, Input } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import { Textarea } from '/@/lib/chat/components/ui/textarea';
+import type { WorkspaceProjectAnalysis } from '/@api/workspace-project-info';
+
+interface Props {
+  analysis: WorkspaceProjectAnalysis | undefined;
+  projectName: string;
+  projectDescription: string;
+  isGitSource?: boolean;
+  gitRepoDisplay?: string;
+  cloneTo?: string;
+  onBrowseCloneTo?: () => Promise<void>;
+  error?: string;
+}
+
+let {
+  analysis,
+  projectName = $bindable(),
+  projectDescription = $bindable(),
+  isGitSource = false,
+  gitRepoDisplay = '',
+  cloneTo = $bindable(''),
+  onBrowseCloneTo,
+  error = '',
+}: Props = $props();
+
+let displayFolder = $derived(analysis?.folder ?? '');
+</script>
+
+<h2 class="text-lg font-semibold text-(--pd-modal-text) mb-1">Review Project</h2>
+<p class="text-sm text-(--pd-content-card-text) opacity-60 mb-5">
+  Review and edit the detected project information.
+</p>
+
+{#if analysis}
+  <!-- Success banner (local path analyzed) -->
+  <div class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) border border-(--pd-state-success) px-4 py-3 mb-5">
+    <Icon icon={faCheckCircle} class="text-(--pd-state-success)" />
+    <span class="text-sm font-medium text-(--pd-state-success)">Project analyzed</span>
+    <span class="ml-auto text-xs text-(--pd-content-card-text) opacity-70 font-mono">{displayFolder}</span>
+  </div>
+{/if}
+
+<div class="space-y-4">
+  <div>
+    <label for="project-name" class="block text-xs font-semibold uppercase tracking-wider text-(--pd-content-card-text) opacity-70 mb-2">
+      Project Name
+    </label>
+    <Input
+      id="project-name"
+      bind:value={projectName}
+      placeholder="My Project"
+      class="w-full"
+    />
+  </div>
+
+  <div>
+    <label for="project-description" class="block text-xs font-semibold uppercase tracking-wider text-(--pd-content-card-text) opacity-70 mb-2">
+      Description
+    </label>
+    <Textarea
+      id="project-description"
+      bind:value={projectDescription}
+      placeholder="Describe your project..."
+      rows={3}
+      class="bg-muted min-h-[24px] resize-none rounded-lg text-sm! dark:border-zinc-700"
+    />
+  </div>
+
+  {#if !isGitSource}
+    <div>
+      <span class="block text-xs font-semibold uppercase tracking-wider text-(--pd-content-card-text) opacity-70 mb-2">
+        Working Directory
+      </span>
+      <div class="rounded-lg bg-(--pd-content-card-bg) px-3 py-2.5 text-sm font-mono text-(--pd-content-card-text)">
+        {displayFolder || '—'}
+      </div>
+    </div>
+
+    {#if analysis?.gitRepository}
+      <div>
+        <span class="block text-xs font-semibold uppercase tracking-wider text-(--pd-content-card-text) opacity-70 mb-2">
+          Git Repository
+        </span>
+        <div class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) px-3 py-2.5">
+          <Icon icon={faCodeBranch} class="text-(--pd-content-card-text) opacity-50" size="sm" />
+          <span class="text-sm font-mono text-(--pd-content-card-text)">{analysis.gitRepository.replace(/^https?:\/\//, '').replace(/\.git$/, '')}</span>
+          {#if analysis.gitBranch}
+            <span class="ml-auto text-xs font-medium bg-(--pd-label-quaternary-bg) text-(--pd-label-quaternary-text) px-2 py-0.5 rounded">
+              {analysis.gitBranch}
+            </span>
+          {/if}
+        </div>
+      </div>
+    {/if}
+  {:else}
+    <!-- Git URL: show git repo + clone to -->
+    <div>
+      <span class="block text-xs font-semibold uppercase tracking-wider text-(--pd-content-card-text) opacity-70 mb-2">
+        Git Repository
+      </span>
+      <div class="flex items-center gap-2 rounded-lg bg-(--pd-content-card-bg) px-3 py-2.5">
+        <Icon icon={faCodeBranch} class="text-(--pd-content-card-text) opacity-50" size="sm" />
+        <span class="text-sm font-mono text-(--pd-content-card-text)">{gitRepoDisplay}</span>
+        <span class="ml-auto text-xs font-medium bg-(--pd-label-quaternary-bg) text-(--pd-label-quaternary-text) px-2 py-0.5 rounded">
+          default
+        </span>
+      </div>
+    </div>
+
+    <div>
+      <label for="project-clone-to" class="block text-xs font-semibold uppercase tracking-wider text-(--pd-content-card-text) opacity-70 mb-2">
+        Clone To
+      </label>
+      <div class="flex gap-2 items-stretch">
+        <Input
+          id="project-clone-to"
+          bind:value={cloneTo}
+          placeholder="~/Dev/my-project"
+          class="grow font-mono text-sm"
+        />
+        <Button onclick={onBrowseCloneTo} aria-label="Browse for clone directory" icon={faFolderOpen}>
+          Browse
+        </Button>
+      </div>
+      <p class="text-xs text-(--pd-content-card-text) opacity-50 mt-1.5">
+        The repository will be cloned into this path. The parent directory must exist.
+      </p>
+    </div>
+  {/if}
+</div>
+
+{#if error}
+  <p class="text-sm text-(--pd-state-error) mt-4">{error}</p>
+{/if}

--- a/packages/renderer/src/lib/projects/ProjectCreateStepSource.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepSource.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { Button, Input } from '@podman-desktop/ui-svelte';
+
+interface Props {
+  sourcePath: string;
+  gitUrl: string;
+  onBrowseSource: () => Promise<void>;
+}
+
+let { sourcePath = $bindable(), gitUrl = $bindable(), onBrowseSource }: Props = $props();
+</script>
+
+<h2 class="text-lg font-semibold text-(--pd-modal-text) mb-1">Source</h2>
+<p class="text-sm text-(--pd-content-card-text) opacity-60 mb-5">
+  Point Kaiden to a local working directory or a git repository, and we'll analyze your project automatically.
+</p>
+
+<div class="space-y-5">
+  <div>
+    <label for="project-source-path" class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+      Local working directory
+    </label>
+    <div class="flex gap-2 items-stretch">
+      <Input
+        id="project-source-path"
+        bind:value={sourcePath}
+        placeholder="/home/user/dev/my-project"
+        class="grow font-mono text-sm"
+      />
+      <Button onclick={onBrowseSource} aria-label="Browse for folder" icon={faFolderOpen}>
+        Browse
+      </Button>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <div class="flex-1 h-px bg-(--pd-content-divider)"></div>
+    <span class="text-xs font-medium text-(--pd-content-card-text) opacity-50 uppercase">OR</span>
+    <div class="flex-1 h-px bg-(--pd-content-divider)"></div>
+  </div>
+
+  <div>
+    <label for="project-git-url" class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+      Git repository
+    </label>
+    <Input
+      id="project-git-url"
+      bind:value={gitUrl}
+      placeholder="https://github.com/org/repo"
+      class="w-full font-mono text-sm"
+    />
+  </div>
+</div>

--- a/packages/renderer/src/lib/projects/ProjectEmptyScreen.svelte
+++ b/packages/renderer/src/lib/projects/ProjectEmptyScreen.svelte
@@ -15,5 +15,7 @@ function navigateToCreate(): void {
   <span class="text-(--pd-content-text)">
     Projects will appear here once created.
   </span>
-  <Button icon={faPlus} onclick={navigateToCreate}>New Project</Button>
+  <div class="mt-4">
+    <Button icon={faPlus} onclick={navigateToCreate}>New Project</Button>
+  </div>
 </EmptyScreen>

--- a/packages/renderer/src/lib/projects/ProjectEmptyScreen.svelte
+++ b/packages/renderer/src/lib/projects/ProjectEmptyScreen.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
+
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
+
+function navigateToCreate(): void {
+  handleNavigation({ page: NavigationPage.PROJECT_CREATE });
+}
 </script>
 
 <EmptyScreen title="No projects" icon={faFolderOpen}>
   <span class="text-(--pd-content-text)">
     Projects will appear here once created.
   </span>
+  <Button icon={faPlus} onclick={navigateToCreate}>New Project</Button>
 </EmptyScreen>

--- a/packages/renderer/src/lib/projects/ProjectList.svelte
+++ b/packages/renderer/src/lib/projects/ProjectList.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-import { FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { Button, FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { handleNavigation } from '/@/navigation';
 import { workspaceProjectInfos } from '/@/stores/workspace-projects';
+import { NavigationPage } from '/@api/navigation-page';
 import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
 
 import ProjectActions from './columns/ProjectActions.svelte';
@@ -10,6 +13,10 @@ import ProjectFolder from './columns/ProjectFolder.svelte';
 import ProjectName from './columns/ProjectName.svelte';
 import ProjectResources from './columns/ProjectResources.svelte';
 import ProjectEmptyScreen from './ProjectEmptyScreen.svelte';
+
+function navigateToCreate(): void {
+  handleNavigation({ page: NavigationPage.PROJECT_CREATE });
+}
 
 type ProjectSelectable = WorkspaceProjectInfo & { selected: boolean };
 
@@ -52,6 +59,10 @@ const columns = [nameColumn, folderColumn, resourcesColumn, actionsColumn];
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="Projects">
+  {#snippet additionalActions()}
+    <Button icon={faPlus} onclick={navigateToCreate}>New Project</Button>
+  {/snippet}
+
   {#snippet content()}
     <div class="flex min-w-full h-full">
       {#if filteredProjects.length === 0}

--- a/packages/renderer/src/lib/projects/git-url-utils.ts
+++ b/packages/renderer/src/lib/projects/git-url-utils.ts
@@ -35,5 +35,6 @@ export function extractRepoName(url: string): string {
 
 export function extractRepoSlug(url: string): string {
   const cleaned = normalizeGitRepoPath(url);
-  return cleaned.split('/').at(-1) ?? 'project';
+  const lastSegment = cleaned.split('/').at(-1);
+  return lastSegment && lastSegment.length > 0 ? lastSegment : 'project';
 }

--- a/packages/renderer/src/lib/projects/git-url-utils.ts
+++ b/packages/renderer/src/lib/projects/git-url-utils.ts
@@ -16,34 +16,26 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { AgentWorkspaceMount, NetworkConfiguration } from './agent-workspace-info.js';
-
-export interface FilesystemConfiguration {
-  mode: string;
-  mounts: AgentWorkspaceMount[];
+export function formatGitUrl(url: string): string {
+  return url
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\.git$/, '');
 }
 
-export interface WorkspaceProjectInfo {
-  id: string;
-  name: string;
-  description?: string;
-  folder: string;
-  skills: string[];
-  mcpServers: string[];
-  knowledges: string[];
-  secrets: string[];
-  filesystem: FilesystemConfiguration;
-  network: NetworkConfiguration;
+export function extractRepoName(url: string): string {
+  const cleaned = url
+    .trim()
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '');
+  const lastSegment = cleaned.split('/').at(-1) ?? '';
+  return lastSegment.charAt(0).toUpperCase() + lastSegment.slice(1);
 }
 
-export type WorkspaceProjectCreateOptions = Omit<WorkspaceProjectInfo, 'id'>;
-
-export type WorkspaceProjectUpdateOptions = Partial<Omit<WorkspaceProjectInfo, 'id'>>;
-
-export interface WorkspaceProjectAnalysis {
-  name: string;
-  description?: string;
-  folder: string;
-  gitRepository?: string;
-  gitBranch?: string;
+export function extractRepoSlug(url: string): string {
+  const cleaned = url
+    .trim()
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '');
+  return cleaned.split('/').at(-1) ?? 'project';
 }

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -212,5 +212,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.PROJECT_DETAILS:
       router.goto(`/projects/${encodeURIComponent(request.parameters.id)}/overview`);
       break;
+    case NavigationPage.PROJECT_CREATE:
+      router.goto('/projects/create');
+      break;
   }
 };


### PR DESCRIPTION
Introduces a two-step wizard (Source → Review) that supports creating projects from either a local directory or a Git repository URL, with path validation, tilde expansion, and inline error display.

https://github.com/user-attachments/assets/6be79577-6ad7-401d-a030-2aeccbb40a59


https://github.com/user-attachments/assets/a87da055-afb3-4a60-8c6c-f1c36e8f7e38


Closes #1928