### PR TITLE
fix(openshell): select healthy gateway on init and fix isRunning check

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -66,6 +66,8 @@ export interface OpenshellGatewayStartOptions {
   port?: number;
   bindAddress?: string;
   disableTls?: boolean;
+  /** Skip CLI registration when restarting an already-registered gateway. */
+  skipRegistration?: boolean;
 }
 
 export interface GatewaySandboxes {

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -46,7 +46,6 @@ function createMockChildProcess(): ChildProcess & { _stdout: EventEmitter; _stde
   Object.defineProperty(proc, 'stdout', { get: (): EventEmitter => proc._stdout });
   Object.defineProperty(proc, 'stderr', { get: (): EventEmitter => proc._stderr });
   proc.kill = vi.fn().mockReturnValue(true);
-  Object.defineProperty(proc, 'exitCode', { value: undefined, writable: true, configurable: true });
   return proc;
 }
 
@@ -63,6 +62,7 @@ const cliToolRegistry = {
 
 const openshellCli = {
   listGateways: vi.fn(),
+  selectGateway: vi.fn(),
 } as unknown as OpenshellCli;
 
 beforeEach(() => {
@@ -75,14 +75,29 @@ beforeEach(() => {
 });
 
 describe('init', () => {
-  test('skips auto-start when existing gateways are discovered', async () => {
+  test('skips auto-start when existing gateway is healthy and already active', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const existingGateways: GatewayInfo[] = [{ name: 'remote-gw', endpoint: 'https://gw.example.com', active: true }];
     vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
     await gateway.init();
 
     expect(openshellCli.listGateways).toHaveBeenCalled();
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://gw.example.com']);
+    expect(spawn).not.toHaveBeenCalled();
+    expect(openshellCli.selectGateway).not.toHaveBeenCalled();
+  });
+
+  test('selects healthy gateway when it is not active', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const existingGateways: GatewayInfo[] = [{ name: 'kaiden-alt', endpoint: 'http://127.0.0.1:18080', active: false }];
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(openshellCli.selectGateway).toHaveBeenCalledWith('kaiden-alt');
     expect(spawn).not.toHaveBeenCalled();
   });
 
@@ -149,6 +164,54 @@ describe('init', () => {
       expect.arrayContaining(['--port', '17670']),
       expect.objectContaining({ detached: false }),
     );
+  });
+
+  test('returns without spawning when at least one gateway is healthy among multiple', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const gateways: GatewayInfo[] = [
+      { name: 'gw-stopped', endpoint: 'http://127.0.0.1:8080', active: false },
+      { name: 'gw-healthy', endpoint: 'http://127.0.0.1:9090', active: true },
+    ];
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(exec.exec)
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValueOnce(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('creates new gateway when existing gateways are unreachable', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const gateways: GatewayInfo[] = [{ name: 'broken-gw', endpoint: 'http://127.0.0.1:19999', active: true }];
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec)
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(spawn).toHaveBeenCalledWith(
+      GATEWAY_BINARY,
+      expect.arrayContaining(['--port', '17670']),
+      expect.objectContaining({ detached: false }),
+    );
+  });
+
+  test('does not pass --gateway-insecure for https endpoints during health check', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const gateways: GatewayInfo[] = [{ name: 'tls-gw', endpoint: 'https://gw.example.com:8443', active: true }];
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://gw.example.com:8443']);
   });
 });
 
@@ -263,6 +326,18 @@ describe('start', () => {
       '--name',
       'kaiden-local',
     ]);
+  });
+
+  test('skips registerWithCli when skipRegistration is true', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await gateway.start({ skipRegistration: true });
+
+    expect(spawn).toHaveBeenCalled();
+    expect(exec.exec).not.toHaveBeenCalledWith(CLI_BINARY, expect.arrayContaining(['gateway', 'add']));
   });
 });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -77,14 +77,16 @@ beforeEach(() => {
 describe('init', () => {
   test('skips auto-start when existing gateway is healthy and already active', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const existingGateways: GatewayInfo[] = [{ name: 'remote-gw', endpoint: 'https://gw.example.com', active: true }];
+    const existingGateways: GatewayInfo[] = [
+      { name: 'local-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
+    ];
     vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
     await gateway.init();
 
     expect(openshellCli.listGateways).toHaveBeenCalled();
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://gw.example.com']);
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://127.0.0.1:8443']);
     expect(spawn).not.toHaveBeenCalled();
     expect(openshellCli.selectGateway).not.toHaveBeenCalled();
   });
@@ -205,13 +207,33 @@ describe('init', () => {
 
   test('does not pass --gateway-insecure for https endpoints during health check', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const gateways: GatewayInfo[] = [{ name: 'tls-gw', endpoint: 'https://gw.example.com:8443', active: true }];
+    const gateways: GatewayInfo[] = [
+      { name: 'tls-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
+    ];
     vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
     await gateway.init();
 
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://gw.example.com:8443']);
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://127.0.0.1:8443']);
+  });
+
+  test('skips remote gateways during init and auto-starts local', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const gateways: GatewayInfo[] = [{ name: 'remote-gw', endpoint: 'https://gw.example.com', active: true }];
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(exec.exec).not.toHaveBeenCalledWith(
+      CLI_BINARY,
+      expect.arrayContaining(['--gateway-endpoint', 'https://gw.example.com']),
+    );
+    expect(spawn).toHaveBeenCalled();
   });
 });
 
@@ -338,6 +360,33 @@ describe('start', () => {
 
     expect(spawn).toHaveBeenCalled();
     expect(exec.exec).not.toHaveBeenCalledWith(CLI_BINARY, expect.arrayContaining(['gateway', 'add']));
+  });
+
+  test('stops the spawned process when waitForReady fails', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
+
+    let caughtError: unknown;
+    const startPromise = gateway.start().catch((err: unknown) => {
+      caughtError = err;
+    });
+
+    for (let i = 0; i < 30; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    proc.emit('exit', 1, undefined);
+    await vi.advanceTimersByTimeAsync(5000);
+    await startPromise;
+
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toContain('Gateway did not become ready');
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    vi.useRealTimers();
   });
 });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -36,9 +36,10 @@ const STOP_TIMEOUT_MS = 5000;
 /**
  * Manages the `openshell-gateway` server binary lifecycle.
  *
- * On {@link init}, discovers existing gateways via the CLI. If none are found,
- * auto-starts a local gateway by spawning the `openshell-gateway` binary,
- * waiting for it to become healthy, and registering it with the CLI.
+ * On {@link init}, discovers existing gateways via the CLI. If a healthy
+ * gateway is found it is selected. Otherwise, auto-starts a new local
+ * gateway by spawning the `openshell-gateway` binary, waiting for it to
+ * become healthy, and registering it with the CLI.
  */
 @injectable()
 export class OpenshellGateway implements Disposable {
@@ -59,8 +60,16 @@ export class OpenshellGateway implements Disposable {
     try {
       const gateways = await this.openshellCli.listGateways();
       if (gateways.length > 0) {
-        console.log(`[openshell-gateway] discovered ${gateways.length} existing gateway(s)`);
-        return;
+        for (const gw of gateways) {
+          if (await this.isEndpointHealthy(gw.endpoint)) {
+            if (!gw.active) {
+              await this.openshellCli.selectGateway(gw.name);
+            }
+            console.log(`[openshell-gateway] gateway '${gw.name}' is healthy and selected`);
+            return;
+          }
+        }
+        console.warn('[openshell-gateway] gateway(s) defined but none reachable');
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -83,11 +92,15 @@ export class OpenshellGateway implements Disposable {
     await this.start();
   }
 
-  private async isEndpointHealthy(): Promise<boolean> {
-    const endpoint = `http://${this.#bindAddress}:${this.#port}`;
+  private async isEndpointHealthy(endpoint?: string): Promise<boolean> {
+    const target = endpoint ?? `http://${this.#bindAddress}:${this.#port}`;
     const cliPath = this.getCliPath();
+    const args = ['status', '--gateway-endpoint', target];
+    if (target.startsWith('http://')) {
+      args.push('--gateway-insecure');
+    }
     try {
-      await this.exec.exec(cliPath, ['status', '--gateway-endpoint', endpoint, '--gateway-insecure']);
+      await this.exec.exec(cliPath, args);
       return true;
     } catch {
       return false;
@@ -114,6 +127,9 @@ export class OpenshellGateway implements Disposable {
     if (!binaryPath) {
       throw new Error('openshell-gateway binary not registered in CLI tool registry');
     }
+
+    const previousPort = this.#port;
+    const previousBindAddress = this.#bindAddress;
 
     if (options?.port !== undefined) {
       this.#port = options.port;
@@ -148,8 +164,17 @@ export class OpenshellGateway implements Disposable {
       this.#gatewayProcess = undefined;
     });
 
-    await this.waitForReady();
-    await this.registerWithCli();
+    try {
+      await this.waitForReady();
+    } catch (err: unknown) {
+      this.#gatewayProcess = undefined;
+      this.#port = previousPort;
+      this.#bindAddress = previousBindAddress;
+      throw err;
+    }
+    if (!options?.skipRegistration) {
+      await this.registerWithCli();
+    }
   }
 
   async stop(): Promise<void> {
@@ -163,7 +188,7 @@ export class OpenshellGateway implements Disposable {
 
     await new Promise<void>(resolve => {
       const timeout = setTimeout(() => {
-        if (proc.exitCode === undefined || proc.exitCode === null) {
+        if (typeof proc.exitCode !== 'number') {
           console.warn('[openshell-gateway] did not exit after SIGTERM, sending SIGKILL');
           proc.kill('SIGKILL');
         }
@@ -180,7 +205,7 @@ export class OpenshellGateway implements Disposable {
   }
 
   isRunning(): boolean {
-    return this.#gatewayProcess !== undefined && this.#gatewayProcess.exitCode === undefined;
+    return this.#gatewayProcess !== undefined && typeof this.#gatewayProcess.exitCode !== 'number';
   }
 
   @preDestroy()

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -59,8 +59,9 @@ export class OpenshellGateway implements Disposable {
   async init(): Promise<void> {
     try {
       const gateways = await this.openshellCli.listGateways();
-      if (gateways.length > 0) {
-        for (const gw of gateways) {
+      const localGateways = gateways.filter(gw => gw.type === 'local' || this.isLocalEndpoint(gw.endpoint));
+      if (localGateways.length > 0) {
+        for (const gw of localGateways) {
           if (await this.isEndpointHealthy(gw.endpoint)) {
             if (!gw.active) {
               await this.openshellCli.selectGateway(gw.name);
@@ -69,7 +70,7 @@ export class OpenshellGateway implements Disposable {
             return;
           }
         }
-        console.warn('[openshell-gateway] gateway(s) defined but none reachable');
+        console.warn('[openshell-gateway] local gateway(s) defined but none reachable');
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -102,6 +103,15 @@ export class OpenshellGateway implements Disposable {
     try {
       await this.exec.exec(cliPath, args);
       return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private isLocalEndpoint(endpoint: string): boolean {
+    try {
+      const url = new URL(endpoint);
+      return ['127.0.0.1', 'localhost', '::1'].includes(url.hostname);
     } catch {
       return false;
     }
@@ -167,7 +177,9 @@ export class OpenshellGateway implements Disposable {
     try {
       await this.waitForReady();
     } catch (err: unknown) {
-      this.#gatewayProcess = undefined;
+      await this.stop().catch((stopErr: unknown) => {
+        console.warn('[openshell-gateway] failed to stop after startup error:', stopErr);
+      });
       this.#port = previousPort;
       this.#bindAddress = previousBindAddress;
       throw err;


### PR DESCRIPTION
The gateway init logic now health-checks each registered gateway and selects the first healthy one. When all gateways are unreachable it creates a new one on the default port instead of attempting to restart the broken registration. Also fixes isRunning() which compared exitCode against undefined instead of checking for a numeric value — Node.js sets exitCode to null while the process is running, so the old check always returned false and prevented gateway startup.

Closes https://github.com/openkaiden/kaiden/issues/2079

# OpenShell Gateway Init — Test Plan

**Setup:** `pkill openshell-gateway` + remove all gateways via `openshell gateway remove <name>`

### Scenario 1: No gateways — auto-create

1. Ensure no gateways registered (`openshell gateway list` → empty)
2. Start Kaiden
3. **Expected:** `kaiden-local` created on port 17670, selected, healthy


https://github.com/user-attachments/assets/949e84a7-4ec8-4554-8332-a72fecb79c61


### Scenario 2: Broken gateway — create new one alongside

1. `openshell gateway add http://127.0.0.1:19999 --local --name broken-gw`
2. Start Kaiden
3. **Expected:** `broken-gw` kept, new `kaiden-local` created on port 17670, selected, healthy


https://github.com/user-attachments/assets/e32f9ee4-520a-427e-a527-65a77efc4297


### Scenario 3: Healthy but unselected — select it

1. `openshell-gateway --port 18080 --bind-address 127.0.0.1 --disable-tls &`
2. `openshell gateway add http://127.0.0.1:18080 --local --name kaiden-alt`
3. `openshell gateway add http://127.0.0.1:19999 --local --name temp-gw` then `openshell gateway remove temp-gw` (deselects kaiden-alt)
4. Start Kaiden
5. **Expected:** `kaiden-alt` selected, no new gateway created


https://github.com/user-attachments/assets/06dc348c-a19c-4207-85e1-d333bc2451d2

