### PR TITLE
fix(claude): support Vertex AI models in Claude Code agent

### DIFF
--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -66,11 +66,12 @@ describe('ClaudeExtension', () => {
     );
   });
 
-  test('registered agent supports anthropic model type', async () => {
+  test('registered agent supports anthropic and vertexai model types', async () => {
     await claudeExtension.activate();
 
     const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
     expect(agent.isSupportedModelType!({ name: 'anthropic' })).toBe(true);
+    expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(false);
   });
 

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -60,7 +60,7 @@ export class ClaudeExtension {
       icon: providerImages,
       command: 'claude',
       tags: ['Cloud'],
-      isSupportedModelType: (type): boolean => type.name === 'anthropic',
+      isSupportedModelType: (type): boolean => type.name === 'anthropic' || type.name === 'vertexai',
     });
 
     this.#inversifyBinding = new InversifyBinding(claudeProvider, this.#extensionContext);


### PR DESCRIPTION
The Claude Code agent was only accepting models with llmMetadata.name === 'anthropic',
which prevented users from using Claude models provided through Google Cloud Vertex AI.

Since Vertex AI provides the same Claude models (just through a different provider),
the Claude Code agent should accept both 'anthropic' and 'vertexai' model types.

This allows users to:
- Use Claude models from direct Anthropic API connections
- Use Claude models from Vertex AI connections
- See both providers' models when configuring the Claude Code agent

Changes:
- Update isSupportedModelType to accept both 'anthropic' and 'vertexai'
- Update test to verify both model types are supported

Fixes #2095

<img width="1840" height="1102" alt="Screenshot 2026-06-09 at 17 03 18" src="https://github.com/user-attachments/assets/67bad296-7a52-485d-b22a-5be8332c35e2" />
