### PR TITLE
feat(openshell-cli): add --upload flag support to sandbox create

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -50,6 +50,7 @@ export interface CreateSandboxOptions {
   memory?: string;
   providers?: string[];
   labels?: Record<string, string>;
+  uploads?: Array<{ local: string; remote: string }>;
   command?: string[];
 }
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -187,6 +187,62 @@ describe('createSandbox', () => {
     ]);
   });
 
+  test('includes single --upload flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({
+      uploads: [{ local: '.agents/skills', remote: '.agents/skills' }],
+    });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'sandbox',
+      'create',
+      '--upload',
+      '.agents/skills:.agents/skills',
+    ]);
+  });
+
+  test('includes multiple --upload flags when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({
+      uploads: [
+        { local: '.agents/skills/generate-sandbox-policy', remote: '.agents/skills/generate-sandbox-policy' },
+        { local: '.agents/skills/openshell-cli', remote: '.agents/skills/openshell-cli' },
+      ],
+    });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'sandbox',
+      'create',
+      '--upload',
+      '.agents/skills/generate-sandbox-policy:.agents/skills/generate-sandbox-policy',
+      '--upload',
+      '.agents/skills/openshell-cli:.agents/skills/openshell-cli',
+    ]);
+  });
+
+  test('places --upload flags before -- command separator', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({
+      uploads: [{ local: '.agents/skills', remote: '.agents/skills' }],
+      command: ['bash'],
+    });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, [
+      'sandbox',
+      'create',
+      '--upload',
+      '.agents/skills:.agents/skills',
+      '--',
+      'bash',
+    ]);
+  });
+
   test('appends command after -- separator', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -139,6 +139,11 @@ export class OpenshellCli {
         args.push('--label', `${key}=${value}`);
       }
     }
+    if (options.uploads) {
+      for (const upload of options.uploads) {
+        args.push('--upload', `${upload.local}:${upload.remote}`);
+      }
+    }
     if (options.command?.length) {
       args.push('--', ...options.command);
     }


### PR DESCRIPTION
## Summary
- Adds `uploads` field to `CreateSandboxOptions` for specifying local→remote path mappings
- `OpenshellCli.createSandbox()` now generates `--upload local:remote` flags, enabling skill injection into OpenShell sandboxes
- Adds tests for single upload, multiple uploads, and upload + command separator ordering

Fixes: https://github.com/openkaiden/kaiden/issues/2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)