### PR TITLE
fix(openshell): reuse existing provider with the same name

### DIFF
--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
@@ -47,6 +47,7 @@ describe('createSecret', () => {
   };
 
   test('delegates to openshellCli.createProvider and returns the secret name', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
     vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
 
     const result = await adapter.createSecret(defaultOptions);
@@ -59,7 +60,17 @@ describe('createSecret', () => {
     expect(result).toEqual({ name: 'my-secret' });
   });
 
+  test('reuses an existing provider when the name matches', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'my-secret', type: 'github' }]);
+
+    const result = await adapter.createSecret(defaultOptions);
+
+    expect(openshellCli.createProvider).not.toHaveBeenCalled();
+    expect(result).toEqual({ name: 'my-secret' });
+  });
+
   test('rejects when openshellCli.createProvider fails', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
     vi.mocked(openshellCli.createProvider).mockRejectedValue(new Error('provider type not supported'));
 
     await expect(adapter.createSecret(defaultOptions)).rejects.toThrow('provider type not supported');

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -49,6 +49,15 @@ export class OpenshellSecretAdapter implements SecretCliBackend {
     if (typeof options.value === 'string') {
       throw new Error('options.value must be a record for Openshell');
     }
+
+    // Reuse an existing provider with the same name rather than re-creating it.
+    // The CLI may normalise the type string (e.g. "claude" → "claude-code"), so
+    // type comparison is unreliable; name alone is sufficient to identify the provider.
+    const existingProviders = await this.openshellCli.listProviders();
+    if (existingProviders.some(p => p.name === options.name)) {
+      return { name: options.name };
+    }
+
     await this.openshellCli.createProvider({
       name: options.name,
       type: options.type,

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -222,6 +222,7 @@ describe('KAIDEN_OPENSHELL backend switching', () => {
   });
 
   test('delegates create to openshellAdapter when KAIDEN_OPENSHELL is set', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
     vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
 
     const result = await manager.create(defaultOptions);
@@ -271,6 +272,7 @@ describe('KAIDEN_OPENSHELL backend switching', () => {
   });
 
   test('still emits secret-manager-update on create', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
     vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
 
     await manager.create(defaultOptions);


### PR DESCRIPTION
When creating a workspace, if an OpenShell provider with the same name already exists, reuse it instead of failing or creating a duplicate.

Type comparison against the list output is intentionally omitted: the CLI normalises the type string on storage (e.g. "claude" becomes "claude-code"), so the value in options.type and the value returned by "openshell provider list" can differ even for the same provider.

Fixes #2154