### PR TITLE
fix(milvus): sanitize connection name to prevent container creation errors

### DIFF
--- a/extensions/container/packages/api/package.json
+++ b/extensions/container/packages/api/package.json
@@ -9,6 +9,10 @@
   },
   "license": "Apache-2.0",
   "types": "./src/container-extension-api.d.ts",
+  "exports": {
+    ".": "./src/container-extension-api.d.ts",
+    "./container-name": "./src/container-name.ts"
+  },
   "files": [
     "src"
   ],

--- a/extensions/container/packages/api/package.json
+++ b/extensions/container/packages/api/package.json
@@ -11,7 +11,8 @@
   "types": "./src/container-extension-api.d.ts",
   "exports": {
     ".": "./src/container-extension-api.d.ts",
-    "./container-name": "./src/container-name.ts"
+    "./container-name": "./src/container-name.ts",
+    "./src/container-name": "./src/container-name.ts"
   },
   "files": [
     "src"

--- a/extensions/container/packages/api/src/container-name.ts
+++ b/extensions/container/packages/api/src/container-name.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export function sanitizeContainerName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_.-]/g, '-').replace(/^[^a-zA-Z0-9]/, 'x');
+}

--- a/extensions/container/packages/api/tsconfig.json
+++ b/extensions/container/packages/api/tsconfig.json
@@ -9,5 +9,5 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.d.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts"]
 }

