### PR TITLE
feat(models): add semantic router create page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -71,6 +71,7 @@ export enum NavigationPage {
   SECRET_VAULT_CREATE = 'secret-vault-create',
   SECRET_VAULT_DETAILS = 'secret-vault-details',
   MODELS = 'models',
+  SEMANTIC_ROUTERS = 'semantic-routers',
   PROJECTS = 'projects',
   PROJECT_DETAILS = 'project-details',
   PROJECT_CREATE = 'project-create',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -93,6 +93,7 @@ export interface NavigationParameters {
     id: string;
   };
   [NavigationPage.MODELS]: never;
+  [NavigationPage.SEMANTIC_ROUTERS]: never;
   [NavigationPage.PROJECTS]: never;
   [NavigationPage.PROJECT_DETAILS]: {
     id: string;

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -75,6 +75,7 @@ import ManifestDetails from './lib/manifest/ManifestDetails.svelte';
 import McpRegistryCreateFromRegistryForm from './lib/mcp/MCPRegistryCreateFromRegistryForm.svelte';
 import McpServerList from './lib/mcp/MCPServerList.svelte';
 import ModelsCatalog from './lib/models/ModelsCatalog.svelte';
+import SemanticRouterCreate from './lib/models/SemanticRouterCreate.svelte';
 import CreateNetwork from './lib/network/CreateNetwork.svelte';
 import NetworkDetails from './lib/network/NetworkDetails.svelte';
 import NetworksList from './lib/network/NetworksList.svelte';
@@ -316,8 +317,13 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
 
         <!-- Models -->
-        <Route path="/models" breadcrumb="Models" navigationHint="root">
-          <ModelsCatalog />
+        <Route path="/models/*" breadcrumb="Models" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Models" navigationHint="root">
+            <ModelsCatalog />
+          </Route>
+          <Route path="/semantic-router/create" breadcrumb="Add Semantic Router" navigationHint="details">
+            <SemanticRouterCreate />
+          </Route>
         </Route>
 
         <!-- Skills -->

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -321,6 +321,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
           <Route path="/" breadcrumb="Models" navigationHint="root">
             <ModelsCatalog />
           </Route>
+          <Route path="/semantic-routers" breadcrumb="Semantic Routers" navigationHint="root">
+            <ModelsCatalog initialCategory="router" />
+          </Route>
           <Route path="/semantic-router/create" breadcrumb="Add Semantic Router" navigationHint="details">
             <SemanticRouterCreate />
           </Route>

--- a/packages/renderer/src/lib/models/ModelsCatalog.svelte
+++ b/packages/renderer/src/lib/models/ModelsCatalog.svelte
@@ -54,7 +54,13 @@ const categories: CategoryInfo[] = [
   },
 ];
 
-let activeCategory: Category = $state('cloud');
+interface Props {
+  initialCategory?: Category;
+}
+
+let { initialCategory = 'cloud' }: Props = $props();
+
+let activeCategory: Category = $state(initialCategory);
 let searchTerm = $state('');
 
 let cloudModels: CatalogModelInfo[] = $derived($cloudCatalogModels);

--- a/packages/renderer/src/lib/models/ModelsCatalog.svelte
+++ b/packages/renderer/src/lib/models/ModelsCatalog.svelte
@@ -10,6 +10,7 @@ import {
   TableRow,
 } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { router } from 'tinro';
 
 import ModelActionsColumn from '/@/lib/models/columns/ModelActionsColumn.svelte';
 import ModelNameColumn from '/@/lib/models/columns/ModelNameColumn.svelte';
@@ -160,8 +161,9 @@ function filterRoutersBySearch(routers: SemanticRouterConfigInfo[], term: string
   );
 }
 
