### PR TITLE
feat(openshell): add openshell-image-builder CLI binary support

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -194,6 +194,22 @@ const config = {
         to: 'openshell',
         filter: ['!.openshell-version'],
       });
+
+      // include pre-downloaded openshell-image-builder binary (same platform filter)
+      const ibAssetsDir = path.join(
+        'extensions',
+        'openshell',
+        'assets',
+        'image-builder',
+        `${context.electronPlatformName}-${openshellArch}`,
+      );
+      if (fs.existsSync(ibAssetsDir)) {
+        context.packager.config.extraResources.push({
+          from: ibAssetsDir,
+          to: 'openshell-image-builder',
+          filter: ['!.openshell-image-builder-version'],
+        });
+      }
     }
 
     // include product.json

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -4,6 +4,7 @@
   "description": "Registers the openshell CLI binary for managing sandboxed workspaces.",
   "version": "0.2.0-next",
   "openshellVersion": "0.0.57",
+  "openshellImageBuilderVersion": "0.9.0",
   "icon": "icon.png",
   "publisher": "kaiden",
   "license": "Apache-2.0",
@@ -22,14 +23,23 @@
           "scope": "DEFAULT",
           "default": "",
           "description": "Custom path to OpenShell binary (Default is blank)"
+        },
+        "openshell.imageBuilder.binary.path": {
+          "type": "string",
+          "format": "file",
+          "scope": "DEFAULT",
+          "default": "",
+          "description": "Custom path to openshell-image-builder binary (Default is blank)"
         }
       }
     }
   },
   "scripts": {
-    "build": "vite build && tsx ./scripts/download.ts --all",
+    "build": "vite build && tsx ./scripts/download.ts --all && tsx ./scripts/download-image-builder.ts --all",
     "download": "tsx ./scripts/download.ts",
     "download:all": "tsx ./scripts/download.ts --all",
+    "download:image-builder": "tsx ./scripts/download-image-builder.ts",
+    "download:image-builder:all": "tsx ./scripts/download-image-builder.ts --all",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "watch": "vite build --watch"

--- a/extensions/openshell/scripts/download-image-builder.ts
+++ b/extensions/openshell/scripts/download-image-builder.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+import { getImageBuilderRelease, downloadImageBuilderBinary } from '../src/openshell-image-builder-download';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ASSETS_DIR = resolve(__dirname, '..', 'assets', 'image-builder');
+
+const SUPPORTED_TARGETS: { platform: string; arch: string }[] = [
+  { platform: 'darwin', arch: 'arm64' },
+  { platform: 'linux', arch: 'x64' },
+  { platform: 'linux', arch: 'arm64' },
+];
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    all: { type: 'boolean', default: false },
+    platform: { type: 'string' },
+    arch: { type: 'string' },
+  },
+  strict: true,
+});
+
+let targets: { platform: string; arch: string }[];
+
+if (values.all) {
+  targets = SUPPORTED_TARGETS;
+} else if (values.platform && values.arch) {
+  const requested = { platform: values.platform, arch: values.arch };
+  const isSupported = SUPPORTED_TARGETS.some(t => t.platform === requested.platform && t.arch === requested.arch);
+  if (!isSupported) {
+    console.error(
+      `Unsupported target "${requested.platform}-${requested.arch}". Use --all or one of: ${SUPPORTED_TARGETS.map(t => `${t.platform}-${t.arch}`).join(', ')}`,
+    );
+    process.exit(1);
+  }
+  targets = [requested];
+} else if (values.platform || values.arch) {
+  console.error('--platform and --arch must be specified together');
+  process.exit(1);
+} else {
+  targets = SUPPORTED_TARGETS.filter(t => t.platform === process.platform && t.arch === process.arch);
+}
+
+if (targets.length === 0) {
+  console.log(
+    `No supported openshell-image-builder target for host platform "${process.platform}", skipping. Use --all or pass --platform and --arch to download for a specific target.`,
+  );
+  process.exit(0);
+}
+
+(async () => {
+  const pkgPath = resolve(__dirname, '..', 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { openshellImageBuilderVersion: string };
+  const pinnedVersion = pkg.openshellImageBuilderVersion;
+  if (!pinnedVersion) {
+    console.error('missing "openshellImageBuilderVersion" in package.json');
+    process.exit(1);
+  }
+
+  const { version, digests } = await getImageBuilderRelease(pinnedVersion);
+  console.log(`openshell-image-builder pinned release: v${version}`);
+
+  for (const { platform, arch } of targets) {
+    const outputDir = resolve(ASSETS_DIR, `${platform}-${arch}`);
+    await downloadImageBuilderBinary(version, platform, arch, outputDir, digests);
+  }
+})();

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -24,6 +24,7 @@ import * as extensionApi from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 
 import { ExtensionContextSymbol } from '/@/inject/symbol';
+import { OpenshellImageBuilderInstaller } from '/@/openshell-image-builder-installer';
 import { OpenshellInstaller } from '/@/openshell-installer';
 
 interface BinaryDiscoveryResult {
@@ -47,7 +48,7 @@ export class OpenshellCliManager implements Disposable {
     const packageJsonPath = join(this.extensionContext.extensionUri.fsPath, 'package.json');
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
-    const cliResult = await this.discoverBinary('openshell', 'openshell.binary.path');
+    const cliResult = await this.discoverBinary('openshell', 'openshell.binary.path', 'openshell');
     const registration: BinaryDiscoveryResult = cliResult ?? {
       installationSource: 'extension',
     };
@@ -67,6 +68,33 @@ export class OpenshellCliManager implements Disposable {
     const installer = new OpenshellInstaller(cliTool, packageJson.openshellVersion, this.extensionContext.storagePath);
 
     this.extensionContext.subscriptions.push(cliTool.registerInstaller(installer));
+
+    const ibResult = await this.discoverBinary(
+      'openshell-image-builder',
+      'openshell.imageBuilder.binary.path',
+      'openshell-image-builder',
+    );
+    const ibRegistration: BinaryDiscoveryResult = ibResult ?? {
+      installationSource: 'extension',
+    };
+
+    if (!ibResult) {
+      console.warn('[openshell-image-builder] CLI not found, registering installer-only entry');
+    }
+
+    const ibCliTool = this.registerCliTool(
+      'openshell-image-builder',
+      'OpenShell Image Builder',
+      'CLI for building custom container images for OpenShell sandboxes',
+      ibRegistration,
+    );
+    const ibInstaller = new OpenshellImageBuilderInstaller(
+      ibCliTool,
+      packageJson.openshellImageBuilderVersion,
+      this.extensionContext.storagePath,
+    );
+
+    this.extensionContext.subscriptions.push(ibCliTool.registerInstaller(ibInstaller));
   }
 
   dispose(): void {}
@@ -91,7 +119,11 @@ export class OpenshellCliManager implements Disposable {
     return cliTool;
   }
 
-  private async discoverBinary(binaryBaseName: string, configKey: string): Promise<BinaryDiscoveryResult | undefined> {
+  private async discoverBinary(
+    binaryBaseName: string,
+    configKey: string,
+    resourceSubdir: string,
+  ): Promise<BinaryDiscoveryResult | undefined> {
     const binDir = join(this.extensionContext.storagePath, 'bin');
     const binaryName = extensionApi.env.isWindows ? `${binaryBaseName}.exe` : binaryBaseName;
     const localBinaryPath = join(binDir, binaryName);
@@ -119,6 +151,19 @@ export class OpenshellCliManager implements Disposable {
     if (systemResult) {
       console.log(`[${binaryBaseName}] binary found in system PATH`);
       return { path: systemResult.path, version: systemResult.version, installationSource: 'external' };
+    }
+
+    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+    if (resourcesPath) {
+      const bundledBinaryPath = join(resourcesPath, resourceSubdir, binaryName);
+      if (existsSync(bundledBinaryPath)) {
+        const version = await this.getVersion(bundledBinaryPath);
+        if (version) {
+          console.log(`[${binaryBaseName}] binary found in bundled resources`);
+          return { path: bundledBinaryPath, version, installationSource: 'extension' };
+        }
+        console.warn(`[${binaryBaseName}] bundled binary at ${bundledBinaryPath} failed to report a version`);
+      }
     }
 
     return undefined;

--- a/extensions/openshell/src/openshell-image-builder-download.ts
+++ b/extensions/openshell/src/openshell-image-builder-download.ts
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { ReleaseInfo } from './openshell-download';
+import { download, verifyChecksum } from './openshell-download';
+
+const IMAGE_BUILDER_REPO = 'openkaiden/openshell-image-builder';
+
+const ASSET_MAP: Record<string, { assetName: string; binaryName: string }> = {
+  'darwin-arm64': {
+    assetName: 'openshell-image-builder-aarch64-apple-darwin',
+    binaryName: 'openshell-image-builder',
+  },
+  'linux-x64': {
+    assetName: 'openshell-image-builder-x86_64-unknown-linux-gnu',
+    binaryName: 'openshell-image-builder',
+  },
+  'linux-arm64': {
+    assetName: 'openshell-image-builder-aarch64-unknown-linux-gnu',
+    binaryName: 'openshell-image-builder',
+  },
+  'win32-x64': {
+    assetName: 'openshell-image-builder-x86_64-pc-windows-msvc.exe',
+    binaryName: 'openshell-image-builder.exe',
+  },
+};
+
+export async function getImageBuilderRelease(version: string): Promise<ReleaseInfo> {
+  const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
+  const token = process.env['GITHUB_TOKEN'];
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`https://api.github.com/repos/${IMAGE_BUILDER_REPO}/releases/tags/v${version}`, {
+    headers,
+    redirect: 'follow',
+  });
+  if (!res.ok) {
+    throw new Error(`failed to fetch openshell-image-builder release v${version}: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { tag_name: string; assets: { name: string; digest: string | null }[] };
+  const resolvedVersion = data.tag_name.replace(/^v/, '');
+  const digests = new Map<string, string>();
+  for (const asset of data.assets) {
+    if (asset.digest) {
+      digests.set(asset.name, asset.digest.replace(/^sha256:/, ''));
+    }
+  }
+  return { version: resolvedVersion, digests };
+}
+
+export async function downloadImageBuilderBinary(
+  version: string,
+  platform: string,
+  arch: string,
+  outputDir: string,
+  digests: Map<string, string>,
+): Promise<void> {
+  const key = `${platform}-${arch}`;
+  const asset = ASSET_MAP[key];
+  if (!asset) {
+    throw new Error(`unsupported target: ${key}. Supported: ${Object.keys(ASSET_MAP).join(', ')}`);
+  }
+
+  const versionFile = join(outputDir, '.openshell-image-builder-version');
+  const versionMarker = `${version}-${platform}-${arch}`;
+  const binaryPath = join(outputDir, asset.binaryName);
+
+  if (existsSync(versionFile) && existsSync(binaryPath)) {
+    const existing = await readFile(versionFile, { encoding: 'utf-8' });
+    if (existing.trim() === versionMarker) {
+      console.log(`openshell-image-builder ${version} for ${platform}/${arch} already downloaded`);
+      return;
+    }
+  }
+
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const url = `https://github.com/${IMAGE_BUILDER_REPO}/releases/download/v${version}/${asset.assetName}`;
+  const downloadPath = join(outputDir, asset.assetName);
+
+  console.log(`downloading openshell-image-builder ${version} for ${platform}/${arch}...`);
+  await download(url, downloadPath);
+  await verifyChecksum(digests, asset.assetName, downloadPath);
+
+  if (downloadPath !== binaryPath) {
+    await rename(downloadPath, binaryPath);
+  }
+
+  if (platform !== 'win32') {
+    await chmod(binaryPath, 0o755);
+  }
+
+  await writeFile(versionFile, versionMarker, { encoding: 'utf-8' });
+  console.log(`openshell-image-builder ${version} for ${platform}/${arch} ready`);
+}

--- a/extensions/openshell/src/openshell-image-builder-installer.ts
+++ b/extensions/openshell/src/openshell-image-builder-installer.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { CliTool, CliToolInstaller, Logger } from '@openkaiden/api';
+import * as extensionApi from '@openkaiden/api';
+
+import { downloadImageBuilderBinary, getImageBuilderRelease } from './openshell-image-builder-download';
+
+export class OpenshellImageBuilderInstaller implements CliToolInstaller {
+  private selectedVersion: string | undefined;
+  readonly #cliTool: CliTool;
+  readonly #imageBuilderVersion: string;
+  readonly #storagePath: string;
+
+  constructor(cliTool: extensionApi.CliTool, imageBuilderVersion: string, storagePath: string) {
+    this.#cliTool = cliTool;
+    this.#imageBuilderVersion = imageBuilderVersion;
+    this.#storagePath = storagePath;
+  }
+
+  async selectVersion(latest?: boolean): Promise<string> {
+    if (latest || !this.selectedVersion) {
+      this.selectedVersion = await this.fetchPinnedVersion();
+    }
+    return this.selectedVersion;
+  }
+
+  async doInstall(logger: Logger): Promise<void> {
+    if (!extensionApi.env.isMac && !extensionApi.env.isLinux) {
+      throw new Error('openshell-image-builder install is not supported on this platform');
+    }
+
+    const version = this.selectedVersion ?? this.#imageBuilderVersion;
+    const platform = extensionApi.env.isMac ? 'darwin' : 'linux';
+    const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+    const binDir = join(this.#storagePath, 'bin');
+
+    logger.log(`Installing openshell-image-builder ${version} for ${platform}/${arch}...`);
+
+    try {
+      const release = await getImageBuilderRelease(version);
+      await downloadImageBuilderBinary(release.version, platform, arch, binDir, release.digests);
+      logger.log('openshell-image-builder installation completed successfully');
+      this.#cliTool.updateVersion({
+        version: release.version,
+        path: join(binDir, extensionApi.env.isWindows ? 'openshell-image-builder.exe' : 'openshell-image-builder'),
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`openshell-image-builder installation failed: ${message}`);
+      throw error;
+    }
+  }
+
+  async doUninstall(logger: Logger): Promise<void> {
+    logger.log('Uninstalling openshell-image-builder...');
+
+    try {
+      if (extensionApi.env.isMac || extensionApi.env.isLinux) {
+        const binaryName = 'openshell-image-builder';
+        const binaryPath = join(this.#storagePath, 'bin', binaryName);
+        await rm(binaryPath, { force: true });
+      }
+      logger.log('openshell-image-builder uninstalled successfully');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`openshell-image-builder uninstall failed: ${message}`);
+      throw error;
+    }
+  }
+
+  private async fetchPinnedVersion(): Promise<string> {
+    const release = await getImageBuilderRelease(this.#imageBuilderVersion);
+    return release.version;
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -72,6 +72,7 @@ import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import { OpenshellImageBuilder } from '/@/plugin/openshell-cli/openshell-image-builder.js';
 import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
@@ -593,6 +594,7 @@ export class PluginSystem {
     container.bind<KdnCli>(KdnCli).toSelf().inSingletonScope();
     container.bind<OpenshellCli>(OpenshellCli).toSelf().inSingletonScope();
     container.bind<OpenshellGateway>(OpenshellGateway).toSelf().inSingletonScope();
+    container.bind<OpenshellImageBuilder>(OpenshellImageBuilder).toSelf().inSingletonScope();
     container.bind<AgentWorkspaceManager>(AgentWorkspaceManager).toSelf().inSingletonScope();
     container.bind<SecretManager>(SecretManager).toSelf().inSingletonScope();
     container.bind<FlowManager>(FlowManager).toSelf().inSingletonScope();

--- a/packages/main/src/plugin/openshell-cli/openshell-image-builder.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-image-builder.ts
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { Exec } from '/@/plugin/util/exec.js';
+
+export interface BuildImageOptions {
+  agent?: string;
+  inference?: string;
+  endpoint?: string;
+  model?: string;
+  config?: string;
+}
+
+/**
+ * Wrapper around the `openshell-image-builder` CLI binary.
+ *
+ * Usage:
+ *   openshell-image-builder [OPTIONS] <TAG>
+ *
+ * Options:
+ *   --agent <AGENT>         Agent to install (claude, opencode)
+ *   --inference <INFERENCE>  Inference provider (anthropic, vertexai, ollama, openai)
+ *   --endpoint <URL>        Override inference provider URL
+ *   --model <MODEL>         Default model for the agent
+ *   --config <DIR>          Config directory containing config.toml
+ *   -v / -vv                Log verbosity
+ */
+@injectable()
+export class OpenshellImageBuilder {
+  constructor(
+    @inject(Exec)
+    private readonly exec: Exec,
+    @inject(CliToolRegistry)
+    private readonly cliToolRegistry: CliToolRegistry,
+  ) {}
+
+  getCliPath(): string {
+    const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell-image-builder');
+    if (tool?.path) {
+      return tool.path;
+    }
+    return 'openshell-image-builder';
+  }
+
+  async getVersion(): Promise<string> {
+    const cliPath = this.getCliPath();
+    try {
+      const result = await this.exec.exec(cliPath, ['--version']);
+      return result.stdout.trim();
+    } catch (err: unknown) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`openshell-image-builder failed: ${cliPath} --version — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+
+  async buildImage(tag: string, options: BuildImageOptions = {}): Promise<void> {
+    const args: string[] = [];
+
+    if (options.config) {
+      args.push('--config', options.config);
+    }
+    if (options.agent) {
+      args.push('--agent', options.agent);
+    }
+    if (options.inference) {
+      args.push('--inference', options.inference);
+    }
+    if (options.endpoint) {
+      args.push('--endpoint', options.endpoint);
+    }
+    if (options.model) {
+      args.push('--model', options.model);
+    }
+
+    args.push(tag);
+
+    const cliPath = this.getCliPath();
+    console.log(`Executing: ${cliPath} ${args.join(' ')}`);
+    try {
+      await this.exec.exec(cliPath, args);
+    } catch (err: unknown) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`openshell-image-builder failed: ${cliPath} ${args.join(' ')} — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+}


### PR DESCRIPTION
Add download, installation, and bundling infrastructure for the openshell-image-builder binary, mirroring the existing openshell CLI pattern. Includes binary discovery in OpenshellCliManager, a dedicated installer, electron-builder packaging, and an OpenshellImageBuilder wrapper registered in the DI container.

<img width="1227" height="911" alt="image" src="https://github.com/user-attachments/assets/40128a32-7a1c-4f83-93d5-444b9e2ab0a2" />

Closes https://github.com/openkaiden/kaiden/issues/2054