### PR TITLE
fix: remove double-prefix on openshell config key lookup

### DIFF
--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -48,7 +48,7 @@ export class OpenshellCliManager implements Disposable {
     const packageJsonPath = join(this.extensionContext.extensionUri.fsPath, 'package.json');
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
-    const cliResult = await this.discoverBinary('openshell', 'openshell.binary.path', 'openshell');
+    const cliResult = await this.discoverBinary('openshell', 'binary.path', 'openshell');
     const registration: BinaryDiscoveryResult = cliResult ?? {
       installationSource: 'extension',
     };
@@ -71,7 +71,7 @@ export class OpenshellCliManager implements Disposable {
 
     const ibResult = await this.discoverBinary(
       'openshell-image-builder',
-      'openshell.imageBuilder.binary.path',
+      'imageBuilder.binary.path',
       'openshell-image-builder',
     );
     const ibRegistration: BinaryDiscoveryResult = ibResult ?? {


### PR DESCRIPTION
## Summary
- `getConfiguration('openshell').get('openshell.binary.path')` was resolving to `openshell.openshell.binary.path`, silently ignoring any user-configured custom binary path
- 
Fixes: https://github.com/openkaiden/kaiden/issues/2142

There is another issue at play here

since openshell needs multiple binaries and only the main openshell binary is loaded we should have the ability to select a custom path for the gateway binary and sandbox? Wondering if we should do a directory walkthrough on a folder having all the binaries? or seperate path configs for each one? Right now only openshell is registered in the clitools

its out of scope for this particular issue but definitely related 