### PR TITLE
feat(copilot): add agent configuration and model settings support

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -23,7 +23,8 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@openkaiden/api": "workspace:*"
+    "@openkaiden/api": "workspace:*",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "adm-zip": "^0.5.16",

--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -134,34 +134,67 @@ describe('activate', () => {
       expect(written.other).toBe(true);
     });
 
+    test('sets model on chat object that has no model field', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const existingConfig = JSON.stringify({ chat: { temperature: 0.7 }, other: true });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile], 'claude-sonnet'));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.chat.model).toBe('claude-sonnet');
+      expect(written.chat.temperature).toBe(0.7);
+      expect(written.other).toBe(true);
+    });
+
+    test('accepts chat object without model field', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const existingConfig = JSON.stringify({ chat: { temperature: 0.7 }, other: true });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile], 'claude-sonnet'));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.chat.model).toBe('claude-sonnet');
+      expect(written.chat.temperature).toBe(0.7);
+      expect(written.other).toBe(true);
+    });
+
     test.each([
       'null',
       '"a string"',
       '123',
       'true',
       '[1, 2]',
-    ])('falls back to empty config when parsed JSON is non-object: %s', async (payload: string) => {
+    ])('rejects non-object JSON: %s', async (payload: string) => {
       await activate(extensionContextMock);
       const agent = getRegisteredAgent();
 
       const configFile = createConfigFile(payload);
-      await agent.preWorkspaceStart(createContext([configFile]));
-
-      expect(configFile.updateMock).toHaveBeenCalledOnce();
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
-      expect(written.chat.model).toBe('gpt-4o');
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
-    test('handles invalid JSON by starting with empty config', async () => {
+    test.each([
+      JSON.stringify({ chat: 'bad-shape' }),
+      JSON.stringify({ chat: null }),
+      JSON.stringify({ chat: [1, 2] }),
+      JSON.stringify({ chat: 123 }),
+    ])('rejects malformed chat field: %s', async (payload: string) => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile(payload);
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+    });
+
+    test('rejects invalid JSON', async () => {
       await activate(extensionContextMock);
       const agent = getRegisteredAgent();
 
       const configFile = createConfigFile('not valid json');
-      await agent.preWorkspaceStart(createContext([configFile]));
-
-      expect(configFile.updateMock).toHaveBeenCalledOnce();
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
-      expect(written.chat.model).toBe('gpt-4o');
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
     test('does nothing when config file is not in context', async () => {

--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -16,11 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Disposable, ExtensionContext } from '@openkaiden/api';
+import type {
+  Agent,
+  AgentConfigurationFile,
+  AgentWorkspaceContext,
+  Disposable,
+  ExtensionContext,
+} from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { activate } from './extension';
+import { activate, COPILOT_SETTINGS_PATH } from './extension';
 
 const AGENT_DISPOSABLE_MOCK: Disposable = { dispose: vi.fn() };
 
@@ -35,6 +41,30 @@ beforeEach(() => {
 
   vi.mocked(agents.registerAgent).mockReturnValue(AGENT_DISPOSABLE_MOCK);
 });
+
+function getRegisteredAgent(): Agent {
+  return vi.mocked(agents.registerAgent).mock.calls[0]![0];
+}
+
+function createContext(configFiles: AgentConfigurationFile[], modelLabel = 'gpt-4o'): AgentWorkspaceContext {
+  return {
+    model: {
+      model: { label: modelLabel },
+    },
+    configurationFiles: configFiles,
+    workspace: {},
+  };
+}
+
+function createConfigFile(content = '{}'): AgentConfigurationFile & { updateMock: ReturnType<typeof vi.fn> } {
+  const updateMock = vi.fn();
+  const file: AgentConfigurationFile = {
+    path: COPILOT_SETTINGS_PATH,
+    read: vi.fn().mockResolvedValue(content),
+    update: updateMock,
+  };
+  return Object.assign(file, { updateMock });
+}
 
 describe('activate', () => {
   test('registers copilot agent', async () => {
@@ -61,9 +91,93 @@ describe('activate', () => {
   test('registered agent supports all model types except vertexai', async () => {
     await activate(extensionContextMock);
 
-    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    const agent = getRegisteredAgent();
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'gemini' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBe(false);
+  });
+
+  test('registers agent with settings.json configuration file', async () => {
+    await activate(extensionContextMock);
+
+    const agent = getRegisteredAgent();
+    expect(agent.configurationFiles).toHaveLength(1);
+    expect(agent.configurationFiles[0]!.path).toBe(COPILOT_SETTINGS_PATH);
+  });
+
+  describe('preWorkspaceStart', () => {
+    test('writes model configuration into settings.json', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(configFile.updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written).toEqual({
+        chat: { model: 'gpt-4o' },
+      });
+    });
+
+    test('preserves existing configuration fields', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const existingConfig = JSON.stringify({ chat: { model: 'old-model', temperature: 0.7 }, other: true });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile], 'claude-sonnet'));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.chat.model).toBe('claude-sonnet');
+      expect(written.chat.temperature).toBe(0.7);
+      expect(written.other).toBe(true);
+    });
+
+    test.each([
+      'null',
+      '"a string"',
+      '123',
+      'true',
+      '[1, 2]',
+    ])('falls back to empty config when parsed JSON is non-object: %s', async (payload: string) => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile(payload);
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(configFile.updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.chat.model).toBe('gpt-4o');
+    });
+
+    test('handles invalid JSON by starting with empty config', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile('not valid json');
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(configFile.updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.chat.model).toBe('gpt-4o');
+    });
+
+    test('does nothing when config file is not in context', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const updateMock = vi.fn();
+      const otherFile: AgentConfigurationFile = {
+        path: 'some/other/path.json',
+        read: vi.fn(),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([otherFile]));
+
+      expect(updateMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -16,8 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@openkaiden/api';
+import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+
+export const COPILOT_SETTINGS_PATH = '.copilot/settings.json';
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -39,13 +41,41 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'copilot',
     acp: { args: ['--acp'] },
     tags: [],
-    configurationFiles: [],
     destinationSkillsFolder: '${HOME}/.copilot/skills',
+    configurationFiles: [
+      {
+        path: COPILOT_SETTINGS_PATH,
+        async read(): Promise<string> {
+          return '{}';
+        },
+      },
+    ],
     isSupportedModelType(type): boolean {
       return type.name !== 'vertexai';
     },
-    async preWorkspaceStart(): Promise<void> {
-      throw new Error('not implemented');
+    async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+      const configFile = context.configurationFiles.find(f => f.path === COPILOT_SETTINGS_PATH);
+      if (!configFile) {
+        return;
+      }
+
+      const content = await configFile.read();
+      let config: Record<string, unknown>;
+      try {
+        const parsed: unknown = JSON.parse(content);
+        config =
+          typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : {};
+      } catch {
+        config = {};
+      }
+
+      const chat = (config.chat as Record<string, unknown> | undefined) ?? {};
+      chat.model = context.model.model.label;
+      config.chat = chat;
+
+      await configFile.update(JSON.stringify(config, undefined, 2));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -18,6 +18,28 @@
 
 import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+import { z } from 'zod';
+
+const CopilotSettingsSchema = z.looseObject({
+  chat: z.looseObject({ model: z.string().optional() }).optional(),
+});
+
+const CopilotSettingsCodec = z.codec(z.string(), CopilotSettingsSchema, {
+  decode: (jsonString, ctx) => {
+    try {
+      return JSON.parse(jsonString);
+    } catch (err: unknown) {
+      ctx.issues.push({
+        code: 'invalid_format',
+        format: 'json',
+        input: jsonString,
+        message: err instanceof Error ? err.message : 'Invalid JSON',
+      });
+      return z.NEVER;
+    }
+  },
+  encode: value => JSON.stringify(value, undefined, 2),
+});
 
 export const COPILOT_SETTINGS_PATH = '.copilot/settings.json';
 
@@ -59,23 +81,10 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         return;
       }
 
-      const content = await configFile.read();
-      let config: Record<string, unknown>;
-      try {
-        const parsed: unknown = JSON.parse(content);
-        config =
-          typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
-            ? (parsed as Record<string, unknown>)
-            : {};
-      } catch {
-        config = {};
-      }
+      const config = CopilotSettingsCodec.decode(await configFile.read());
+      config.chat = { ...config.chat, model: context.model.model.label };
 
-      const chat = (config.chat as Record<string, unknown> | undefined) ?? {};
-      chat.model = context.model.model.label;
-      config.chat = chat;
-
-      await configFile.update(JSON.stringify(config, undefined, 2));
+      await configFile.update(CopilotSettingsCodec.encode(config));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
       '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
+      zod:
+        specifier: ^4.3.5
+        version: 4.4.3
     devDependencies:
       adm-zip:
         specifier: ^0.5.16


### PR DESCRIPTION
Implement settings.json configuration file management for the copilot agent. The preWorkspaceStart hook now writes the selected model into the copilot settings file so the agent launches with the correct model.

Closes https://github.com/openkaiden/kaiden/issues/2171