### PR TITLE
feat(workspace-settings): add danger zone with delete workspace

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -23,6 +23,7 @@ import { writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import * as agentWorkspaceRuntimeStore from '/@/stores/agentworkspace-runtime';
 import * as mcpStore from '/@/stores/mcp-remote-servers';
 import * as ragStore from '/@/stores/rag-environments';
@@ -40,6 +41,7 @@ vi.mock(import('/@/stores/rag-environments'));
 vi.mock(import('/@/navigation'));
 vi.mock(import('/@/stores/mcp-remote-servers'));
 vi.mock(import('/@/stores/agentworkspace-runtime'));
+vi.mock(import('/@/lib/dialogs/messagebox-utils'));
 
 const routerStore = writable({
   path: '/agent-workspaces/ws-1/settings',
@@ -1059,4 +1061,63 @@ test('Expect error dialog shown when network save fails', async () => {
       message: expect.stringContaining('server error'),
     }),
   );
+});
+
+// --- Advanced / Danger Zone section tests ---
+
+test('Expect Advanced section shows danger zone with delete button', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  await fireEvent.click(screen.getByRole('link', { name: 'Advanced' }));
+
+  expect(screen.getByText('Danger Zone')).toBeInTheDocument();
+  expect(screen.getByText('Irreversible and destructive actions')).toBeInTheDocument();
+  expect(screen.getByText('Delete Workspace')).toBeInTheDocument();
+  expect(screen.getByText('Permanently delete this workspace and all its data')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Delete workspace' })).toBeInTheDocument();
+});
+
+test('Expect clicking Delete calls withConfirmation', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  await fireEvent.click(screen.getByRole('link', { name: 'Advanced' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Delete workspace' }));
+
+  expect(withConfirmation).toHaveBeenCalledWith(expect.any(Function), 'remove workspace api-refactor');
+});
+
+test('Expect delete confirmation calls removeAgentWorkspace and navigates', async () => {
+  vi.mocked(withConfirmation).mockImplementation(fn => fn());
+  vi.mocked(window.removeAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  await fireEvent.click(screen.getByRole('link', { name: 'Advanced' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Delete workspace' }));
+
+  expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1');
+  await vi.waitFor(() => {
+    expect(router.goto).toHaveBeenCalledWith('/agent-workspaces');
+  });
+});
+
+test('Expect delete confirmation uses workspace ID when name is unavailable', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary: undefined, configuration: {} });
+
+  await fireEvent.click(screen.getByRole('link', { name: 'Advanced' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Delete workspace' }));
+
+  expect(withConfirmation).toHaveBeenCalledWith(expect.any(Function), 'remove workspace ws-1');
+});
+
+test('Expect delete does not proceed when confirmation dialog fails', async () => {
+  vi.mocked(withConfirmation).mockImplementation(fn => fn(new Error('dialog error')));
+
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
+
+  await fireEvent.click(screen.getByRole('link', { name: 'Advanced' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Delete workspace' }));
+
+  expect(window.removeAgentWorkspace).not.toHaveBeenCalled();
+  expect(router.goto).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -590,7 +590,7 @@ function handleDeleteWorkspace(): void {
             Advanced configuration options for this workspace.
           </p>
 
-          <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-danger-action-text,#f87171)] border-opacity-30 rounded-lg p-6">
+          <div class="bg-[var(--pd-content-card-bg)] border border-[color-mix(in_srgb,var(--pd-danger-action-text,#f87171)_30%,transparent)] rounded-lg p-6">
             <div class="mb-5">
               <h3 class="text-[15px] font-semibold text-[var(--pd-danger-action-text,#f87171)] mb-1">Danger Zone</h3>
               <p class="text-[13px] text-[var(--pd-content-text)] opacity-60 m-0">Irreversible and destructive actions</p>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -439,7 +439,11 @@ function navigateToMcp(): void {
 
 function handleDeleteWorkspace(): void {
   withConfirmation(
-    async () => {
+    async (err?: unknown) => {
+      if (err) {
+        console.error('Confirmation dialog failed', err);
+        return;
+      }
       try {
         await window.removeAgentWorkspace(workspaceId);
         router.goto('/agent-workspaces');
@@ -600,16 +604,7 @@ function handleDeleteWorkspace(): void {
                 <div class="text-sm font-medium text-[var(--pd-content-card-header-text)]">Delete Workspace</div>
                 <div class="text-xs text-[var(--pd-content-text)] opacity-60">Permanently delete this workspace and all its data</div>
               </div>
-              <button
-                class="flex items-center gap-2 px-4 py-2.5 rounded-lg text-[13px] font-medium cursor-pointer transition-all duration-200
-                  bg-[color-mix(in_srgb,var(--pd-danger-action-text,#f87171)_15%,transparent)]
-                  border border-[color-mix(in_srgb,var(--pd-danger-action-text,#f87171)_30%,transparent)]
-                  text-[var(--pd-danger-action-text,#f87171)]
-                  hover:bg-[color-mix(in_srgb,var(--pd-danger-action-text,#f87171)_25%,transparent)]"
-                aria-label="Delete workspace"
-                onclick={handleDeleteWorkspace}>
-                Delete
-              </button>
+              <Button type="danger" aria-label="Delete workspace" onclick={handleDeleteWorkspace}>Delete</Button>
             </div>
           </div>
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -7,6 +7,7 @@ import AgentWorkspaceCreateStepFileSystem, {
   type CustomMount,
 } from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepFileSystem.svelte';
 import AgentWorkspaceCreateStepNetworking from '/@/lib/agent-workspaces/AgentWorkspaceCreateStepNetworking.svelte';
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import ChecklistPanel from '/@/lib/ui/ChecklistPanel.svelte';
 import { handleNavigation } from '/@/navigation';
@@ -435,6 +436,20 @@ function navigateToSkills(): void {
 function navigateToMcp(): void {
   router.goto('/mcps');
 }
+
+function handleDeleteWorkspace(): void {
+  withConfirmation(
+    async () => {
+      try {
+        await window.removeAgentWorkspace(workspaceId);
+        router.goto('/agent-workspaces');
+      } catch (error: unknown) {
+        console.error('Failed to remove agent workspace', error);
+      }
+    },
+    `remove workspace ${workspaceSummary?.name ?? workspaceId}`,
+  );
+}
 </script>
 
 <div class="flex flex-row w-full h-full">
@@ -569,6 +584,34 @@ function navigateToMcp(): void {
             onAddCustomHost={addCustomHost}
             onRemoveCustomHost={removeCustomHost}
             onUpdateCustomHost={updateCustomHost} />
+
+        {:else if activeSection === 'advanced'}
+          <p class="text-sm text-[var(--pd-content-text)] mb-7">
+            Advanced configuration options for this workspace.
+          </p>
+
+          <div class="bg-[var(--pd-content-card-bg)] border border-[var(--pd-danger-action-text,#f87171)] border-opacity-30 rounded-lg p-6">
+            <div class="mb-5">
+              <h3 class="text-[15px] font-semibold text-[var(--pd-danger-action-text,#f87171)] mb-1">Danger Zone</h3>
+              <p class="text-[13px] text-[var(--pd-content-text)] opacity-60 m-0">Irreversible and destructive actions</p>
+            </div>
+            <div class="flex items-center justify-between py-4">
+              <div class="flex-1">
+                <div class="text-sm font-medium text-[var(--pd-content-card-header-text)]">Delete Workspace</div>
+                <div class="text-xs text-[var(--pd-content-text)] opacity-60">Permanently delete this workspace and all its data</div>
+              </div>
+              <button
+                class="flex items-center gap-2 px-4 py-2.5 rounded-lg text-[13px] font-medium cursor-pointer transition-all duration-200
+                  bg-[color-mix(in_srgb,var(--pd-danger-action-text,#f87171)_15%,transparent)]
+                  border border-[color-mix(in_srgb,var(--pd-danger-action-text,#f87171)_30%,transparent)]
+                  text-[var(--pd-danger-action-text,#f87171)]
+                  hover:bg-[color-mix(in_srgb,var(--pd-danger-action-text,#f87171)_25%,transparent)]"
+                aria-label="Delete workspace"
+                onclick={handleDeleteWorkspace}>
+                Delete
+              </button>
+            </div>
+          </div>
 
         {:else}
           <p class="text-sm text-[var(--pd-content-text)] mb-7">


### PR DESCRIPTION
## Summary
- Implements the **Advanced** tab in workspace settings with a **Danger Zone** card
- Adds a **Delete Workspace** button that uses the existing `withConfirmation` dialog and `removeAgentWorkspace` API, matching the pattern from `AgentWorkspaceDetails.svelte`
- Also fixes a missing `#!/bin/sh` shebang in the husky pre-commit hook that caused `Exec format error` on Windows

<img width="1034" height="615" alt="image" src="https://github.com/user-attachments/assets/4b17720d-e0bb-4e3c-b4da-cc49ed8800a9" />


Fixes: https://github.com/openkaiden/kaiden/issues/1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)