### PR TITLE
feat(workspaces): add Project step to workspace creation wizard

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { writable } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { resetDraft, wizard } from '/@/stores/agent-workspace-create-draft.svelte';
 import * as agentsStore from '/@/stores/agents';
@@ -33,6 +33,7 @@ import * as providerStore from '/@/stores/providers';
 import * as ragStore from '/@/stores/rag-environments';
 import * as secretVaultStore from '/@/stores/secret-vault';
 import * as skillsStore from '/@/stores/skills';
+import * as workspaceProjectsStore from '/@/stores/workspace-projects';
 import type { AgentInfo } from '/@api/agent-info';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 import type { CatalogModelInfo } from '/@api/model-registry-info';
@@ -40,6 +41,7 @@ import type { ProviderInfo } from '/@api/provider-info';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
 import type { SkillInfo } from '/@api/skill/skill-info';
+import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
 
 import AgentWorkspaceCreate from './AgentWorkspaceCreate.svelte';
 
@@ -53,6 +55,7 @@ vi.mock(import('/@/stores/providers'));
 vi.mock(import('/@/stores/rag-environments'));
 vi.mock(import('/@/stores/model-catalog'));
 vi.mock(import('/@/stores/models'));
+vi.mock(import('/@/stores/workspace-projects'));
 
 function buildCatalogModels(providers: ProviderInfo[]): CatalogModelInfo[] {
   const result: CatalogModelInfo[] = [];
@@ -134,6 +137,7 @@ beforeEach(() => {
   vi.mocked(modelCatalogStore.modelSelectionKey).mockImplementation(
     (providerId: string, connectionId: string, label: string): string => `${providerId}::${connectionId}::${label}`,
   );
+  vi.mocked(workspaceProjectsStore).workspaceProjectInfos = writable<readonly WorkspaceProjectInfo[]>([]);
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   resetDraft();
@@ -1671,3 +1675,356 @@ test('Expect navigation still called when startWorkspace fails', async () => {
 });
 
 const wizardStepCount = 5;
+
+const sampleProject: WorkspaceProjectInfo = {
+  id: 'my-app',
+  name: 'My App',
+  description: 'A sample project',
+  folder: '/home/user/my-app',
+  skills: ['kubernetes'],
+  mcpServers: ['mcp-github'],
+  knowledges: [],
+  secrets: ['github-token'],
+  filesystem: { mode: 'project', mounts: [] },
+  network: { mode: 'deny', hosts: ['registry.npmjs.org'] },
+};
+
+function setProjects(projects: WorkspaceProjectInfo[]): void {
+  vi.mocked(workspaceProjectsStore).workspaceProjectInfos = writable<readonly WorkspaceProjectInfo[]>(projects);
+}
+
+describe('when projects exist', () => {
+  beforeEach(() => {
+    setProjects([sampleProject]);
+  });
+
+  test('Expect wizard still has five steps when projects exist', () => {
+    render(AgentWorkspaceCreate);
+
+    expect(screen.getByText(/Step 1 of 5/)).toBeInTheDocument();
+  });
+
+  test('Expect Saved project accordion visible on workspace step', () => {
+    render(AgentWorkspaceCreate);
+
+    expect(screen.getByRole('button', { name: /Saved project/ })).toBeInTheDocument();
+  });
+
+  test('Expect project selection cards rendered after expanding accordion', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+
+    expect(screen.getByRole('option', { name: /None/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /My App/ })).toBeInTheDocument();
+  });
+
+  test('Expect selecting a project pre-fills source path', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect((screen.getByPlaceholderText('/path/to/project') as HTMLInputElement).value).toBe('/home/user/my-app');
+  });
+
+  test('Expect selecting a project pre-fills session name', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect((screen.getByPlaceholderText('e.g., Frontend Refactoring') as HTMLInputElement).value).toBe('My App');
+  });
+
+  test('Expect createAgentWorkspace called with project id', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+    expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: 'my-app',
+        sourcePath: '/home/user/my-app',
+      }),
+    );
+  });
+
+  test('Expect createAgentWorkspace called without project when None selected', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /None/ }));
+
+    await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+      target: { value: '/home/user/other-repo' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+    expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: undefined,
+      }),
+    );
+  });
+
+  test('Expect selecting a project populates draft skill ids', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['kubernetes']);
+  });
+
+  test('Expect selecting a project populates draft MCP ids', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedMcpIds).toEqual(['mcp-github']);
+  });
+
+  test('Expect selecting a project populates draft secret ids', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedSecretIds).toEqual(['github-token']);
+  });
+
+  test('Expect selecting a project maps deny network with custom hosts to blocked mode', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedNetwork).toBe('blocked');
+    expect(wizard.draft.hostsByMode['blocked']).toEqual(['registry.npmjs.org']);
+  });
+
+  test('Expect clearing project resets draft fields', async () => {
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+    expect(wizard.draft.selectedProjectId).toBe('my-app');
+
+    await fireEvent.click(screen.getByRole('option', { name: /None/ }));
+
+    expect(wizard.draft.selectedProjectId).toBeUndefined();
+    expect(wizard.draft.sourcePath).toBe('');
+    expect(wizard.draft.sessionName).toBe('');
+  });
+
+  test('Expect clearing project restores all-selected defaults for resources', async () => {
+    vi.mocked(skillsStore).skillInfos = writable<SkillInfo[]>([
+      { name: 'kubernetes', description: 'K8s', path: '/skills/k8s', enabled: true, managed: false },
+      { name: 'docker', description: 'Docker', path: '/skills/docker', enabled: true, managed: false },
+    ]);
+    vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([
+      { id: 'mcp-1', name: 'MCP One', description: '', url: '', infos: {}, tools: {} } as MCPRemoteServerInfo,
+    ]);
+
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+    expect(wizard.draft.selectedSkillIds).toEqual(['kubernetes']);
+    expect(wizard.draft.selectedMcpIds).toEqual(['mcp-github']);
+
+    await fireEvent.click(screen.getByRole('option', { name: /None/ }));
+
+    expect(wizard.draft.selectedSkillIds).toEqual(['kubernetes', 'docker']);
+    expect(wizard.draft.selectedMcpIds).toEqual(['mcp-1']);
+  });
+});
+
+describe('project filesystem mapping', () => {
+  test('Expect allow network mapped to open mode', async () => {
+    const openNetProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'open-net',
+      network: { mode: 'allow' },
+    };
+    setProjects([openNetProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedNetwork).toBe('open');
+  });
+
+  test('Expect allow network falls back to registries when runtime is openshell', async () => {
+    vi.mocked(agentWorkspaceRuntimeStore).agentWorkspaceRuntime = writable<string>('openshell');
+    const openNetProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'open-net',
+      network: { mode: 'allow' },
+    };
+    setProjects([openNetProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedNetwork).toBe('registries');
+  });
+
+  test('Expect deny network without hosts mapped to blocked mode', async () => {
+    const blockedProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'blocked',
+      network: { mode: 'deny' },
+    };
+    setProjects([blockedProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedNetwork).toBe('blocked');
+  });
+
+  test('Expect deny network with registry preset hosts mapped to registries mode', async () => {
+    const registryProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'registry-preset',
+      network: { mode: 'deny', hosts: ['registry.npmjs.org', 'pypi.python.org'] },
+    };
+    setProjects([registryProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedNetwork).toBe('registries');
+    expect(wizard.draft.hostsByMode['registries']).toEqual(['registry.npmjs.org', 'pypi.python.org']);
+  });
+
+  test('Expect deny network with custom hosts mapped to blocked mode', async () => {
+    const customHostsProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'custom-hosts',
+      network: { mode: 'deny', hosts: ['internal.corp.local'] },
+    };
+    setProjects([customHostsProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedNetwork).toBe('blocked');
+    expect(wizard.draft.hostsByMode['blocked']).toEqual(['internal.corp.local']);
+  });
+
+  test('Expect Deny All radio checked on networking step after selecting project with custom hosts', async () => {
+    const customHostsProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'custom-hosts',
+      network: { mode: 'deny', hosts: ['internal.corp.local'] },
+    };
+    setProjects([customHostsProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    for (let i = 0; i < 4; i++) {
+      await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    }
+
+    expect(screen.getByRole('radio', { name: 'Use Deny All' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).not.toBeChecked();
+  });
+
+  test('Expect Developer Preset radio checked on networking step after selecting project with registry preset', async () => {
+    const registryProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'registry-preset',
+      network: { mode: 'deny', hosts: ['registry.npmjs.org', 'pypi.python.org'] },
+    };
+    setProjects([registryProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    for (let i = 0; i < 4; i++) {
+      await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    }
+
+    expect(screen.getByRole('radio', { name: 'Use Developer Preset' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Use Deny All' })).not.toBeChecked();
+  });
+
+  test('Expect home mount mapped to home file access', async () => {
+    const homeProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'home-mount',
+      filesystem: { mode: 'custom', mounts: [{ host: '$HOME', target: '$HOME', ro: false }] },
+    };
+    setProjects([homeProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedFileAccess).toBe('home');
+  });
+
+  test('Expect root mount mapped to full file access', async () => {
+    const rootProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'root-mount',
+      filesystem: { mode: 'custom', mounts: [{ host: '/', target: '/', ro: false }] },
+    };
+    setProjects([rootProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedFileAccess).toBe('full');
+  });
+
+  test('Expect custom mounts mapped to custom file access', async () => {
+    const customProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'custom-mounts',
+      filesystem: {
+        mode: 'custom',
+        mounts: [{ host: '/data', target: '/workspace/data', ro: true }],
+      },
+    };
+    setProjects([customProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedFileAccess).toBe('custom');
+    expect(wizard.draft.customMounts).toEqual([{ host: '/data', target: '/workspace/data', ro: true }]);
+  });
+
+  test('Expect empty mounts mapped to workspace file access', async () => {
+    const noMountProject: WorkspaceProjectInfo = {
+      ...sampleProject,
+      id: 'no-mounts',
+      filesystem: { mode: 'project', mounts: [] },
+    };
+    setProjects([noMountProject]);
+    render(AgentWorkspaceCreate);
+
+    await fireEvent.click(screen.getByRole('button', { name: /Saved project/ }));
+    await fireEvent.click(screen.getByRole('option', { name: /My App/ }));
+
+    expect(wizard.draft.selectedFileAccess).toBe('workspace');
+  });
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -19,7 +19,9 @@ import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalo
 import { catalogModels } from '/@/stores/models';
 import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
+import { secretVaultInfos } from '/@/stores/secret-vault';
 import { skillInfos } from '/@/stores/skills';
+import { workspaceProjectInfos } from '/@/stores/workspace-projects';
 import type {
   AgentWorkspaceConfiguration,
   AgentWorkspaceMount,
@@ -27,6 +29,7 @@ import type {
 } from '/@api/agent-workspace-info';
 import { NavigationPage } from '/@api/navigation-page';
 import type { DefaultWorkspaceSettings } from '/@api/onboarding-settings-info';
+import type { FilesystemConfiguration, WorkspaceProjectInfo } from '/@api/workspace-project-info';
 
 import AgentWorkspaceCreateStepAgentModel from './AgentWorkspaceCreateStepAgentModel.svelte';
 import type { CustomMount } from './AgentWorkspaceCreateStepFileSystem.svelte';
@@ -55,6 +58,86 @@ const wizardSteps = [
   { id: 'filesystem', title: 'File System' },
   { id: 'networking', title: 'Networking' },
 ];
+
+function applyFilesystemFromProject(fs: FilesystemConfiguration): void {
+  const hasMounts = fs.mounts.length > 0;
+  if (!hasMounts) {
+    wizard.draft.selectedFileAccess = 'workspace';
+    wizard.draft.customMounts = [{ host: '', target: '', ro: false }];
+    return;
+  }
+  const hasHome = fs.mounts.some(m => m.host === '$HOME' && m.target === '$HOME');
+  const hasRoot = fs.mounts.some(m => m.host === '/' && m.target === '/');
+  if (hasRoot) {
+    wizard.draft.selectedFileAccess = 'full';
+  } else if (hasHome && fs.mounts.length === 1) {
+    wizard.draft.selectedFileAccess = 'home';
+  } else {
+    wizard.draft.selectedFileAccess = 'custom';
+    wizard.draft.customMounts = fs.mounts.map(m => ({ host: m.host, target: m.target, ro: m.ro ?? false }));
+  }
+}
+
+const REGISTRY_PRESET = ['registry.npmjs.org', 'pypi.python.org'];
+
+function isRegistryPreset(hosts: string[]): boolean {
+  return hosts.length === REGISTRY_PRESET.length && hosts.every((h, i) => h === REGISTRY_PRESET[i]);
+}
+
+function applyNetworkFromProject(net: NetworkConfiguration | undefined): void {
+  if (!net) return;
+  if (net.mode === 'allow') {
+    wizard.draft.selectedNetwork = $agentWorkspaceRuntime === 'openshell' ? 'registries' : 'open';
+    return;
+  }
+  const hosts = net.hosts ?? [];
+  if (hosts.length > 0 && isRegistryPreset(hosts)) {
+    wizard.draft.selectedNetwork = 'registries';
+    wizard.draft.hostsByMode = { ...wizard.draft.hostsByMode, registries: [...hosts] };
+  } else if (hosts.length > 0) {
+    wizard.draft.selectedNetwork = 'blocked';
+    wizard.draft.hostsByMode = { ...wizard.draft.hostsByMode, blocked: [...hosts] };
+  } else {
+    wizard.draft.selectedNetwork = 'blocked';
+    wizard.draft.hostsByMode = { ...wizard.draft.hostsByMode, blocked: [''] };
+  }
+}
+
+function applyProject(project: WorkspaceProjectInfo): void {
+  wizard.draft.selectedProjectId = project.id;
+  wizard.draft.sourcePath = project.folder;
+  wizard.draft.sessionName = project.name;
+  wizard.draft.nameManuallyEdited = true;
+  wizard.draft.selectedSkillIds = [...project.skills];
+  wizard.draft.selectedMcpIds = [...project.mcpServers];
+  wizard.draft.selectedSecretIds = [...project.secrets];
+  wizard.draft.selectedKnowledgeIds = [...project.knowledges];
+  applyFilesystemFromProject(project.filesystem);
+  applyNetworkFromProject(project.network);
+}
+
+function clearProject(): void {
+  wizard.draft.selectedProjectId = undefined;
+  wizard.draft.sourcePath = '';
+  wizard.draft.sessionName = '';
+  wizard.draft.nameManuallyEdited = false;
+  wizard.draft.selectedSkillIds = $skillInfos.filter(s => s.enabled).map(s => s.name);
+  wizard.draft.selectedMcpIds = $mcpRemoteServerInfos.map(m => m.id);
+  wizard.draft.selectedSecretIds = $secretVaultInfos.map(s => s.id);
+  wizard.draft.selectedKnowledgeIds = $ragEnvironments.filter(r => r.mcpServer).map(r => r.name);
+  wizard.draft.selectedFileAccess = 'workspace';
+  wizard.draft.selectedNetwork = 'registries';
+  wizard.draft.customMounts = [{ host: '', target: '', ro: false }];
+  wizard.draft.hostsByMode = { registries: ['registry.npmjs.org', 'pypi.python.org'], blocked: [''] };
+}
+
+function handleProjectSelect(project: WorkspaceProjectInfo | undefined): void {
+  if (project) {
+    applyProject(project);
+  } else {
+    clearProject();
+  }
+}
 
 let skillItems: ChecklistItem[] = $derived(
   $skillInfos
@@ -319,6 +402,7 @@ async function startAsIs(): Promise<void> {
       runtime: $agentWorkspaceRuntime,
       agent: draftSnapshot.selectedAgent,
       name: draftSnapshot.sessionName || getDefaultSessionName(draftSnapshot.sourcePath),
+      project: draftSnapshot.selectedProjectId,
     });
     resetDraft();
   } catch (err: unknown) {
@@ -383,6 +467,7 @@ async function startWorkspace(): Promise<void> {
         : undefined,
       workspaceConfiguration: getAgentWorkspaceConfiguration(draftSnapshot.selectedAgent),
       replaceConfig: draftSnapshot.configExists && draftSnapshot.configAction === 'replace' ? true : undefined,
+      project: draftSnapshot.selectedProjectId,
     });
     resetDraft();
   } catch (err: unknown) {
@@ -430,10 +515,14 @@ async function startWorkspace(): Promise<void> {
                 bind:description={wizard.draft.description}
                 bind:nameManuallyEdited={wizard.draft.nameManuallyEdited}
                 bind:descriptionOpen={wizard.draft.descriptionOpen}
+                bind:projectOpen={wizard.draft.projectOpen}
                 onBrowseSource={handleBrowseSource}
                 configExists={wizard.draft.configExists}
                 bind:configAction={wizard.draft.configAction}
-                onStartAsIs={startAsIs} />
+                onStartAsIs={startAsIs}
+                projects={[...$workspaceProjectInfos]}
+                selectedProjectId={wizard.draft.selectedProjectId}
+                onProjectSelect={handleProjectSelect} />
             {:else if currentStepId === 'agent-model'}
               <AgentWorkspaceCreateStepAgentModel bind:selectedAgent={wizard.draft.selectedAgent} bind:selectedModel={wizard.draft.selectedModel} />
             {:else if currentStepId === 'tools-secrets'}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
@@ -29,6 +29,7 @@ const defaultProps = {
   description: '',
   nameManuallyEdited: false,
   descriptionOpen: false,
+  projectOpen: false,
   onBrowseSource: vi.fn(),
 };
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-import { faChevronDown, faFolderOpen, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faFolder, faFolderOpen, faInfoCircle, faRocket } from '@fortawesome/free-solid-svg-icons';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { Textarea } from '/@/lib/chat/components/ui/textarea';
+import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
 
 interface Props {
   sourcePath: string;
@@ -11,10 +12,14 @@ interface Props {
   description: string;
   nameManuallyEdited: boolean;
   descriptionOpen: boolean;
+  projectOpen: boolean;
   onBrowseSource: () => Promise<void>;
   configExists?: boolean;
   configAction?: 'merge' | 'replace';
   onStartAsIs?: () => Promise<void>;
+  projects?: WorkspaceProjectInfo[];
+  selectedProjectId?: string;
+  onProjectSelect?: (project: WorkspaceProjectInfo | undefined) => void;
 }
 
 let {
@@ -23,10 +28,14 @@ let {
   description = $bindable(),
   nameManuallyEdited = $bindable(),
   descriptionOpen = $bindable(),
+  projectOpen = $bindable(),
   onBrowseSource,
   configExists = false,
   configAction = $bindable('merge'),
   onStartAsIs,
+  projects = [],
+  selectedProjectId,
+  onProjectSelect,
 }: Props = $props();
 
 function markNameEdited(): void {
@@ -35,6 +44,10 @@ function markNameEdited(): void {
 
 function toggleDescription(): void {
   descriptionOpen = !descriptionOpen;
+}
+
+function toggleProject(): void {
+  projectOpen = !projectOpen;
 }
 </script>
 
@@ -147,4 +160,79 @@ function toggleDescription(): void {
       </div>
     {/if}
   </div>
+
+  {#if projects.length > 0}
+    <div class="rounded-xl border border-[var(--pd-content-card-border)]/85 bg-[var(--pd-content-card-bg)]/35 overflow-hidden">
+      <button
+        class="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-[var(--pd-modal-text)] hover:bg-[var(--pd-content-card-inset-bg)]/50 transition-colors cursor-pointer"
+        onclick={toggleProject}>
+        <span>
+          Saved project <span class="text-xs font-normal opacity-50">(optional)</span>
+        </span>
+        <span
+          class="transition-transform duration-150 {projectOpen ? 'rotate-180' : ''}"
+          aria-hidden="true">
+          <Icon icon={faChevronDown} size="xs" />
+        </span>
+      </button>
+      {#if projectOpen}
+        <div class="px-4 pb-4 space-y-3">
+          <p class="text-xs text-[var(--pd-content-card-text)] opacity-60">
+            Load defaults from a project — path, skills, MCP, secrets, and access presets.
+          </p>
+          <div role="listbox" aria-label="Project selection" class="space-y-2">
+            <button
+              type="button"
+              role="option"
+              aria-selected={selectedProjectId === undefined}
+              class="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border cursor-pointer text-left text-sm transition-colors
+                {selectedProjectId === undefined
+                  ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)] text-[var(--pd-modal-text)]'
+                  : 'border-[var(--pd-content-card-border)] bg-transparent text-[var(--pd-content-card-text)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+              onclick={(): void => onProjectSelect?.(undefined)}>
+              <span class="w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0
+                {selectedProjectId === undefined ? 'border-[var(--pd-link)]' : 'border-[var(--pd-content-card-border)]'}">
+                {#if selectedProjectId === undefined}
+                  <span class="w-2 h-2 rounded-full bg-[var(--pd-link)]"></span>
+                {/if}
+              </span>
+              <span>None — keep what I entered above</span>
+            </button>
+
+            <div class="grid grid-cols-2 gap-2">
+              {#each projects as project (project.id)}
+                {@const isSelected = selectedProjectId === project.id}
+                {@const resourceCount = project.skills.length + project.mcpServers.length + project.secrets.length + project.knowledges.length}
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  class="flex flex-col gap-2 p-3 rounded-lg border cursor-pointer text-left transition-colors
+                    {isSelected
+                      ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
+                      : 'border-[var(--pd-content-card-border)] bg-transparent hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+                  onclick={(): void => onProjectSelect?.(project)}>
+                  <div class="flex items-center gap-2">
+                    <div class="w-8 h-8 rounded-lg flex items-center justify-center bg-[var(--pd-link)]/15 text-[var(--pd-link)] shrink-0">
+                      <Icon icon={faRocket} size="sm" />
+                    </div>
+                    <span class="font-semibold text-sm text-[var(--pd-modal-text)] truncate">{project.name}</span>
+                  </div>
+                  <div class="flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-[var(--pd-content-card-text)] opacity-60">
+                    <span class="flex items-center gap-1">
+                      <Icon icon={faFolder} size="xs" />
+                      <span class="font-mono truncate max-w-[160px]">{project.folder}</span>
+                    </span>
+                    {#if resourceCount > 0}
+                      <span>{resourceCount} resource{resourceCount !== 1 ? 's' : ''}</span>
+                    {/if}
+                  </div>
+                </button>
+              {/each}
+            </div>
+          </div>
+        </div>
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
@@ -29,6 +29,7 @@ const REGISTRY_HOSTS = ['registry.npmjs.org', 'pypi.python.org'];
 
 interface WorkspaceCreateDraft {
   currentStepIndex: number;
+  selectedProjectId: string | undefined;
   sourcePath: string;
   sessionName: string;
   description: string;
@@ -42,6 +43,7 @@ interface WorkspaceCreateDraft {
   hostsByMode: Record<string, string[]>;
   nameManuallyEdited: boolean;
   descriptionOpen: boolean;
+  projectOpen: boolean;
   selectedSkillIds: string[];
   selectedMcpIds: string[];
   selectedSecretIds: string[];
@@ -52,6 +54,7 @@ interface WorkspaceCreateDraft {
 function createInitialDraft(): WorkspaceCreateDraft {
   return {
     currentStepIndex: 0,
+    selectedProjectId: undefined,
     sourcePath: '',
     sessionName: '',
     description: '',
@@ -68,6 +71,7 @@ function createInitialDraft(): WorkspaceCreateDraft {
     },
     nameManuallyEdited: false,
     descriptionOpen: false,
+    projectOpen: false,
     selectedSkillIds: [],
     selectedMcpIds: [],
     selectedSecretIds: [],


### PR DESCRIPTION
Introduces a project selection step that pre-fills workspace settings (source path, name, skills, MCP servers, secrets, filesystem, network) from a project definition, or allows starting from scratch.

Closes https://github.com/openkaiden/kaiden/issues/2111