### PR TITLE
fix(renderer): load UI state before Keychain authentication

### DIFF
--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -75,6 +75,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   callbacks.clear();
   vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(AppearanceSettings.IconAndTitle);
   onDidChangeConfiguration.addEventListener = vi.fn().mockImplementation((message: string, callback: () => void) => {
     callbacks.set(message, callback);
   });
@@ -99,6 +100,7 @@ test('Test rendering of the navigation bar with empty items', async (_arg: unkno
     meta,
     exitSettingsCallback: () => {},
   });
+  await tick();
 
   const navigationBar = screen.getByRole('navigation', { name: 'AppNavigation' });
   expect(navigationBar).toBeInTheDocument();

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -24,7 +24,7 @@ interface Props {
 }
 let { exitSettingsCallback, meta = $bindable() }: Props = $props();
 
-let iconWithTitle = $state(false);
+let iconWithTitle = $state<boolean | undefined>(undefined);
 
 const iconSize = '22';
 const NAV_BAR_LAYOUT = `${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`;
@@ -62,6 +62,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 </script>
 
 <svelte:window />
+{#if iconWithTitle !== undefined}
 <nav
   class="group w-leftnavbar {minNavbarWidth} flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
@@ -104,3 +105,4 @@ function onDidChangeConfigurationCallback(e: Event): void {
     {/if}
   </NavItem>
 </nav>
+{/if}

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -6,12 +6,20 @@ import App from './App.svelte';
 import LoaderAnimation from './lib/images/LoaderAnimation.svelte';
 import ColorsStyle from './lib/style/ColorsStyle.svelte';
 import { lastPage } from './stores/breadcrumb';
+import { colorsInfos } from './stores/colors';
 
 let systemReady = $state(false);
+let colorsLoaded = $state(false);
 let showTitle = $state(false);
 
 let titleTimer: NodeJS.Timeout;
 let extensionsStarterChecker: NodeJS.Timeout;
+
+const unsubscribeColors = colorsInfos.subscribe(colors => {
+  if (colors && colors.length > 0) {
+    colorsLoaded = true;
+  }
+});
 
 onMount(async () => {
   titleTimer = setTimeout(() => {
@@ -47,6 +55,7 @@ onMount(async () => {
 
 onDestroy(() => {
   clearTimeout(titleTimer);
+  unsubscribeColors();
 
   if (extensionsStarterChecker) {
     clearInterval(extensionsStarterChecker);
@@ -64,7 +73,7 @@ window.events?.receive('install-extension:from-id', (extensionId: unknown) => {
     lastPage.set({ name: 'Extensions', path: '/extensions' });
   };
 
-  if (!systemReady) {
+  if (!systemReady || !colorsLoaded) {
     // need to wait for the system to be ready, so we delay the install
     window.addEventListener('system-ready', () => {
       action().catch((err: unknown) => console.log('Error while redirecting to extensions', err));
@@ -86,7 +95,7 @@ window.events.receive('starting-extensions', (value: unknown) => {
 
 <ColorsStyle />
 
-{#if !systemReady}
+{#if !systemReady || !colorsLoaded}
   <main class="flex flex-row w-screen h-screen justify-center" style="-webkit-app-region: drag;">
     <div class="flex flex-col justify-center">
       <LoaderAnimation />


### PR DESCRIPTION
Fixes #2091

On macOS initial startup from DMG, UI was not properly initialized until
after Keychain authentication completed. Window showed with black background
and missing navigation labels while waiting for user to authenticate.

Root cause: SafeStorageRegistry.init() was called before ColorRegistry,
ConfigurationRegistry, and their IPC handlers were registered. When the
renderer loaded, critical IPC handlers were unavailable, preventing colors,
configuration properties, and navigation from loading until the entire
initialization sequence completed (including Keychain auth).

Changes:
- Reordered initialization: ConfigurationRegistry and ColorRegistry now
  initialize before SafeStorageRegistry
- Registered configuration and color IPC handlers immediately after their
  respective registries initialize
- Added immediate fetch in EventStores for colors, configuration properties,
  and navigation registry instead of waiting for events
- Added undefined guard in ColorsStyle for test environments

Result: Colors, configuration, and navigation labels all load immediately
when the renderer starts, before SafeStorageRegistry initialization. The UI
is fully styled and functional even when the Keychain authentication prompt
appears during extension activation.

<img width="1239" height="918" alt="Screenshot 2026-06-09 at 11 56 28" src="https://github.com/user-attachments/assets/96611754-e2a9-4ce9-90c8-b5b82113be38" />