### PR TITLE
feat(mcp): add a registered option to local mcps

### DIFF
--- a/packages/api/src/mcp/mcp-server-info.ts
+++ b/packages/api/src/mcp/mcp-server-info.ts
@@ -34,4 +34,5 @@ export interface MCPRemoteServerInfo {
   commandSpec?: MCPCommandSpec;
   tools: Record<string, { description?: string }>;
   isValidSchema?: boolean;
+  status?: 'running' | 'registered';
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2441,6 +2441,14 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('mcp-manager:startMCPServer', async (_listener, key: string): Promise<void> => {
+      await mcpRegistry.startMCPServer(key);
+    });
+
+    this.ipcHandle('mcp-manager:stopMCPServer', async (_listener, key: string): Promise<void> => {
+      await mcpRegistry.stopMCPServer(key);
+    });
+
     this.ipcHandle(
       'image-registry:updateRegistry',
       async (_listener, registry: containerDesktopAPI.Registry): Promise<void> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -142,7 +142,7 @@ import type { ContainerCreateOptions as PodmanContainerCreateOptions, PlayKubeIn
 import type { ListOrganizerItem } from '/@api/list-organizer.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info.js';
-import type { MCPSetupOptions } from '/@api/mcp/mcp-setup.js';
+import type { MCPSetupOptions, MCPSetupPackageOptions } from '/@api/mcp/mcp-setup.js';
 import type { Menu } from '/@api/menu.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
@@ -2398,6 +2398,13 @@ export class PluginSystem {
       'mcp-registry:setup',
       async (_listener, serverId: string, options: MCPSetupOptions): Promise<void> => {
         await mcpRegistry.setupMCPServer(serverId, options);
+      },
+    );
+
+    this.ipcHandle(
+      'mcp-registry:register',
+      async (_listener, serverId: string, options: MCPSetupPackageOptions): Promise<void> => {
+        await mcpRegistry.registerMCPServerOnly(serverId, options);
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2442,14 +2442,6 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle('mcp-manager:startMCPServer', async (_listener, key: string): Promise<void> => {
-      await mcpRegistry.startMCPServer(key);
-    });
-
-    this.ipcHandle('mcp-manager:stopMCPServer', async (_listener, key: string): Promise<void> => {
-      await mcpRegistry.stopMCPServer(key);
-    });
-
     this.ipcHandle(
       'image-registry:updateRegistry',
       async (_listener, registry: containerDesktopAPI.Registry): Promise<void> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2437,6 +2437,7 @@ export class PluginSystem {
       'mcp-manager:removeMcpRemoteServer',
       async (_listener, key: string, options: { serverId: string; remoteId: number }): Promise<void> => {
         await mcpRegistry.deleteRemoteMcpFromConfiguration(options.serverId, options.remoteId);
+        await mcpRegistry.deletePackageFromConfiguration(options.serverId, options.remoteId);
         return mcpManager.removeMcpRemoteServer(key);
       },
     );

--- a/packages/main/src/plugin/mcp/mcp-ipc-handler.ts
+++ b/packages/main/src/plugin/mcp/mcp-ipc-handler.ts
@@ -40,6 +40,8 @@ export class MCPIPCHandler {
     this.ipcHandle('mcp-registry:createMCPRegistry', this.createMCPRegistry.bind(this));
     this.ipcHandle('mcp-registry:exportServer', this.exportServer.bind(this));
     this.ipcHandle('mcp-registry:getExportConfigPath', this.getExportConfigPath.bind(this));
+    this.ipcHandle('mcp-manager:startMCPServer', this.startMCPServer.bind(this));
+    this.ipcHandle('mcp-manager:stopMCPServer', this.stopMCPServer.bind(this));
   }
 
   protected async createMCPRegistry(
@@ -55,5 +57,13 @@ export class MCPIPCHandler {
 
   protected getExportConfigPath(_: IpcMainInvokeEvent, target: MCPExportTarget): string {
     return this.mcpExporter.getConfigFilePath(target);
+  }
+
+  protected async startMCPServer(_: IpcMainInvokeEvent, key: string): Promise<void> {
+    await this.mcpRegistry.startMCPServer(key);
+  }
+
+  protected async stopMCPServer(_: IpcMainInvokeEvent, key: string): Promise<void> {
+    await this.mcpRegistry.stopMCPServer(key);
   }
 }

--- a/packages/main/src/plugin/mcp/mcp-manager.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { experimental_createMCPClient } from '@ai-sdk/mcp';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -25,8 +26,6 @@ import type { MCPExchanges } from './mcp-exchanges.js';
 import { MCPManager } from './mcp-manager.js';
 
 vi.mock(import('@ai-sdk/mcp'));
-
-const { experimental_createMCPClient } = await import('@ai-sdk/mcp');
 
 const apiSender: ApiSenderType = {
   send: vi.fn(),

--- a/packages/main/src/plugin/mcp/mcp-manager.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.spec.ts
@@ -1,0 +1,115 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+
+import type { MCPExchanges } from './mcp-exchanges.js';
+import { MCPManager } from './mcp-manager.js';
+
+vi.mock(import('@ai-sdk/mcp'));
+
+const { experimental_createMCPClient } = await import('@ai-sdk/mcp');
+
+const apiSender: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
+};
+
+const exchanges: MCPExchanges = {
+  createMiddleware: vi.fn().mockImplementation((_key: string, transport: Transport) => transport),
+  clearExchanges: vi.fn(),
+} as unknown as MCPExchanges;
+
+let mcpManager: MCPManager;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(exchanges.createMiddleware).mockImplementation((_key: string, transport: Transport) => transport);
+  mcpManager = new MCPManager(apiSender, exchanges);
+});
+
+function createMockTransport(): Transport {
+  return {} as Transport;
+}
+
+function mockMCPClient(toolSet: Record<string, { description?: string }> = {}): void {
+  vi.mocked(experimental_createMCPClient).mockResolvedValue({
+    tools: vi.fn().mockResolvedValue(toolSet),
+    close: vi.fn(),
+  } as never);
+}
+
+test('addClient spawns client on a registered server and updates status', async () => {
+  mockMCPClient({ myTool: { description: 'a tool' } });
+
+  mcpManager.registerMCPWithoutClient('provider', 'srv1', 'package', 0, 'Test Server');
+
+  const servers = await mcpManager.listMCPRemoteServers();
+  expect(servers).toHaveLength(1);
+  expect(servers[0]!.status).toBe('registered');
+  expect(servers[0]!.tools).toEqual({});
+
+  await mcpManager.addClient(servers[0]!.id, createMockTransport());
+
+  const updated = await mcpManager.listMCPRemoteServers();
+  expect(updated).toHaveLength(1);
+  expect(updated[0]!.status).toBeUndefined();
+  expect(updated[0]!.tools).toEqual({ myTool: { description: 'a tool' } });
+  expect(apiSender.send).toHaveBeenCalledWith('mcp-manager-update');
+});
+
+test('removeClient stops client on a spawned server and updates status', async () => {
+  mockMCPClient({ myTool: { description: 'a tool' } });
+
+  await mcpManager.registerMCPClient('provider', 'srv1', 'package', 0, 'Test Server', createMockTransport());
+
+  const servers = await mcpManager.listMCPRemoteServers();
+  expect(servers[0]!.status).toBeUndefined();
+  expect(Object.keys(servers[0]!.tools)).toHaveLength(1);
+
+  await mcpManager.removeClient(servers[0]!.id);
+
+  const updated = await mcpManager.listMCPRemoteServers();
+  expect(updated).toHaveLength(1);
+  expect(updated[0]!.status).toBe('registered');
+  expect(updated[0]!.tools).toEqual({});
+  expect(exchanges.clearExchanges).toHaveBeenCalledWith(servers[0]!.id);
+});
+
+test('addClient throws if server does not exist', async () => {
+  await expect(mcpManager.addClient('nonexistent', createMockTransport())).rejects.toThrow(
+    'cannot find MCP server with id nonexistent',
+  );
+});
+
+test('removeClient throws if server does not exist', async () => {
+  await expect(mcpManager.removeClient('nonexistent')).rejects.toThrow('cannot find MCP server with id nonexistent');
+});
+
+test('removeClient is safe when no client exists', async () => {
+  mcpManager.registerMCPWithoutClient('provider', 'srv1', 'package', 0, 'Test Server');
+
+  const servers = await mcpManager.listMCPRemoteServers();
+  await mcpManager.removeClient(servers[0]!.id);
+
+  const updated = await mcpManager.listMCPRemoteServers();
+  expect(updated[0]!.status).toBe('registered');
+});

--- a/packages/main/src/plugin/mcp/mcp-manager.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,28 @@ test('addClient throws if client already exists', async () => {
 
   const servers = await mcpManager.listMCPRemoteServers();
   await expect(mcpManager.addClient(servers[0]!.id, createMockTransport())).rejects.toThrow('is already started');
+});
+
+test('addClient cleans up client state when tool discovery fails', async () => {
+  const close = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(experimental_createMCPClient).mockResolvedValueOnce({
+    tools: vi.fn().mockRejectedValue(new Error('tool discovery failed')),
+    close,
+  } as never);
+
+  mcpManager.registerMCPWithoutClient('provider', 'srv1', 'package', 0, 'Test Server');
+
+  const servers = await mcpManager.listMCPRemoteServers();
+  await expect(mcpManager.addClient(servers[0]!.id, createMockTransport())).rejects.toThrow('tool discovery failed');
+
+  expect(close).toHaveBeenCalled();
+  expect(exchanges.clearExchanges).toHaveBeenCalledWith(servers[0]!.id);
+
+  mockMCPClient({ recovered: { description: 'after retry' } });
+  await expect(mcpManager.addClient(servers[0]!.id, createMockTransport())).resolves.toBeUndefined();
+
+  const updated = await mcpManager.listMCPRemoteServers();
+  expect(updated[0]!.tools).toEqual({ recovered: { description: 'after retry' } });
 });
 
 test('removeClient throws if server does not exist', async () => {

--- a/packages/main/src/plugin/mcp/mcp-manager.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.spec.ts
@@ -100,6 +100,15 @@ test('addClient throws if server does not exist', async () => {
   );
 });
 
+test('addClient throws if client already exists', async () => {
+  mockMCPClient();
+
+  await mcpManager.registerMCPClient('provider', 'srv1', 'package', 0, 'Test Server', createMockTransport());
+
+  const servers = await mcpManager.listMCPRemoteServers();
+  await expect(mcpManager.addClient(servers[0]!.id, createMockTransport())).rejects.toThrow('is already started');
+});
+
 test('removeClient throws if server does not exist', async () => {
   await expect(mcpManager.removeClient('nonexistent')).rejects.toThrow('cannot find MCP server with id nonexistent');
 });

--- a/packages/main/src/plugin/mcp/mcp-manager.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.ts
@@ -235,6 +235,7 @@ export class MCPManager implements IAsyncDisposable {
 
   public async addClient(key: string, transport: Transport): Promise<void> {
     const server = this.get(key);
+    if (this.#client.has(key)) throw new Error(`MCP server ${key} is already started`);
 
     const wrapped = this.exchanges.createMiddleware(key, transport);
     const client = await experimental_createMCPClient({ transport: wrapped });

--- a/packages/main/src/plugin/mcp/mcp-manager.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.ts
@@ -140,22 +140,7 @@ export class MCPManager implements IAsyncDisposable {
   ): Promise<void> {
     const key = this.getKey(internalProviderId, serverId, setupType, index);
 
-    const wrapped = this.exchanges.createMiddleware(key, transport);
-
-    const client = await experimental_createMCPClient({ transport: wrapped });
-
-    console.log('[MCPManager] Registering MCP client for ', internalProviderId, ' with name ', connectionName);
-    this.#client.set(key, client);
-
-    const toolSet = await client.tools();
-    const tools = Object.fromEntries(
-      Object.entries(toolSet).map(([key, value]) => [
-        key,
-        {
-          description: value.description ?? '',
-        },
-      ]),
-    );
+    const tools = await this.createClientTools(key, transport);
 
     const mcpRemoteServerInfo: MCPRemoteServerInfo = {
       id: key,
@@ -237,14 +222,7 @@ export class MCPManager implements IAsyncDisposable {
     const server = this.get(key);
     if (this.#client.has(key)) throw new Error(`MCP server ${key} is already started`);
 
-    const wrapped = this.exchanges.createMiddleware(key, transport);
-    const client = await experimental_createMCPClient({ transport: wrapped });
-    this.#client.set(key, client);
-
-    const toolSet = await client.tools();
-    server.tools = Object.fromEntries(
-      Object.entries(toolSet).map(([k, v]) => [k, { description: v.description ?? '' }]),
-    );
+    server.tools = await this.createClientTools(key, transport);
     server.status = undefined;
 
     this.apiSender.send('mcp-manager-update');
@@ -274,5 +252,32 @@ export class MCPManager implements IAsyncDisposable {
   ): MCPRemoteServerInfo | undefined {
     const key = this.getKey(INTERNAL_PROVIDER_ID, serverId, type, index);
     return this.#mcps.find(mcp => mcp.id === key);
+  }
+
+  private async createClientTools(
+    key: string,
+    transport: Transport,
+  ): Promise<Record<string, { description?: string }>> {
+    const wrapped = this.exchanges.createMiddleware(key, transport);
+    const client = await experimental_createMCPClient({ transport: wrapped });
+
+    try {
+      const toolSet = await client.tools();
+      const tools = Object.fromEntries(
+        Object.entries(toolSet).map(([toolName, value]) => [
+          toolName,
+          {
+            description: value.description ?? '',
+          },
+        ]),
+      );
+
+      this.#client.set(key, client);
+      return tools;
+    } catch (error) {
+      await client.close().catch(console.error);
+      this.exchanges.clearExchanges(key);
+      throw error;
+    }
   }
 }

--- a/packages/main/src/plugin/mcp/mcp-manager.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.ts
@@ -233,6 +233,38 @@ export class MCPManager implements IAsyncDisposable {
     this.apiSender.send('mcp-manager-update');
   }
 
+  public async addClient(key: string, transport: Transport): Promise<void> {
+    const server = this.get(key);
+
+    const wrapped = this.exchanges.createMiddleware(key, transport);
+    const client = await experimental_createMCPClient({ transport: wrapped });
+    this.#client.set(key, client);
+
+    const toolSet = await client.tools();
+    server.tools = Object.fromEntries(
+      Object.entries(toolSet).map(([k, v]) => [k, { description: v.description ?? '' }]),
+    );
+    server.status = undefined;
+
+    this.apiSender.send('mcp-manager-update');
+  }
+
+  public async removeClient(key: string): Promise<void> {
+    const server = this.get(key);
+
+    const instance = this.#client.get(key);
+    if (instance) {
+      await instance.close();
+      this.#client.delete(key);
+      this.exchanges.clearExchanges(key);
+    }
+
+    server.tools = {};
+    server.status = 'registered';
+
+    this.apiSender.send('mcp-manager-update');
+  }
+
   findMcpRemoteServer(
     INTERNAL_PROVIDER_ID: string,
     serverId: string,

--- a/packages/main/src/plugin/mcp/mcp-manager.ts
+++ b/packages/main/src/plugin/mcp/mcp-manager.ts
@@ -174,6 +174,36 @@ export class MCPManager implements IAsyncDisposable {
     this.apiSender.send('mcp-manager-update');
   }
 
+  public registerMCPWithoutClient(
+    internalProviderId: string,
+    serverId: string,
+    setupType: 'remote' | 'package',
+    index: number,
+    connectionName: string,
+    url?: string,
+    description?: string,
+    isValidSchema?: boolean,
+    commandSpec?: MCPCommandSpec,
+  ): void {
+    const key = this.getKey(internalProviderId, serverId, setupType, index);
+
+    const mcpRemoteServerInfo: MCPRemoteServerInfo = {
+      id: key,
+      infos: { internalProviderId, remoteId: index, serverId },
+      name: connectionName,
+      url: url ?? '',
+      setupType,
+      commandSpec,
+      description: description ?? '',
+      tools: {},
+      isValidSchema,
+      status: 'registered',
+    };
+    this.#mcps.push(mcpRemoteServerInfo);
+
+    this.apiSender.send('mcp-manager-update');
+  }
+
   public async unregisterMCPClient(
     internalProviderId: string,
     serverId: string,
@@ -192,19 +222,14 @@ export class MCPManager implements IAsyncDisposable {
 
   public async removeMcpRemoteServer(key: string): Promise<void> {
     const instance = this.#client.get(key);
-    if (!instance) throw new Error(`cannot find MCP instance with key ${key}`);
+    if (instance) {
+      await instance.close();
+      this.#client.delete(key);
+      this.exchanges.clearExchanges(key);
+    }
 
-    // Close the client connection
-    await instance.close();
-
-    // remove the instance
-    this.#client.delete(key);
-    this.exchanges.clearExchanges(key);
-
-    // clear from the #mcps list
     this.#mcps = this.#mcps.filter(mcp => mcp.id !== key);
 
-    // broadcast new items
     this.apiSender.send('mcp-manager-update');
   }
 

--- a/packages/main/src/plugin/mcp/mcp-registry.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.spec.ts
@@ -412,6 +412,7 @@ test('listMCPServersFromRegistries handles both updates and additions', async ()
 describe('startMCPServer / stopMCPServer', () => {
   const SERVER_KEY = 'internal:test-server:package:0';
   const SERVER_ID = 'test-server';
+  const OTHER_SERVER_KEY = 'internal:test-server:package:1';
 
   const registeredServer: MCPRemoteServerInfo = {
     id: SERVER_KEY,
@@ -431,6 +432,18 @@ describe('startMCPServer / stopMCPServer', () => {
     tools: { myTool: { description: 'a tool' } },
   };
 
+  const otherRegisteredServer: MCPRemoteServerInfo = {
+    ...registeredServer,
+    id: OTHER_SERVER_KEY,
+    infos: { internalProviderId: 'internal', serverId: SERVER_ID, remoteId: 1 },
+  };
+
+  const otherSpawnedServer: MCPRemoteServerInfo = {
+    ...spawnedServer,
+    id: OTHER_SERVER_KEY,
+    infos: { internalProviderId: 'internal', serverId: SERVER_ID, remoteId: 1 },
+  };
+
   const remoteServer: MCPRemoteServerInfo = {
     ...registeredServer,
     setupType: 'remote',
@@ -441,21 +454,36 @@ describe('startMCPServer / stopMCPServer', () => {
     serverId: SERVER_ID,
     packageId: 0,
     autoSpawn: false,
-    runtimeArguments: [],
-    packageArguments: [],
-    environmentVariables: {},
+    runtimeArguments: ['--port=3000'],
+    packageArguments: ['serve'],
+    environmentVariables: { TOKEN: 'default-token' },
   };
 
   const serverDetail = {
     serverId: SERVER_ID,
     name: 'Test MCP',
     description: 'A test server',
-    packages: [{ registryType: 'npm', name: 'test-mcp', version: '1.0.0' }],
+    packages: [
+      {
+        registryType: 'npm',
+        name: 'test-mcp',
+        version: '1.0.0',
+        runtimeArguments: [{ default: '--port=3000' }],
+        packageArguments: [{ default: 'serve' }],
+        environmentVariables: [{ name: 'TOKEN', default: 'default-token' }],
+      },
+      {
+        registryType: 'npm',
+        name: 'test-mcp-alt',
+        version: '2.0.0',
+      },
+    ],
   };
 
   let mockMcpManager: MCPManager;
   let mockSafeStorage: { get: ReturnType<typeof vi.fn>; store: ReturnType<typeof vi.fn> };
   let registry: MCPRegistry;
+  let storedConfigs: Array<Record<string, unknown>>;
 
   beforeEach(() => {
     mockMcpManager = {
@@ -468,9 +496,12 @@ describe('startMCPServer / stopMCPServer', () => {
       removeMcpRemoteServer: vi.fn(),
     } as unknown as MCPManager;
 
+    storedConfigs = [{ ...savedConfig }];
     mockSafeStorage = {
-      get: vi.fn().mockResolvedValue(JSON.stringify([savedConfig])),
-      store: vi.fn(),
+      get: vi.fn().mockImplementation(async () => JSON.stringify(storedConfigs)),
+      store: vi.fn().mockImplementation(async (_key: string, value: string) => {
+        storedConfigs = JSON.parse(value);
+      }),
     };
 
     const mockSafeStorageRegistry = {
@@ -509,9 +540,7 @@ describe('startMCPServer / stopMCPServer', () => {
     await registry.startMCPServer(SERVER_KEY);
 
     expect(mockMcpManager.addClient).toHaveBeenCalledWith(SERVER_KEY, mockTransport);
-    expect(mockSafeStorage.store).toHaveBeenCalled();
-    const storedConfigs = JSON.parse(vi.mocked(mockSafeStorage.store).mock.calls[0]![1] as string);
-    expect(storedConfigs[0].autoSpawn).toBe(true);
+    expect(storedConfigs[0]?.['autoSpawn']).toBe(true);
   });
 
   test('startMCPServer throws if server is already spawned', async () => {
@@ -532,9 +561,7 @@ describe('startMCPServer / stopMCPServer', () => {
     await registry.stopMCPServer(SERVER_KEY);
 
     expect(mockMcpManager.removeClient).toHaveBeenCalledWith(SERVER_KEY);
-    expect(mockSafeStorage.store).toHaveBeenCalled();
-    const storedConfigs = JSON.parse(vi.mocked(mockSafeStorage.store).mock.calls[0]![1] as string);
-    expect(storedConfigs[0].autoSpawn).toBe(false);
+    expect(storedConfigs[0]?.['autoSpawn']).toBe(false);
   });
 
   test('stopMCPServer throws if server is already registered', async () => {
@@ -549,7 +576,7 @@ describe('startMCPServer / stopMCPServer', () => {
     await expect(registry.stopMCPServer(SERVER_KEY)).rejects.toThrow('Only package MCP servers can be stopped.');
   });
 
-  test('setupMCPServer starts a registered server instead of erroring', async () => {
+  test('setupMCPServer starts the matching registered server and refreshes its saved config', async () => {
     vi.mocked(mockMcpManager.get).mockReturnValue(registeredServer);
     vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([registeredServer]);
 
@@ -560,12 +587,20 @@ describe('startMCPServer / stopMCPServer', () => {
     await registry.setupMCPServer(SERVER_ID, {
       type: 'package',
       index: 0,
-      runtimeArguments: {},
-      packageArguments: {},
-      environmentVariables: {},
+      runtimeArguments: { 0: { value: '--port=9000', variables: {} } },
+      packageArguments: { 0: { value: 'serve-updated', variables: {} } },
+      environmentVariables: { TOKEN: { value: 'updated-token', variables: {} } },
     });
 
     expect(mockMcpManager.addClient).toHaveBeenCalledWith(SERVER_KEY, expect.anything());
+    expect(storedConfigs[0]).toMatchObject({
+      serverId: SERVER_ID,
+      packageId: 0,
+      autoSpawn: true,
+      runtimeArguments: ['--port=9000'],
+      packageArguments: ['serve-updated'],
+      environmentVariables: { TOKEN: 'updated-token' },
+    });
   });
 
   test('setupMCPServer throws if server is already spawned', async () => {
@@ -582,11 +617,14 @@ describe('startMCPServer / stopMCPServer', () => {
     ).rejects.toThrow('MCP server is already spawned.');
   });
 
-  test('registerMCPServerOnly stops a spawned server instead of erroring', async () => {
-    vi.mocked(mockMcpManager.get).mockReturnValue(spawnedServer);
-    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([spawnedServer]);
+  test('setupMCPServer registers a different package target for the same server id', async () => {
+    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([otherRegisteredServer]);
 
-    await registry.registerMCPServerOnly(SERVER_ID, {
+    const { MCPPackage } = await import('/@/plugin/mcp/package/mcp-package.js');
+    vi.mocked(MCPPackage.prototype.spawn).mockResolvedValue({} as Transport);
+    vi.mocked(MCPPackage.prototype.buildCommandSpec).mockReturnValue({ command: 'node', args: ['server.js'] });
+
+    await registry.setupMCPServer(SERVER_ID, {
       type: 'package',
       index: 0,
       runtimeArguments: {},
@@ -594,7 +632,42 @@ describe('startMCPServer / stopMCPServer', () => {
       environmentVariables: {},
     });
 
+    expect(mockMcpManager.addClient).not.toHaveBeenCalled();
+    expect(mockMcpManager.registerMCPClient).toHaveBeenCalledWith(
+      'internal',
+      SERVER_ID,
+      'package',
+      0,
+      'Test MCP',
+      expect.anything(),
+      undefined,
+      'A test server',
+      undefined,
+      { command: 'node', args: ['server.js'] },
+    );
+  });
+
+  test('registerMCPServerOnly stops the matching spawned server and refreshes its saved config', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(spawnedServer);
+    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([spawnedServer]);
+
+    await registry.registerMCPServerOnly(SERVER_ID, {
+      type: 'package',
+      index: 0,
+      runtimeArguments: { 0: { value: '--port=9100', variables: {} } },
+      packageArguments: { 0: { value: 'serve-registered', variables: {} } },
+      environmentVariables: { TOKEN: { value: 'registered-token', variables: {} } },
+    });
+
     expect(mockMcpManager.removeClient).toHaveBeenCalledWith(SERVER_KEY);
+    expect(storedConfigs[0]).toMatchObject({
+      serverId: SERVER_ID,
+      packageId: 0,
+      autoSpawn: false,
+      runtimeArguments: ['--port=9100'],
+      packageArguments: ['serve-registered'],
+      environmentVariables: { TOKEN: 'registered-token' },
+    });
   });
 
   test('registerMCPServerOnly throws if server is already registered', async () => {
@@ -609,5 +682,33 @@ describe('startMCPServer / stopMCPServer', () => {
         environmentVariables: {},
       }),
     ).rejects.toThrow('MCP server is already registered.');
+  });
+
+  test('registerMCPServerOnly registers a different package target for the same server id', async () => {
+    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([otherSpawnedServer]);
+
+    const { MCPPackage } = await import('/@/plugin/mcp/package/mcp-package.js');
+    vi.mocked(MCPPackage.prototype.buildCommandSpec).mockReturnValue({ command: 'node', args: ['server.js'] });
+
+    await registry.registerMCPServerOnly(SERVER_ID, {
+      type: 'package',
+      index: 0,
+      runtimeArguments: {},
+      packageArguments: {},
+      environmentVariables: {},
+    });
+
+    expect(mockMcpManager.removeClient).not.toHaveBeenCalled();
+    expect(mockMcpManager.registerMCPWithoutClient).toHaveBeenCalledWith(
+      'internal',
+      SERVER_ID,
+      'package',
+      0,
+      'Test MCP',
+      undefined,
+      'A test server',
+      undefined,
+      { command: 'node', args: ['server.js'] },
+    );
   });
 });

--- a/packages/main/src/plugin/mcp/mcp-registry.spec.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.spec.ts
@@ -16,11 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationRegistry } from '/@api/configuration/models.js';
+import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info.js';
 
 import type { Certificates } from '../certificates.js';
 import type { Proxy } from '../proxy.js';
@@ -29,6 +31,8 @@ import type { Telemetry } from '../telemetry/telemetry.js';
 import type { MCPManager } from './mcp-manager.js';
 import { MCPRegistry, normalizeMcpRegistryServerUrl } from './mcp-registry.js';
 import type { MCPSchemaValidator } from './mcp-schema-validator.js';
+
+vi.mock(import('/@/plugin/mcp/package/mcp-package.js'));
 
 const proxy: Proxy = {
   onDidStateChange: vi.fn(),
@@ -403,4 +407,207 @@ test('listMCPServersFromRegistries handles both updates and additions', async ()
   // Verify the new addition
   expect(newGamma?.description).toBe('New gamma');
   expect(newGamma?.version).toBe('1.0.0');
+});
+
+describe('startMCPServer / stopMCPServer', () => {
+  const SERVER_KEY = 'internal:test-server:package:0';
+  const SERVER_ID = 'test-server';
+
+  const registeredServer: MCPRemoteServerInfo = {
+    id: SERVER_KEY,
+    infos: { internalProviderId: 'internal', serverId: SERVER_ID, remoteId: 0 },
+    name: 'Test MCP',
+    description: 'A test server',
+    url: '',
+    setupType: 'package',
+    commandSpec: { command: 'node', args: ['server.js'], env: {} },
+    tools: {},
+    status: 'registered',
+  };
+
+  const spawnedServer: MCPRemoteServerInfo = {
+    ...registeredServer,
+    status: undefined,
+    tools: { myTool: { description: 'a tool' } },
+  };
+
+  const remoteServer: MCPRemoteServerInfo = {
+    ...registeredServer,
+    setupType: 'remote',
+    url: 'https://example.com',
+  };
+
+  const savedConfig = {
+    serverId: SERVER_ID,
+    packageId: 0,
+    autoSpawn: false,
+    runtimeArguments: [],
+    packageArguments: [],
+    environmentVariables: {},
+  };
+
+  const serverDetail = {
+    serverId: SERVER_ID,
+    name: 'Test MCP',
+    description: 'A test server',
+    packages: [{ registryType: 'npm', name: 'test-mcp', version: '1.0.0' }],
+  };
+
+  let mockMcpManager: MCPManager;
+  let mockSafeStorage: { get: ReturnType<typeof vi.fn>; store: ReturnType<typeof vi.fn> };
+  let registry: MCPRegistry;
+
+  beforeEach(() => {
+    mockMcpManager = {
+      get: vi.fn(),
+      addClient: vi.fn(),
+      removeClient: vi.fn(),
+      listMCPRemoteServers: vi.fn().mockResolvedValue([]),
+      registerMCPWithoutClient: vi.fn(),
+      registerMCPClient: vi.fn(),
+      removeMcpRemoteServer: vi.fn(),
+    } as unknown as MCPManager;
+
+    mockSafeStorage = {
+      get: vi.fn().mockResolvedValue(JSON.stringify([savedConfig])),
+      store: vi.fn(),
+    };
+
+    const mockSafeStorageRegistry = {
+      getCoreStorage: vi.fn().mockReturnValue(mockSafeStorage),
+    } as unknown as SafeStorageRegistry;
+
+    const localConfigRegistry = {
+      registerConfigurations: vi.fn(),
+      getConfiguration: vi.fn().mockReturnValue({ get: vi.fn().mockReturnValue([]) }),
+    } as unknown as IConfigurationRegistry;
+
+    registry = new MCPRegistry(
+      apiSender,
+      { track: vi.fn() } as unknown as Telemetry,
+      {} as Certificates,
+      proxy,
+      mockMcpManager,
+      mockSafeStorageRegistry,
+      localConfigRegistry,
+      schemaValidator,
+      providerRegistry,
+    );
+
+    registry.init();
+    registry.registerInternalMCPServer(serverDetail as never);
+  });
+
+  test('startMCPServer spawns a registered package server', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(registeredServer);
+
+    const { MCPPackage } = await import('/@/plugin/mcp/package/mcp-package.js');
+    const mockTransport = {} as Transport;
+    vi.mocked(MCPPackage.prototype.spawn).mockResolvedValue(mockTransport);
+    vi.mocked(MCPPackage.prototype.buildCommandSpec).mockReturnValue({ command: 'node', args: ['server.js'] });
+
+    await registry.startMCPServer(SERVER_KEY);
+
+    expect(mockMcpManager.addClient).toHaveBeenCalledWith(SERVER_KEY, mockTransport);
+    expect(mockSafeStorage.store).toHaveBeenCalled();
+    const storedConfigs = JSON.parse(vi.mocked(mockSafeStorage.store).mock.calls[0]![1] as string);
+    expect(storedConfigs[0].autoSpawn).toBe(true);
+  });
+
+  test('startMCPServer throws if server is already spawned', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(spawnedServer);
+
+    await expect(registry.startMCPServer(SERVER_KEY)).rejects.toThrow('MCP server is already spawned.');
+  });
+
+  test('startMCPServer throws for remote servers', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(remoteServer);
+
+    await expect(registry.startMCPServer(SERVER_KEY)).rejects.toThrow('Only package MCP servers can be started.');
+  });
+
+  test('stopMCPServer stops a spawned package server', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(spawnedServer);
+
+    await registry.stopMCPServer(SERVER_KEY);
+
+    expect(mockMcpManager.removeClient).toHaveBeenCalledWith(SERVER_KEY);
+    expect(mockSafeStorage.store).toHaveBeenCalled();
+    const storedConfigs = JSON.parse(vi.mocked(mockSafeStorage.store).mock.calls[0]![1] as string);
+    expect(storedConfigs[0].autoSpawn).toBe(false);
+  });
+
+  test('stopMCPServer throws if server is already registered', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(registeredServer);
+
+    await expect(registry.stopMCPServer(SERVER_KEY)).rejects.toThrow('MCP server is already stopped.');
+  });
+
+  test('stopMCPServer throws for remote servers', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(remoteServer);
+
+    await expect(registry.stopMCPServer(SERVER_KEY)).rejects.toThrow('Only package MCP servers can be stopped.');
+  });
+
+  test('setupMCPServer starts a registered server instead of erroring', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(registeredServer);
+    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([registeredServer]);
+
+    const { MCPPackage } = await import('/@/plugin/mcp/package/mcp-package.js');
+    vi.mocked(MCPPackage.prototype.spawn).mockResolvedValue({} as Transport);
+    vi.mocked(MCPPackage.prototype.buildCommandSpec).mockReturnValue({ command: 'node', args: ['server.js'] });
+
+    await registry.setupMCPServer(SERVER_ID, {
+      type: 'package',
+      index: 0,
+      runtimeArguments: {},
+      packageArguments: {},
+      environmentVariables: {},
+    });
+
+    expect(mockMcpManager.addClient).toHaveBeenCalledWith(SERVER_KEY, expect.anything());
+  });
+
+  test('setupMCPServer throws if server is already spawned', async () => {
+    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([spawnedServer]);
+
+    await expect(
+      registry.setupMCPServer(SERVER_ID, {
+        type: 'package',
+        index: 0,
+        runtimeArguments: {},
+        packageArguments: {},
+        environmentVariables: {},
+      }),
+    ).rejects.toThrow('MCP server is already spawned.');
+  });
+
+  test('registerMCPServerOnly stops a spawned server instead of erroring', async () => {
+    vi.mocked(mockMcpManager.get).mockReturnValue(spawnedServer);
+    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([spawnedServer]);
+
+    await registry.registerMCPServerOnly(SERVER_ID, {
+      type: 'package',
+      index: 0,
+      runtimeArguments: {},
+      packageArguments: {},
+      environmentVariables: {},
+    });
+
+    expect(mockMcpManager.removeClient).toHaveBeenCalledWith(SERVER_KEY);
+  });
+
+  test('registerMCPServerOnly throws if server is already registered', async () => {
+    vi.mocked(mockMcpManager.listMCPRemoteServers).mockResolvedValue([registeredServer]);
+
+    await expect(
+      registry.registerMCPServerOnly(SERVER_ID, {
+        type: 'package',
+        index: 0,
+        runtimeArguments: {},
+        packageArguments: {},
+        environmentVariables: {},
+      }),
+    ).rejects.toThrow('MCP server is already registered.');
+  });
 });

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -460,8 +460,11 @@ export class MCPRegistry {
     const existingServers = await this.mcpManager.listMCPRemoteServers();
     const existing = existingServers.find(srv => srv.infos.serverId === serverId);
     if (existing) {
-      const state = existing.status === 'registered' ? 'registered' : 'spawned';
-      throw new Error(`MCP server is already ${state}. Please delete it first and try again.`);
+      if (existing.status === 'registered') {
+        await this.startMCPServer(existing.id);
+        return;
+      }
+      throw new Error('MCP server is already spawned.');
     }
 
     const serverDetails = await this.listMCPServersFromRegistries();
@@ -574,8 +577,11 @@ export class MCPRegistry {
     const existingServers = await this.mcpManager.listMCPRemoteServers();
     const existing = existingServers.find(srv => srv.infos.serverId === serverId);
     if (existing) {
-      const state = existing.status === 'registered' ? 'registered' : 'spawned';
-      throw new Error(`MCP server is already ${state}. Please delete it first and try again.`);
+      if (existing.status !== 'registered') {
+        await this.stopMCPServer(existing.id);
+        return;
+      }
+      throw new Error('MCP server is already registered.');
     }
 
     const serverDetails = await this.listMCPServersFromRegistries();
@@ -643,6 +649,60 @@ export class MCPRegistry {
     );
 
     await this.saveConfiguration(config);
+  }
+
+  async startMCPServer(key: string): Promise<void> {
+    const server = this.mcpManager.get(key);
+    if (server.setupType !== 'package') throw new Error('Only package MCP servers can be started.');
+    if (server.status !== 'registered') throw new Error('MCP server is already spawned.');
+
+    const { serverId, remoteId } = server.infos;
+
+    const configs = await this.getConfigurations();
+    const config = configs.find(
+      (c): c is PackageStorageConfigFormat => 'packageId' in c && c.serverId === serverId && c.packageId === remoteId,
+    );
+    if (!config) throw new Error(`No saved configuration found for MCP server ${serverId}`);
+
+    const serverDetails = await this.listMCPServersFromRegistries();
+    const serverDetail = serverDetails.find(s => s.serverId === serverId);
+    if (!serverDetail) throw new Error(`MCP server with id ${serverId} not found in remote registry`);
+
+    const pack = serverDetail.packages?.[remoteId];
+    if (!pack) throw new Error('package not found');
+
+    const spawner = new MCPPackage({
+      ...pack,
+      packageArguments: config.packageArguments,
+      runtimeArguments: config.runtimeArguments,
+      environmentVariables: config.environmentVariables,
+    });
+    const transport = await spawner.spawn();
+
+    await this.mcpManager.addClient(key, transport);
+    await this.updateConfigurationAutoSpawn(serverId, remoteId, true);
+  }
+
+  async stopMCPServer(key: string): Promise<void> {
+    const server = this.mcpManager.get(key);
+    if (server.setupType !== 'package') throw new Error('Only package MCP servers can be stopped.');
+    if (server.status === 'registered') throw new Error('MCP server is already stopped.');
+
+    const { serverId, remoteId } = server.infos;
+
+    await this.mcpManager.removeClient(key);
+    await this.updateConfigurationAutoSpawn(serverId, remoteId, false);
+  }
+
+  private async updateConfigurationAutoSpawn(serverId: string, packageId: number, autoSpawn: boolean): Promise<void> {
+    const configs = await this.getConfigurations();
+    const updated = configs.map(c => {
+      if ('packageId' in c && c.serverId === serverId && c.packageId === packageId) {
+        return { ...c, autoSpawn };
+      }
+      return c;
+    });
+    await this.safeStorage?.store(STORAGE_KEY, JSON.stringify(updated));
   }
 
   async deletePackageFromConfiguration(serverId: string, packageId: number): Promise<void> {

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -37,7 +37,7 @@ import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { ValidatedServerDetail, ValidatedServerList, ValidatedServerResponse } from '/@api/mcp/mcp-server-info.js';
 import { MCPServerDetail } from '/@api/mcp/mcp-server-info.js';
-import { InputWithVariableResponse, MCPSetupOptions } from '/@api/mcp/mcp-setup.js';
+import { InputWithVariableResponse, MCPSetupOptions, MCPSetupPackageOptions } from '/@api/mcp/mcp-setup.js';
 
 import { Certificates } from '../certificates.js';
 import { Emitter } from '../events/emitter.js';
@@ -81,6 +81,7 @@ interface PackageStorageConfigFormat {
   runtimeArguments?: Array<string>;
   packageArguments?: Array<string>;
   environmentVariables?: Record<string, string>;
+  autoSpawn?: boolean;
 }
 
 type StorageConfigFormat = RemoteStorageConfigFormat | PackageStorageConfigFormat;
@@ -273,19 +274,34 @@ export class MCPRegistry {
           });
 
           const cmdSpec = spawner.buildCommandSpec();
-          const transport = await spawner.spawn();
-          await this.mcpManager.registerMCPClient(
-            INTERNAL_PROVIDER_ID,
-            server.serverId,
-            'package',
-            config.packageId,
-            server.name,
-            transport,
-            undefined,
-            server.description,
-            server.isValidSchema,
-            cmdSpec,
-          );
+
+          if (config.autoSpawn === false) {
+            this.mcpManager.registerMCPWithoutClient(
+              INTERNAL_PROVIDER_ID,
+              server.serverId,
+              'package',
+              config.packageId,
+              server.name,
+              undefined,
+              server.description,
+              server.isValidSchema,
+              cmdSpec,
+            );
+          } else {
+            const transport = await spawner.spawn();
+            await this.mcpManager.registerMCPClient(
+              INTERNAL_PROVIDER_ID,
+              server.serverId,
+              'package',
+              config.packageId,
+              server.name,
+              transport,
+              undefined,
+              server.description,
+              server.isValidSchema,
+              cmdSpec,
+            );
+          }
         }
       }
     });
@@ -441,7 +457,13 @@ export class MCPRegistry {
   }
 
   async setupMCPServer(serverId: string, options: MCPSetupOptions): Promise<void> {
-    // Get back the server
+    const existingServers = await this.mcpManager.listMCPRemoteServers();
+    const existing = existingServers.find(srv => srv.infos.serverId === serverId);
+    if (existing) {
+      const state = existing.status === 'registered' ? 'registered' : 'spawned';
+      throw new Error(`MCP server is already ${state}. Please delete it first and try again.`);
+    }
+
     const serverDetails = await this.listMCPServersFromRegistries();
     const serverDetail = serverDetails.find(server => server.serverId === serverId);
     if (!serverDetail) {
@@ -478,6 +500,7 @@ export class MCPRegistry {
         config = {
           packageId: options.index,
           serverId: serverDetail.serverId,
+          autoSpawn: true,
           runtimeArguments: formatArguments(
             pack.runtimeArguments,
             Object.fromEntries(
@@ -545,6 +568,89 @@ export class MCPRegistry {
   async resetMCPServer(serverId: string, setupType: 'remote' | 'package', remoteId: number): Promise<void> {
     await this.deleteRemoteMcpFromConfiguration(serverId, remoteId);
     return this.mcpManager.unregisterMCPClient(INTERNAL_PROVIDER_ID, serverId, setupType, remoteId);
+  }
+
+  async registerMCPServerOnly(serverId: string, options: MCPSetupPackageOptions): Promise<void> {
+    const existingServers = await this.mcpManager.listMCPRemoteServers();
+    const existing = existingServers.find(srv => srv.infos.serverId === serverId);
+    if (existing) {
+      const state = existing.status === 'registered' ? 'registered' : 'spawned';
+      throw new Error(`MCP server is already ${state}. Please delete it first and try again.`);
+    }
+
+    const serverDetails = await this.listMCPServersFromRegistries();
+    const serverDetail = serverDetails.find(server => server.serverId === serverId);
+    if (!serverDetail) {
+      throw new Error(`MCP server with id ${serverId} not found in remote registry`);
+    }
+
+    const pack = serverDetail.packages?.[options.index];
+    if (!pack) throw new Error('package not found');
+
+    const config: PackageStorageConfigFormat = {
+      packageId: options.index,
+      serverId: serverDetail.serverId,
+      autoSpawn: false,
+      runtimeArguments: formatArguments(
+        pack.runtimeArguments,
+        Object.fromEntries(
+          Object.entries(options.runtimeArguments).map(([key, response]) => [
+            key,
+            this.formatInputWithVariableResponse(response),
+          ]),
+        ),
+      ),
+      packageArguments: formatArguments(
+        pack.packageArguments,
+        Object.fromEntries(
+          Object.entries(options.packageArguments).map(([key, response]) => [
+            key,
+            this.formatInputWithVariableResponse(response),
+          ]),
+        ),
+      ),
+      environmentVariables: formatKeyValueInputs(
+        pack.environmentVariables,
+        Object.fromEntries(
+          Object.entries(options.environmentVariables).map(([key, response]) => [
+            key,
+            this.formatInputWithVariableResponse(response),
+          ]),
+        ),
+      ),
+    };
+
+    const spawner = new MCPPackage({
+      ...pack,
+      packageArguments: config.packageArguments,
+      runtimeArguments: config.runtimeArguments,
+      environmentVariables: config.environmentVariables,
+    });
+    const cmdSpec = spawner.buildCommandSpec();
+
+    const { name, description, isValidSchema } = serverDetail;
+
+    this.mcpManager.registerMCPWithoutClient(
+      INTERNAL_PROVIDER_ID,
+      serverId,
+      'package',
+      options.index,
+      name,
+      undefined,
+      description,
+      isValidSchema,
+      cmdSpec,
+    );
+
+    await this.saveConfiguration(config);
+  }
+
+  async deletePackageFromConfiguration(serverId: string, packageId: number): Promise<void> {
+    const existingConfiguration = await this.getConfigurations();
+    const filtered = existingConfiguration.filter(
+      config => !('packageId' in config && config.serverId === serverId && config.packageId === packageId),
+    );
+    await this.safeStorage?.store(STORAGE_KEY, JSON.stringify(filtered));
   }
 
   protected formatInputWithVariableResponse(input: InputWithVariableResponse): string {

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -204,68 +204,61 @@ export class MCPRegistry {
       const configurations = await this.getConfigurations();
       console.log(`[MCPRegistry] found ${configurations.length} saved configurations`);
 
-      // serverId => config
-      const mapping: Map<string, StorageConfigFormat> = new Map(
-        configurations.map(config => [config.serverId, config]),
-      );
-
       const { servers } = await this.listMCPServersFromRegistry(registry.serverUrl);
       for (const rawServer of servers) {
         const server = this.enhanceServerDetail(rawServer.server);
         if (!server.serverId) {
           continue;
         }
-        const config = mapping.get(server.serverId);
-        if (!config) {
+        const matchingConfigs = configurations.filter(config => config.serverId === server.serverId);
+        if (matchingConfigs.length === 0) {
           continue;
         }
 
-        // dealing with remote config
-        if ('remoteId' in config) {
-          const remote = server.remotes?.[config.remoteId];
-          if (!remote) {
-            continue;
-          }
-
-          // client already exists ?
+        for (const config of matchingConfigs) {
           const existingServers = await this.mcpManager.listMCPRemoteServers();
-          const existing = existingServers.find(srv => srv.id.includes(server.serverId ?? 'unknown'));
+          const existing = this.findExistingServer(
+            existingServers,
+            server.serverId,
+            this.getSetupTypeFromConfig(config),
+            this.getConfigIndex(config),
+          );
           if (existing) {
             console.log(`[MCPRegistry] MCP client for server ${server.serverId} already exists, skipping`);
             continue;
           }
 
-          // create transport
-          const transport = new StreamableHTTPClientTransport(new URL(remote.url), {
-            requestInit: {
-              headers: config.headers,
-            },
-          });
+          if ('remoteId' in config) {
+            const remote = server.remotes?.[config.remoteId];
+            if (!remote) {
+              continue;
+            }
 
-          await this.mcpManager.registerMCPClient(
-            INTERNAL_PROVIDER_ID,
-            server.serverId,
-            'remote',
-            config.remoteId,
-            server.name,
-            transport,
-            remote.url,
-            server.description,
-            server.isValidSchema,
-          );
-        } else {
+            const transport = new StreamableHTTPClientTransport(new URL(remote.url), {
+              requestInit: {
+                headers: config.headers,
+              },
+            });
+
+            await this.mcpManager.registerMCPClient(
+              INTERNAL_PROVIDER_ID,
+              server.serverId,
+              'remote',
+              config.remoteId,
+              server.name,
+              transport,
+              remote.url,
+              server.description,
+              server.isValidSchema,
+            );
+            continue;
+          }
+
           const pack = server.packages?.[config.packageId];
           if (!pack) {
             continue;
           }
 
-          // client already exists ?
-          const existingServers = await this.mcpManager.listMCPRemoteServers();
-          const existing = existingServers.find(srv => srv.id.includes(server.serverId ?? 'unknown'));
-          if (existing) {
-            console.log(`[MCPRegistry] MCP client for server ${server.serverId} already exists, skipping`);
-            continue;
-          }
           const spawner = new MCPPackage({
             ...pack,
             packageArguments: config.packageArguments,
@@ -457,23 +450,16 @@ export class MCPRegistry {
   }
 
   async setupMCPServer(serverId: string, options: MCPSetupOptions): Promise<void> {
-    const existingServers = await this.mcpManager.listMCPRemoteServers();
-    const existing = existingServers.find(srv => srv.infos.serverId === serverId);
-    if (existing) {
-      if (existing.status === 'registered') {
-        await this.startMCPServer(existing.id);
-        return;
-      }
-      throw new Error('MCP server is already spawned.');
-    }
-
     const serverDetails = await this.listMCPServersFromRegistries();
     const serverDetail = serverDetails.find(server => server.serverId === serverId);
     if (!serverDetail) {
       throw new Error(`MCP server with id ${serverId} not found in remote registry`);
     }
 
-    let transport: Transport;
+    const existingServers = await this.mcpManager.listMCPRemoteServers();
+    const existing = this.findExistingServer(existingServers, serverId, options.type, options.index);
+
+    let transport: Transport | undefined;
     let config: StorageConfigFormat;
     let cmdSpec: CommandSpec | undefined;
 
@@ -541,11 +527,25 @@ export class MCPRegistry {
           environmentVariables: config.environmentVariables,
         });
         cmdSpec = spawner.buildCommandSpec();
+
+        if (existing) {
+          if (existing.status === 'registered') {
+            await this.saveConfiguration(config);
+            await this.startMCPServer(existing.id);
+            return;
+          }
+          throw new Error('MCP server is already spawned.');
+        }
+
         transport = await spawner.spawn();
         break;
       }
       default:
         throw new Error('invalid options type for setupMCPServer');
+    }
+
+    if (existing) {
+      throw new Error('MCP server is already spawned.');
     }
 
     // get values from the server detail
@@ -574,16 +574,6 @@ export class MCPRegistry {
   }
 
   async registerMCPServerOnly(serverId: string, options: MCPSetupPackageOptions): Promise<void> {
-    const existingServers = await this.mcpManager.listMCPRemoteServers();
-    const existing = existingServers.find(srv => srv.infos.serverId === serverId);
-    if (existing) {
-      if (existing.status !== 'registered') {
-        await this.stopMCPServer(existing.id);
-        return;
-      }
-      throw new Error('MCP server is already registered.');
-    }
-
     const serverDetails = await this.listMCPServersFromRegistries();
     const serverDetail = serverDetails.find(server => server.serverId === serverId);
     if (!serverDetail) {
@@ -633,6 +623,17 @@ export class MCPRegistry {
       environmentVariables: config.environmentVariables,
     });
     const cmdSpec = spawner.buildCommandSpec();
+    const existingServers = await this.mcpManager.listMCPRemoteServers();
+    const existing = this.findExistingServer(existingServers, serverId, 'package', options.index);
+
+    if (existing) {
+      if (existing.status !== 'registered') {
+        await this.saveConfiguration(config);
+        await this.stopMCPServer(existing.id);
+        return;
+      }
+      throw new Error('MCP server is already registered.');
+    }
 
     const { name, description, isValidSchema } = serverDetail;
 
@@ -724,6 +725,33 @@ export class MCPRegistry {
     await this.safeStorage?.store(STORAGE_KEY, JSON.stringify(filtered));
   }
 
+  private findExistingServer(
+    servers: Awaited<ReturnType<MCPManager['listMCPRemoteServers']>>,
+    serverId: string,
+    setupType: 'remote' | 'package',
+    index: number,
+  ): Awaited<ReturnType<MCPManager['listMCPRemoteServers']>>[number] | undefined {
+    return servers.find(
+      server => server.infos.serverId === serverId && server.setupType === setupType && server.infos.remoteId === index,
+    );
+  }
+
+  private getSetupTypeFromConfig(config: StorageConfigFormat): 'remote' | 'package' {
+    return 'remoteId' in config ? 'remote' : 'package';
+  }
+
+  private getConfigIndex(config: StorageConfigFormat): number {
+    return 'remoteId' in config ? config.remoteId : config.packageId;
+  }
+
+  private hasSameConfigTarget(left: StorageConfigFormat, right: StorageConfigFormat): boolean {
+    return (
+      left.serverId === right.serverId &&
+      this.getSetupTypeFromConfig(left) === this.getSetupTypeFromConfig(right) &&
+      this.getConfigIndex(left) === this.getConfigIndex(right)
+    );
+  }
+
   protected formatInputWithVariableResponse(input: InputWithVariableResponse): string {
     let template = input.value;
 
@@ -782,7 +810,8 @@ export class MCPRegistry {
 
   async saveConfiguration(config: StorageConfigFormat): Promise<void> {
     const existing = await this.getConfigurations();
-    await this.safeStorage?.store(STORAGE_KEY, JSON.stringify([...existing, config]));
+    const filtered = existing.filter(existingConfig => !this.hasSameConfigTarget(existingConfig, config));
+    await this.safeStorage?.store(STORAGE_KEY, JSON.stringify([...filtered, config]));
   }
 
   async deleteRemoteMcpFromConfiguration(serverId: string, remoteId: number): Promise<void> {

--- a/packages/main/src/plugin/mcp/mcp-registry.ts
+++ b/packages/main/src/plugin/mcp/mcp-registry.ts
@@ -679,8 +679,14 @@ export class MCPRegistry {
     });
     const transport = await spawner.spawn();
 
-    await this.mcpManager.addClient(key, transport);
     await this.updateConfigurationAutoSpawn(serverId, remoteId, true);
+    try {
+      await this.mcpManager.addClient(key, transport);
+    } catch (err) {
+      await transport.close?.().catch(console.error);
+      await this.updateConfigurationAutoSpawn(serverId, remoteId, false);
+      throw err;
+    }
   }
 
   async stopMCPServer(key: string): Promise<void> {
@@ -690,8 +696,13 @@ export class MCPRegistry {
 
     const { serverId, remoteId } = server.infos;
 
-    await this.mcpManager.removeClient(key);
     await this.updateConfigurationAutoSpawn(serverId, remoteId, false);
+    try {
+      await this.mcpManager.removeClient(key);
+    } catch (err) {
+      await this.updateConfigurationAutoSpawn(serverId, remoteId, true);
+      throw err;
+    }
   }
 
   private async updateConfigurationAutoSpawn(serverId: string, packageId: number, autoSpawn: boolean): Promise<void> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2390,6 +2390,14 @@ export function initExposure(): void {
     return ipcInvoke('mcp-registry:getExportConfigPath', target);
   });
 
+  contextBridge.exposeInMainWorld('startMcpServer', async (key: string): Promise<void> => {
+    return ipcInvoke('mcp-manager:startMCPServer', key);
+  });
+
+  contextBridge.exposeInMainWorld('stopMcpServer', async (key: string): Promise<void> => {
+    return ipcInvoke('mcp-manager:stopMCPServer', key);
+  });
+
   // can't send configuration object as it is not serializable
   // https://www.electronjs.org/docs/latest/api/context-bridge#parameter--error--return-type-support
   contextBridge.exposeInMainWorld(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -121,7 +121,7 @@ import type { ListOrganizerItem } from '/@api/list-organizer';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { MCPExportTarget } from '/@api/mcp/mcp-export';
 import type { MCPRemoteServerInfo, MCPServerDetail } from '/@api/mcp/mcp-server-info';
-import type { MCPSetupOptions } from '/@api/mcp/mcp-setup';
+import type { MCPSetupOptions, MCPSetupPackageOptions } from '/@api/mcp/mcp-setup';
 import type { Menu } from '/@api/menu.js';
 import type { CatalogModelInfo, InferenceConnectionSummary } from '/@api/model-registry-info';
 import { NavigationPage } from '/@api/navigation-page';
@@ -2349,6 +2349,13 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('setupMCP', async (serverId: string, options: MCPSetupOptions): Promise<void> => {
     return ipcInvoke('mcp-registry:setup', serverId, options);
   });
+
+  contextBridge.exposeInMainWorld(
+    'registerMCP',
+    async (serverId: string, options: MCPSetupPackageOptions): Promise<void> => {
+      return ipcInvoke('mcp-registry:register', serverId, options);
+    },
+  );
 
   contextBridge.exposeInMainWorld('fetchMcpRemoteServers', async (): Promise<MCPRemoteServerInfo[]> => {
     return ipcInvoke('mcp-manager:fetchMcpRemoteServers');

--- a/packages/renderer/src/lib/mcp/MCPDetails.svelte
+++ b/packages/renderer/src/lib/mcp/MCPDetails.svelte
@@ -31,7 +31,7 @@ async function refreshMessages(): Promise<void> {
 const mcpServer: MCPRemoteServerInfo | undefined = $derived($mcpRemoteServerInfos.find(server => server.id === id));
 const mcpServerName = $derived(mcpServer?.name ?? id);
 const mcpServerUrl = $derived(mcpServer?.url ?? '');
-const isRunning = $derived(mcpServer?.status !== 'registered');
+const isRunning = $derived(mcpServer !== undefined && mcpServer.status !== 'registered');
 const toolSet: string | undefined = $derived(mcpServer?.tools ? JSON.stringify(mcpServer.tools, null, 2) : undefined);
 
 onMount(() => {

--- a/packages/renderer/src/lib/mcp/MCPDetails.svelte
+++ b/packages/renderer/src/lib/mcp/MCPDetails.svelte
@@ -31,15 +31,18 @@ async function refreshMessages(): Promise<void> {
 const mcpServer: MCPRemoteServerInfo | undefined = $derived($mcpRemoteServerInfos.find(server => server.id === id));
 const mcpServerName = $derived(mcpServer?.name ?? id);
 const mcpServerUrl = $derived(mcpServer?.url ?? '');
+const isRunning = $derived(mcpServer?.status !== 'registered');
 const toolSet: string | undefined = $derived(mcpServer?.tools ? JSON.stringify(mcpServer.tools, null, 2) : undefined);
 
 onMount(() => {
-  // Initial load of messages
-  refreshMessages().catch(console.error);
-
-  // Subscribe to updates from main process
-  return window.events?.receive('mcp-manager-update', () => {
+  if (isRunning) {
     refreshMessages().catch(console.error);
+  }
+
+  return window.events?.receive('mcp-manager-update', () => {
+    if (isRunning) {
+      refreshMessages().catch(console.error);
+    }
   });
 });
 </script>

--- a/packages/renderer/src/lib/mcp/MCPRegistryCreateFromRegistryForm.svelte
+++ b/packages/renderer/src/lib/mcp/MCPRegistryCreateFromRegistryForm.svelte
@@ -8,7 +8,7 @@ import MCPSetupDropdown from '/@/lib/mcp/setup/MCPSetupDropdown.svelte';
 import PackageSetupForm from '/@/lib/mcp/setup/PackageSetupForm.svelte';
 import RemoteSetupForm from '/@/lib/mcp/setup/RemoteSetupForm.svelte';
 import { mcpRegistriesServerInfos } from '/@/stores/mcp-registry-servers';
-import type { MCPSetupOptions } from '/@api/mcp/mcp-setup';
+import type { MCPSetupOptions, MCPSetupPackageOptions } from '/@api/mcp/mcp-setup';
 
 interface Props {
   serverId: string;
@@ -39,6 +39,19 @@ async function submit(options: MCPSetupOptions): Promise<void> {
     loading = true;
     error = undefined;
     await window.setupMCP(serverId, options);
+    return navigateToMcps();
+  } catch (err: unknown) {
+    error = String(err);
+  } finally {
+    loading = false;
+  }
+}
+
+async function register(options: MCPSetupPackageOptions): Promise<void> {
+  try {
+    loading = true;
+    error = undefined;
+    await window.registerMCP(serverId, options);
     return navigateToMcps();
   } catch (err: unknown) {
     error = String(err);
@@ -86,7 +99,7 @@ async function close(): Promise<void> {
                 {#if 'url' in mcpTarget}  <!-- remote -->
                   <RemoteSetupForm submit={submit} remoteIndex={mcpTarget.index} bind:loading={loading} object={mcpTarget} cancel={close}/>
                 {:else} <!-- package -->
-                  <PackageSetupForm submit={submit} packageIndex={mcpTarget.index} bind:loading={loading} object={mcpTarget} cancel={close}/>
+                  <PackageSetupForm submit={submit} register={register} packageIndex={mcpTarget.index} bind:loading={loading} object={mcpTarget} cancel={close}/>
                 {/if}
               {/key}
             {/if}

--- a/packages/renderer/src/lib/mcp/MCPServerListRemoteReady.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerListRemoteReady.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 import { FilteredEmptyScreen, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import SimpleColumn from '@podman-desktop/ui-svelte/TableSimpleColumn';
 
 import MCPNameColumn from '/@/lib/mcp/column/MCPNameColumn.svelte';
+import MCPStatusColumn from '/@/lib/mcp/column/MCPStatusColumn.svelte';
 import { filteredMcpRemoteServerInfos, mcpRemoteServerInfoSearchPattern } from '/@/stores/mcp-remote-servers';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 
@@ -32,8 +34,8 @@ const servers: SelectableMCPRemoteServerInfo[] = $derived(
 );
 
 const statusColumn = new TableColumn<MCPRemoteServerInfo>('Status', {
-  width: '60px',
-  renderer: McpIcon,
+  width: '150px',
+  renderer: MCPStatusColumn,
 });
 
 const nameColumn = new TableColumn<MCPRemoteServerInfo>('Name', {
@@ -42,13 +44,20 @@ const nameColumn = new TableColumn<MCPRemoteServerInfo>('Name', {
   comparator: (a, b): number => b.name.localeCompare(a.name),
 });
 
+const typeColumn = new TableColumn<MCPRemoteServerInfo, string>('Type', {
+  width: '100px',
+  renderMapping: (server): string => (server.setupType === 'remote' ? 'Remote' : 'Local'),
+  renderer: SimpleColumn,
+  comparator: (a, b): number => (b.setupType ?? '').localeCompare(a.setupType ?? ''),
+});
+
 const actionsColumn = new TableColumn<MCPRemoteServerInfo>('Actions', {
   align: 'right',
   renderer: McpServerRemoteListActions,
   overflow: true,
 });
 
-const columns = [statusColumn, nameColumn, new MCPServerDescriptionColumn(), actionsColumn];
+const columns = [statusColumn, nameColumn, typeColumn, new MCPServerDescriptionColumn(), actionsColumn];
 
 const row = new TableRow<MCPRemoteServerInfo>({});
 </script>

--- a/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.spec.ts
+++ b/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.spec.ts
+++ b/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.spec.ts
@@ -1,0 +1,91 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
+
+import MCPServerRemoteListActions from './MCPServerRemoteListActions.svelte';
+
+const packageServer: MCPRemoteServerInfo = {
+  id: 'internal:test:package:0',
+  infos: { internalProviderId: 'internal', serverId: 'test', remoteId: 0 },
+  name: 'Test MCP',
+  description: 'A test server',
+  url: '',
+  setupType: 'package',
+  commandSpec: { command: 'node', args: ['server.js'] },
+  tools: {},
+  status: 'registered',
+};
+
+const remoteServer: MCPRemoteServerInfo = {
+  ...packageServer,
+  setupType: 'remote',
+  url: 'https://example.com',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('start button is rendered for registered package server', () => {
+  render(MCPServerRemoteListActions, { object: packageServer });
+
+  expect(screen.getByRole('button', { name: 'Start MCP server' })).toBeInTheDocument();
+});
+
+test('stop button is rendered for spawned package server', () => {
+  render(MCPServerRemoteListActions, { object: { ...packageServer, status: undefined } });
+
+  expect(screen.getByRole('button', { name: 'Stop MCP server' })).toBeInTheDocument();
+});
+
+test('start/stop button is not rendered for remote server', () => {
+  render(MCPServerRemoteListActions, { object: remoteServer });
+
+  expect(screen.queryByRole('button', { name: 'Start MCP server' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Stop MCP server' })).not.toBeInTheDocument();
+});
+
+test('clicking start calls startMcpServer', async () => {
+  render(MCPServerRemoteListActions, { object: packageServer });
+
+  const startButton = screen.getByRole('button', { name: 'Start MCP server' });
+  await fireEvent.click(startButton);
+
+  expect(window.startMcpServer).toHaveBeenCalledWith('internal:test:package:0');
+});
+
+test('clicking stop calls stopMcpServer', async () => {
+  render(MCPServerRemoteListActions, { object: { ...packageServer, status: undefined } });
+
+  const stopButton = screen.getByRole('button', { name: 'Stop MCP server' });
+  await fireEvent.click(stopButton);
+
+  expect(window.stopMcpServer).toHaveBeenCalledWith('internal:test:package:0');
+});
+
+test('remove button is always rendered', () => {
+  render(MCPServerRemoteListActions, { object: packageServer });
+
+  expect(screen.getByRole('button', { name: 'Remove instance of MCP' })).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.spec.ts
+++ b/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.spec.ts
@@ -44,6 +44,7 @@ const remoteServer: MCPRemoteServerInfo = {
 };
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
 });
 
@@ -82,6 +83,25 @@ test('clicking stop calls stopMcpServer', async () => {
   await fireEvent.click(stopButton);
 
   expect(window.stopMcpServer).toHaveBeenCalledWith('internal:test:package:0');
+});
+
+test('error dialog shown when start fails', async () => {
+  vi.mocked(window.startMcpServer).mockRejectedValue(new Error('no kubeconfig provided'));
+
+  render(MCPServerRemoteListActions, { object: packageServer });
+
+  const startButton = screen.getByRole('button', { name: 'Start MCP server' });
+  await fireEvent.click(startButton);
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'MCP Server',
+        type: 'error',
+        message: expect.stringContaining('no kubeconfig provided'),
+      }),
+    );
+  });
 });
 
 test('remove button is always rendered', () => {

--- a/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faClaude } from '@fortawesome/free-brands-svg-icons';
-import { faFileExport, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faFileExport, faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
 
 import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
@@ -17,6 +17,23 @@ interface Props {
 const { object, dropdownMenu = true, detailed = false }: Props = $props();
 
 let exportInProgress = $state(false);
+let startStopInProgress = $state(false);
+
+const isPackage = $derived(object.setupType === 'package');
+const isRegistered = $derived(object.status === 'registered');
+
+async function handleStartStop(): Promise<void> {
+  startStopInProgress = true;
+  try {
+    if (isRegistered) {
+      await window.startMcpServer(object.id);
+    } else {
+      await window.stopMcpServer(object.id);
+    }
+  } finally {
+    startStopInProgress = false;
+  }
+}
 
 async function removeMcp(): Promise<void> {
   const options = object.infos;
@@ -77,6 +94,14 @@ function exportToVSCode(): Promise<void> {
 
 const ActionsStyle = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
 </script>
+
+{#if isPackage}
+  <ListItemButtonIcon
+    title={isRegistered ? 'Start MCP server' : 'Stop MCP server'}
+    icon={isRegistered ? faPlay : faStop}
+    inProgress={startStopInProgress}
+    onClick={handleStartStop} />
+{/if}
 
  <ListItemButtonIcon
     title="Remove instance of MCP"

--- a/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.svelte
+++ b/packages/renderer/src/lib/mcp/MCPServerRemoteListActions.svelte
@@ -30,6 +30,14 @@ async function handleStartStop(): Promise<void> {
     } else {
       await window.stopMcpServer(object.id);
     }
+  } catch (error: unknown) {
+    const action = isRegistered ? 'starting' : 'stopping';
+    await window.showMessageBox({
+      title: 'MCP Server',
+      type: 'error',
+      message: `Error while ${action} "${object.name}": ${error instanceof Error ? error.message : String(error)}`,
+      buttons: ['OK'],
+    });
   } finally {
     startStopInProgress = false;
   }

--- a/packages/renderer/src/lib/mcp/column/MCPStatusColumn.svelte
+++ b/packages/renderer/src/lib/mcp/column/MCPStatusColumn.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
+
+interface Props {
+  object: MCPRemoteServerInfo;
+}
+
+let { object }: Props = $props();
+
+const isRegistered = $derived(object.status === 'registered');
+
+const label = $derived.by(() => {
+  if (object.setupType === 'remote') return 'Connected';
+  return isRegistered ? 'Registered' : 'Spawned';
+});
+
+const badgeStyle = $derived(
+  isRegistered
+    ? 'bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] border border-[var(--pd-content-card-border)]'
+    : 'text-[var(--pd-status-running)] bg-[color-mix(in_srgb,var(--pd-status-running)_12%,transparent)] border border-[color-mix(in_srgb,var(--pd-status-running)_25%,transparent)]',
+);
+</script>
+
+<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium {badgeStyle}">
+  {label}
+</span>

--- a/packages/renderer/src/lib/mcp/setup/PackageSetupForm.svelte
+++ b/packages/renderer/src/lib/mcp/setup/PackageSetupForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
 import { faTableList } from '@fortawesome/free-solid-svg-icons/faTableList';
 import { faWrench } from '@fortawesome/free-solid-svg-icons/faWrench';
@@ -15,10 +16,14 @@ interface Props {
   loading: boolean;
   packageIndex: number;
   submit: (options: MCPSetupPackageOptions) => Promise<void>;
+  register: (options: MCPSetupPackageOptions) => Promise<void>;
   cancel: () => void;
 }
 
-let { object, packageIndex, loading = $bindable(false), submit, cancel }: Props = $props();
+let { object, packageIndex, loading = $bindable(false), submit, register, cancel }: Props = $props();
+
+let spawning = $state(false);
+let registering = $state(false);
 
 let runtimeArgumentsResponses = new SvelteMap<number, InputWithVariableResponse>(
   (object.runtimeArguments ?? []).map((argument, index) => [index, createInputWithVariables(argument)]),
@@ -70,14 +75,32 @@ function updateArgumentVariableValue<K extends string | number>(
   });
 }
 
-async function spawn(): Promise<void> {
-  return submit({
+function buildOptions(): MCPSetupPackageOptions {
+  return {
     type: 'package',
     index: packageIndex,
     runtimeArguments: Object.fromEntries(runtimeArgumentsResponses.entries()),
     packageArguments: Object.fromEntries(packageArgumentsResponses.entries()),
     environmentVariables: Object.fromEntries(environmentVariablesResponses.entries()),
-  });
+  };
+}
+
+async function spawn(): Promise<void> {
+  spawning = true;
+  try {
+    return await submit(buildOptions());
+  } finally {
+    spawning = false;
+  }
+}
+
+async function registerPackage(): Promise<void> {
+  registering = true;
+  try {
+    return await register(buildOptions());
+  } finally {
+    registering = false;
+  }
 }
 </script>
 
@@ -154,9 +177,17 @@ async function spawn(): Promise<void> {
   </Button>
   <Button
     class="w-auto"
+    type="secondary"
+    icon={faFloppyDisk}
+    onclick={registerPackage}
+    inProgress={registering}>
+    Register
+  </Button>
+  <Button
+    class="w-auto"
     icon={faPlay}
     onclick={spawn}
-    inProgress={loading}>
+    inProgress={spawning}>
     Spawn
   </Button>
 </div>

--- a/packages/renderer/src/lib/mcp/setup/PackageSetupForm.svelte
+++ b/packages/renderer/src/lib/mcp/setup/PackageSetupForm.svelte
@@ -24,6 +24,7 @@ let { object, packageIndex, loading = $bindable(false), submit, register, cancel
 
 let spawning = $state(false);
 let registering = $state(false);
+const busy = $derived(loading || spawning || registering);
 
 let runtimeArgumentsResponses = new SvelteMap<number, InputWithVariableResponse>(
   (object.runtimeArguments ?? []).map((argument, index) => [index, createInputWithVariables(argument)]),
@@ -86,6 +87,7 @@ function buildOptions(): MCPSetupPackageOptions {
 }
 
 async function spawn(): Promise<void> {
+  if (busy) return;
   spawning = true;
   try {
     return await submit(buildOptions());
@@ -95,6 +97,7 @@ async function spawn(): Promise<void> {
 }
 
 async function registerPackage(): Promise<void> {
+  if (busy) return;
   registering = true;
   try {
     return await register(buildOptions());
@@ -180,6 +183,7 @@ async function registerPackage(): Promise<void> {
     type="secondary"
     icon={faFloppyDisk}
     onclick={registerPackage}
+    disabled={busy}
     inProgress={registering}>
     Register
   </Button>
@@ -187,6 +191,7 @@ async function registerPackage(): Promise<void> {
     class="w-auto"
     icon={faPlay}
     onclick={spawn}
+    disabled={busy}
     inProgress={spawning}>
     Spawn
   </Button>


### PR DESCRIPTION
## Summary
- Package-based MCPs (npm/pypi) can now be **registered** without spawning a process on the host, saving config for export to external tools
- Ready tab shows status badges (Connected/Spawned/Registered) and a Type column (Remote/Local)
- Duplicate MCP prevention: attempting to register or spawn an already-existing MCP shows a clear error
- Registered MCPs persist across restarts without auto-spawning

Updated video

https://github.com/user-attachments/assets/d1e02990-971e-419b-8cd0-a6dfc81577d0


Fixes: https://github.com/openkaiden/kaiden/issues/2144

🤖 Generated with [Claude Code](https://claude.com/claude-code)