### PR TITLE
fix: display workspace name instead of ID when deleting

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -816,6 +816,7 @@ describe('list', () => {
 
 describe('remove', () => {
   test('delegates to kdnCli.remove and returns the workspace id', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(kdnCli.removeWorkspaces).mockResolvedValue({ id: 'ws-1' });
 
     const result = await manager.remove('ws-1');
@@ -824,17 +825,28 @@ describe('remove', () => {
     expect(result).toEqual({ id: 'ws-1' });
   });
 
-  test('creates a task and sets success status on completion', async () => {
+  test('creates a task with workspace name and sets success status on completion', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(kdnCli.removeWorkspaces).mockResolvedValue({ id: 'ws-1' });
 
     await manager.remove('ws-1');
 
-    expect(taskManager.createTask).toHaveBeenCalledWith({ title: 'Deleting workspace ws-1' });
+    expect(taskManager.createTask).toHaveBeenCalledWith({ title: 'Deleting workspace "test-workspace-1"' });
     expect(mockTask.status).toBe('success');
     expect(mockTask.state).toBe('completed');
   });
 
+  test('uses workspace id as fallback when workspace not found in list', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue([]);
+    vi.mocked(kdnCli.removeWorkspaces).mockResolvedValue({ id: 'unknown-id' });
+
+    await manager.remove('unknown-id');
+
+    expect(taskManager.createTask).toHaveBeenCalledWith({ title: 'Deleting workspace "unknown-id"' });
+  });
+
   test('sets task failure status when CLI fails', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(kdnCli.removeWorkspaces).mockRejectedValue(new Error('workspace not found: unknown-id'));
 
     await expect(manager.remove('unknown-id')).rejects.toThrow('workspace not found: unknown-id');
@@ -845,6 +857,7 @@ describe('remove', () => {
   });
 
   test('preserves error detail in task error message', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(kdnCli.removeWorkspaces).mockRejectedValue(new Error('failed to remove workspace: permission denied'));
 
     await expect(manager.remove('ws-1')).rejects.toThrow('failed to remove workspace: permission denied');
@@ -853,6 +866,7 @@ describe('remove', () => {
   });
 
   test('emits agent-workspace-update event', async () => {
+    vi.mocked(kdnCli.listWorkspaces).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(kdnCli.removeWorkspaces).mockResolvedValue({ id: 'ws-1' });
 
     await manager.remove('ws-1');

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -258,7 +258,10 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   async remove(id: string): Promise<AgentWorkspaceId> {
-    const task = this.taskManager.createTask({ title: `Deleting workspace ${id}` });
+    const workspaces = await this.list();
+    const workspace = workspaces.find(ws => ws.id === id);
+    const workspaceName = workspace?.name ?? id;
+    const task = this.taskManager.createTask({ title: `Deleting workspace "${workspaceName}"` });
     task.state = 'running';
     task.status = 'in-progress';
     try {


### PR DESCRIPTION
When deleting a workspace, the task notification now shows the
workspace name instead of the workspace ID, matching the behavior
shown when creating a workspace.

The implementation fetches the workspace list first to lookup the
name, falling back to the ID if the workspace is not found in the
list.

Updated tests to verify the new task title format and added a test
case for the fallback scenario.

Fixes #1778

<img width="1354" height="1102" alt="Screenshot 2026-06-04 at 11 28 09" src="https://github.com/user-attachments/assets/27c19353-de28-4a3e-a8b1-1d434857daaa" />
<img width="1354" height="1102" alt="Screenshot 2026-06-04 at 11 28 38" src="https://github.com/user-attachments/assets/fdc5ed6b-d340-4cc2-8bb5-2ce54531b9b3" />
