### PR TITLE
feat(projects): add MCP Servers step to create wizard

### DIFF
--- a/packages/renderer/src/lib/projects/ProjectCreate.spec.ts
+++ b/packages/renderer/src/lib/projects/ProjectCreate.spec.ts
@@ -47,21 +47,22 @@ beforeEach(() => {
   vi.mocked(skillsStore).skillInfos = writable<readonly SkillInfo[]>(SAMPLE_SKILLS);
 });
 
-test('wizard displays 3 steps in stepper', () => {
+test('wizard displays 4 steps in stepper', () => {
   render(ProjectCreate);
 
   expect(screen.getAllByText('Source').length).toBeGreaterThanOrEqual(1);
-  expect(screen.getByText('Skills')).toBeInTheDocument();
   expect(screen.getByText('Review')).toBeInTheDocument();
+  expect(screen.getByText('MCP Servers')).toBeInTheDocument();
+  expect(screen.getByText('Skills')).toBeInTheDocument();
 });
 
-test('step counter shows Step 1 of 3', () => {
+test('step counter shows Step 1 of 4', () => {
   render(ProjectCreate);
 
-  expect(screen.getByText('Step 1 of 3')).toBeInTheDocument();
+  expect(screen.getByText('Step 1 of 4')).toBeInTheDocument();
 });
 
-test('navigates to skills step after analyze with local path', async () => {
+test('navigates to review step after analyze with local path', async () => {
   const analysisResult: WorkspaceProjectAnalysis = {
     name: 'my-project',
     description: 'A project',
@@ -78,11 +79,11 @@ test('navigates to skills step after analyze with local path', async () => {
   await fireEvent.click(analyzeButton);
 
   await waitFor(() => {
-    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Step 2 of 4')).toBeInTheDocument();
   });
 });
 
-test('skills step shows all enabled skills selected by default after analyze', async () => {
+test('skills step shows all enabled skills selected by default', async () => {
   const analysisResult: WorkspaceProjectAnalysis = {
     name: 'my-project',
     folder: '/home/user/my-project',
@@ -94,6 +95,18 @@ test('skills step shows all enabled skills selected by default after analyze', a
   const input = screen.getByPlaceholderText('/home/user/dev/my-project');
   await fireEvent.input(input, { target: { value: '/home/user/my-project' } });
   await fireEvent.click(screen.getByText('Analyze'));
+
+  await waitFor(() => {
+    expect(screen.getByText('Step 2 of 4')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByText('Continue'));
+
+  await waitFor(() => {
+    expect(screen.getByText('Step 3 of 4')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByText('Continue'));
 
   await waitFor(() => {
     expect(screen.getByText(/2\/2 skills/)).toBeInTheDocument();
@@ -115,13 +128,19 @@ test('passes selected skills to createWorkspaceProject', async () => {
   await fireEvent.click(screen.getByText('Analyze'));
 
   await waitFor(() => {
-    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Step 2 of 4')).toBeInTheDocument();
   });
 
   await fireEvent.click(screen.getByText('Continue'));
 
   await waitFor(() => {
-    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Step 3 of 4')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByText('Continue'));
+
+  await waitFor(() => {
+    expect(screen.getByText('Step 4 of 4')).toBeInTheDocument();
   });
 
   await fireEvent.click(screen.getByText('Create Project'));

--- a/packages/renderer/src/lib/projects/ProjectCreate.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreate.svelte
@@ -6,11 +6,13 @@ import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
+import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import { skillInfos } from '/@/stores/skills';
 import { NavigationPage } from '/@api/navigation-page';
 import type { WorkspaceProjectAnalysis } from '/@api/workspace-project-info';
 
 import { extractRepoName, extractRepoSlug, formatGitUrl } from './git-url-utils';
+import ProjectCreateStepMcpServers, { type McpServerItem } from './ProjectCreateStepMcpServers.svelte';
 import ProjectCreateStepReview from './ProjectCreateStepReview.svelte';
 import ProjectCreateStepSkills from './ProjectCreateStepSkills.svelte';
 import ProjectCreateStepSource from './ProjectCreateStepSource.svelte';
@@ -19,6 +21,7 @@ const wizardSteps = [
   { id: 'source', title: 'Source' },
   { id: 'skills', title: 'Skills' },
   { id: 'review', title: 'Review' },
+  { id: 'mcp-servers', title: 'MCP Servers' },
 ];
 
 let currentStepIndex = $state(0);
@@ -49,6 +52,23 @@ let skillItems: ChecklistItem[] = $derived(
     })),
 );
 
+const RECOMMENDED_SERVER_KEYWORDS = ['github', 'fetch'];
+
+function isRecommendedServer(name: string): boolean {
+  const lower = name.toLowerCase();
+  return RECOMMENDED_SERVER_KEYWORDS.some(kw => lower.includes(kw));
+}
+
+let mcpItems: McpServerItem[] = $derived(
+  $mcpRemoteServerInfos.map(m => ({
+    id: m.id,
+    name: m.name,
+    description: m.description,
+    recommended: isRecommendedServer(m.name),
+  })),
+);
+let selectedMcpIds: string[] = $state([]);
+
 let isGitSource = $derived(gitUrl.trim() !== '' && sourcePath.trim() === '');
 let gitRepoDisplay = $derived(formatGitUrl(gitUrl));
 
@@ -64,11 +84,25 @@ function goBack(): void {
   if (currentStepIndex > 0) currentStepIndex--;
 }
 
+function preselectRecommendedMcpServers(): void {
+  if (selectedMcpIds.length === 0 && mcpItems.length > 0) {
+    selectedMcpIds = mcpItems.filter(m => m.recommended).map(m => m.id);
+  }
+}
+
+function goNext(): void {
+  if (currentStepIndex < wizardSteps.length - 1) {
+    currentStepIndex++;
+    if (wizardSteps[currentStepIndex]?.id === 'mcp-servers') preselectRecommendedMcpServers();
+  }
+}
+
 function handleStepClick(index: number): void {
   if (index > currentStepIndex && !isGitSource && !analysis) {
     return;
   }
   currentStepIndex = index;
+  if (wizardSteps[index]?.id === 'mcp-servers') preselectRecommendedMcpServers();
 }
 
 async function handleBrowseSource(): Promise<void> {
@@ -162,7 +196,7 @@ async function createProject(): Promise<void> {
       description: projectDescription.trim() || undefined,
       folder,
       skills: [...selectedSkillIds],
-      mcpServers: [],
+      mcpServers: [...selectedMcpIds],
       knowledges: [],
       secrets: [],
       filesystem: { mode: 'project', mounts: [] },
@@ -220,6 +254,11 @@ async function createProject(): Promise<void> {
                 onBrowseCloneTo={handleBrowseCloneTo}
                 {error}
               />
+            {:else if currentStepId === 'mcp-servers'}
+              <ProjectCreateStepMcpServers
+                {mcpItems}
+                bind:selectedMcpIds={selectedMcpIds}
+              />
             {/if}
           </div>
 
@@ -236,6 +275,10 @@ async function createProject(): Promise<void> {
               {#if currentStepId === 'source'}
                 <Button disabled={!isSourceStepComplete || analyzing} onclick={handleAnalyze}>
                   {analyzing ? 'Analyzing...' : 'Analyze'}
+                </Button>
+              {:else if currentStepId === 'review'}
+                <Button disabled={!isReviewStepComplete} onclick={goNext}>
+                  Configure MCP Servers
                 </Button>
               {:else if isLastStep}
                 <Button disabled={!isReviewStepComplete || creating} onclick={createProject}>

--- a/packages/renderer/src/lib/projects/ProjectCreate.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreate.svelte
@@ -68,6 +68,7 @@ let mcpItems: McpServerItem[] = $derived(
   })),
 );
 let selectedMcpIds: string[] = $state([]);
+let hasInitializedMcpSelection = $state(false);
 
 let isGitSource = $derived(gitUrl.trim() !== '' && sourcePath.trim() === '');
 let gitRepoDisplay = $derived(formatGitUrl(gitUrl));
@@ -85,9 +86,9 @@ function goBack(): void {
 }
 
 function preselectRecommendedMcpServers(): void {
-  if (selectedMcpIds.length === 0 && mcpItems.length > 0) {
-    selectedMcpIds = mcpItems.filter(m => m.recommended).map(m => m.id);
-  }
+  if (hasInitializedMcpSelection || mcpItems.length === 0) return;
+  selectedMcpIds = mcpItems.filter(m => m.recommended).map(m => m.id);
+  hasInitializedMcpSelection = true;
 }
 
 function goNext(): void {

--- a/packages/renderer/src/lib/projects/ProjectCreate.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreate.svelte
@@ -19,9 +19,9 @@ import ProjectCreateStepSource from './ProjectCreateStepSource.svelte';
 
 const wizardSteps = [
   { id: 'source', title: 'Source' },
-  { id: 'skills', title: 'Skills' },
   { id: 'review', title: 'Review' },
   { id: 'mcp-servers', title: 'MCP Servers' },
+  { id: 'skills', title: 'Skills' },
 ];
 
 let currentStepIndex = $state(0);
@@ -89,13 +89,6 @@ function preselectRecommendedMcpServers(): void {
   if (hasInitializedMcpSelection || mcpItems.length === 0) return;
   selectedMcpIds = mcpItems.filter(m => m.recommended).map(m => m.id);
   hasInitializedMcpSelection = true;
-}
-
-function goNext(): void {
-  if (currentStepIndex < wizardSteps.length - 1) {
-    currentStepIndex++;
-    if (wizardSteps[currentStepIndex]?.id === 'mcp-servers') preselectRecommendedMcpServers();
-  }
 }
 
 function handleStepClick(index: number): void {
@@ -277,10 +270,6 @@ async function createProject(): Promise<void> {
                 <Button disabled={!isSourceStepComplete || analyzing} onclick={handleAnalyze}>
                   {analyzing ? 'Analyzing...' : 'Analyze'}
                 </Button>
-              {:else if currentStepId === 'review'}
-                <Button disabled={!isReviewStepComplete} onclick={goNext}>
-                  Configure MCP Servers
-                </Button>
               {:else if isLastStep}
                 <Button disabled={!isReviewStepComplete || creating} onclick={createProject}>
                   {#if creating}
@@ -290,7 +279,7 @@ async function createProject(): Promise<void> {
                   {/if}
                 </Button>
               {:else}
-                <Button onclick={(): void => { currentStepIndex++; }}>Continue</Button>
+                <Button onclick={(): void => { currentStepIndex++; if (wizardSteps[currentStepIndex]?.id === 'mcp-servers') preselectRecommendedMcpServers(); }}>Continue</Button>
               {/if}
             </div>
           </div>

--- a/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.spec.ts
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.spec.ts
@@ -1,0 +1,126 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { McpServerItem } from './ProjectCreateStepMcpServers.svelte';
+import ProjectCreateStepMcpServers from './ProjectCreateStepMcpServers.svelte';
+
+const recommendedItems: McpServerItem[] = [
+  { id: 'mcp-github', name: 'GitHub', description: 'Repository access, PRs, issues', recommended: true },
+  { id: 'mcp-filesystem', name: 'Filesystem', description: 'Read, write, and manage project files', recommended: true },
+];
+
+const availableItems: McpServerItem[] = [
+  { id: 'mcp-terminal', name: 'Terminal', description: 'Execute shell commands and manage processes' },
+  { id: 'mcp-playwright', name: 'Playwright', description: 'Browser automation for testing' },
+];
+
+const allItems: McpServerItem[] = [...recommendedItems, ...availableItems];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect description text is shown', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: allItems, selectedMcpIds: [] });
+
+  expect(screen.getByText(/we recommend the following MCP servers/)).toBeInTheDocument();
+});
+
+test('Expect recommended section header and badges are shown', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: allItems, selectedMcpIds: [] });
+
+  const matches = screen.getAllByText('Recommended');
+  expect(matches.length).toBeGreaterThanOrEqual(1);
+});
+
+test('Expect available section header is shown', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: allItems, selectedMcpIds: [] });
+
+  expect(screen.getByText('Available')).toBeInTheDocument();
+});
+
+test('Expect all server names are rendered', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: allItems, selectedMcpIds: [] });
+
+  expect(screen.getByText('GitHub')).toBeInTheDocument();
+  expect(screen.getByText('Filesystem')).toBeInTheDocument();
+  expect(screen.getByText('Terminal')).toBeInTheDocument();
+  expect(screen.getByText('Playwright')).toBeInTheDocument();
+});
+
+test('Expect server descriptions are rendered', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: allItems, selectedMcpIds: [] });
+
+  expect(screen.getByText('Repository access, PRs, issues')).toBeInTheDocument();
+  expect(screen.getByText('Execute shell commands and manage processes')).toBeInTheDocument();
+});
+
+test('Expect recommended badges are shown for recommended items', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: recommendedItems, selectedMcpIds: [] });
+
+  const badges = screen.getAllByText('Recommended');
+  expect(badges.length).toBe(3);
+});
+
+test('Expect optional badges are shown for available items', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: availableItems, selectedMcpIds: [] });
+
+  const badges = screen.getAllByText('Optional');
+  expect(badges.length).toBe(2);
+});
+
+test('Expect clicking a server toggles selection', async () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: allItems, selectedMcpIds: [] });
+
+  const checkbox = screen.getByRole('checkbox', { name: 'GitHub' });
+  await fireEvent.click(checkbox);
+
+  expect(checkbox).toBeChecked();
+});
+
+test('Expect clicking a selected server deselects it', async () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: allItems, selectedMcpIds: ['mcp-github'] });
+
+  const checkbox = screen.getByRole('checkbox', { name: 'GitHub' });
+  await fireEvent.click(checkbox);
+
+  expect(checkbox).not.toBeChecked();
+});
+
+test('Expect empty state when no MCP servers available', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: [], selectedMcpIds: [] });
+
+  expect(screen.getByText('No MCP servers available. Set up servers in the MCP section first.')).toBeInTheDocument();
+});
+
+test('Expect no recommended section when no recommended items', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: availableItems, selectedMcpIds: [] });
+
+  expect(screen.queryByText('Recommended')).not.toBeInTheDocument();
+});
+
+test('Expect no available section when no available items', () => {
+  render(ProjectCreateStepMcpServers, { mcpItems: recommendedItems, selectedMcpIds: [] });
+
+  expect(screen.queryByText('Available')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.svelte
@@ -34,46 +34,46 @@ function toggle(id: string): void {
 </script>
 
 <div class="flex flex-col gap-5">
-  <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 leading-relaxed">
+  <p class="text-sm text-(--pd-content-card-text) opacity-70 leading-relaxed">
     Based on your project analysis, we recommend the following MCP servers. Select the ones you want to enable for this
     project.
   </p>
 
   {#if mcpItems.length === 0}
     <div
-      class="rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] px-5 py-8 text-center text-sm text-[var(--pd-content-card-text)] opacity-50 italic">
+      class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-bg) px-5 py-8 text-center text-sm text-(--pd-content-card-text) opacity-50 italic">
       No MCP servers available. Set up servers in the MCP section first.
     </div>
   {:else}
     {#if recommendedItems.length > 0}
       <div class="flex flex-col gap-2">
         <span
-          class="text-[11px] font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]"
+          class="text-[11px] font-semibold uppercase tracking-wider text-(--pd-table-header-text)"
           >Recommended</span>
         {#each recommendedItems as item (item.id)}
           <button
             class="flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors cursor-pointer
               {isSelected(item.id)
-              ? 'bg-[var(--pd-content-card-hover-inset-bg)] border-[var(--pd-button-primary-bg)]'
-              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+              ? 'bg-(--pd-content-card-hover-inset-bg) border-(--pd-button-primary-bg)'
+              : 'bg-(--pd-content-card-bg) border-(--pd-content-card-border) hover:bg-(--pd-content-card-hover-inset-bg)'}"
             onclick={(): void => toggle(item.id)}
             aria-label={item.name}>
             <div class="flex-shrink-0" onclick={(e): void => e.stopPropagation()}>
               <Checkbox checked={isSelected(item.id)} title={item.name} onclick={(): void => toggle(item.id)} />
             </div>
             <div
-              class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-[var(--pd-label-quaternary-bg)] text-[var(--pd-label-quaternary-text)]">
+              class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-(--pd-label-quaternary-bg) text-(--pd-label-quaternary-text)">
               <Icon icon={faServer} class="text-base" />
             </div>
             <div class="flex-1 min-w-0 text-left">
-              <div class="text-sm font-medium text-[var(--pd-table-body-text-highlight)]">{item.name}</div>
+              <div class="text-sm font-medium text-(--pd-table-body-text-highlight)">{item.name}</div>
               {#if item.description}
-                <div class="text-xs text-[var(--pd-table-body-text)] mt-px">{item.description}</div>
+                <div class="text-xs text-(--pd-table-body-text) mt-px">{item.description}</div>
               {/if}
             </div>
             <span
               class="text-[10px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-md flex-shrink-0
-                bg-[var(--pd-status-running)]/15 text-[var(--pd-status-running)]"
+                bg-(--pd-status-running)/15 text-(--pd-status-running)"
               >Recommended</span>
           </button>
         {/each}
@@ -83,32 +83,32 @@ function toggle(id: string): void {
     {#if availableItems.length > 0}
       <div class="flex flex-col gap-2">
         <span
-          class="text-[11px] font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]"
+          class="text-[11px] font-semibold uppercase tracking-wider text-(--pd-table-header-text)"
           >Available</span>
         {#each availableItems as item (item.id)}
           <button
             class="flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors cursor-pointer
               {isSelected(item.id)
-              ? 'bg-[var(--pd-content-card-hover-inset-bg)] border-[var(--pd-button-primary-bg)]'
-              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+              ? 'bg-(--pd-content-card-hover-inset-bg) border-(--pd-button-primary-bg)'
+              : 'bg-(--pd-content-card-bg) border-(--pd-content-card-border) hover:bg-(--pd-content-card-hover-inset-bg)'}"
             onclick={(): void => toggle(item.id)}
             aria-label={item.name}>
             <div class="flex-shrink-0" onclick={(e): void => e.stopPropagation()}>
               <Checkbox checked={isSelected(item.id)} title={item.name} onclick={(): void => toggle(item.id)} />
             </div>
             <div
-              class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-[var(--pd-label-quaternary-bg)] text-[var(--pd-label-quaternary-text)]">
+              class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-(--pd-label-quaternary-bg) text-(--pd-label-quaternary-text)">
               <Icon icon={faServer} class="text-base" />
             </div>
             <div class="flex-1 min-w-0 text-left">
-              <div class="text-sm font-medium text-[var(--pd-table-body-text-highlight)]">{item.name}</div>
+              <div class="text-sm font-medium text-(--pd-table-body-text-highlight)">{item.name}</div>
               {#if item.description}
-                <div class="text-xs text-[var(--pd-table-body-text)] mt-px">{item.description}</div>
+                <div class="text-xs text-(--pd-table-body-text) mt-px">{item.description}</div>
               {/if}
             </div>
             <span
               class="text-[10px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-md flex-shrink-0
-                bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] text-[var(--pd-content-card-text)] opacity-60"
+                bg-(--pd-content-card-bg) border border-(--pd-content-card-border) text-(--pd-content-card-text) opacity-60"
               >Optional</span>
           </button>
         {/each}

--- a/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faServer } from '@fortawesome/free-solid-svg-icons';
+import { Checkbox } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 export interface McpServerItem {
@@ -50,27 +51,16 @@ function toggle(id: string): void {
           class="text-[11px] font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]"
           >Recommended</span>
         {#each recommendedItems as item (item.id)}
-          <label
+          <button
             class="flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors cursor-pointer
               {isSelected(item.id)
               ? 'bg-[var(--pd-content-card-hover-inset-bg)] border-[var(--pd-button-primary-bg)]'
-              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}">
-            <input
-              type="checkbox"
-              class="sr-only"
-              checked={isSelected(item.id)}
-              onchange={(): void => toggle(item.id)}
-              aria-label={item.name} />
-            <span
-              class="flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center pointer-events-none
-                {isSelected(item.id) ? 'bg-[var(--pd-button-primary-bg)] border-[var(--pd-button-primary-bg)]' : 'border-[var(--pd-content-card-border)]'}"
-              aria-hidden="true">
-              {#if isSelected(item.id)}
-                <svg class="w-2.5 h-2.5 text-white" viewBox="0 0 10 8" fill="none">
-                  <path d="M1 4l3 3 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-              {/if}
-            </span>
+              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+            onclick={(): void => toggle(item.id)}
+            aria-label={item.name}>
+            <div class="flex-shrink-0" onclick={(e): void => e.stopPropagation()}>
+              <Checkbox checked={isSelected(item.id)} title={item.name} onclick={(): void => toggle(item.id)} />
+            </div>
             <div
               class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-[var(--pd-label-quaternary-bg)] text-[var(--pd-label-quaternary-text)]">
               <Icon icon={faServer} class="text-base" />
@@ -85,7 +75,7 @@ function toggle(id: string): void {
               class="text-[10px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-md flex-shrink-0
                 bg-[var(--pd-status-running)]/15 text-[var(--pd-status-running)]"
               >Recommended</span>
-          </label>
+          </button>
         {/each}
       </div>
     {/if}
@@ -96,27 +86,16 @@ function toggle(id: string): void {
           class="text-[11px] font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]"
           >Available</span>
         {#each availableItems as item (item.id)}
-          <label
+          <button
             class="flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors cursor-pointer
               {isSelected(item.id)
               ? 'bg-[var(--pd-content-card-hover-inset-bg)] border-[var(--pd-button-primary-bg)]'
-              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}">
-            <input
-              type="checkbox"
-              class="sr-only"
-              checked={isSelected(item.id)}
-              onchange={(): void => toggle(item.id)}
-              aria-label={item.name} />
-            <span
-              class="flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center pointer-events-none
-                {isSelected(item.id) ? 'bg-[var(--pd-button-primary-bg)] border-[var(--pd-button-primary-bg)]' : 'border-[var(--pd-content-card-border)]'}"
-              aria-hidden="true">
-              {#if isSelected(item.id)}
-                <svg class="w-2.5 h-2.5 text-white" viewBox="0 0 10 8" fill="none">
-                  <path d="M1 4l3 3 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-              {/if}
-            </span>
+              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+            onclick={(): void => toggle(item.id)}
+            aria-label={item.name}>
+            <div class="flex-shrink-0" onclick={(e): void => e.stopPropagation()}>
+              <Checkbox checked={isSelected(item.id)} title={item.name} onclick={(): void => toggle(item.id)} />
+            </div>
             <div
               class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-[var(--pd-label-quaternary-bg)] text-[var(--pd-label-quaternary-text)]">
               <Icon icon={faServer} class="text-base" />
@@ -131,7 +110,7 @@ function toggle(id: string): void {
               class="text-[10px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-md flex-shrink-0
                 bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] text-[var(--pd-content-card-text)] opacity-60"
               >Optional</span>
-          </label>
+          </button>
         {/each}
       </div>
     {/if}

--- a/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.svelte
+++ b/packages/renderer/src/lib/projects/ProjectCreateStepMcpServers.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+import { faServer } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+export interface McpServerItem {
+  id: string;
+  name: string;
+  description?: string;
+  recommended?: boolean;
+}
+
+interface Props {
+  mcpItems: McpServerItem[];
+  selectedMcpIds: string[];
+}
+
+let { mcpItems, selectedMcpIds = $bindable() }: Props = $props();
+
+const recommendedItems = $derived(mcpItems.filter(m => m.recommended));
+const availableItems = $derived(mcpItems.filter(m => !m.recommended));
+
+function isSelected(id: string): boolean {
+  return selectedMcpIds.includes(id);
+}
+
+function toggle(id: string): void {
+  if (isSelected(id)) {
+    selectedMcpIds = selectedMcpIds.filter(s => s !== id);
+  } else {
+    selectedMcpIds = [...selectedMcpIds, id];
+  }
+}
+</script>
+
+<div class="flex flex-col gap-5">
+  <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 leading-relaxed">
+    Based on your project analysis, we recommend the following MCP servers. Select the ones you want to enable for this
+    project.
+  </p>
+
+  {#if mcpItems.length === 0}
+    <div
+      class="rounded-xl border border-[var(--pd-content-card-border)] bg-[var(--pd-content-card-bg)] px-5 py-8 text-center text-sm text-[var(--pd-content-card-text)] opacity-50 italic">
+      No MCP servers available. Set up servers in the MCP section first.
+    </div>
+  {:else}
+    {#if recommendedItems.length > 0}
+      <div class="flex flex-col gap-2">
+        <span
+          class="text-[11px] font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]"
+          >Recommended</span>
+        {#each recommendedItems as item (item.id)}
+          <label
+            class="flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors cursor-pointer
+              {isSelected(item.id)
+              ? 'bg-[var(--pd-content-card-hover-inset-bg)] border-[var(--pd-button-primary-bg)]'
+              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}">
+            <input
+              type="checkbox"
+              class="sr-only"
+              checked={isSelected(item.id)}
+              onchange={(): void => toggle(item.id)}
+              aria-label={item.name} />
+            <span
+              class="flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center pointer-events-none
+                {isSelected(item.id) ? 'bg-[var(--pd-button-primary-bg)] border-[var(--pd-button-primary-bg)]' : 'border-[var(--pd-content-card-border)]'}"
+              aria-hidden="true">
+              {#if isSelected(item.id)}
+                <svg class="w-2.5 h-2.5 text-white" viewBox="0 0 10 8" fill="none">
+                  <path d="M1 4l3 3 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              {/if}
+            </span>
+            <div
+              class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-[var(--pd-label-quaternary-bg)] text-[var(--pd-label-quaternary-text)]">
+              <Icon icon={faServer} class="text-base" />
+            </div>
+            <div class="flex-1 min-w-0 text-left">
+              <div class="text-sm font-medium text-[var(--pd-table-body-text-highlight)]">{item.name}</div>
+              {#if item.description}
+                <div class="text-xs text-[var(--pd-table-body-text)] mt-px">{item.description}</div>
+              {/if}
+            </div>
+            <span
+              class="text-[10px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-md flex-shrink-0
+                bg-[var(--pd-status-running)]/15 text-[var(--pd-status-running)]"
+              >Recommended</span>
+          </label>
+        {/each}
+      </div>
+    {/if}
+
+    {#if availableItems.length > 0}
+      <div class="flex flex-col gap-2">
+        <span
+          class="text-[11px] font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]"
+          >Available</span>
+        {#each availableItems as item (item.id)}
+          <label
+            class="flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors cursor-pointer
+              {isSelected(item.id)
+              ? 'bg-[var(--pd-content-card-hover-inset-bg)] border-[var(--pd-button-primary-bg)]'
+              : 'bg-[var(--pd-content-card-bg)] border-[var(--pd-content-card-border)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}">
+            <input
+              type="checkbox"
+              class="sr-only"
+              checked={isSelected(item.id)}
+              onchange={(): void => toggle(item.id)}
+              aria-label={item.name} />
+            <span
+              class="flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center pointer-events-none
+                {isSelected(item.id) ? 'bg-[var(--pd-button-primary-bg)] border-[var(--pd-button-primary-bg)]' : 'border-[var(--pd-content-card-border)]'}"
+              aria-hidden="true">
+              {#if isSelected(item.id)}
+                <svg class="w-2.5 h-2.5 text-white" viewBox="0 0 10 8" fill="none">
+                  <path d="M1 4l3 3 5-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              {/if}
+            </span>
+            <div
+              class="w-9 h-9 rounded-[9px] flex items-center justify-center flex-shrink-0 bg-[var(--pd-label-quaternary-bg)] text-[var(--pd-label-quaternary-text)]">
+              <Icon icon={faServer} class="text-base" />
+            </div>
+            <div class="flex-1 min-w-0 text-left">
+              <div class="text-sm font-medium text-[var(--pd-table-body-text-highlight)]">{item.name}</div>
+              {#if item.description}
+                <div class="text-xs text-[var(--pd-table-body-text)] mt-px">{item.description}</div>
+              {/if}
+            </div>
+            <span
+              class="text-[10px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-md flex-shrink-0
+                bg-[var(--pd-content-card-bg)] border border-[var(--pd-content-card-border)] text-[var(--pd-content-card-text)] opacity-60"
+              >Optional</span>
+          </label>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/packages/renderer/src/lib/projects/ProjectDetailsOverview.spec.ts
+++ b/packages/renderer/src/lib/projects/ProjectDetailsOverview.spec.ts
@@ -40,6 +40,7 @@ const sampleProject: WorkspaceProjectInfo = {
 };
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
   mcpRemoteServerInfos.set([{ id: 'mcp-server-1', name: 'My MCP Server' } as MCPRemoteServerInfo]);
 });

--- a/packages/renderer/src/lib/projects/ProjectDetailsOverview.spec.ts
+++ b/packages/renderer/src/lib/projects/ProjectDetailsOverview.spec.ts
@@ -21,6 +21,8 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
+import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
 
 import ProjectDetailsOverview from './ProjectDetailsOverview.svelte';
@@ -39,6 +41,7 @@ const sampleProject: WorkspaceProjectInfo = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  mcpRemoteServerInfos.set([{ id: 'mcp-server-1', name: 'My MCP Server' } as MCPRemoteServerInfo]);
 });
 
 test('Expect project name is displayed in info card', () => {
@@ -60,7 +63,14 @@ test('Expect skills are listed in skills card', () => {
   expect(screen.getByText('testing')).toBeInTheDocument();
 });
 
-test('Expect MCP servers are listed', () => {
+test('Expect MCP servers are listed by name', () => {
+  render(ProjectDetailsOverview, { project: sampleProject });
+
+  expect(screen.getByText('My MCP Server')).toBeInTheDocument();
+});
+
+test('Expect MCP server falls back to id when name is not found', () => {
+  mcpRemoteServerInfos.set([]);
   render(ProjectDetailsOverview, { project: sampleProject });
 
   expect(screen.getByText('mcp-server-1')).toBeInTheDocument();

--- a/packages/renderer/src/lib/projects/ProjectDetailsOverview.svelte
+++ b/packages/renderer/src/lib/projects/ProjectDetailsOverview.svelte
@@ -10,6 +10,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
+import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
 
 interface Props {
@@ -19,6 +20,10 @@ interface Props {
 let { project }: Props = $props();
 
 const networkLabel = $derived(project.network.mode === 'allow' ? 'Unrestricted' : 'Deny All');
+
+function mcpServerName(id: string): string {
+  return $mcpRemoteServerInfos.find(s => s.id === id)?.name ?? id;
+}
 
 const filesystemBadge = $derived.by((): string => {
   const mounts = project.filesystem.mounts;
@@ -135,7 +140,7 @@ const filesystemBadge = $derived.by((): string => {
                   class="w-7 h-7 rounded-md flex items-center justify-center shrink-0 bg-[var(--pd-link)]/15 text-[var(--pd-link)]">
                   <Icon icon={faServer} size="sm" />
                 </div>
-                <span class="flex-1 min-w-0 text-[13px] font-medium text-[var(--pd-content-card-header-text)] truncate">{server}</span>
+                <span class="flex-1 min-w-0 text-[13px] font-medium text-[var(--pd-content-card-header-text)] truncate">{mcpServerName(server)}</span>
               </div>
             {/each}
           {:else}


### PR DESCRIPTION
## Summary
- Adds a third step ("MCP Servers") to the project creation wizard between Review and project creation
- Users can select which MCP servers to attach to the new project via a card-based checklist UI
- Servers with known names (github, fetch) are shown as "Recommended" and pre-selected; all others appear as "Available" with an "Optional" badge
- Selected server IDs are passed through to `createWorkspaceProject()` instead of an empty array

Fixes: https://github.com/openkaiden/kaiden/issues/1929

<img width="1116" height="793" alt="Screenshot From 2026-06-05 20-37-05" src="https://github.com/user-attachments/assets/eeb06ad0-d742-43de-8bcb-dbc3b8a053b8" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)