### PR TITLE
fix(openshell): refresh sandbox list on page navigation

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -100,6 +100,7 @@ beforeEach(() => {
   };
   Object.defineProperty(window, 'dispatchEvent', { value: dispatchEventMock });
   (window.getConfigurationValue as unknown) = vi.fn();
+  (window.listOpenshellSandboxes as unknown) = vi.fn().mockResolvedValue([]);
   vi.mocked(window.inferenceGetChats).mockResolvedValue([]);
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.spec.ts
@@ -29,6 +29,7 @@ import AgentWorkspaceList from './AgentWorkspaceList.svelte';
 beforeEach(() => {
   vi.resetAllMocks();
   agentWorkspaces.set([]);
+  (window as unknown as Record<string, unknown>).listOpenshellSandboxes = vi.fn().mockResolvedValue([]);
 });
 
 test('Expect empty screen when no workspaces', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceList.svelte
@@ -10,6 +10,7 @@ import {
   TableDurationColumn,
   TableRow,
 } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 import { handleNavigation } from '/@/navigation';
@@ -17,6 +18,7 @@ import { agentWorkspaces, type AgentWorkspaceSummaryUI } from '/@/stores/agent-w
 import {
   allOpenshellSandboxes,
   filteredOpenshellSandboxes,
+  openshellSandboxesEventStoreInfo,
   type SandboxInfoWithGateway,
   searchPattern as sandboxSearchPattern,
 } from '/@/stores/openshell-sandboxes';
@@ -42,6 +44,14 @@ let searchTerm = $state('');
 // Sync searchTerm with sandbox store's searchPattern
 $effect(() => {
   sandboxSearchPattern.set(searchTerm);
+});
+
+onMount(async () => {
+  try {
+    await openshellSandboxesEventStoreInfo.fetch();
+  } catch (error: unknown) {
+    console.error('Failed to fetch OpenShell sandboxes:', error);
+  }
 });
 
 function navigateToCreate(): void {

--- a/packages/renderer/src/stores/openshell-sandboxes.ts
+++ b/packages/renderer/src/stores/openshell-sandboxes.ts
@@ -50,7 +50,7 @@ export const openshellSandboxesEventStore = new EventStore<GatewaySandboxes[]>(
   windowListeners,
   listOpenshellSandboxes,
 );
-openshellSandboxesEventStore.setup();
+export const openshellSandboxesEventStoreInfo = openshellSandboxesEventStore.setup();
 
 export interface SandboxInfoWithGateway extends SandboxInfo {
   gatewayName: string;


### PR DESCRIPTION
## Summary
- Re-fetch the OpenShell sandbox list whenever the Agentic Workspaces page mounts, so externally deleted sandboxes are detected on page navigation
- OpenShell sandboxes are remote (gateway-managed) resources with no local state file to watch — unlike kdn workspaces which use `~/.kdn/instances.json` — so the existing file watcher cannot detect external deletions
- Exports the `EventStoreInfo` from the openshell sandboxes store so components can call `.fetch()` to force a re-fetch
