### PR TITLE
fix: ensure secrets are loaded on initial app startup

### DIFF
--- a/packages/renderer/src/stores/secret-vault.ts
+++ b/packages/renderer/src/stores/secret-vault.ts
@@ -58,7 +58,7 @@ export const filteredSecretVaultInfos = derived(
 let readyToUpdate = false;
 
 async function checkForUpdate(eventName: string): Promise<boolean> {
-  if ('system-ready' === eventName) {
+  if ('extensions-already-started' === eventName) {
     readyToUpdate = true;
   }
   return readyToUpdate;
@@ -74,7 +74,7 @@ export const secretVaultEventStore = new EventStore<readonly SecretVaultInfo[]>(
   secretVaultInfos,
   checkForUpdate,
   ['secret-manager-update'],
-  ['system-ready'],
+  ['extensions-already-started'],
   listSecrets,
 );
 secretVaultEventStore.setup();


### PR DESCRIPTION
Root cause: secret-vault EventStore listened to 'system-ready' which
fires BEFORE kaiden.kdn extension activates. kdn extension provides
bundled kdn CLI binary needed to list secrets.

Timeline (before fix):
- system-ready fires
- secret fetch attempts → spawn kdn ENOENT (kdn not available)
- kaiden.kdn activates 300ms later
- secrets never load

Fix: listen to 'extensions-already-started' instead. Ensures kdn
extension active before fetch attempt.

Matches pattern used by containers, pods, images, cli-tools stores.

This only happens with a bundled app, not when running from `pnpm watch`.

To test it on Mac:
```bash
# generate the .app
pnpm run compile:current

# Manually install the Kaiden.app from dist/kaiden-0.2.0-next-arm64.dmg into /Applications

# Remove quarantine attribute and self sign it
xattr -cr /Applications/Kaiden.app
codesign --force --deep --sign - /Applications/Kaiden.app
# run the app
open /Applications/Kaiden.app
```
Fixes #1658

The kdn extension takes a while to be ready, so secrets might take a couple seconds to show up if you open their page directly. But typically, if the workspaces are already visible, so will the secrets