### PR TITLE
feat(renderer): add semantic router tab and cards to models catalog 

### DIFF
--- a/packages/renderer/src/lib/models/ModelsCatalog.svelte
+++ b/packages/renderer/src/lib/models/ModelsCatalog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-import { faCloud, faDesktop, faIndustry } from '@fortawesome/free-solid-svg-icons';
+import { faCloud, faDesktop, faDiagramProject, faIndustry } from '@fortawesome/free-solid-svg-icons';
 import {
+  Button,
   FilteredEmptyScreen,
   SearchInput,
   SettingsNavItem,
@@ -19,6 +20,7 @@ import LocalRuntimeTiles from '/@/lib/models/LocalRuntimeTiles.svelte';
 import type { CatalogModelInfo, InferenceConnectionSummary } from '/@/lib/models/models-utils';
 import ModelsCatalogEmptyScreen from '/@/lib/models/ModelsCatalogEmptyScreen.svelte';
 import ProviderConnectionTiles from '/@/lib/models/ProviderConnectionTiles.svelte';
+import SemanticRouterCards from '/@/lib/models/SemanticRouterCards.svelte';
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 import {
   cloudConnectionSummaries as cloudConnectionSummariesStore,
@@ -26,9 +28,11 @@ import {
   localConnectionSummaries as localConnectionSummariesStore,
 } from '/@/stores/inference-connection-summaries';
 import { cloudCatalogModels, inHouseCatalogModels, localCatalogModels } from '/@/stores/models';
+import { semanticRouterInfos } from '/@/stores/semantic-routers';
+import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
 
 type ModelSelectable = CatalogModelInfo & { selected: boolean };
-type Category = 'cloud' | 'corporate' | 'local';
+type Category = 'cloud' | 'corporate' | 'local' | 'router';
 
 interface CategoryInfo {
   id: Category;
@@ -41,6 +45,12 @@ const categories: CategoryInfo[] = [
   { id: 'cloud', label: 'LLM Providers', icon: faCloud, subtitle: 'API keys for hosted providers' },
   { id: 'corporate', label: 'In-house', icon: faIndustry, subtitle: 'In-house · OpenShift AI & models' },
   { id: 'local', label: 'Local', icon: faDesktop, subtitle: 'Host detection & loaded models' },
+  {
+    id: 'router',
+    label: 'Semantic Routers',
+    icon: faDiagramProject,
+    subtitle: 'Intelligent request routers across multiple backends',
+  },
 ];
 
 let activeCategory: Category = $state('cloud');
@@ -71,6 +81,9 @@ let filteredLocalModels: ModelSelectable[] = $derived(
 let filteredLocalConnections: InferenceConnectionSummary[] = $derived(
   filterConnectionsBySearch(localConnections, searchTerm),
 );
+
+let semanticRouters: SemanticRouterConfigInfo[] = $derived($semanticRouterInfos as SemanticRouterConfigInfo[]);
+let filteredRouters: SemanticRouterConfigInfo[] = $derived(filterRoutersBySearch(semanticRouters, searchTerm));
 
 let activeSubtitle: string = $derived(categories.find(c => c.id === activeCategory)?.subtitle ?? '');
 
@@ -130,6 +143,25 @@ function filterConnectionsBySearch(conns: InferenceConnectionSummary[], term: st
       (c.connectionType?.toLowerCase().includes(q) ?? false),
   );
 }
+
+function filterRoutersBySearch(routers: SemanticRouterConfigInfo[], term: string): SemanticRouterConfigInfo[] {
+  if (!term.trim()) return routers;
+  const q = term.trim().toLowerCase();
+  return routers.filter(
+    r =>
+      r.name.toLowerCase().includes(q) ||
+      (r.description?.toLowerCase().includes(q) ?? false) ||
+      r.routing.keywords.some(k => k.name.toLowerCase().includes(q)) ||
+      r.routing.decisions.some(
+        d =>
+          d.name.toLowerCase().includes(q) ||
+          d.rules.some(rule => rule.modelRefs.some(m => m.label.toLowerCase().includes(q))),
+      ),
+  );
+}
+
+// TODO: implement router creation flow
+function addSemanticRouter(): void {}
 
 function selectCategory(cat: Category): void {
   activeCategory = cat;
@@ -265,6 +297,30 @@ function selectCategory(cat: Category): void {
                   <Table kind="models" data={filteredLocalModels} columns={columns} row={row} defaultSortColumn="Name" />
                 </div>
               {/if}
+            {/if}
+          </div>
+        </div>
+      {:else if activeCategory === 'router'}
+        <div class="flex items-center justify-between px-5 pb-3">
+          <p class="text-xs text-[var(--pd-content-text)] opacity-70">
+            Semantic routers classify incoming requests and route them to the appropriate backend models based on keyword rules and priorities.
+          </p>
+          <Button onclick={addSemanticRouter}>Add Semantic Router</Button>
+        </div>
+        <div class="flex min-w-full h-full">
+          <div class="flex flex-col w-full">
+            {#if semanticRouters.length === 0}
+              <div class="flex items-center justify-center h-full">
+                <div class="text-center text-[var(--pd-content-text)]">
+                  <Icon icon={faDiagramProject} class="mb-3 opacity-40" size="2.5em" />
+                  <p class="text-sm">No semantic routers configured</p>
+                  <p class="text-xs mt-1 opacity-60">Add a router to classify and route requests across multiple backends</p>
+                </div>
+              </div>
+            {:else if searchTerm && filteredRouters.length === 0}
+              <FilteredEmptyScreen icon={NoLogIcon} kind="routers" bind:searchTerm />
+            {:else}
+              <SemanticRouterCards routers={filteredRouters} />
             {/if}
           </div>
         </div>

--- a/packages/renderer/src/lib/models/SemanticRouterCards.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCards.spec.ts
@@ -19,11 +19,49 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { CatalogModelInfo } from '/@/lib/models/models-utils';
+import * as modelsStore from '/@/stores/models';
 import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
 
 import SemanticRouterCards from './SemanticRouterCards.svelte';
+
+vi.mock(import('/@/stores/models'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([
+    {
+      providerId: 'ollama',
+      connectionId: 'conn-2',
+      connectionName: 'Ollama',
+      type: 'local',
+      label: 'qwen3-coder',
+      connectionStatus: 'started',
+      providerName: 'Ollama',
+    },
+    {
+      providerId: 'gemini',
+      connectionId: 'conn-1',
+      connectionName: 'Gemini',
+      type: 'cloud',
+      label: 'gemini-2.5-pro',
+      connectionStatus: 'started',
+      providerName: 'Gemini',
+    },
+    {
+      providerId: 'openshift-ai',
+      connectionId: 'conn-3',
+      connectionName: 'OpenShift AI',
+      type: 'self-hosted',
+      label: 'llama-3.1-70b',
+      connectionStatus: 'started',
+      providerName: 'OpenShift AI',
+    },
+  ]);
+});
 
 const mockRouter: SemanticRouterConfigInfo = {
   name: 'coding-router',
@@ -119,6 +157,35 @@ test('should show cloud badge for gemini provider', () => {
   render(SemanticRouterCards, { routers: [mockRouter] });
 
   expect(screen.getByText('cloud')).toBeInTheDocument();
+});
+
+test('should show in-house badge for self-hosted provider', () => {
+  const routerWithSelfHosted: SemanticRouterConfigInfo = {
+    name: 'corp-router',
+    listeners: [{ address: '0.0.0.0', port: 9000 }],
+    routing: {
+      keywords: [],
+      decisions: [
+        {
+          name: 'decision-1',
+          priority: 1,
+          rules: [
+            {
+              operator: 'OR',
+              conditions: [],
+              modelRefs: [
+                { providerId: 'openshift-ai', connectionId: 'c1', label: 'llama-3.1-70b', useReasoning: false },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  render(SemanticRouterCards, { routers: [routerWithSelfHosted] });
+
+  expect(screen.getByText('in-house')).toBeInTheDocument();
 });
 
 test('should deduplicate model refs across rules', () => {

--- a/packages/renderer/src/lib/models/SemanticRouterCards.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCards.spec.ts
@@ -1,0 +1,165 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
+
+import SemanticRouterCards from './SemanticRouterCards.svelte';
+
+const mockRouter: SemanticRouterConfigInfo = {
+  name: 'coding-router',
+  description: 'Routes coding requests',
+  listeners: [{ address: '0.0.0.0', port: 8899 }],
+  routing: {
+    keywords: [
+      { name: 'coding-keywords', operator: 'OR', keywords: ['code', 'debug'], caseSensitive: false },
+      { name: 'review-keywords', operator: 'AND', keywords: ['review', 'PR'], caseSensitive: false },
+    ],
+    decisions: [
+      {
+        name: 'code-decision',
+        priority: 1,
+        rules: [
+          {
+            operator: 'AND',
+            conditions: [{ type: 'keyword', name: 'coding-keywords' }],
+            modelRefs: [
+              { providerId: 'gemini', connectionId: 'conn-1', label: 'gemini-2.5-pro', useReasoning: false },
+              { providerId: 'ollama', connectionId: 'conn-2', label: 'qwen3-coder', useReasoning: true },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const mockRouterNoListeners: SemanticRouterConfigInfo = {
+  name: 'empty-router',
+  listeners: [],
+  routing: {
+    keywords: [],
+    decisions: [],
+  },
+};
+
+test('should render the router name', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByText('coding-router')).toBeInTheDocument();
+});
+
+test('should render the endpoint from the first listener', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByText('localhost:8899')).toBeInTheDocument();
+});
+
+test('should render unique model refs as backend entries', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByText('gemini-2.5-pro')).toBeInTheDocument();
+  expect(screen.getByText('qwen3-coder')).toBeInTheDocument();
+});
+
+test('should render keyword group names as feature badges', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByText('coding-keywords')).toBeInTheDocument();
+  expect(screen.getByText('review-keywords')).toBeInTheDocument();
+});
+
+test('should render the flow diagram labels', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByText('Agents')).toBeInTheDocument();
+  expect(screen.getByText('Router')).toBeInTheDocument();
+  expect(screen.getByText('Backends')).toBeInTheDocument();
+});
+
+test('should render multiple router cards', () => {
+  render(SemanticRouterCards, { routers: [mockRouter, mockRouterNoListeners] });
+
+  expect(screen.getByText('coding-router')).toBeInTheDocument();
+  expect(screen.getByText('empty-router')).toBeInTheDocument();
+});
+
+test('should render the list container with correct aria label', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByRole('list', { name: 'Semantic Routers' })).toBeInTheDocument();
+});
+
+test('should show local badge for ollama provider', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByText('local')).toBeInTheDocument();
+});
+
+test('should show cloud badge for gemini provider', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.getByText('cloud')).toBeInTheDocument();
+});
+
+test('should deduplicate model refs across rules', () => {
+  const routerWithDuplicates: SemanticRouterConfigInfo = {
+    name: 'dup-router',
+    listeners: [{ address: '0.0.0.0', port: 9000 }],
+    routing: {
+      keywords: [],
+      decisions: [
+        {
+          name: 'decision-1',
+          priority: 1,
+          rules: [
+            {
+              operator: 'OR',
+              conditions: [],
+              modelRefs: [{ providerId: 'gemini', connectionId: 'c1', label: 'gemini-2.5-pro', useReasoning: false }],
+            },
+          ],
+        },
+        {
+          name: 'decision-2',
+          priority: 2,
+          rules: [
+            {
+              operator: 'OR',
+              conditions: [],
+              modelRefs: [
+                { providerId: 'gemini', connectionId: 'c1', label: 'gemini-2.5-pro', useReasoning: false },
+                { providerId: 'ollama', connectionId: 'c2', label: 'granite-3.3-8b', useReasoning: true },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  render(SemanticRouterCards, { routers: [routerWithDuplicates] });
+
+  const geminiElements = screen.getAllByText('gemini-2.5-pro');
+  expect(geminiElements).toHaveLength(1);
+  expect(screen.getByText('granite-3.3-8b')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/models/SemanticRouterCards.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCards.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+import { faDesktop, faNetworkWired, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { InferenceProviderConnectionType } from '@openkaiden/api';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { SvelteSet } from 'svelte/reactivity';
+
+import type { CatalogModelInfo } from '/@/lib/models/models-utils';
+import { catalogModels } from '/@/stores/models';
+import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
+
+interface Props {
+  routers: SemanticRouterConfigInfo[];
+}
+
+let { routers }: Props = $props();
+
+let providerTypeMap: Map<string, InferenceProviderConnectionType> = $derived(
+  new Map($catalogModels.map((m: CatalogModelInfo) => [m.providerId, m.type])),
+);
+
+interface ModelRef {
+  label: string;
+  providerId: string;
+  type: InferenceProviderConnectionType;
+}
+
+async function removeRouter(name: string): Promise<void> {
+  try {
+    await window.removeSemanticRouter(name);
+  } catch (err: unknown) {
+    console.error('Failed to remove semantic router', err);
+  }
+}
+
+function getEndpoint(router: SemanticRouterConfigInfo): string {
+  const listener = router.listeners[0];
+  if (!listener) return '';
+  const addr = listener.address === '0.0.0.0' ? 'localhost' : listener.address;
+  return listener.port > 0 ? `${addr}:${listener.port}` : addr;
+}
+
+function getBackendType(providerId: string): InferenceProviderConnectionType {
+  return providerTypeMap.get(providerId) ?? 'cloud';
+}
+
+function getUniqueModelRefs(router: SemanticRouterConfigInfo): ModelRef[] {
+  const seen = new SvelteSet<string>();
+  const refs: ModelRef[] = [];
+  for (const decision of router.routing.decisions) {
+    for (const rule of decision.rules) {
+      for (const ref of rule.modelRefs) {
+        const key = `${ref.providerId}::${ref.label}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          refs.push({ label: ref.label, providerId: ref.providerId, type: getBackendType(ref.providerId) });
+        }
+      }
+    }
+  }
+  return refs;
+}
+
+function getKeywordGroupNames(router: SemanticRouterConfigInfo): string[] {
+  return router.routing.keywords.map(k => k.name);
+}
+</script>
+
+<div class="grid gap-4 px-5 grid-cols-[repeat(auto-fill,minmax(320px,1fr))]" role="list" aria-label="Semantic Routers">
+  {#each routers as router (router.name)}
+    {@const endpoint = getEndpoint(router)}
+    {@const modelRefs = getUniqueModelRefs(router)}
+    {@const keywordGroups = getKeywordGroupNames(router)}
+
+    <div
+      class="flex flex-col rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] overflow-hidden transition-colors hover:bg-[var(--pd-content-card-hover-bg)]"
+      role="listitem">
+      <!-- Header -->
+      <div class="flex items-center gap-3 px-4 pt-4 pb-3 border-b border-[var(--pd-content-divider)]">
+        <div class="w-9 h-9 rounded-lg bg-[color-mix(in_srgb,var(--pd-button-primary-bg)_12%,transparent)] border border-[color-mix(in_srgb,var(--pd-button-primary-bg)_25%,transparent)] grid place-items-center flex-shrink-0 text-[var(--pd-button-primary-bg)]">
+          <Icon icon={faNetworkWired} size="lg" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-bold text-[var(--pd-content-card-header-text)] truncate">{router.name}</div>
+          {#if endpoint}
+            <div class="text-[11px] font-mono text-[var(--pd-state-info)]">{endpoint}</div>
+          {/if}
+        </div>
+        <button
+          class="w-7 h-7 rounded-md flex items-center justify-center text-[var(--pd-content-card-text)] opacity-50 hover:opacity-100 hover:text-[var(--pd-status-terminated)] hover:bg-[color-mix(in_srgb,var(--pd-status-terminated)_10%,transparent)] transition-all flex-shrink-0"
+          aria-label={`Delete ${router.name}`}
+          onclick={(): Promise<void> => removeRouter(router.name)}>
+          <Icon icon={faTrash} />
+        </button>
+      </div>
+
+      <!-- Flow diagram -->
+      <div class="grid grid-cols-[auto_1fr_auto_1fr_auto] items-start gap-0 px-4 py-3 border-b border-[var(--pd-content-divider)]">
+        <div class="flex flex-col items-center gap-1">
+          <div class="grid place-items-center w-8 h-8 rounded-lg bg-[color-mix(in_srgb,var(--pd-state-info)_10%,transparent)] border border-[color-mix(in_srgb,var(--pd-state-info)_20%,transparent)] text-[var(--pd-state-info)]">
+            <Icon icon={faDesktop} size="sm" />
+          </div>
+          <span class="text-[9px] font-bold uppercase tracking-wide text-[var(--pd-content-card-text)] opacity-50">Agents</span>
+        </div>
+
+        <div class="flex items-center h-8 px-1">
+          <div class="flex-1 h-[1px] bg-[var(--pd-content-card-text)] opacity-30"></div>
+          <div class="w-0 h-0 border-t-[4px] border-t-transparent border-b-[4px] border-b-transparent border-l-[6px] border-l-[color-mix(in_srgb,var(--pd-content-card-text)_40%,transparent)]"></div>
+        </div>
+
+        <div class="flex flex-col items-center gap-1">
+          <div class="grid place-items-center w-8 h-8 rounded-lg bg-[color-mix(in_srgb,var(--pd-button-primary-bg)_18%,transparent)] border border-[color-mix(in_srgb,var(--pd-button-primary-bg)_35%,transparent)] text-[var(--pd-button-primary-bg)]">
+            <Icon icon={faNetworkWired} size="sm" />
+          </div>
+          <span class="text-[9px] font-bold uppercase tracking-wide text-[var(--pd-content-card-text)] opacity-50">Router</span>
+        </div>
+
+        <div class="flex items-center h-8 px-1">
+          <div class="flex-1 h-[1px] bg-[var(--pd-content-card-text)] opacity-30"></div>
+          <div class="w-0 h-0 border-t-[4px] border-t-transparent border-b-[4px] border-b-transparent border-l-[6px] border-l-[color-mix(in_srgb,var(--pd-content-card-text)_40%,transparent)]"></div>
+        </div>
+
+        <div class="flex flex-col items-center gap-1">
+          <div class="grid grid-flow-col auto-cols-auto gap-x-1 gap-y-[3px] items-center justify-center h-8 grid-rows-[repeat(3,auto)]">
+            {#each modelRefs as ref (ref.providerId + '::' + ref.label)}
+              <span
+                class="w-2.5 h-2.5 rounded-full"
+                class:bg-[var(--pd-status-running)]={ref.type === 'local'}
+                class:bg-[var(--pd-state-info)]={ref.type === 'cloud'}
+                class:bg-[var(--pd-state-warning)]={ref.type === 'self-hosted'}>
+              </span>
+            {/each}
+          </div>
+          <span class="text-[9px] font-bold uppercase tracking-wide text-[var(--pd-content-card-text)] opacity-50">Backends</span>
+        </div>
+      </div>
+
+      <!-- Backend model list -->
+      {#if modelRefs.length > 0}
+        <div class="flex flex-col gap-1.5 px-4 py-3 border-b border-[var(--pd-content-divider)]">
+          {#each modelRefs as ref (ref.providerId + '::' + ref.label)}
+            <div class="flex items-center gap-2">
+              <span
+                class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                class:bg-[var(--pd-status-running)]={ref.type === 'local'}
+                class:bg-[var(--pd-state-info)]={ref.type === 'cloud'}
+                class:bg-[var(--pd-state-warning)]={ref.type === 'self-hosted'}>
+              </span>
+              <span class="text-xs font-mono text-[var(--pd-content-card-text)] truncate">{ref.label}</span>
+              <span
+                class="ml-auto text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded-full flex-shrink-0 border"
+                class:bg-[color-mix(in_srgb,var(--pd-status-running)_10%,transparent)]={ref.type === 'local'}
+                class:text-[var(--pd-status-running)]={ref.type === 'local'}
+                class:border-[color-mix(in_srgb,var(--pd-status-running)_20%,transparent)]={ref.type === 'local'}
+                class:bg-[color-mix(in_srgb,var(--pd-state-info)_10%,transparent)]={ref.type === 'cloud'}
+                class:text-[var(--pd-state-info)]={ref.type === 'cloud'}
+                class:border-[color-mix(in_srgb,var(--pd-state-info)_20%,transparent)]={ref.type === 'cloud'}
+                class:bg-[color-mix(in_srgb,var(--pd-state-warning)_10%,transparent)]={ref.type === 'self-hosted'}
+                class:text-[var(--pd-state-warning)]={ref.type === 'self-hosted'}
+                class:border-[color-mix(in_srgb,var(--pd-state-warning)_20%,transparent)]={ref.type === 'self-hosted'}>
+                {ref.type}
+              </span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <!-- Feature badges (keyword groups) -->
+      {#if keywordGroups.length > 0}
+        <div class="flex flex-wrap gap-1.5 px-4 py-3">
+          {#each keywordGroups as group (group)}
+            <span class="text-[10px] px-2 py-0.5 rounded-full bg-[color-mix(in_srgb,var(--pd-state-info)_10%,transparent)] text-[var(--pd-state-info)] border border-[color-mix(in_srgb,var(--pd-state-info)_20%,transparent)]">
+              {group}
+            </span>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/each}
+</div>

--- a/packages/renderer/src/lib/models/SemanticRouterCards.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCards.svelte
@@ -157,7 +157,7 @@ function getKeywordGroupNames(router: SemanticRouterConfigInfo): string[] {
                 class:bg-[color-mix(in_srgb,var(--pd-state-warning)_10%,transparent)]={ref.type === 'self-hosted'}
                 class:text-[var(--pd-state-warning)]={ref.type === 'self-hosted'}
                 class:border-[color-mix(in_srgb,var(--pd-state-warning)_20%,transparent)]={ref.type === 'self-hosted'}>
-                {ref.type}
+                {ref.type === 'self-hosted' ? 'in-house' : ref.type}
               </span>
             </div>
           {/each}


### PR DESCRIPTION
Adds semantic router page
Add  semantic router button does nothing so far


https://github.com/user-attachments/assets/14495a8e-7d14-4477-a443-195601bed3bd




Needs rebase after https://github.com/openkaiden/kaiden/pull/2047
Closes https://github.com/openkaiden/kaiden/issues/2052