### PR TITLE
feat(secret-manager): add OpenShell backend for secret management

### DIFF
--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -36,3 +36,16 @@ export type SecretService = components['schemas']['SecretService'];
 export interface SecretCreateOptions extends SecretInfo {
   value: string;
 }
+
+/**
+ * Common interface for CLI backends that support secret management.
+ *
+ * Both `KdnCli` and `OpenshellSecretAdapter` implement this contract
+ * so that `SecretManager` can switch between them at runtime.
+ */
+export interface SecretCliBackend {
+  createSecret(options: SecretCreateOptions): Promise<SecretName>;
+  listSecrets(): Promise<SecretInfo[]>;
+  removeSecret(name: string): Promise<SecretName>;
+  listServices(): Promise<SecretService[]>;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -74,6 +74,7 @@ import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
+import { OpenshellSecretAdapter } from '/@/plugin/secret-manager/openshell-secret-adapter.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import { SemanticRouterManager } from '/@/plugin/semantic-router/semantic-router-manager.js';
 import { SkillManager } from '/@/plugin/skill/skill-manager.js';
@@ -594,6 +595,7 @@ export class PluginSystem {
     container.bind<OpenshellCli>(OpenshellCli).toSelf().inSingletonScope();
     container.bind<OpenshellGateway>(OpenshellGateway).toSelf().inSingletonScope();
     container.bind<AgentWorkspaceManager>(AgentWorkspaceManager).toSelf().inSingletonScope();
+    container.bind<OpenshellSecretAdapter>(OpenshellSecretAdapter).toSelf().inSingletonScope();
     container.bind<SecretManager>(SecretManager).toSelf().inSingletonScope();
     container.bind<FlowManager>(FlowManager).toSelf().inSingletonScope();
     container.bind<SkillManager>(SkillManager).toSelf().inSingletonScope();

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -33,7 +33,13 @@ import type {
   AgentWorkspaceSummary,
   CliInfo,
 } from '/@api/agent-workspace-info.js';
-import type { SecretCreateOptions, SecretInfo, SecretName, SecretService } from '/@api/secret-info.js';
+import type {
+  SecretCliBackend,
+  SecretCreateOptions,
+  SecretInfo,
+  SecretName,
+  SecretService,
+} from '/@api/secret-info.js';
 
 type WorkspaceConfiguration = workspaceComponents['schemas']['WorkspaceConfiguration'];
 
@@ -45,7 +51,7 @@ type WorkspaceConfiguration = workspaceComponents['schemas']['WorkspaceConfigura
  * orchestration (tasks, events, IPC) stays in the manager.
  */
 @injectable()
-export class KdnCli {
+export class KdnCli implements SecretCliBackend {
   constructor(
     @inject(Exec)
     private readonly exec: Exec,

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { Exec } from '/@/plugin/util/exec.js';
+import type { SecretCreateOptions } from '/@api/secret-info.js';
+
+import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
+
+vi.mock(import('/@/plugin/openshell-cli/openshell-cli.js'));
+
+let adapter: OpenshellSecretAdapter;
+const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  adapter = new OpenshellSecretAdapter(openshellCli);
+});
+
+describe('createSecret', () => {
+  const defaultOptions: SecretCreateOptions = {
+    name: 'my-secret',
+    type: 'github',
+    value: 'ghp_abc123',
+  };
+
+  test('delegates to openshellCli.createProvider and returns the secret name', async () => {
+    vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
+
+    const result = await adapter.createSecret(defaultOptions);
+
+    expect(openshellCli.createProvider).toHaveBeenCalledWith({
+      name: 'my-secret',
+      type: 'github',
+      credentials: { value: 'ghp_abc123' },
+    });
+    expect(result).toEqual({ name: 'my-secret' });
+  });
+
+  test('rejects when openshellCli.createProvider fails', async () => {
+    vi.mocked(openshellCli.createProvider).mockRejectedValue(new Error('provider type not supported'));
+
+    await expect(adapter.createSecret(defaultOptions)).rejects.toThrow('provider type not supported');
+  });
+});
+
+describe('listSecrets', () => {
+  test('maps providers to SecretInfo array', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([
+      { name: 'my-openai', type: 'openai' },
+      { name: 'my-anthropic', type: 'anthropic' },
+    ]);
+
+    const result = await adapter.listSecrets();
+
+    expect(openshellCli.listProviders).toHaveBeenCalled();
+    expect(result).toEqual([
+      { name: 'my-openai', type: 'openai' },
+      { name: 'my-anthropic', type: 'anthropic' },
+    ]);
+  });
+
+  test('returns empty array when no providers exist', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
+
+    const result = await adapter.listSecrets();
+
+    expect(result).toEqual([]);
+  });
+
+  test('rejects when openshellCli.listProviders fails', async () => {
+    vi.mocked(openshellCli.listProviders).mockRejectedValue(new Error('no gateway configured'));
+
+    await expect(adapter.listSecrets()).rejects.toThrow('no gateway configured');
+  });
+});
+
+describe('removeSecret', () => {
+  test('delegates to openshellCli.deleteProvider and returns the secret name', async () => {
+    vi.mocked(openshellCli.deleteProvider).mockResolvedValue(undefined);
+
+    const result = await adapter.removeSecret('my-openai');
+
+    expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai');
+    expect(result).toEqual({ name: 'my-openai' });
+  });
+
+  test('rejects when openshellCli.deleteProvider fails', async () => {
+    vi.mocked(openshellCli.deleteProvider).mockRejectedValue(new Error('provider not found: unknown'));
+
+    await expect(adapter.removeSecret('unknown')).rejects.toThrow('provider not found: unknown');
+  });
+});
+
+describe('listServices', () => {
+  test('returns empty array (not supported by OpenShell)', async () => {
+    const result = await adapter.listServices();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -55,8 +55,7 @@ export class OpenshellSecretAdapter implements SecretCliBackend {
   }
 
   async listSecrets(): Promise<SecretInfo[]> {
-    const providers = await this.openshellCli.listProviders();
-    return providers.map(p => ({ name: p.name, type: p.type }));
+    return await this.openshellCli.listProviders();
   }
 
   async removeSecret(name: string): Promise<SecretName> {

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type {
+  SecretCliBackend,
+  SecretCreateOptions,
+  SecretInfo,
+  SecretName,
+  SecretService,
+} from '/@api/secret-info.js';
+
+/**
+ * Adapts {@link OpenshellCli} provider commands to the
+ * {@link SecretCliBackend} interface used by {@link SecretManager}.
+ *
+ * OpenShell manages credentials as "providers" rather than "secrets".
+ * This adapter maps:
+ *   - `createSecret`  → `openshell provider create`
+ *   - `listSecrets`   → `openshell provider list`
+ *   - `removeSecret`  → `openshell provider delete`
+ *   - `listServices`  → returns `[]` (not supported by OpenShell)
+ */
+@injectable()
+export class OpenshellSecretAdapter implements SecretCliBackend {
+  constructor(
+    @inject(OpenshellCli)
+    private readonly openshellCli: OpenshellCli,
+  ) {}
+
+  async createSecret(options: SecretCreateOptions): Promise<SecretName> {
+    await this.openshellCli.createProvider({
+      name: options.name,
+      type: options.type,
+      credentials: { value: options.value },
+    });
+    return { name: options.name };
+  }
+
+  async listSecrets(): Promise<SecretInfo[]> {
+    const providers = await this.openshellCli.listProviders();
+    return providers.map(p => ({ name: p.name, type: p.type }));
+  }
+
+  async removeSecret(name: string): Promise<SecretName> {
+    await this.openshellCli.deleteProvider(name);
+    return { name };
+  }
+
+  async listServices(): Promise<SecretService[]> {
+    return [];
+  }
+}

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -17,19 +17,22 @@
  ***********************************************************************/
 
 import type { FileSystemWatcher } from '@openkaiden/api';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
+import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { Exec } from '/@/plugin/util/exec.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { SecretCreateOptions, SecretInfo } from '/@api/secret-info.js';
 
+import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
 import { SecretManager } from './secret-manager.js';
 
 vi.mock(import('/@/plugin/kdn-cli/kdn-cli.js'));
+vi.mock(import('/@/plugin/openshell-cli/openshell-cli.js'));
 
 const TEST_SECRETS: SecretInfo[] = [
   { name: 'my-secret', type: 'github', description: 'GitHub token' },
@@ -53,6 +56,8 @@ const apiSender: ApiSenderType = {
 };
 const ipcHandle: IPCHandle = vi.fn();
 const kdnCli = new KdnCli({} as Exec, {} as CliToolRegistry);
+const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
+const openshellAdapter = new OpenshellSecretAdapter(openshellCli);
 
 const mockWatcher = {
   onDidChange: vi.fn(),
@@ -66,9 +71,14 @@ const filesystemMonitoring = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  delete process.env['KAIDEN_OPENSHELL'];
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
-  manager = new SecretManager(apiSender, ipcHandle, kdnCli, filesystemMonitoring);
+  manager = new SecretManager(apiSender, ipcHandle, kdnCli, openshellAdapter, filesystemMonitoring);
   manager.init();
+});
+
+afterEach(() => {
+  delete process.env['KAIDEN_OPENSHELL'];
 });
 
 describe('init', () => {
@@ -189,5 +199,86 @@ describe('remove', () => {
     vi.mocked(kdnCli.removeSecret).mockRejectedValue(new Error('secret not found: unknown'));
 
     await expect(manager.remove('unknown')).rejects.toThrow('secret not found: unknown');
+  });
+});
+
+describe('KAIDEN_OPENSHELL backend switching', () => {
+  const defaultOptions: SecretCreateOptions = {
+    name: 'my-secret',
+    type: 'github',
+    value: 'ghp_abc123',
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env['KAIDEN_OPENSHELL'] = '1';
+    vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
+    manager = new SecretManager(apiSender, ipcHandle, kdnCli, openshellAdapter, filesystemMonitoring);
+    manager.init();
+  });
+
+  test('delegates create to openshellAdapter when KAIDEN_OPENSHELL is set', async () => {
+    vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
+
+    const result = await manager.create(defaultOptions);
+
+    expect(openshellCli.createProvider).toHaveBeenCalledWith({
+      name: 'my-secret',
+      type: 'github',
+      credentials: { value: 'ghp_abc123' },
+    });
+    expect(kdnCli.createSecret).not.toHaveBeenCalled();
+    expect(result).toEqual({ name: 'my-secret' });
+  });
+
+  test('delegates list to openshellAdapter when KAIDEN_OPENSHELL is set', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([
+      { name: 'my-openai', type: 'openai' },
+      { name: 'my-anthropic', type: 'anthropic' },
+    ]);
+
+    const result = await manager.list();
+
+    expect(openshellCli.listProviders).toHaveBeenCalled();
+    expect(kdnCli.listSecrets).not.toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(result.map(s => s.name)).toEqual(['my-openai', 'my-anthropic']);
+  });
+
+  test('delegates remove to openshellAdapter when KAIDEN_OPENSHELL is set', async () => {
+    vi.mocked(openshellCli.deleteProvider).mockResolvedValue(undefined);
+
+    const result = await manager.remove('my-openai');
+
+    expect(openshellCli.deleteProvider).toHaveBeenCalledWith('my-openai');
+    expect(kdnCli.removeSecret).not.toHaveBeenCalled();
+    expect(result).toEqual({ name: 'my-openai' });
+  });
+
+  test('listServices returns empty array when KAIDEN_OPENSHELL is set', async () => {
+    const result = await manager.listServices();
+
+    expect(kdnCli.listServices).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  test('skips file watching when KAIDEN_OPENSHELL is set', () => {
+    expect(filesystemMonitoring.createFileSystemWatcher).not.toHaveBeenCalled();
+  });
+
+  test('still emits secret-manager-update on create', async () => {
+    vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
+
+    await manager.create(defaultOptions);
+
+    expect(apiSender.send).toHaveBeenCalledWith('secret-manager-update');
+  });
+
+  test('still emits secret-manager-update on remove', async () => {
+    vi.mocked(openshellCli.deleteProvider).mockResolvedValue(undefined);
+
+    await manager.remove('my-openai');
+
+    expect(apiSender.send).toHaveBeenCalledWith('secret-manager-update');
   });
 });

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -26,14 +26,27 @@ import { IPCHandle } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { SecretCreateOptions, SecretInfo, SecretName, SecretService } from '/@api/secret-info.js';
+import type {
+  SecretCliBackend,
+  SecretCreateOptions,
+  SecretInfo,
+  SecretName,
+  SecretService,
+} from '/@api/secret-info.js';
+
+import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
 
 /**
- * Manages secrets by delegating to the `kdn` CLI.
+ * Manages secrets by delegating to a CLI backend.
+ *
+ * By default the `kdn` CLI is used. When the `KAIDEN_OPENSHELL`
+ * environment variable is set, the OpenShell provider commands
+ * are used instead (via {@link OpenshellSecretAdapter}).
  *
  * Watches `~/.kdn/secrets.json` so that external mutations
  * (e.g. `kdn secret remove` run from a terminal) are picked
- * up and forwarded to the renderer.
+ * up and forwarded to the renderer. File watching is skipped
+ * when the OpenShell backend is active.
  */
 @injectable()
 export class SecretManager implements Disposable {
@@ -46,28 +59,37 @@ export class SecretManager implements Disposable {
     private readonly ipcHandle: IPCHandle,
     @inject(KdnCli)
     private readonly kdnCli: KdnCli,
+    @inject(OpenshellSecretAdapter)
+    private readonly openshellAdapter: OpenshellSecretAdapter,
     @inject(FilesystemMonitoring)
     private readonly filesystemMonitoring: FilesystemMonitoring,
   ) {}
 
+  private get cli(): SecretCliBackend {
+    if (process.env['KAIDEN_OPENSHELL']) {
+      return this.openshellAdapter;
+    }
+    return this.kdnCli;
+  }
+
   async create(options: SecretCreateOptions): Promise<SecretName> {
-    const result = await this.kdnCli.createSecret(options);
+    const result = await this.cli.createSecret(options);
     this.apiSender.send('secret-manager-update');
     return result;
   }
 
   async list(): Promise<SecretInfo[]> {
-    return this.kdnCli.listSecrets();
+    return this.cli.listSecrets();
   }
 
   async remove(name: string): Promise<SecretName> {
-    const result = await this.kdnCli.removeSecret(name);
+    const result = await this.cli.removeSecret(name);
     this.apiSender.send('secret-manager-update');
     return result;
   }
 
   async listServices(): Promise<SecretService[]> {
-    return this.kdnCli.listServices();
+    return this.cli.listServices();
   }
 
   init(): void {
@@ -90,7 +112,9 @@ export class SecretManager implements Disposable {
       return this.listServices();
     });
 
-    this.watchSecretsFile();
+    if (!process.env['KAIDEN_OPENSHELL']) {
+      this.watchSecretsFile();
+    }
   }
 
   private watchSecretsFile(): void {


### PR DESCRIPTION
Introduce OpenshellSecretAdapter that maps SecretManager operations to OpenShell provider commands, and a SecretCliBackend interface so SecretManager can switch between kdn and OpenShell at runtime based on the KAIDEN_OPENSHELL environment variable.

Closes https://github.com/openkaiden/kaiden/issues/2096