### PR TITLE
feat(cursor): implement agent configuration for workspace preparation

### DIFF
--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -53,7 +53,8 @@
   },
   "dependencies": {
     "ai": "^6.0.208",
-    "inversify": "^7.7.1"
+    "inversify": "^7.7.1",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@openkaiden/api": "workspace:*",

--- a/extensions/cursor/src/extension.spec.ts
+++ b/extensions/cursor/src/extension.spec.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Disposable, ExtensionContext } from '@openkaiden/api';
+import type { AgentConfigurationFile, AgentWorkspaceContext, Disposable, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { CursorExtension } from './cursor-extension';
-import { activate } from './extension';
+import { activate, CURSOR_CLI_CONFIG_PATH } from './extension';
 
 vi.mock(import('@openkaiden/api'));
 vi.mock(import('./cursor-extension'));
@@ -79,5 +79,106 @@ describe('activate', () => {
     expect(agent.isSupportedModelType!({ name: 'cursor' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(false);
     expect(agent.isSupportedModelType!({ name: 'anthropic' })).toBe(false);
+  });
+
+  test('registers agent with cli-config.json configuration file', async () => {
+    await activate(extensionContextMock);
+
+    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    expect(agent.configurationFiles).toHaveLength(1);
+    expect(agent.configurationFiles[0]!.path).toBe(CURSOR_CLI_CONFIG_PATH);
+  });
+
+  describe('preWorkspaceStart', () => {
+    function createContext(configFiles: AgentConfigurationFile[], modelLabel = 'gpt-4o'): AgentWorkspaceContext {
+      return {
+        model: {
+          model: { label: modelLabel },
+        },
+        configurationFiles: configFiles,
+      };
+    }
+
+    test('writes model configuration into cli-config.json', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CURSOR_CLI_CONFIG_PATH,
+        read: vi.fn().mockResolvedValue('{}'),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written).toEqual({
+        model: {
+          modelId: 'gpt-4o',
+          displayModelId: 'gpt-4o',
+          displayName: 'gpt-4o',
+          displayNameShort: 'gpt-4o',
+          maxMode: false,
+        },
+        hasChangedDefaultModel: true,
+      });
+    });
+
+    test('preserves existing configuration fields', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const existingConfig = JSON.stringify({ customSetting: 'keep-me', version: 2 });
+      const configFile: AgentConfigurationFile = {
+        path: CURSOR_CLI_CONFIG_PATH,
+        read: vi.fn().mockResolvedValue(existingConfig),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile], 'claude-sonnet'));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.customSetting).toBe('keep-me');
+      expect(written.version).toBe(2);
+      expect(written.model.modelId).toBe('claude-sonnet');
+    });
+
+    test('handles invalid JSON by starting with empty config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CURSOR_CLI_CONFIG_PATH,
+        read: vi.fn().mockResolvedValue('not valid json'),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.model.modelId).toBe('gpt-4o');
+      expect(written.hasChangedDefaultModel).toBe(true);
+    });
+
+    test('does nothing when config file is not in context', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const otherFile: AgentConfigurationFile = {
+        path: 'some/other/path.json',
+        read: vi.fn(),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([otherFile]));
+
+      expect(updateMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/extensions/cursor/src/extension.spec.ts
+++ b/extensions/cursor/src/extension.spec.ts
@@ -165,6 +165,27 @@ describe('activate', () => {
       expect(written.hasChangedDefaultModel).toBe(true);
     });
 
+    test('normalizes non-object JSON to empty config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      for (const nonObject of ['null', '"string"', '123', '[]']) {
+        const updateMock = vi.fn();
+        const configFile: AgentConfigurationFile = {
+          path: CURSOR_CLI_CONFIG_PATH,
+          read: vi.fn().mockResolvedValue(nonObject),
+          update: updateMock,
+        };
+
+        await agent.preWorkspaceStart(createContext([configFile]));
+
+        expect(updateMock).toHaveBeenCalledOnce();
+        const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+        expect(written.model.modelId).toBe('gpt-4o');
+        expect(written.hasChangedDefaultModel).toBe(true);
+      }
+    });
+
     test('does nothing when config file is not in context', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];

--- a/extensions/cursor/src/extension.spec.ts
+++ b/extensions/cursor/src/extension.spec.ts
@@ -96,6 +96,7 @@ describe('activate', () => {
           model: { label: modelLabel },
         },
         configurationFiles: configFiles,
+        workspace: {},
       };
     }
 
@@ -146,44 +147,30 @@ describe('activate', () => {
       expect(written.model.modelId).toBe('claude-sonnet');
     });
 
