### PR TITLE
feat(claude): support custom baseURL for Anthropic provider

### DIFF
--- a/extensions/claude/package.json
+++ b/extensions/claude/package.json
@@ -20,6 +20,11 @@
           "scope": "InferenceProviderConnectionFactory",
           "markdownDescription": "Provide a Claude API key\n\n:button[Grab a key]{href=\"https://console.anthropic.com/settings/keys\"}"
         },
+        "claude.factory.baseURL": {
+          "type": "string",
+          "scope": "InferenceProviderConnectionFactory",
+          "description": "Custom base URL (leave empty for https://api.anthropic.com)"
+        },
         "claude.factory.apiKey": {
           "type": "string",
           "scope": "InferenceProviderConnectionFactory",

--- a/extensions/claude/src/manager/claude-inference-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.spec.ts
@@ -130,6 +130,28 @@ describe('init', () => {
     );
   });
 
+  test('should restore connection with custom baseURL', async () => {
+    const stored: StoredConnection[] = [{ id: 'custom-id', token: 'key1', baseURL: 'http://localhost:8080' }];
+    vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(JSON.stringify(stored));
+
+    const manager = await createManager();
+    await manager.init();
+
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: 'key1',
+      baseURL: 'http://localhost:8080',
+    });
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'custom-id',
+        name: 'http://localhost:8080',
+        type: 'self-hosted',
+        endpoint: 'http://localhost:8080',
+      }),
+    );
+  });
+
   test('should handle empty secret storage', async () => {
     vi.mocked(SECRET_STORAGE_MOCK.get).mockResolvedValue(undefined);
 
@@ -210,7 +232,7 @@ describe('factory', () => {
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
 
-  test('calling create with proper params should register inference connection', async () => {
+  test('calling create with default baseURL should not pass baseURL to SDK', async () => {
     await create({
       'claude.factory.apiKey': 'dummyKey',
     });
@@ -239,6 +261,56 @@ describe('factory', () => {
       sdk: ANTHROPIC_PROVIDER_MOCK,
       models: [{ label: 'claude-sonnet-4-20250514' }, { label: 'claude-haiku-3.5-20241022' }],
       credentials: expect.any(Function),
+    });
+  });
+
+  test('calling create with custom baseURL should pass it to SDKs', async () => {
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+      'claude.factory.baseURL': 'http://localhost:8080',
+    });
+
+    expect(createAnthropic).toHaveBeenCalledOnce();
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
+      baseURL: 'http://localhost:8080',
+    });
+
+    expect(AnthropicClient).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
+      baseURL: 'http://localhost:8080',
+    });
+
+    const expected: StoredConnection[] = [{ id: 'fake-uuid-1', token: 'dummyKey', baseURL: 'http://localhost:8080' }];
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
+
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith({
+      id: 'fake-uuid-1',
+      name: 'http://localhost:8080',
+      type: 'self-hosted',
+      llmMetadata: {
+        name: 'anthropic',
+      },
+      endpoint: 'http://localhost:8080',
+      status: expect.any(Function),
+      lifecycle: {
+        delete: expect.any(Function),
+      },
+      sdk: ANTHROPIC_PROVIDER_MOCK,
+      models: [{ label: 'claude-sonnet-4-20250514' }, { label: 'claude-haiku-3.5-20241022' }],
+      credentials: expect.any(Function),
+    });
+  });
+
+  test('calling create with empty baseURL should use default', async () => {
+    await create({
+      'claude.factory.apiKey': 'dummyKey',
+      'claude.factory.baseURL': '  ',
+    });
+
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: 'dummyKey',
     });
   });
 });

--- a/extensions/claude/src/manager/claude-inference-manager.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.ts
@@ -27,9 +27,12 @@ import { ClaudeProviderSymbol, SecretStorageSymbol } from '/@/inject/symbol';
 
 export const TOKENS_KEY = 'claude:tokens';
 
+const DEFAULT_BASE_URL = 'https://api.anthropic.com';
+
 export interface StoredConnection {
   id: string;
   token: string;
+  baseURL?: string;
 }
 
 @injectable()