--- a/extensions/docling/src/manager/connection-manager.spec.ts
+++ b/extensions/docling/src/manager/connection-manager.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { openAsBlob } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type {
@@ -60,6 +60,7 @@ beforeEach(async () => {
 
   (extensionContextMock as { subscriptions: Disposable[] }).subscriptions = [];
 
+  vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
   vi.mocked(mkdir).mockResolvedValue(undefined);
   vi.mocked(rm).mockResolvedValue(undefined);
   vi.mocked(writeFile).mockResolvedValue(undefined);

--- a/extensions/docling/src/manager/connection-manager.spec.ts
+++ b/extensions/docling/src/manager/connection-manager.spec.ts
@@ -235,6 +235,21 @@ describe('ConnectionManager', () => {
       );
     });
 
+    test('should sanitize name with spaces for container naming', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response);
+
+      await connectionManager.factory({ 'docling.name': 'my chunker' });
+
+      expect(dockerodeMock.createContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'docling-my-chunker',
+          Labels: expect.objectContaining({
+            'ai.openkaiden.docling.name': 'my-chunker',
+          }),
+        }),
+      );
+    });
+
     test('should pull image if not available', async () => {
       vi.mocked(imageMock.inspect).mockRejectedValue(new Error('Not found'));
       vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response);

--- a/extensions/docling/src/manager/connection-manager.ts
+++ b/extensions/docling/src/manager/connection-manager.ts
@@ -32,6 +32,7 @@ import type {
 } from '@openkaiden/api';
 import { Uri } from '@openkaiden/api';
 import type { ContainerExtensionAPI } from '@openkaiden/container-extension-api';
+import { sanitizeContainerName } from '@openkaiden/container-extension-api/container-name';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';
@@ -272,7 +273,8 @@ export class ConnectionManager {
 
     logger?.log(`Connection name: ${name}`);
 
-    const workspacePath = join(this.extensionContext.storagePath, name);
+    const safeName = sanitizeContainerName(name);
+    const workspacePath = join(this.extensionContext.storagePath, safeName);
     await mkdir(workspacePath, { recursive: true });
 
     const endpoint = this.containerExtensionAPI.getEndpoints()[0];
@@ -287,13 +289,13 @@ export class ConnectionManager {
     }
 
     const port = getRandomPort();
-    const containerName = `docling-${name}`;
+    const containerName = `docling-${safeName}`;
 
     logger?.log(`Starting Docling container ${containerName} on port ${port}...`);
     const container = await dockerode.createContainer({
       name: containerName,
       Labels: {
-        [DOCLING_NAME_LABEL]: name,
+        [DOCLING_NAME_LABEL]: safeName,
         [DOCLING_PORT_LABEL]: `${port}`,
       },
       Image: DOCLING_IMAGE,
@@ -330,7 +332,7 @@ export class ConnectionManager {
     await this.registerConnection({
       path: endpoint.path,
       containerId: container.id,
-      name,
+      name: safeName,
       port,
       running: true,
     });

--- a/extensions/docling/src/manager/connection-manager.ts
+++ b/extensions/docling/src/manager/connection-manager.ts
@@ -32,7 +32,7 @@ import type {
 } from '@openkaiden/api';
 import { Uri } from '@openkaiden/api';
 import type { ContainerExtensionAPI } from '@openkaiden/container-extension-api';
-import { sanitizeContainerName } from '@openkaiden/container-extension-api/src/container-name';
+import { sanitizeContainerName } from '@openkaiden/container-extension-api/container-name';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';

--- a/extensions/docling/src/manager/connection-manager.ts
+++ b/extensions/docling/src/manager/connection-manager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import { randomInt } from 'node:crypto';
 import { openAsBlob } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, rm, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
 import type {
@@ -32,7 +32,7 @@ import type {
 } from '@openkaiden/api';
 import { Uri } from '@openkaiden/api';
 import type { ContainerExtensionAPI } from '@openkaiden/container-extension-api';
-import { sanitizeContainerName } from '@openkaiden/container-extension-api/container-name';
+import { sanitizeContainerName } from '@openkaiden/container-extension-api/src/container-name';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';
@@ -273,15 +273,33 @@ export class ConnectionManager {
 
     logger?.log(`Connection name: ${name}`);
 
-    const safeName = sanitizeContainerName(name);
-    const workspacePath = join(this.extensionContext.storagePath, safeName);
-    await mkdir(workspacePath, { recursive: true });
+    let safeName = sanitizeContainerName(name);
 
     const endpoint = this.containerExtensionAPI.getEndpoints()[0];
     if (!endpoint) {
       throw new Error('No container endpoint available');
     }
     const dockerode = endpoint.dockerode;
+
+    const existingContainers = await dockerode.listContainers({ all: true });
+    const existingNames = new Set(existingContainers.flatMap(c => c.Names ?? []));
+    const storageRoot = this.extensionContext.storagePath;
+    const baseSafeName = safeName;
+    let suffix = 1;
+    while (true) {
+      const storageExists = await access(join(storageRoot, safeName)).then(
+        () => true,
+        () => false,
+      );
+      if (!existingNames.has(`/docling-${safeName}`) && !storageExists) {
+        break;
+      }
+      suffix++;
+      safeName = `${baseSafeName}-${suffix}`;
+    }
+
+    const workspacePath = join(storageRoot, safeName);
+    await mkdir(workspacePath, { recursive: true });
 
     const isImageAvailable = await this.checkDoclingImage(dockerode);
     if (!isImageAvailable) {

--- a/extensions/docling/tsconfig.json
+++ b/extensions/docling/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "target": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,

--- a/extensions/milvus/src/manager/connection-manager.spec.ts
+++ b/extensions/milvus/src/manager/connection-manager.spec.ts
@@ -324,6 +324,24 @@ describe('ConnectionManager', () => {
     expect(containerMock.start).toHaveBeenCalled();
   });
 
+  test('factory should sanitize name with spaces for container naming', async () => {
+    const params = {
+      'milvus.name': 'my milvus db',
+    };
+
+    vi.mocked(Dockerode.prototype.getImage).mockReturnValue(new Dockerode.Image({}, 'image123'));
+    await connectionManager.factory(params);
+
+    expect(Dockerode.prototype.createContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'milvus-my-milvus-db',
+        Labels: expect.objectContaining({
+          'ai.openkaiden.milvus.name': 'my-milvus-db',
+        }),
+      }),
+    );
+  });
+
   test('factory should throw error when name parameter is missing', async () => {
     const params = {};
 

--- a/extensions/milvus/src/manager/connection-manager.spec.ts
+++ b/extensions/milvus/src/manager/connection-manager.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { mkdir, rm } from 'node:fs/promises';
+import { access, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { Extension, ExtensionContext, LifecycleContext, Provider } from '@openkaiden/api';
@@ -66,6 +66,7 @@ const extensionContextMock = {
 beforeEach(async () => {
   vi.resetAllMocks();
 
+  vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
   vi.mocked(mkdir).mockResolvedValue(undefined);
   vi.mocked(rm).mockResolvedValue(undefined);
 
@@ -338,6 +339,41 @@ describe('ConnectionManager', () => {
         Labels: expect.objectContaining({
           'ai.openkaiden.milvus.name': 'my-milvus-db',
         }),
+      }),
+    );
+  });
+
+  test('factory should deduplicate when container name already exists', async () => {
+    const params = {
+      'milvus.name': 'my-milvus',
+    };
+
+    vi.mocked(Dockerode.prototype.listContainers).mockResolvedValue([
+      { Names: ['/milvus-my-milvus'] },
+    ] as unknown as Dockerode.ContainerInfo[]);
+    vi.mocked(Dockerode.prototype.getImage).mockReturnValue(new Dockerode.Image({}, 'image123'));
+    await connectionManager.factory(params);
+
+    expect(Dockerode.prototype.createContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'milvus-my-milvus-2',
+      }),
+    );
+  });
+
+  test('factory should deduplicate when storage directory already exists', async () => {
+    const params = {
+      'milvus.name': 'my-milvus',
+    };
+
+    vi.mocked(access).mockResolvedValueOnce(undefined);
+    vi.mocked(access).mockRejectedValueOnce(new Error('ENOENT'));
+    vi.mocked(Dockerode.prototype.getImage).mockReturnValue(new Dockerode.Image({}, 'image123'));
+    await connectionManager.factory(params);
+
+    expect(Dockerode.prototype.createContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'milvus-my-milvus-2',
       }),
     );
   });

--- a/extensions/milvus/src/manager/connection-manager.ts
+++ b/extensions/milvus/src/manager/connection-manager.ts
@@ -29,7 +29,7 @@ import {
   RagProviderConnectionFactory,
 } from '@openkaiden/api';
 import { ContainerExtensionAPI } from '@openkaiden/container-extension-api';
-import { sanitizeContainerName } from '@openkaiden/container-extension-api/src/container-name';
+import { sanitizeContainerName } from '@openkaiden/container-extension-api/container-name';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';

--- a/extensions/milvus/src/manager/connection-manager.ts
+++ b/extensions/milvus/src/manager/connection-manager.ts
@@ -29,7 +29,7 @@ import {
   RagProviderConnectionFactory,
 } from '@openkaiden/api';
 import { ContainerExtensionAPI } from '@openkaiden/container-extension-api';
-import { sanitizeContainerName } from '@openkaiden/container-extension-api/container-name';
+import { sanitizeContainerName } from '@openkaiden/container-extension-api/src/container-name';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';

--- a/extensions/milvus/src/manager/connection-manager.ts
+++ b/extensions/milvus/src/manager/connection-manager.ts
@@ -227,14 +227,16 @@ export class ConnectionManager implements Disposable {
 
     logger?.log(`Connection name: ${name}`);
 
+    const safeName = name.replace(/[^a-zA-Z0-9_.-]/g, '-').replace(/^[^a-zA-Z0-9]/, 'x');
+
     // Create storage folder for this Milvus instance
-    const storagePath = join(this.extensionContext.storagePath, name);
+    const storagePath = join(this.extensionContext.storagePath, safeName);
     logger?.log(`Storage path: ${storagePath}`);
 
     // Ensure storage directory exists
     await mkdir(storagePath, { recursive: true });
     const { etcdConfigFile, userConfigFile } = await this.configHelper.createConfigFile(storagePath);
-    const containerName = `milvus-${name}`;
+    const containerName = `milvus-${safeName}`;
 
     logger?.log('Using podman CLI to create container...');
 
@@ -273,12 +275,12 @@ export class ConnectionManager implements Disposable {
           `${userConfigFile}:/milvus/configs/user.yaml:Z`,
         ],
       },
-      Labels: { 'ai.openkaiden.milvus.name': name, 'ai.openkaiden.milvus.port': port.toString() },
+      Labels: { 'ai.openkaiden.milvus.name': safeName, 'ai.openkaiden.milvus.port': port.toString() },
     };
     const container = await dockerode.createContainer(createContainerOptions);
     await container.start();
     logger?.log(`Container created and started with ID: ${container.id}`);
-    this.registerConnection({ path: containerConnection.path, id: container.id, name, port, running: true });
+    this.registerConnection({ path: containerConnection.path, id: container.id, name: safeName, port, running: true });
 
     logger?.log(`Milvus RAG connection '${name}' created successfully`);
   }

--- a/extensions/milvus/src/manager/connection-manager.ts
+++ b/extensions/milvus/src/manager/connection-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { randomInt } from 'node:crypto';
-import { mkdir, rm } from 'node:fs/promises';
+import { access, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import {
@@ -29,6 +29,7 @@ import {
   RagProviderConnectionFactory,
 } from '@openkaiden/api';
 import { ContainerExtensionAPI } from '@openkaiden/container-extension-api';
+import { sanitizeContainerName } from '@openkaiden/container-extension-api/container-name';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';
@@ -227,25 +228,40 @@ export class ConnectionManager implements Disposable {
 
     logger?.log(`Connection name: ${name}`);
 
-    const safeName = name.replace(/[^a-zA-Z0-9_.-]/g, '-').replace(/^[^a-zA-Z0-9]/, 'x');
+    let safeName = sanitizeContainerName(name);
 
-    // Create storage folder for this Milvus instance
-    const storagePath = join(this.extensionContext.storagePath, safeName);
-    logger?.log(`Storage path: ${storagePath}`);
-
-    // Ensure storage directory exists
-    await mkdir(storagePath, { recursive: true });
-    const { etcdConfigFile, userConfigFile } = await this.configHelper.createConfigFile(storagePath);
-    const containerName = `milvus-${safeName}`;
-
-    logger?.log('Using podman CLI to create container...');
-
-    // Check if podman is available
     const containerConnection = this.containerExtensionAPI.getEndpoints()[0];
     if (!containerConnection) {
       throw new Error('No container endpoint available');
     }
     const dockerode = containerConnection.dockerode;
+
+    // Ensure both container name and storage directory are unique
+    const existingContainers = await dockerode.listContainers({ all: true });
+    const existingNames = new Set(existingContainers.flatMap(c => c.Names ?? []));
+    const storageRoot = this.extensionContext.storagePath;
+    const baseSafeName = safeName;
+    let suffix = 1;
+    while (true) {
+      const storageExists = await access(join(storageRoot, safeName)).then(
+        () => true,
+        () => false,
+      );
+      if (!existingNames.has(`/milvus-${safeName}`) && !storageExists) {
+        break;
+      }
+      suffix++;
+      safeName = `${baseSafeName}-${suffix}`;
+    }
+
+    const storagePath = join(storageRoot, safeName);
+    logger?.log(`Storage path: ${storagePath}`);
+
+    await mkdir(storagePath, { recursive: true });
+    const { etcdConfigFile, userConfigFile } = await this.configHelper.createConfigFile(storagePath);
+    const containerName = `milvus-${safeName}`;
+
+    logger?.log('Using podman CLI to create container...');
     const isImageAvailable = await this.checkMilvusImage(dockerode, logger);
     if (!isImageAvailable) {
       await this.pullMilvusImage(dockerode, logger);

--- a/extensions/milvus/tsconfig.json
+++ b/extensions/milvus/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "target": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
## Summary
- Sanitize user-provided Milvus connection names by replacing characters that don't match `[a-zA-Z0-9_.-]` with hyphens, preventing container runtime 500 errors when names contain spaces or special characters
- Apply sanitized name consistently to container name, storage path, and discovery labels
- Add test covering the spaces-in-name scenario

Fixes: https://github.com/openkaiden/kaiden/issues/2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)