### PR TITLE
fix: show workspaces during creation and deletion

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -837,7 +837,7 @@ describe('listSandboxesPerGateway', () => {
   });
 });
 
-describe('listSandboxesPerGateway auto-refresh', () => {
+describe('listSandboxesPerGateway transitional auto-refresh', () => {
   const gateways = [{ name: 'gw-1', endpoint: 'https://gw1.example.com', active: true }];
 
   beforeEach(() => {
@@ -872,7 +872,30 @@ describe('listSandboxesPerGateway auto-refresh', () => {
     expect(listener).toHaveBeenCalledWith([{ gateway: gateways[0], sandboxes: readySandboxes }]);
   });
 
-  test('does not schedule poll when no sandbox is in Deleting state', async () => {
+  test('schedules re-list 5s after detecting a Provisioning sandbox and fires emitter', async () => {
+    const provisioningSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Provisioning' }];
+    const readySandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(provisioningSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+
+    expect(listener).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith([{ gateway: gateways[0], sandboxes: readySandboxes }]);
+  });
+
+  test('does not schedule poll when no sandbox is in a transitional state', async () => {
     const readySandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
 
     vi.mocked(exec.exec)
@@ -911,7 +934,7 @@ describe('listSandboxesPerGateway auto-refresh', () => {
     expect(listener).toHaveBeenCalledOnce();
   });
 
-  test('does not fire emitter when sandbox counts are unchanged', async () => {
+  test('does not fire emitter when sandbox phases are unchanged', async () => {
     const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
 
     vi.mocked(exec.exec)
@@ -929,7 +952,7 @@ describe('listSandboxesPerGateway auto-refresh', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
-  test('continues polling while Deleting sandboxes remain and fires only on change', async () => {
+  test('continues polling while transitional sandboxes remain and fires only on change', async () => {
     const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
     const readySandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
 
@@ -973,7 +996,7 @@ describe('listSandboxesPerGateway auto-refresh', () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     expect(listener).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deleting-poll refresh failed'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('transitional-poll refresh failed'));
   });
 
   test('dispose clears pending poll timer', async () => {
@@ -991,6 +1014,190 @@ describe('listSandboxesPerGateway auto-refresh', () => {
     await vi.advanceTimersByTimeAsync(10000);
 
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('early and post-operation polls during createSandbox and deleteSandbox', () => {
+  const gateways = [{ name: 'gw-1', endpoint: 'https://gw1.example.com', active: true }];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    openshellCli.dispose();
+    vi.useRealTimers();
+  });
+
+  test('createSandbox fires early poll at 500ms to catch Provisioning phase', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const provisioningSandboxes = [{ id: 'sb-new', name: 'sb-new', phase: 'Provisioning' }];
+
+    let resolveCreate!: () => void;
+    vi.mocked(exec.exec).mockReturnValueOnce(
+      new Promise<{ command: string; stdout: string; stderr: string }>((r): void => {
+        resolveCreate = (): void => r(mockExecResult(''));
+      }),
+    );
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(provisioningSandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    const createPromise = openshellCli.createSandbox({ name: 'sb-new' });
+
+    expect(listener).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith([{ gateway: gateways[0], sandboxes: provisioningSandboxes }]);
+
+    resolveCreate();
+    await createPromise;
+  });
+
+  test('createSandbox refreshes immediately when CLI completes', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const readySandboxes = [{ id: 'sb-new', name: 'sb-new', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(''))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.createSandbox({ name: 'sb-new' });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith([{ gateway: gateways[0], sandboxes: readySandboxes }]);
+  });
+
+  test('skips early poll when CLI finishes before 500ms', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const readySandboxes = [{ id: 'sb-new', name: 'sb-new', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(''))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)))
+      // delayed refresh at 500ms after CLI completes
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.createSandbox({ name: 'sb-new' });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(listener).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  test('createSandbox refreshes immediately on CLI failure', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const sandboxes = [{ id: 'sb-new', name: 'sb-new', phase: 'Error' }];
+
+    vi.mocked(exec.exec)
+      .mockRejectedValueOnce(new Error('creation failed'))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await expect(openshellCli.createSandbox({ name: 'sb-new' })).rejects.toThrow('creation failed');
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  test('deleteSandbox fires early poll at 500ms to catch Deleting phase', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+
+    let resolveDelete!: () => void;
+    vi.mocked(exec.exec).mockReturnValueOnce(
+      new Promise<{ command: string; stdout: string; stderr: string }>((r): void => {
+        resolveDelete = (): void => r(mockExecResult(''));
+      }),
+    );
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    const deletePromise = openshellCli.deleteSandbox('sb-1');
+
+    expect(listener).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(listener).toHaveBeenCalledOnce();
+
+    resolveDelete();
+    await deletePromise;
+  });
+
+  test('deleteSandbox refreshes immediately when CLI completes', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(''))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify([])));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.deleteSandbox('sb-1');
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith([{ gateway: gateways[0], sandboxes: [] }]);
+  });
+
+  test('deleteSandbox fires delayed refresh 500ms after CLI completes to catch server lag', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(''))
+      // immediate refresh — server still shows Deleting
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      // delayed refresh at 500ms — sandbox gone
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify([])));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.deleteSandbox('sb-1');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith([{ gateway: gateways[0], sandboxes: deletingSandboxes }]);
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith([{ gateway: gateways[0], sandboxes: [] }]);
   });
 });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -85,11 +85,17 @@ const OpenshellSettingsSchema = z.looseObject({
  *   - `openshell provider delete <name>`
  *   - `openshell provider create`
  */
+const TRANSITIONAL_PHASES = new Set(['Deleting', 'Provisioning']);
+const TRANSITIONAL_POLL_INTERVAL_MS = 5_000;
+const EARLY_POLL_DELAY_MS = 500;
+const MAX_TRANSITIONAL_POLL_RETRIES = 3;
+
 @injectable()
 export class OpenshellCli {
   private readonly _onDidSandboxListChange = new Emitter<GatewaySandboxes[]>();
   readonly onDidSandboxListChange: Event<GatewaySandboxes[]> = this._onDidSandboxListChange.event;
-  private _deletingPollTimer: ReturnType<typeof setTimeout> | undefined;
+  private _transitionalPollTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly _delayedRefreshTimers = new Set<ReturnType<typeof setTimeout>>();
 
   constructor(
     @inject(Exec)
@@ -219,7 +225,7 @@ export class OpenshellCli {
     if (options.command?.length) {
       args.push('--', ...options.command);
     }
-    await this.runCli(args, { redact: true });
+    await this.runCliWithOperationPoll(args, { redact: true });
   }
 
   async listSandboxes(gatewayName?: string): Promise<SandboxInfo[]> {
@@ -244,7 +250,7 @@ export class OpenshellCli {
     if (gatewayName) {
       args.push('-g', gatewayName);
     }
-    await this.runCli(args);
+    await this.runCliWithOperationPoll(args);
   }
 
   async deleteAllSandboxes(gatewayName?: string): Promise<void> {
@@ -297,33 +303,82 @@ export class OpenshellCli {
       }
     }
 
-    this.scheduleDeletingPollIfNeeded(results);
+    this.scheduleTransitionalPollIfNeeded(results);
     return results;
   }
 
-  private scheduleDeletingPollIfNeeded(results: GatewaySandboxes[]): void {
+  private snapshotPhases(sandboxes: SandboxInfo[]): string {
+    return sandboxes
+      .map(s => `${s.id}:${s.phase}`)
+      .sort((a, b) => a.localeCompare(b))
+      .join(',');
+  }
+
+  private scheduleTransitionalPollIfNeeded(results: GatewaySandboxes[], retries = 0): void {
     const allSandboxes = results.flatMap(entry => entry.sandboxes);
-    const deletingCount = allSandboxes.filter(s => s.phase === 'Deleting').length;
-    if (deletingCount === 0 || this._deletingPollTimer !== undefined) {
+    const transitionalCount = allSandboxes.filter(s => TRANSITIONAL_PHASES.has(s.phase)).length;
+    if (
+      transitionalCount === 0 ||
+      retries > MAX_TRANSITIONAL_POLL_RETRIES ||
+      this._transitionalPollTimer !== undefined
+    ) {
       return;
     }
-    const sandboxCount = allSandboxes.length;
-    this._deletingPollTimer = setTimeout(() => {
-      this._deletingPollTimer = undefined;
+    const previousSnapshot = this.snapshotPhases(allSandboxes);
+    this._transitionalPollTimer = setTimeout(() => {
+      this._transitionalPollTimer = undefined;
       this.listSandboxesPerGateway()
         .then(updated => {
           const updatedSandboxes = updated.flatMap(entry => entry.sandboxes);
-          const newSandboxCount = updatedSandboxes.length;
-          const newDeletingCount = updatedSandboxes.filter(s => s.phase === 'Deleting').length;
-          if (newSandboxCount !== sandboxCount || newDeletingCount !== deletingCount) {
+          if (this.snapshotPhases(updatedSandboxes) !== previousSnapshot) {
             this._onDidSandboxListChange.fire(updated);
           }
         })
         .catch((err: unknown) => {
-          console.warn(`[openshell] deleting-poll refresh failed: ${err instanceof Error ? err.message : String(err)}`);
-          this.scheduleDeletingPollIfNeeded(results);
+          console.warn(
+            `[openshell] transitional-poll refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          this.scheduleTransitionalPollIfNeeded(results, retries + 1);
         });
-    }, 5000);
+    }, TRANSITIONAL_POLL_INTERVAL_MS);
+  }
+
+  // Operation poll for create/delete: two targeted refreshes instead of
+  // continuous polling. The emitter update causes the renderer to re-fetch
+  // via listSandboxesPerGateway(), which activates the 5s transitional poll
+  // if transitional sandboxes are present. This is desirable: after the CLI
+  // completes, the transitional poll keeps monitoring until the sandbox
+  // reaches its final state (e.g. actually disappears after deletion).
+  private async runCliWithOperationPoll(
+    args: string[],
+    options?: { redact?: boolean; env?: { [p: string]: string }; quiet?: boolean },
+  ): Promise<void> {
+    let cliDone = false;
+    const earlyPoll = setTimeout(() => {
+      if (cliDone) return;
+      this.listSandboxesPerGateway()
+        .then(updated => this._onDidSandboxListChange.fire(updated))
+        .catch(() => {});
+    }, EARLY_POLL_DELAY_MS);
+    try {
+      await this.runCli(args, options);
+    } finally {
+      cliDone = true;
+      clearTimeout(earlyPoll);
+      this.listSandboxesPerGateway()
+        .then(updated => this._onDidSandboxListChange.fire(updated))
+        .catch(() => {});
+      // Delayed refresh — the server may not have fully processed the
+      // operation when the CLI returns (e.g. sandbox still briefly visible
+      // as Deleting after the delete command completes).
+      const delayedRefresh = setTimeout(() => {
+        this._delayedRefreshTimers.delete(delayedRefresh);
+        this.listSandboxesPerGateway()
+          .then(updated => this._onDidSandboxListChange.fire(updated))
+          .catch(() => {});
+      }, EARLY_POLL_DELAY_MS);
+      this._delayedRefreshTimers.add(delayedRefresh);
+    }
   }
 
   // ── gateway registration commands ─────────────────────────────────
@@ -519,10 +574,14 @@ export class OpenshellCli {
 
   @preDestroy()
   dispose(): void {
-    if (this._deletingPollTimer !== undefined) {
-      clearTimeout(this._deletingPollTimer);
-      this._deletingPollTimer = undefined;
+    if (this._transitionalPollTimer !== undefined) {
+      clearTimeout(this._transitionalPollTimer);
+      this._transitionalPollTimer = undefined;
     }
+    for (const timer of this._delayedRefreshTimers) {
+      clearTimeout(timer);
+    }
+    this._delayedRefreshTimers.clear();
     this._onDidSandboxListChange.dispose();
   }
 }

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -182,6 +182,7 @@ beforeEach(() => {
   vi.mocked(openshellSandboxesStore).allOpenshellSandboxes = writable<(SandboxInfo & { gatewayName: string })[]>([]);
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
   vi.mocked(window.checkAgentWorkspaceGlobalConfigExists).mockResolvedValue(false);
+  vi.mocked(window.createAgentWorkspace).mockResolvedValue({ id: 'ws-1' });
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   resetDraft();
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -467,7 +467,7 @@ function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorksp
   }
 }
 
-async function startAsIs(): Promise<void> {
+function startAsIs(): void {
   if (
     !wizard.draft.selectedGateway ||
     !wizard.draft.selectedModel ||
@@ -479,8 +479,8 @@ async function startAsIs(): Promise<void> {
 
   const draftSnapshot = $state.snapshot(wizard.draft);
 
-  try {
-    await window.createAgentWorkspace({
+  window
+    .createAgentWorkspace({
       sourcePath: draftSnapshot.sourcePath.trim() || undefined,
       agent: draftSnapshot.selectedAgent,
       model: getModelId(draftSnapshot.selectedModel!),
@@ -488,24 +488,23 @@ async function startAsIs(): Promise<void> {
       name: getEffectiveWorkspaceNameFromSnapshot(draftSnapshot),
       description: draftSnapshot.description || undefined,
       project: draftSnapshot.selectedProjectId,
+    })
+    .then(() => resetDraft())
+    .catch((err: unknown) => {
+      console.error('Failed to create agent workspace (as-is)', err);
+      window
+        .showMessageBox({
+          title: 'Agent Workspace',
+          type: 'error',
+          message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
+          buttons: ['OK'],
+        })
+        .catch(console.error);
     });
-    resetDraft();
-  } catch (err: unknown) {
-    console.error('Failed to create agent workspace (as-is)', err);
-    window
-      .showMessageBox({
-        title: 'Agent Workspace',
-        type: 'error',
-        message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
-        buttons: ['OK'],
-      })
-      .catch(console.error);
-  } finally {
-    handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
-  }
+  handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 }
 
-async function startWorkspace(): Promise<void> {
+function startWorkspace(): void {
   if (
     !wizard.draft.selectedGateway ||
     !getEffectiveWorkspaceName() ||
@@ -518,31 +517,29 @@ async function startWorkspace(): Promise<void> {
 
   const draftSnapshot = $state.snapshot(wizard.draft);
 
-  try {
-    const selectedSkillPaths = $skillInfos
-      .filter(s => draftSnapshot.selectedSkillIds.includes(s.name))
-      .map(s => s.path);
-    const network = mapNetworkSelection(
-      draftSnapshot.selectedNetwork,
-      draftSnapshot.hostsByMode[draftSnapshot.selectedNetwork] ?? [],
-    );
-    const mounts = buildMountsFrom(draftSnapshot.selectedFileAccess, draftSnapshot.customMounts);
+  const selectedSkillPaths = $skillInfos.filter(s => draftSnapshot.selectedSkillIds.includes(s.name)).map(s => s.path);
+  const network = mapNetworkSelection(
+    draftSnapshot.selectedNetwork,
+    draftSnapshot.hostsByMode[draftSnapshot.selectedNetwork] ?? [],
+  );
+  const mounts = buildMountsFrom(draftSnapshot.selectedFileAccess, draftSnapshot.customMounts);
 
-    const selected = $mcpRemoteServerInfos.filter(m => draftSnapshot.selectedMcpIds.includes(m.id));
-    const remoteServers = selected
-      .filter(m => m.setupType === 'remote' || (!m.setupType && m.url))
-      .map(m => ({ name: m.name, url: m.url }));
-    const commandServers = selected
-      .filter(m => m.setupType === 'package' && m.commandSpec)
-      .map(m => ({
-        name: m.name,
-        command: m.commandSpec!.command,
-        args: m.commandSpec!.args,
-        env: m.commandSpec!.env,
-      }));
-    const hasMcp = remoteServers.length > 0 || commandServers.length > 0;
+  const selected = $mcpRemoteServerInfos.filter(m => draftSnapshot.selectedMcpIds.includes(m.id));
+  const remoteServers = selected
+    .filter(m => m.setupType === 'remote' || (!m.setupType && m.url))
+    .map(m => ({ name: m.name, url: m.url }));
+  const commandServers = selected
+    .filter(m => m.setupType === 'package' && m.commandSpec)
+    .map(m => ({
+      name: m.name,
+      command: m.commandSpec!.command,
+      args: m.commandSpec!.args,
+      env: m.commandSpec!.env,
+    }));
+  const hasMcp = remoteServers.length > 0 || commandServers.length > 0;
 
-    await window.createAgentWorkspace({
+  window
+    .createAgentWorkspace({
       sourcePath: draftSnapshot.sourcePath.trim() || undefined,
       agent: draftSnapshot.selectedAgent,
       model: getModelId(draftSnapshot.selectedModel!),
@@ -562,21 +559,20 @@ async function startWorkspace(): Promise<void> {
       workspaceConfiguration: getAgentWorkspaceConfiguration(draftSnapshot.selectedAgent),
       replaceConfig: draftSnapshot.configExists && draftSnapshot.configAction === 'replace' ? true : undefined,
       project: draftSnapshot.selectedProjectId,
+    })
+    .then(() => resetDraft())
+    .catch((err: unknown) => {
+      console.error('Failed to create agent workspace', err);
+      window
+        .showMessageBox({
+          title: 'Agent Workspace',
+          type: 'error',
+          message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
+          buttons: ['OK'],
+        })
+        .catch(console.error);
     });
-    resetDraft();
-  } catch (err: unknown) {
-    console.error('Failed to create agent workspace', err);
-    window
-      .showMessageBox({
-        title: 'Agent Workspace',
-        type: 'error',
-        message: `Error while creating workspace: ${err instanceof Error ? err.message : String(err)}`,
-        buttons: ['OK'],
-      })
-      .catch(console.error);
-  } finally {
-    handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
-  }
+  handleNavigation({ page: NavigationPage.AGENT_WORKSPACES });
 }
 </script>
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
@@ -20,7 +20,7 @@ interface Props {
   onBrowseSource: () => Promise<void>;
   configExists?: boolean;
   configAction?: 'merge' | 'replace';
-  onStartAsIs?: () => Promise<void>;
+  onStartAsIs?: () => void;
   startAsIsDisabled?: boolean;
   projects?: WorkspaceProjectInfo[];
   selectedProjectId?: string;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -213,7 +213,7 @@ test('Expect clicking terminal redirects to terminal', async () => {
   expect(router.goto).toHaveBeenCalledWith('/agent-workspaces/ws-1/terminal');
 });
 
-test('Expect no navigation when removal fails', async () => {
+test('Expect navigation even when removal fails', async () => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   vi.mocked(window.removeAgentWorkspace).mockRejectedValue(new Error('removal failed'));
 
@@ -230,7 +230,7 @@ test('Expect no navigation when removal fails', async () => {
     expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1', 'kaiden');
   });
 
-  expect(router.goto).not.toHaveBeenCalled();
+  expect(router.goto).toHaveBeenCalledWith('/agent-workspaces');
 });
 
 test('Expect files tab is not present', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -25,7 +25,7 @@ let configurationError: string | undefined = $state(undefined);
 
 const workspaceSummary = $derived($allOpenshellSandboxes.find(ws => ws.id === workspaceId));
 
-const status = $derived(workspaceSummary?.phase ?? 'Provisioning');
+const status = $derived(workspaceSummary?.phase ?? 'Unknown');
 const isRunning = $derived(status === 'Ready' || status === 'Deleting');
 const inProgress = $derived(status === 'Provisioning' || status === 'Deleting');
 
@@ -36,6 +36,15 @@ const isOnTerminalTab = $derived(isTabSelected($router.path, 'terminal'));
 $effect(() => {
   if (status === 'Unknown') {
     removeTerminal(workspaceId);
+  }
+});
+
+let wasFound = false;
+$effect(() => {
+  if (workspaceSummary) {
+    wasFound = true;
+  } else if (wasFound) {
+    router.goto('/agent-workspaces');
   }
 });
 
@@ -69,16 +78,13 @@ async function handleTerminal(): Promise<void> {
 
 function handleRemove(): void {
   withConfirmation(
-    async () => {
-      try {
-        if (!workspaceSummary) {
-          throw new Error(`workspace "${workspaceId}" not found`);
-        }
-        await window.removeAgentWorkspace(workspaceId, workspaceSummary.gatewayName);
-        router.goto('/agent-workspaces');
-      } catch (error: unknown) {
-        console.error('Failed to remove agent workspace', error);
+    () => {
+      if (workspaceSummary) {
+        window.removeAgentWorkspace(workspaceId, workspaceSummary.gatewayName).catch((error: unknown) => {
+          console.error('Failed to remove agent workspace', error);
+        });
       }
+      router.goto('/agent-workspaces');
     },
     `remove workspace ${workspaceSummary?.name ?? workspaceId}`,
   );

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -455,20 +455,17 @@ function navigateToMcp(): void {
 
 function handleDeleteWorkspace(): void {
   withConfirmation(
-    async (err?: unknown) => {
+    (err?: unknown) => {
       if (err) {
         console.error('Confirmation dialog failed', err);
         return;
       }
-      try {
-        if (!workspaceSummary) {
-          throw new Error(`workspace "${workspaceId}" not found`);
-        }
-        await window.removeAgentWorkspace(workspaceId, workspaceSummary.gatewayName);
-        router.goto('/agent-workspaces');
-      } catch (error: unknown) {
-        console.error('Failed to remove agent workspace', error);
+      if (workspaceSummary) {
+        window.removeAgentWorkspace(workspaceId, workspaceSummary.gatewayName).catch((error: unknown) => {
+          console.error('Failed to remove agent workspace', error);
+        });
       }
+      router.goto('/agent-workspaces');
     },
     `remove workspace ${workspaceSummary?.name ?? workspaceId}`,
   );

--- a/packages/renderer/src/lib/agent-workspaces/columns/SandboxActions.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/columns/SandboxActions.svelte
@@ -11,6 +11,8 @@ interface Props {
 
 let { object }: Props = $props();
 
+const isDeleting = $derived(object.phase === 'Deleting');
+
 function handleRemove(): void {
   withConfirmation(
     () => window.deleteOpenshellSandbox(object.name, object.gatewayName).catch(console.error),
@@ -19,4 +21,4 @@ function handleRemove(): void {
 }
 </script>
 
-<ListItemButtonIcon title="Remove workspace" icon={faTrash} onClick={handleRemove} />
+<ListItemButtonIcon title="Remove workspace" icon={faTrash} onClick={handleRemove} enabled={!isDeleting} />

--- a/packages/renderer/src/lib/agent-workspaces/columns/SandboxName.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/columns/SandboxName.spec.ts
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { SandboxInfo } from '/@api/openshell-gateway-info';
 
@@ -38,6 +38,11 @@ const mockSandbox: SandboxInfo = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 test('Expect sandbox name is displayed', () => {
@@ -163,4 +168,20 @@ test('Expect button is clickable and accessible', () => {
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('flex', 'items-start');
+});
+
+test('Expect button is disabled when sandbox is Deleting', () => {
+  render(SandboxName, { object: { ...mockSandbox, phase: 'Deleting' } });
+
+  const button = screen.getByRole('button');
+  expect(button).toBeDisabled();
+});
+
+test('Expect clicking does not navigate when sandbox is Deleting', async () => {
+  render(SandboxName, { object: { ...mockSandbox, phase: 'Deleting' } });
+
+  const button = screen.getByRole('button');
+  await fireEvent.click(button);
+
+  expect(router.goto).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/agent-workspaces/columns/SandboxName.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/columns/SandboxName.svelte
@@ -10,14 +10,18 @@ interface Props {
 
 let { object }: Props = $props();
 
+const isDeleting = $derived(object.phase === 'Deleting');
+
 function openDetails(): void {
-  router.goto(`/agent-workspaces/${encodeURIComponent(object.id)}/overview`);
+  if (!isDeleting) {
+    router.goto(`/agent-workspaces/${encodeURIComponent(object.id)}/overview`);
+  }
 }
 </script>
 
 <div class="flex flex-col">
   <Tooltip top tip={object.sourcePath ?? object.name}>
-    <button class="flex items-start" onclick={openDetails}>
+    <button class="flex items-start" onclick={openDetails} disabled={isDeleting} class:opacity-50={isDeleting} class:cursor-default={isDeleting}>
     <div class="text-sm text-[var(--pd-table-body-text)]">{object.name}</div>
     </button>
   </Tooltip>

--- a/packages/renderer/src/stores/openshell-sandboxes.ts
+++ b/packages/renderer/src/stores/openshell-sandboxes.ts
@@ -56,15 +56,35 @@ export interface SandboxInfoWithGateway extends SandboxInfo {
   gatewayName: string;
 }
 
+// Workaround: the Podman driver's event watcher can briefly report a sandbox as
+// Provisioning between Deleting and actual removal (stop event → inspect →
+// derive_phase returns Provisioning before the remove event arrives).
+// Pin the phase to Deleting once observed until the sandbox disappears.
+const deletingSandboxIds = new Set<string>();
+
 // Derived store: flatten all sandboxes across gateways and add gateway name for easier UI consumption
 export const allOpenshellSandboxes = derived(openshellSandboxes, $sandboxes => {
   const flattened: SandboxInfoWithGateway[] = [];
+  const currentIds = new Set<string>();
   for (const gatewaySandboxes of $sandboxes) {
     for (const sandbox of gatewaySandboxes.sandboxes) {
+      currentIds.add(sandbox.id);
+      if (sandbox.phase === 'Deleting') {
+        deletingSandboxIds.add(sandbox.id);
+      } else if (sandbox.phase !== 'Provisioning' && deletingSandboxIds.has(sandbox.id)) {
+        deletingSandboxIds.delete(sandbox.id);
+      }
+      const phase = deletingSandboxIds.has(sandbox.id) ? 'Deleting' : sandbox.phase;
       flattened.push({
         ...sandbox,
+        phase,
         gatewayName: gatewaySandboxes.gateway.name,
       });
+    }
+  }
+  for (const id of deletingSandboxIds) {
+    if (!currentIds.has(id)) {
+      deletingSandboxIds.delete(id);
     }
   }
   return flattened;


### PR DESCRIPTION
Show Provisioning and Deleting sandbox phases via polling during
create/delete operations:

- Add early poll at 500ms and immediate refresh on CLI completion to
  catch transitional phases quickly (runCliWithOperationPoll)
- Keep 5s transitional poll for externally-created sandboxes, using
  per-sandbox id:phase snapshots for accurate change detection
- Fire-and-forget IPC calls: redirect to workspace list immediately
  after clicking Create or confirming Delete
- Disable interactions with sandboxes in Deleting phase (actions,
  name link)
- Auto-redirect from details page when workspace disappears
- Pin Deleting phase in Svelte store to work around Podman driver race
  

https://github.com/user-attachments/assets/670e4346-621e-4bdb-8e51-8e27e6d4b4db



  fixes #2030 
  fixes #2033 