-    test('handles invalid JSON by starting with empty config', async () => {
+    test('rejects invalid JSON', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
 
-      const updateMock = vi.fn();
       const configFile: AgentConfigurationFile = {
         path: CURSOR_CLI_CONFIG_PATH,
         read: vi.fn().mockResolvedValue('not valid json'),
-        update: updateMock,
+        update: vi.fn(),
       };
 
-      await agent.preWorkspaceStart(createContext([configFile]));
-
-      expect(updateMock).toHaveBeenCalledOnce();
-      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
-      expect(written.model.modelId).toBe('gpt-4o');
-      expect(written.hasChangedDefaultModel).toBe(true);
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
-    test('normalizes non-object JSON to empty config', async () => {
+    test.each(['null', '"string"', '123', '[]'])('rejects non-object JSON: %s', async (payload: string) => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
 
-      for (const nonObject of ['null', '"string"', '123', '[]']) {
-        const updateMock = vi.fn();
-        const configFile: AgentConfigurationFile = {
-          path: CURSOR_CLI_CONFIG_PATH,
-          read: vi.fn().mockResolvedValue(nonObject),
-          update: updateMock,
-        };
+      const configFile: AgentConfigurationFile = {
+        path: CURSOR_CLI_CONFIG_PATH,
+        read: vi.fn().mockResolvedValue(payload),
+        update: vi.fn(),
+      };
 
-        await agent.preWorkspaceStart(createContext([configFile]));
-
-        expect(updateMock).toHaveBeenCalledOnce();
-        const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
-        expect(written.model.modelId).toBe('gpt-4o');
-        expect(written.hasChangedDefaultModel).toBe(true);
-      }
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
     test('does nothing when config file is not in context', async () => {

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -16,10 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@openkaiden/api';
+import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
 import { CursorExtension } from './cursor-extension';
+
+export const CURSOR_CLI_CONFIG_PATH = '.cursor/cli-config.json';
 
 let cursorExtension: CursorExtension | undefined;
 
@@ -37,13 +39,44 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     },
     command: 'cursor',
     tags: ['Local'],
-    configurationFiles: [],
+    configurationFiles: [
+      {
+        path: CURSOR_CLI_CONFIG_PATH,
+        async read(): Promise<string> {
+          return '{}';
+        },
+        async update(): Promise<void> {},
+      },
+    ],
     destinationSkillsFolder: '${HOME}/.cursor/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'cursor';
     },
-    async preWorkspaceStart(): Promise<void> {
-      throw new Error('not implemented');
+    async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+      const configFile = context.configurationFiles.find(f => f.path === CURSOR_CLI_CONFIG_PATH);
+      if (!configFile) {
+        return;
+      }
+
+      const content = await configFile.read();
+      let config: Record<string, unknown>;
+      try {
+        config = JSON.parse(content) as Record<string, unknown>;
+      } catch {
+        config = {};
+      }
+
+      const modelName = context.model.model.label;
+      config['model'] = {
+        modelId: modelName,
+        displayModelId: modelName,
+        displayName: modelName,
+        displayNameShort: modelName,
+        maxMode: false,
+      };
+      config['hasChangedDefaultModel'] = true;
+
+      await configFile.update(JSON.stringify(config, undefined, 2));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -45,7 +45,6 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         async read(): Promise<string> {
           return '{}';
         },
-        async update(): Promise<void> {},
       },
     ],
     destinationSkillsFolder: '${HOME}/.cursor/skills',

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -60,7 +60,11 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       const content = await configFile.read();
       let config: Record<string, unknown>;
       try {
-        config = JSON.parse(content) as Record<string, unknown>;
+        const parsed: unknown = JSON.parse(content);
+        config =
+          parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : {};
       } catch {
         config = {};
       }

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -18,10 +18,24 @@
 
 import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+import { z } from 'zod';
 
 import { CursorExtension } from './cursor-extension';
 
 export const CURSOR_CLI_CONFIG_PATH = '.cursor/cli-config.json';
+
+const CursorModelSchema = z.looseObject({
+  modelId: z.string(),
+  displayModelId: z.string(),
+  displayName: z.string(),
+  displayNameShort: z.string(),
+  maxMode: z.boolean(),
+});
+
+const CursorCliConfigSchema = z.looseObject({
+  model: CursorModelSchema.optional(),
+  hasChangedDefaultModel: z.boolean().optional(),
+});
 
 let cursorExtension: CursorExtension | undefined;
 
@@ -57,27 +71,16 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         return;
       }
 
-      const content = await configFile.read();
-      let config: Record<string, unknown>;
-      try {
-        const parsed: unknown = JSON.parse(content);
-        config =
-          parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
-            ? (parsed as Record<string, unknown>)
-            : {};
-      } catch {
-        config = {};
-      }
-
+      const config = CursorCliConfigSchema.parse(JSON.parse(await configFile.read()));
       const modelName = context.model.model.label;
-      config['model'] = {
+      config.model = {
         modelId: modelName,
         displayModelId: modelName,
         displayName: modelName,
         displayNameShort: modelName,
         maxMode: false,
       };
-      config['hasChangedDefaultModel'] = true;
+      config.hasChangedDefaultModel = true;
 
       await configFile.update(JSON.stringify(config, undefined, 2));
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       inversify:
         specifier: ^7.7.1
         version: 7.11.0(reflect-metadata@0.2.2)
+      zod:
+        specifier: ^4.3.5
+        version: 4.4.3
     devDependencies:
       '@openkaiden/api':
         specifier: workspace:*
@@ -9098,8 +9101,8 @@ snapshots:
   '@mistralai/mistralai@2.2.0':
     dependencies:
       ws: 8.19.0
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16285,7 +16288,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-    optional: true
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
Replaces the configurationFiles and preWorkspaceStart stubs with a real implementation that writes model configuration into .cursor/cli-config.json.

Closes #2172