@@ -53,7 +56,11 @@ export class ClaudeInferenceManager {
   private async restoreConnections(): Promise<void> {
     const stored = await this.getStoredConnections();
     for (const entry of stored) {
-      await this.registerInferenceProviderConnection({ id: entry.id, token: entry.token });
+      await this.registerInferenceProviderConnection({
+        id: entry.id,
+        token: entry.token,
+        baseURL: entry.baseURL ?? DEFAULT_BASE_URL,
+      });
     }
   }
 
@@ -89,9 +96,20 @@ export class ClaudeInferenceManager {
     await this.secrets.store(TOKENS_KEY, JSON.stringify(filtered));
   }
 
-  private async registerInferenceProviderConnection({ id, token }: { id: string; token: string }): Promise<void> {
+  private async registerInferenceProviderConnection({
+    id,
+    token,
+    baseURL,
+  }: {
+    id: string;
+    token: string;
+    baseURL: string;
+  }): Promise<void> {
+    const isCustomBaseURL = baseURL !== DEFAULT_BASE_URL;
+
     const anthropic = createAnthropic({
       apiKey: token,
+      ...(isCustomBaseURL && { baseURL }),
     });
 
     const clean = async (): Promise<void> => {
@@ -104,18 +122,21 @@ export class ClaudeInferenceManager {
     let models: InferenceModel[] = [];
 
     try {
-      models = await this.getAnthropicModels(token);
+      models = await this.getAnthropicModels(token, baseURL);
     } catch (err: unknown) {
       status = 'stopped';
     }
 
+    const connectionName = isCustomBaseURL ? baseURL : this.maskKey(token);
+
     const connectionDisposable = this.claudeProvider.registerInferenceProviderConnection({
       id,
-      name: this.maskKey(token),
-      type: 'cloud',
+      name: connectionName,
+      type: isCustomBaseURL ? 'self-hosted' : 'cloud',
       llmMetadata: {
         name: 'anthropic',
       },
+      ...(isCustomBaseURL && { endpoint: baseURL }),
       sdk: anthropic,
       status(): ProviderConnectionStatus {
         return status;
@@ -133,8 +154,12 @@ export class ClaudeInferenceManager {
     this.connections.set(id, connectionDisposable);
   }
 
-  private async getAnthropicModels(token: string): Promise<Array<{ label: string }>> {
-    const client = new AnthropicClient({ apiKey: token });
+  private async getAnthropicModels(token: string, baseURL: string): Promise<Array<{ label: string }>> {
+    const isCustomBaseURL = baseURL !== DEFAULT_BASE_URL;
+    const client = new AnthropicClient({
+      apiKey: token,
+      ...(isCustomBaseURL && { baseURL }),
+    });
     const models: InferenceModel[] = [];
     for await (const model of client.models.list()) {
       if (model.id) {
@@ -153,9 +178,13 @@ export class ClaudeInferenceManager {
     const apiKey = params['claude.factory.apiKey'];
     if (!apiKey || typeof apiKey !== 'string') throw new Error('invalid apiKey');
 
+    const rawBaseURL = params['claude.factory.baseURL'];
+    const baseURL = typeof rawBaseURL === 'string' && rawBaseURL.trim() ? rawBaseURL.trim() : DEFAULT_BASE_URL;
+
     const id = randomUUID();
-    await this.saveConnection({ id, token: apiKey });
-    await this.registerInferenceProviderConnection({ id, token: apiKey });
+    const isCustomBaseURL = baseURL !== DEFAULT_BASE_URL;
+    await this.saveConnection({ id, token: apiKey, ...(isCustomBaseURL && { baseURL }) });
+    await this.registerInferenceProviderConnection({ id, token: apiKey, baseURL });
   }
 
   dispose(): void {


### PR DESCRIPTION
Allow users to configure a custom base URL when creating a Claude connection, enabling compatibility with local inference engines (e.g. llama-server) and proxy services. Defaults to https://api.anthropic.com when left empty.

Closes #1855