### PR TITLE
fix: use SetupServer interface instead of SetupServerApi class from msw

### DIFF
--- a/extensions/ollama/src/ollama-extension.spec.ts
+++ b/extensions/ollama/src/ollama-extension.spec.ts
@@ -22,7 +22,7 @@ import { networkInterfaces } from 'node:os';
 import type { ExtensionContext, Provider } from '@openkaiden/api';
 import { env, provider } from '@openkaiden/api';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { OllamaExtension } from './ollama-extension';
@@ -41,7 +41,7 @@ describe('OllamaExtension', () => {
   let extensionContext: ExtensionContext;
   let ollamaProvider: Provider;
   let extension: TestOllamaExtension;
-  let server: SetupServerApi | undefined = undefined;
+  let server: SetupServer | undefined = undefined;
 
   beforeEach(() => {
     ollamaProvider = {

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -27,7 +27,7 @@ import type * as podmanDesktopAPI from '@openkaiden/api';
 import Dockerode from 'dockerode';
 import moment from 'moment';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import type { Headers, PackOptions } from 'tar-fs';
 import * as tarstream from 'tar-stream';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -319,7 +319,7 @@ const fakeContainerInspectInfoWithVolume = {
   },
 };
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 class TestContainerProviderRegistry extends ContainerProviderRegistry {
   public override extractContainerEnvironment(container: ContainerInspectInfo): { [key: string]: string } {

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -23,7 +23,7 @@ import type Dockerode from 'dockerode';
 import type { IpcMainEvent } from 'electron';
 import type { Method } from 'got';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
@@ -66,7 +66,7 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 class TestDockerDesktopInstallation extends DockerDesktopInstallation {
   // transform the method name to a got method

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -27,7 +27,7 @@ import type DockerModem from 'docker-modem';
 import Dockerode from 'dockerode';
 import type { DefaultBodyType, HttpResponseResolver, PathParams, ResponseResolverReturnType } from 'msw';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { DockerodeInternals, LibPod } from '/@/plugin/dockerode/libpod-dockerode.js';
@@ -37,7 +37,7 @@ import type { PlayKubeInfo } from '/@api/libpod/libpod.js';
 
 import podmanInfo from '../../../tests/resources/data/plugin/podman-info.json' with { type: 'json' };
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 beforeAll(() => {
   const libpod = new LibpodDockerode();

--- a/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
@@ -18,7 +18,7 @@
 
 import type { Configuration, ProxySettings } from '@openkaiden/api';
 import { delay, http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { Certificates } from '/@/plugin/certificates.js';
@@ -41,7 +41,7 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 // unlisted field is not present (assuming it should be listed then)
 const fakePublishedExtension1 = {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -26,7 +26,7 @@ import * as path from 'node:path';
 import type { Registry } from '@openkaiden/api';
 import * as fzstd from 'fzstd';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import * as nodeTar from 'tar';
 import { afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
@@ -51,7 +51,7 @@ import type { EventType, Telemetry } from './telemetry/telemetry.js';
 import type { Disposable } from './types/disposable.js';
 
 let imageRegistry: ImageRegistry;
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 const pxoxyIsEnabledMock = vi.fn();
 const proxyGetProxyMock = vi.fn();


### PR DESCRIPTION
## Summary
- `msw` resolved to `2.14.6` (from `^2.12.7`), which changed `setupServer()` return type from `SetupServerApi` (class) to `SetupServer` (interface)
- Updated all 6 test files that referenced `SetupServerApi` to use the `SetupServer` interface instead
- Fixes typecheck failures in CI for all open PRs

## Test plan
- [x] `pnpm run typecheck` passes locally
- [ ] CI typecheck job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)