### PR TITLE
refactor(renderer): replace hardcoded Tailwind colors in micromark with color-registry tokens

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -53,7 +53,7 @@ describe('Custom button', () => {
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML(
-      '<a class="px-4 py-[6px] rounded-[4px] text-white! text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500! no-underline!">Name of the button</a>',
+      '<a class="px-4 py-[6px] rounded-[4px] text-[var(--pd-button-text)]! text-[13px] whitespace-nowrap bg-[var(--pd-button-primary-bg)] hover:bg-[var(--pd-button-primary-hover-bg)]! no-underline!">Name of the button</a>',
     );
   });
 
@@ -71,7 +71,7 @@ describe('Custom button', () => {
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML(
-      '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline"',
+      '<button class="px-4 py-[6px] rounded-[4px] text-[var(--pd-button-text)] text-[13px] whitespace-nowrap bg-[var(--pd-button-primary-bg)] hover:bg-[var(--pd-button-primary-hover-bg)] no-underline"',
     );
     expect(markdownContent).toContainHTML('data-command="command"');
     expect(markdownContent).toContainHTML('Name of the button</button>');

--- a/packages/renderer/src/lib/markdown/component/micromark-button.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-button.ts
@@ -40,9 +40,9 @@ interface ButtonElement {
 }
 
 const BASE_BUTTON_CSS =
-  'flex flex-row items-center justify-center px-4 py-[6px] max-w-[200px] rounded-[4px] text-white text-[13px] whitespace-nowrap no-underline';
-export const NORMAL_MODE_CSS = `${BASE_BUTTON_CSS} bg-purple-600 hover:bg-purple-500`;
-export const ERROR_MODE_CSS = `${BASE_BUTTON_CSS} text-gray-400 bg-red-900 hover:bg-red-700`;
+  'flex flex-row items-center justify-center px-4 py-[6px] max-w-[200px] rounded-[4px] text-[var(--pd-button-text)] text-[13px] whitespace-nowrap no-underline';
+const NORMAL_MODE_CSS = `${BASE_BUTTON_CSS} bg-[var(--pd-button-primary-bg)] hover:bg-[var(--pd-button-primary-hover-bg)]`;
+const ERROR_MODE_CSS = `${BASE_BUTTON_CSS} text-[var(--pd-button-disabled-text)] bg-[var(--pd-button-danger-hover-bg)] hover:bg-[var(--pd-button-danger-hover-bg)]`;
 
 /**
  * it creates a new button by associating the command to it and returns its new generated button id
@@ -109,7 +109,7 @@ export async function executeButtonCommand(buttonId: string): Promise<void> {
 function createHtmlErrorContent(reason: string): string {
   // it uses inline style to constraint the height as tailwind max-height classes do not work with html injected
   return `
-    <div class='bg-black text-sm overflow-y-auto overflow-x-auto p-3' style='height: 150px'>
+    <div class='bg-[var(--pd-terminal-background)] text-sm overflow-y-auto overflow-x-auto p-3' style='height: 150px'>
     ${reason}
     </div>
     `;
@@ -162,7 +162,7 @@ function enableErrorMode(id: string, error: string): void {
 }
 
 /**
- * it disable the error mode so the button is reset to its normal state (purple color, hide expandable section)
+ * it disable the error mode so the button is reset to its normal state (primary color, hide expandable section)
  * @param id button id
  */
 function disableErrorMode(id: string): void {
@@ -200,8 +200,8 @@ function toggleButtonMode(id: string, isErrorMode: boolean): void {
 export function createUIButton(this: CompileContext, command: Command): void {
   const buttonId = createButton(command);
   this.tag(
-    `<button 
-      id='${buttonId}' 
+    `<button
+      id='${buttonId}'
       class='${NORMAL_MODE_CSS}'
       title='${command.title}'
     >`,
@@ -211,7 +211,9 @@ export function createUIButton(this: CompileContext, command: Command): void {
   this.tag(createSpinner(buttonId));
 
   // add the failed icon which gets visible in error mode
-  this.tag(`<i id='${buttonId}-failed-icon' class='fas fa-times text-gray-100 mr-1' style='display: none'></i>`);
+  this.tag(
+    `<i id='${buttonId}-failed-icon' class='fas fa-times text-[var(--pd-button-text)] mr-1' style='display: none'></i>`,
+  );
 
   // Add the command title
   this.raw(command.title);

--- a/packages/renderer/src/lib/markdown/component/micromark-expandable-section.spec.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-expandable-section.spec.ts
@@ -65,7 +65,7 @@ test('Expect createExpandableSection to return a button with an expandable secti
 
   const htmlSanitized = html.replace('\n', '').replace(/\s+/g, ' ');
   expect(htmlSanitized).toContain(
-    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-1'`,
+    `<button class='flex space-x-2 text-[var(--pd-button-link-text)] w-fit hover:bg-[var(--pd-default-item-hover)] text-xs items-center' data-expandable='micromark-expandable-1'`,
   );
   expect(htmlSanitized).toContain(
     `<div class='flex-col w-[250px] text-sm micromark-expandable-1' style='display: none;'`,
@@ -90,7 +90,7 @@ test('Expect createExpandableSection to return a button and a visible expandable
 
   const htmlSanitized = html.replace('\n', '').replace(/\s+/g, ' ');
   expect(htmlSanitized).toContain(
-    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-2'`,
+    `<button class='flex space-x-2 text-[var(--pd-button-link-text)] w-fit hover:bg-[var(--pd-default-item-hover)] text-xs items-center' data-expandable='micromark-expandable-2'`,
   );
   expect(htmlSanitized).toContain(
     `<div class='flex-col w-[250px] text-sm micromark-expandable-2' style='display: flex;'`,
@@ -115,7 +115,7 @@ test('Expect createExpandableSection to return a hidden button and expandable se
 
   const htmlSanitized = html.replace('\n', '').replace(/\s+/g, ' ');
   expect(htmlSanitized).toContain(
-    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-3' style='display: none;'`,
+    `<button class='flex space-x-2 text-[var(--pd-button-link-text)] w-fit hover:bg-[var(--pd-default-item-hover)] text-xs items-center' data-expandable='micromark-expandable-3' style='display: none;'`,
   );
   expect(htmlSanitized).toContain(
     `<div class='flex-col w-[250px] text-sm micromark-expandable-3' style='display: none;'`,

--- a/packages/renderer/src/lib/markdown/component/micromark-expandable-section.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-expandable-section.ts
@@ -25,8 +25,8 @@ import type { ExpandableSection, ExpandableSectionProps } from '/@/lib/markdown/
 let expandableCount = 0;
 const expandables = new Map<string, ExpandableSection>();
 
-const OPENED_STATE_TOGGLE_ICON = `<i class='fas fa-chevron-up text-gray-100 mr-1'></i>`;
-const CLOSED_STATE_TOGGLE_ICON = `<i class='fas fa-chevron-down text-gray-100 mr-1'></i>`;
+const OPENED_STATE_TOGGLE_ICON = `<i class='fas fa-chevron-up text-[var(--pd-button-text)] mr-1'></i>`;
+const CLOSED_STATE_TOGGLE_ICON = `<i class='fas fa-chevron-down text-[var(--pd-button-text)] mr-1'></i>`;
 
 /**
  * it creates a new expandable section object
@@ -77,7 +77,7 @@ export function createExpandableSection(this: CompileContext, expandable: Expand
 
   // create button (icon + label)
   this.tag(
-    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='${
+    `<button class='flex space-x-2 text-[var(--pd-button-link-text)] w-fit hover:bg-[var(--pd-default-item-hover)] text-xs items-center' data-expandable='${
       expandableElement.id
     }' style='display: ${expandable.showToggle ? 'flex' : 'none'};' aria-label='${expandableElement.id}'>`,
   );

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -44,10 +44,10 @@ export function button(d: Directive): void {
   // Icon format of a button
   if (d.attributes && 'command' in d.attributes && 'args' in d.attributes) {
     this.tag(`
-      <button 
-        class="fa-solid ${this.encode(d.label)} before:px-1 fa-3x hover:text-[var(--pd-action-button-primary-hover-text)]" 
+      <button
+        class="fa-solid ${this.encode(d.label)} before:px-1 ${this.encode(d.attributes.size ?? 'fa-3x')} hover:text-[var(--pd-action-button-primary-hover-text)]"
         aria-label="${this.encode(d.label)}"
-        data-command="${this.encode(d.attributes.command)}" 
+        data-command="${this.encode(d.attributes.command)}"
         data-args="${JSON.parse(d.attributes.args)}">
       </button>
     `);
@@ -56,7 +56,7 @@ export function button(d: Directive): void {
   } else if (d.attributes && 'command' in d.attributes) {
     // Make this a button if it's a command
     this.tag(
-      '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
+      '<button class="px-4 py-[6px] rounded-[4px] text-[var(--pd-button-text)] text-[13px] whitespace-nowrap bg-[var(--pd-button-primary-bg)] hover:bg-[var(--pd-button-primary-hover-bg)] no-underline" data-command="' +
         this.encode(d.attributes.command) +
         '">',
     );
@@ -72,7 +72,7 @@ export function button(d: Directive): void {
   } else {
     // If href is passed in, make this an anchor tag but make it look like a button
     this.tag(
-      '<a class="px-4 py-[6px] rounded-[4px] text-white! text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500! no-underline!"',
+      '<a class="px-4 py-[6px] rounded-[4px] text-[var(--pd-button-text)]! text-[13px] whitespace-nowrap bg-[var(--pd-button-primary-bg)] hover:bg-[var(--pd-button-primary-hover-bg)]! no-underline!"',
     );
 
     // Href & title
@@ -99,6 +99,7 @@ export function getSpinnerCode(): string {
 
     // replace the size
     spinnerHtmlCode = spinnerHtmlCode.replaceAll('{size}', '16px');
+    spinnerHtmlCode = spinnerHtmlCode.replaceAll('{label}', 'Loading');
   }
   return spinnerHtmlCode;
 }


### PR DESCRIPTION
Replace hardcoded Tailwind colors (purple, white, red, gray) with
theme-aware CSS variables (--pd-button-*) in micromark button directives
and expandable sections to ensure consistent theming.

Cherry-picked from podman-desktop/podman-desktop@4c8869311ee

Fixes #1804

<img width="1354" height="1102" alt="Screenshot 2026-06-04 at 11 12 08" src="https://github.com/user-attachments/assets/4638e356-3c85-41f3-84d5-99db779d2ddd" />
