### PR TITLE
fix(milvus): add missing icon attribute to package.json

### DIFF
--- a/extensions/milvus/package.json
+++ b/extensions/milvus/package.json
@@ -3,6 +3,7 @@
   "displayName": "Milvus Knowledges Provider",
   "description": "Provides Milvus vector database for Knowledges",
   "version": "0.2.0-next",
+  "icon": "milvus-icon-color.png",
   "publisher": "kaiden",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
## Summary
- Adds the missing `icon` attribute to the Milvus extension's `package.json`, pointing to the existing `milvus-icon-color.png` file

Fixes: https://github.com/openkaiden/kaiden/issues/2097