-// TODO: implement router creation flow
-function addSemanticRouter(): void {}
+function addSemanticRouter(): void {
+  router.goto('/models/semantic-router/create');
+}
 
 function selectCategory(cat: Category): void {
   activeCategory = cat;

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
@@ -1,0 +1,170 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
+
+import SemanticRouterCreate from './SemanticRouterCreate.svelte';
+
+vi.mock(import('/@/navigation'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.createSemanticRouter).mockResolvedValue({
+    name: 'test-router',
+    listeners: [{ address: '0.0.0.0', port: 8899 }],
+    routing: { keywords: [], decisions: [] },
+  });
+});
+
+test('renders the form title', () => {
+  render(SemanticRouterCreate);
+
+  expect(screen.getByText('Configure a Semantic Router')).toBeInTheDocument();
+});
+
+test('renders all form fields', () => {
+  render(SemanticRouterCreate);
+
+  expect(screen.getByLabelText('Router name')).toBeInTheDocument();
+  expect(screen.getByLabelText('Description')).toBeInTheDocument();
+  expect(screen.getByLabelText('Listener address')).toBeInTheDocument();
+  expect(screen.getByLabelText('Listener port')).toBeInTheDocument();
+  expect(screen.getByLabelText('Timeout')).toBeInTheDocument();
+});
+
+test('create button is disabled when name is empty', () => {
+  render(SemanticRouterCreate);
+
+  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  expect(createBtn).toBeDisabled();
+});
+
+test('create button is enabled when name is provided', async () => {
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  expect(createBtn).toBeEnabled();
+});
+
+test('calls createSemanticRouter on submit', async () => {
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  await fireEvent.click(createBtn);
+
+  await waitFor(() => {
+    expect(window.createSemanticRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'my-router',
+        listeners: expect.arrayContaining([expect.objectContaining({ address: '0.0.0.0', port: 8899 })]),
+        routing: { keywords: [], decisions: [] },
+      }),
+    );
+  });
+});
+
+test('navigates to models page after successful creation', async () => {
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  await fireEvent.click(createBtn);
+
+  const { handleNavigation } = await import('/@/navigation');
+  await waitFor(() => {
+    expect(handleNavigation).toHaveBeenCalledWith({ page: 'models' });
+  });
+});
+
+test('shows error message on creation failure', async () => {
+  vi.mocked(window.createSemanticRouter).mockRejectedValue(new Error('Router already exists'));
+
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  await fireEvent.click(createBtn);
+
+  await waitFor(() => {
+    expect(screen.getByText('Router already exists')).toBeInTheDocument();
+  });
+});
+
+test('navigates to models page on cancel', async () => {
+  render(SemanticRouterCreate);
+
+  const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
+  await fireEvent.click(cancelBtn);
+
+  const { handleNavigation } = await import('/@/navigation');
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'models' });
+});
+
+test('passes description when provided', async () => {
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const descInput = screen.getByLabelText('Description');
+  await fireEvent.input(descInput, { target: { value: 'Routes coding tasks' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  await fireEvent.click(createBtn);
+
+  await waitFor(() => {
+    expect(window.createSemanticRouter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'Routes coding tasks',
+      }),
+    );
+  });
+});
+
+test('parses timeout value with seconds suffix', async () => {
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const timeoutInput = screen.getByLabelText('Timeout');
+  await fireEvent.input(timeoutInput, { target: { value: '600s' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  await fireEvent.click(createBtn);
+
+  await waitFor(() => {
+    const call = vi.mocked(window.createSemanticRouter).mock.calls[0][0] as SemanticRouterConfigInfo;
+    expect(call.listeners[0].timeout).toBe(600);
+  });
+});

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
@@ -18,10 +18,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
 
 import SemanticRouterCreate from './SemanticRouterCreate.svelte';
 
@@ -70,58 +68,7 @@ test('create button is enabled when name is provided', async () => {
   expect(createBtn).toBeEnabled();
 });
 
-test('calls createSemanticRouter on submit', async () => {
-  render(SemanticRouterCreate);
-
-  const nameInput = screen.getByLabelText('Router name');
-  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
-
-  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
-  await fireEvent.click(createBtn);
-
-  await waitFor(() => {
-    expect(window.createSemanticRouter).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'my-router',
-        listeners: expect.arrayContaining([expect.objectContaining({ address: '0.0.0.0', port: 8899 })]),
-        routing: { keywords: [], decisions: [] },
-      }),
-    );
-  });
-});
-
-test('navigates to models page after successful creation', async () => {
-  render(SemanticRouterCreate);
-
-  const nameInput = screen.getByLabelText('Router name');
-  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
-
-  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
-  await fireEvent.click(createBtn);
-
-  const { handleNavigation } = await import('/@/navigation');
-  await waitFor(() => {
-    expect(handleNavigation).toHaveBeenCalledWith({ page: 'semantic-routers' });
-  });
-});
-
-test('shows error message on creation failure', async () => {
-  vi.mocked(window.createSemanticRouter).mockRejectedValue(new Error('Router already exists'));
-
-  render(SemanticRouterCreate);
-
-  const nameInput = screen.getByLabelText('Router name');
-  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
-
-  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
-  await fireEvent.click(createBtn);
-
-  await waitFor(() => {
-    expect(screen.getByText('Router already exists')).toBeInTheDocument();
-  });
-});
-
-test('navigates to models page on cancel', async () => {
+test('navigates to semantic routers page on cancel', async () => {
   render(SemanticRouterCreate);
 
   const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
@@ -129,43 +76,4 @@ test('navigates to models page on cancel', async () => {
 
   const { handleNavigation } = await import('/@/navigation');
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'semantic-routers' });
-});
-
-test('passes description when provided', async () => {
-  render(SemanticRouterCreate);
-
-  const nameInput = screen.getByLabelText('Router name');
-  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
-
-  const descInput = screen.getByLabelText('Description');
-  await fireEvent.input(descInput, { target: { value: 'Routes coding tasks' } });
-
-  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
-  await fireEvent.click(createBtn);
-
-  await waitFor(() => {
-    expect(window.createSemanticRouter).toHaveBeenCalledWith(
-      expect.objectContaining({
-        description: 'Routes coding tasks',
-      }),
-    );
-  });
-});
-
-test('parses timeout value with seconds suffix', async () => {
-  render(SemanticRouterCreate);
-
-  const nameInput = screen.getByLabelText('Router name');
-  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
-
-  const timeoutInput = screen.getByLabelText('Timeout');
-  await fireEvent.input(timeoutInput, { target: { value: '600s' } });
-
-  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
-  await fireEvent.click(createBtn);
-
-  await waitFor(() => {
-    const call = vi.mocked(window.createSemanticRouter).mock.calls[0][0] as SemanticRouterConfigInfo;
-    expect(call.listeners[0].timeout).toBe(600);
-  });
 });

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
@@ -29,6 +29,7 @@ vi.mock(import('/@/navigation'));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.mocked(window.createSemanticRouter).mockResolvedValue({
     name: 'test-router',
     listeners: [{ address: '0.0.0.0', port: 8899 }],
@@ -100,7 +101,7 @@ test('navigates to models page after successful creation', async () => {
 
   const { handleNavigation } = await import('/@/navigation');
   await waitFor(() => {
-    expect(handleNavigation).toHaveBeenCalledWith({ page: 'models' });
+    expect(handleNavigation).toHaveBeenCalledWith({ page: 'semantic-routers' });
   });
 });
 
@@ -127,7 +128,7 @@ test('navigates to models page on cancel', async () => {
   await fireEvent.click(cancelBtn);
 
   const { handleNavigation } = await import('/@/navigation');
-  expect(handleNavigation).toHaveBeenCalledWith({ page: 'models' });
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'semantic-routers' });
 });
 
 test('passes description when provided', async () => {

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
@@ -54,7 +54,7 @@ test('renders all form fields', () => {
 test('create button is disabled when name is empty', () => {
   render(SemanticRouterCreate);
 
-  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  const createBtn = screen.getByRole('button', { name: 'Create' });
   expect(createBtn).toBeDisabled();
 });
 
@@ -64,8 +64,44 @@ test('create button is enabled when name is provided', async () => {
   const nameInput = screen.getByLabelText('Router name');
   await fireEvent.input(nameInput, { target: { value: 'my-router' } });
 
-  const createBtn = screen.getByRole('button', { name: 'Next: Backend models' });
+  const createBtn = screen.getByRole('button', { name: 'Create' });
   expect(createBtn).toBeEnabled();
+});
+
+test('calls createSemanticRouter and navigates on success', async () => {
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Create' });
+  await fireEvent.click(createBtn);
+  await vi.advanceTimersToNextTimerAsync();
+
+  expect(window.createSemanticRouter).toHaveBeenCalledWith({
+    name: 'my-router',
+    description: undefined,
+    listeners: [{ address: '0.0.0.0', port: 8899, timeout: 300 }],
+    routing: { keywords: [], decisions: [] },
+  });
+
+  const { handleNavigation } = await import('/@/navigation');
+  expect(handleNavigation).toHaveBeenCalledWith({ page: 'semantic-routers' });
+});
+
+test('displays error when createSemanticRouter fails', async () => {
+  vi.mocked(window.createSemanticRouter).mockRejectedValueOnce(new Error('duplicate name'));
+
+  render(SemanticRouterCreate);
+
+  const nameInput = screen.getByLabelText('Router name');
+  await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+  const createBtn = screen.getByRole('button', { name: 'Create' });
+  await fireEvent.click(createBtn);
+  await vi.advanceTimersToNextTimerAsync();
+
+  expect(screen.getByText('Error: duplicate name')).toBeInTheDocument();
 });
 
 test('navigates to semantic routers page on cancel', async () => {

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { Button, ErrorMessage, Input, NumberInput } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import FormPage from '/@/lib/ui/FormPage.svelte';
+import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
+import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
+
+const WIZARD_STEPS = [
+  { id: 'basic', title: 'Basic setup' },
+  { id: 'backends', title: 'Backend models' },
+  { id: 'signals', title: 'Signals & decisions' },
+  { id: 'advanced', title: 'Advanced & review' },
+];
+
+let name = $state('');
+let description = $state('');
+let listenerAddress = $state('0.0.0.0');
+let listenerPort = $state(8899);
+let timeout = $state('300s');
+
+let saving = $state(false);
+let error = $state('');
+
+let canSave = $derived(name.trim().length > 0 && listenerPort >= 1024 && listenerPort <= 65535);
+
+function cancel(): void {
+  handleNavigation({ page: NavigationPage.MODELS });
+}
+
+async function createRouter(): Promise<void> {
+  if (!canSave || saving) return;
+
+  saving = true;
+  error = '';
+
+  try {
+    const config: SemanticRouterConfigInfo = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      listeners: [
+        {
+          address: listenerAddress.trim() || '0.0.0.0',
+          port: listenerPort,
+          timeout: parseTimeout(timeout),
+        },
+      ],
+      routing: {
+        keywords: [],
+        decisions: [],
+      },
+    };
+
+    await window.createSemanticRouter(config);
+    handleNavigation({ page: NavigationPage.MODELS });
+  } catch (err: unknown) {
+    error = err instanceof Error ? err.message : String(err);
+  } finally {
+    saving = false;
+  }
+}
+
+function parseTimeout(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const match = /^(\d+)\s*s?$/.exec(trimmed);
+  if (match) return parseInt(match[1], 10);
+  return undefined;
+}
+</script>
+
+<FormPage title="Add Semantic Router">
+  {#snippet content()}
+    <div class="px-5 pb-5 min-w-full">
+      <div class="bg-(--pd-content-card-bg) py-6">
+        <div class="flex flex-col px-6 max-w-4xl mx-auto space-y-5">
+
+          <!-- Page header -->
+          <div class="mb-2">
+            <span
+              class="text-xs font-semibold uppercase tracking-widest text-(--pd-label-primary-text)
+                bg-(--pd-label-primary-bg) px-2 py-0.5 rounded mb-2 inline-flex items-center gap-1.5">
+              <Icon icon={faPlus} size="xs" />
+              New Semantic Router
+            </span>
+            <h1 class="text-2xl font-bold text-(--pd-modal-text) mb-1">Configure a Semantic Router</h1>
+            <p class="text-sm text-(--pd-content-card-text) opacity-70 max-w-2xl leading-relaxed">
+              Define backend model pools, signal rules, and routing decisions. The router exposes a single
+              <code class="text-(--pd-button-primary-bg) text-[13px]">/v1/chat/completions</code> endpoint your
+              agents use — no code changes needed.
+            </p>
+          </div>
+
+          <!-- Stepper -->
+          <WizardStepper steps={WIZARD_STEPS} currentIndex={0} />
+
+          <!-- Step content card -->
+          <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+            <h2 class="text-lg font-semibold text-(--pd-modal-text) mb-1">Basic setup</h2>
+            <p class="text-sm text-(--pd-content-card-text) opacity-60 mb-5">
+              Give the router a name and configure the listener. Agents connect to the listener endpoint; they never
+              talk to backends directly.
+            </p>
+
+            <div class="space-y-4">
+              <!-- Name + Description row -->
+              <div class="grid grid-cols-2 gap-3.5">
+                <div>
+                  <label for="router-name" class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                    Router name <span class="text-(--pd-input-field-error-text)">*</span>
+                  </label>
+                  <Input id="router-name" bind:value={name} placeholder="e.g. coding-router" aria-label="Router name" />
+                  <p class="text-xs text-(--pd-content-card-text) opacity-50 mt-1.5">
+                    Used as the identifier when selecting this router in workspace creation.
+                  </p>
+                </div>
+                <div>
+                  <label for="router-description" class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                    Description
+                  </label>
+                  <Input id="router-description" bind:value={description} placeholder="Short description of the routing strategy" aria-label="Description" />
+                </div>
+              </div>
+
+              <!-- Address + Port row -->
+              <div class="grid grid-cols-2 gap-3.5">
+                <div>
+                  <label for="listener-address" class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                    Listener address
+                  </label>
+                  <Input id="listener-address" bind:value={listenerAddress} placeholder="0.0.0.0" aria-label="Listener address" />
+                  <p class="text-xs text-(--pd-content-card-text) opacity-50 mt-1.5">
+                    Use <code class="text-(--pd-button-primary-bg)">host.containers.internal</code> when running
+                    inside a container to reach host services.
+                  </p>
+                </div>
+                <div>
+                  <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                    Listener port
+                  </span>
+                  <NumberInput bind:value={listenerPort} minimum={1024} maximum={65535} type="integer" aria-label="Listener port" />
+                  <p class="text-xs text-(--pd-content-card-text) opacity-50 mt-1.5">
+                    Default: <strong>8899</strong>. Agents connect to
+                    <code class="text-(--pd-button-primary-bg)">http://host:{listenerPort}/v1/chat/completions</code>.
+                  </p>
+                </div>
+              </div>
+
+              <!-- Timeout row -->
+              <div class="max-w-[calc(50%-7px)]">
+                <label for="router-timeout" class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                  Timeout
+                </label>
+                <Input id="router-timeout" bind:value={timeout} placeholder="300s" aria-label="Timeout" />
+                <p class="text-xs text-(--pd-content-card-text) opacity-50 mt-1.5">
+                  Maximum time before the request is cancelled.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {#if error}
+            <ErrorMessage error={error} />
+          {/if}
+
+          <!-- Footer actions -->
+          <div class="flex items-center justify-between pt-4 border-t border-(--pd-content-card-border)">
+            <span class="text-sm text-(--pd-content-card-text) opacity-70">
+              Step 1 of {WIZARD_STEPS.length}
+            </span>
+            <div class="flex flex-wrap items-center justify-end gap-3">
+              <Button onclick={cancel}>Cancel</Button>
+              <Button disabled={!canSave || saving} onclick={createRouter}>
+                {saving ? 'Creating...' : 'Next: Backend models'}
+              </Button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  {/snippet}
+</FormPage>

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -7,7 +7,6 @@ import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
-import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
 
 const WIZARD_STEPS = [
   { id: 'basic', title: 'Basic setup' },
@@ -20,55 +19,16 @@ let name = $state('');
 let description = $state('');
 let listenerAddress = $state('0.0.0.0');
 let listenerPort = $state(8899);
-let timeout = $state('300s');
+let timeout = $state(300);
 
-let saving = $state(false);
 let error = $state('');
 
-let canSave = $derived(name.trim().length > 0 && listenerPort >= 1024 && listenerPort <= 65535);
+let canSave = $derived(
+  name.trim().length > 0 && listenerPort >= 1024 && listenerPort <= 65535 && timeout > 0 && timeout <= 3600,
+);
 
 function cancel(): void {
   handleNavigation({ page: NavigationPage.SEMANTIC_ROUTERS });
-}
-
-async function createRouter(): Promise<void> {
-  if (!canSave || saving) return;
-
-  saving = true;
-  error = '';
-
-  try {
-    const config: SemanticRouterConfigInfo = {
-      name: name.trim(),
-      description: description.trim() || undefined,
-      listeners: [
-        {
-          address: listenerAddress.trim() || '0.0.0.0',
-          port: listenerPort,
-          timeout: parseTimeout(timeout),
-        },
-      ],
-      routing: {
-        keywords: [],
-        decisions: [],
-      },
-    };
-
-    await window.createSemanticRouter(config);
-    handleNavigation({ page: NavigationPage.SEMANTIC_ROUTERS });
-  } catch (err: unknown) {
-    error = err instanceof Error ? err.message : String(err);
-  } finally {
-    saving = false;
-  }
-}
-
-function parseTimeout(value: string): number | undefined {
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  const match = /^(\d+)\s*s?$/.exec(trimmed);
-  if (match) return Number.parseInt(match[1], 10);
-  return undefined;
 }
 </script>
 
@@ -154,9 +114,9 @@ function parseTimeout(value: string): number | undefined {
                 <label for="router-timeout" class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
                   Timeout
                 </label>
-                <Input id="router-timeout" bind:value={timeout} placeholder="300s" aria-label="Timeout" />
+                <NumberInput bind:value={timeout} minimum={1} maximum={3600} type="integer" aria-label="Timeout" />
                 <p class="text-xs text-(--pd-content-card-text) opacity-50 mt-1.5">
-                  Maximum time before the request is cancelled.
+                  Maximum time (in seconds) before the request is cancelled.
                 </p>
               </div>
             </div>
@@ -173,8 +133,9 @@ function parseTimeout(value: string): number | undefined {
             </span>
             <div class="flex flex-wrap items-center justify-end gap-3">
               <Button onclick={cancel}>Cancel</Button>
-              <Button disabled={!canSave || saving} onclick={createRouter}>
-                {saving ? 'Creating...' : 'Next: Backend models'}
+              <!-- TODO: wire to step navigation once backend models step is implemented -->
+              <Button disabled={!canSave}>
+                Next: Backend models
               </Button>
             </div>
           </div>

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -8,12 +8,11 @@ import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
 
-const WIZARD_STEPS = [
-  { id: 'basic', title: 'Basic setup' },
-  { id: 'backends', title: 'Backend models' },
-  { id: 'signals', title: 'Signals & decisions' },
-  { id: 'advanced', title: 'Advanced & review' },
-];
+const WIZARD_STEPS = [{ id: 'basic', title: 'Basic setup' }];
+
+let currentStepIndex = $state(0);
+let currentStepId = $derived(WIZARD_STEPS[currentStepIndex]?.id ?? '');
+let isLastStep = $derived(currentStepIndex === WIZARD_STEPS.length - 1);
 
 let name = $state('');
 let description = $state('');
@@ -22,10 +21,34 @@ let listenerPort = $state(8899);
 let timeout = $state(300);
 
 let error = $state('');
+let creating = $state(false);
 
 let canSave = $derived(
   name.trim().length > 0 && listenerPort >= 1024 && listenerPort <= 65535 && timeout > 0 && timeout <= 3600,
 );
+
+async function goNext(): Promise<void> {
+  if (!isLastStep) {
+    currentStepIndex++;
+    return;
+  }
+
+  error = '';
+  creating = true;
+  try {
+    await window.createSemanticRouter({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      listeners: [{ address: listenerAddress, port: listenerPort, timeout }],
+      routing: { keywords: [], decisions: [] },
+    });
+    handleNavigation({ page: NavigationPage.SEMANTIC_ROUTERS });
+  } catch (err: unknown) {
+    error = String(err);
+  } finally {
+    creating = false;
+  }
+}
 
 function cancel(): void {
   handleNavigation({ page: NavigationPage.SEMANTIC_ROUTERS });
@@ -55,10 +78,11 @@ function cancel(): void {
           </div>
 
           <!-- Stepper -->
-          <WizardStepper steps={WIZARD_STEPS} currentIndex={0} />
+          <WizardStepper steps={WIZARD_STEPS} currentIndex={currentStepIndex} />
 
           <!-- Step content card -->
           <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+            {#if currentStepId === 'basic'}
             <h2 class="text-lg font-semibold text-(--pd-modal-text) mb-1">Basic setup</h2>
             <p class="text-sm text-(--pd-content-card-text) opacity-60 mb-5">
               Give the router a name and configure the listener. Agents connect to the listener endpoint; they never
@@ -120,6 +144,7 @@ function cancel(): void {
                 </p>
               </div>
             </div>
+            {/if}
           </div>
 
           {#if error}
@@ -129,13 +154,12 @@ function cancel(): void {
           <!-- Footer actions -->
           <div class="flex items-center justify-between pt-4 border-t border-(--pd-content-card-border)">
             <span class="text-sm text-(--pd-content-card-text) opacity-70">
-              Step 1 of {WIZARD_STEPS.length}
+              Step {currentStepIndex + 1} of {WIZARD_STEPS.length}
             </span>
             <div class="flex flex-wrap items-center justify-end gap-3">
               <Button onclick={cancel}>Cancel</Button>
-              <!-- TODO: wire to step navigation once backend models step is implemented -->
-              <Button disabled={!canSave}>
-                Next: Backend models
+              <Button onclick={goNext} disabled={!canSave || creating} inProgress={creating}>
+                {isLastStep ? 'Create' : `Next: ${WIZARD_STEPS[currentStepIndex + 1]?.title}`}
               </Button>
             </div>
           </div>

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -28,7 +28,7 @@ let error = $state('');
 let canSave = $derived(name.trim().length > 0 && listenerPort >= 1024 && listenerPort <= 65535);
 
 function cancel(): void {
-  handleNavigation({ page: NavigationPage.MODELS });
+  handleNavigation({ page: NavigationPage.SEMANTIC_ROUTERS });
 }
 
 async function createRouter(): Promise<void> {
@@ -55,7 +55,7 @@ async function createRouter(): Promise<void> {
     };
 
     await window.createSemanticRouter(config);
-    handleNavigation({ page: NavigationPage.MODELS });
+    handleNavigation({ page: NavigationPage.SEMANTIC_ROUTERS });
   } catch (err: unknown) {
     error = err instanceof Error ? err.message : String(err);
   } finally {
@@ -67,7 +67,7 @@ function parseTimeout(value: string): number | undefined {
   const trimmed = value.trim();
   if (!trimmed) return undefined;
   const match = /^(\d+)\s*s?$/.exec(trimmed);
-  if (match) return parseInt(match[1], 10);
+  if (match) return Number.parseInt(match[1], 10);
   return undefined;
 }
 </script>

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -314,3 +314,9 @@ test(`Test navigationHandle for ${NavigationPage.AGENT_WORKSPACES}`, () => {
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/agent-workspaces');
 });
+
+test(`Test navigationHandle for ${NavigationPage.MODELS}`, () => {
+  handleNavigation({ page: NavigationPage.MODELS });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/models');
+});

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -320,3 +320,9 @@ test(`Test navigationHandle for ${NavigationPage.MODELS}`, () => {
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/models');
 });
+
+test(`Test navigationHandle for ${NavigationPage.SEMANTIC_ROUTERS}`, () => {
+  handleNavigation({ page: NavigationPage.SEMANTIC_ROUTERS });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/models/semantic-routers');
+});

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -218,5 +218,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.MODELS:
       router.goto('/models');
       break;
+    case NavigationPage.SEMANTIC_ROUTERS:
+      router.goto('/models/semantic-routers');
+      break;
   }
 };

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -215,5 +215,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.PROJECT_CREATE:
       router.goto('/projects/create');
       break;
+    case NavigationPage.MODELS:
+      router.goto('/models');
+      break;
   }
 };


### PR DESCRIPTION
## Summary
- Add the "Create Semantic Router" page (step 1: basic setup) with name, description, listener address, port, and timeout fields
- Wire the "Add Semantic Router" button in the Models > Semantic Routers tab to navigate to the new page
- Add `NavigationPage.MODELS` handler to the navigation registry

<img width="974" height="568" alt="image" src="https://github.com/user-attachments/assets/a3ea1526-b962-47d9-a1f2-f0a5193ce062" />

Fixes: https://github.com/openkaiden/kaiden/issues/2102