### PR TITLE
feat: use new agent registration and implement workspace creation on OpenShell

### DIFF
--- a/extensions/gemini/src/extension.spec.ts
+++ b/extensions/gemini/src/extension.spec.ts
@@ -103,6 +103,7 @@ describe('activate', () => {
           model: { label: modelLabel },
         },
         configurationFiles: configFiles,
+        workspace: {},
       };
     }
 

--- a/packages/main/src/plugin/agent-registry.spec.ts
+++ b/packages/main/src/plugin/agent-registry.spec.ts
@@ -206,6 +206,28 @@ describe('AgentRegistry', () => {
     });
   });
 
+  describe('getAgentRegistration', () => {
+    test('returns undefined for unknown id', () => {
+      expect(agentRegistry.getAgentRegistration('unknown')).toBeUndefined();
+    });
+
+    test('returns the raw Agent object for known id', () => {
+      const agent = createAgent();
+      agentRegistry.registerAgent(agent);
+
+      const result = agentRegistry.getAgentRegistration('test-agent');
+      expect(result).toBe(agent);
+    });
+
+    test('returns undefined after agent is disposed', () => {
+      const agent = createAgent();
+      const disposable = agentRegistry.registerAgent(agent);
+      disposable.dispose();
+
+      expect(agentRegistry.getAgentRegistration('test-agent')).toBeUndefined();
+    });
+  });
+
   describe('getModelTypes', () => {
     test('filters model types using isSupportedModelType callback', async () => {
       vi.mocked(modelRegistry.getCatalogModels).mockReturnValue([

--- a/packages/main/src/plugin/agent-registry.ts
+++ b/packages/main/src/plugin/agent-registry.ts
@@ -151,4 +151,8 @@ export class AgentRegistry {
     agentRegistration.agentInfo ??= await this.toAgentInfo(agentRegistration.agent);
     return agentRegistration.agentInfo;
   }
+
+  getAgentRegistration(id: string): Agent | undefined {
+    return this.agentRegistrations.get(id)?.agent;
+  }
 }

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -19,18 +19,18 @@
 import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { FileSystemWatcher, InferenceProviderConnection } from '@openkaiden/api';
+import type { Agent, FileSystemWatcher, InferenceProviderConnection } from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import type { IPty } from 'node-pty';
 import { spawn } from 'node-pty';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { AgentRegistry } from '/@/plugin/agent-registry.js';
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
-import { OpenshellImageBuilder } from '/@/plugin/openshell-cli/openshell-image-builder.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { SafeStorageRegistry, SecretStorageWrapper } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import type { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
@@ -50,7 +50,6 @@ vi.mock(import('node-pty'));
 
 vi.mock(import('/@/plugin/kdn-cli/kdn-cli.js'));
 vi.mock(import('/@/plugin/openshell-cli/openshell-cli.js'));
-vi.mock(import('/@/plugin/openshell-cli/openshell-image-builder.js'));
 
 const TEST_SUMMARIES: AgentWorkspaceSummary[] = [
   {
@@ -87,7 +86,10 @@ const apiSender: ApiSenderType = {
 const ipcHandle: IPCHandle = vi.fn();
 const kdnCli = new KdnCli({} as Exec, {} as CliToolRegistry);
 const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
-const imageBuilderCli = new OpenshellImageBuilder({} as Exec, {} as CliToolRegistry);
+
+const agentRegistry = {
+  getAgentRegistration: vi.fn(),
+} as unknown as AgentRegistry;
 
 const mockTask = {
   id: 'task-1',
@@ -173,7 +175,7 @@ beforeEach(() => {
     secretManager,
     openshellCli,
     safeStorageRegistry,
-    imageBuilderCli,
+    agentRegistry,
   );
   manager.init();
 });
@@ -370,33 +372,32 @@ describe('create – OpenShell mode', () => {
     name: 'my-sandbox',
   };
 
+  const mockAgent: Agent = {
+    id: 'claude',
+    name: 'Claude Code',
+    description: 'Test agent',
+    command: 'claude',
+    configurationFiles: [],
+    async preWorkspaceStart(): Promise<void> {},
+  };
+
   beforeEach(() => {
     process.env['KAIDEN_OPENSHELL'] = '1';
     vi.mocked(kdnCli.writeWorkspaceConfig).mockResolvedValue(undefined);
-    vi.mocked(imageBuilderCli.buildImage).mockResolvedValue(undefined);
     vi.mocked(openshellCli.createSandbox).mockResolvedValue(undefined);
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue(mockAgent);
   });
 
   afterEach(() => {
     delete process.env['KAIDEN_OPENSHELL'];
   });
 
-  test('calls imageBuilderCli.buildImage with correct tag and agent option', async () => {
-    await manager.create(defaultOptions);
-
-    expect(imageBuilderCli.buildImage).toHaveBeenCalledWith(
-      'kaiden-workspace-my-sandbox:latest',
-      expect.objectContaining({ agent: 'claude', cwd: '/tmp/my-project' }),
-    );
-  });
-
-  test('calls openshellCli.createSandbox with from, name, providers, and workspace label', async () => {
+  test('calls openshellCli.createSandbox with name, providers, and workspace label', async () => {
     const options = { ...defaultOptions, secrets: ['my-secret'] };
     await manager.create(options);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith({
       name: 'my-sandbox',
-      from: 'kaiden-workspace-my-sandbox:latest',
       providers: ['my-secret'],
       labels: { 'ai.openkaiden.kaiden.workspace': Buffer.from('/tmp/my-project').toString('base64url') },
       noTty: true,
@@ -424,17 +425,9 @@ describe('create – OpenShell mode', () => {
     expect(result).toEqual({ id: 'my-project' });
   });
 
-  test('sanitizes uppercase and special characters in sandbox name for image tag', async () => {
-    const options = { ...defaultOptions, name: 'My Project/V2!' };
-    await manager.create(options);
-
-    expect(imageBuilderCli.buildImage).toHaveBeenCalledWith(
-      'kaiden-workspace-my-project-v2:latest',
-      expect.any(Object),
-    );
-  });
-
-  test('passes model name, inference, and endpoint to buildImage', async () => {
+  test('calls agent.preWorkspaceStart with correct context', async () => {
+    const preWorkspaceStart = vi.fn();
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({ ...mockAgent, preWorkspaceStart });
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { 'claude:tokens': 'sk-ant-secret' },
       llmMetadataName: 'anthropic',
@@ -445,21 +438,74 @@ describe('create – OpenShell mode', () => {
     const options = { ...defaultOptions, model: 'anthropic::claude-3-5-sonnet::' };
     await manager.create(options);
 
-    expect(imageBuilderCli.buildImage).toHaveBeenCalledWith(
-      'kaiden-workspace-my-sandbox:latest',
-      expect.objectContaining({
-        model: 'claude-3-5-sonnet',
-        inference: 'anthropic',
+    expect(preWorkspaceStart).toHaveBeenCalledWith({
+      model: {
+        llmMetadata: { name: 'anthropic' },
+        model: { label: 'claude-3-5-sonnet' },
         endpoint: 'https://api.anthropic.com',
+      },
+      configurationFiles: [],
+    });
+  });
+
+  test('uploads updated configuration files to sandbox', async () => {
+    const configFile = {
+      path: '/home/user/.config/agent/config.toml',
+      read: vi.fn().mockResolvedValue(''),
+    };
+    const preWorkspaceStart = vi
+      .fn()
+      .mockImplementation(async (ctx: { configurationFiles: Array<{ update(c: string): Promise<void> }> }) => {
+        await ctx.configurationFiles[0]!.update('key = "value"');
+      });
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({
+      ...mockAgent,
+      configurationFiles: [configFile],
+      preWorkspaceStart,
+    });
+
+    await manager.create(defaultOptions);
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: [{ local: expect.any(String), remote: '/home/user/.config/agent/config.toml' }],
       }),
     );
   });
 
-  test('falls back to "workspace" image tag component when name sanitizes to empty', async () => {
-    const options = { ...defaultOptions, name: '!!!' };
-    await manager.create(options);
+  test('does not include uploads when agent has no config files', async () => {
+    await manager.create(defaultOptions);
 
-    expect(imageBuilderCli.buildImage).toHaveBeenCalledWith('kaiden-workspace-workspace:latest', expect.any(Object));
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.not.objectContaining({ uploads: expect.anything() }),
+    );
+  });
+
+  test('uploads config files even when preWorkspaceStart does not update them', async () => {
+    const configFile = {
+      path: '/home/user/.config/agent/config.toml',
+      read: vi.fn().mockResolvedValue('initial content'),
+    };
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({
+      ...mockAgent,
+      configurationFiles: [configFile],
+    });
+
+    await manager.create(defaultOptions);
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: [{ local: expect.any(String), remote: '/home/user/.config/agent/config.toml' }],
+      }),
+    );
+  });
+
+  test('throws when agent is not found in registry', async () => {
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue(undefined);
+
+    await expect(manager.create(defaultOptions)).rejects.toThrow('agent claude not registered');
+
+    expect(openshellCli.createSandbox).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -26,6 +26,7 @@ import { spawn } from 'node-pty';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { AgentRegistry } from '/@/plugin/agent-registry.js';
+import type { WorkspaceConfiguration } from '/@/plugin/agent-workspace/workspace-config-writer.js';
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
@@ -150,6 +151,12 @@ const extensionStorageMock = {
 const safeStorageRegistry = {
   getExtensionStorage: vi.fn().mockReturnValue(extensionStorageMock),
 } as unknown as SafeStorageRegistry;
+
+function mockEnoent(): NodeJS.ErrnoException {
+  const err: NodeJS.ErrnoException = new Error('ENOENT');
+  err.code = 'ENOENT';
+  return err;
+}
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -383,9 +390,10 @@ describe('create – OpenShell mode', () => {
 
   beforeEach(() => {
     process.env['KAIDEN_OPENSHELL'] = '1';
-    vi.mocked(kdnCli.writeWorkspaceConfig).mockResolvedValue(undefined);
+    vi.mocked(kdnCli.writeWorkspaceConfig).mockResolvedValue({} as WorkspaceConfiguration);
     vi.mocked(openshellCli.createSandbox).mockResolvedValue(undefined);
     vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue(mockAgent);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
   });
 
   afterEach(() => {
@@ -445,6 +453,7 @@ describe('create – OpenShell mode', () => {
         endpoint: 'https://api.anthropic.com',
       },
       configurationFiles: [],
+      workspace: expect.anything(),
     });
   });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { access, readFile, rm, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
@@ -26,11 +26,12 @@ import { inject, injectable, preDestroy } from 'inversify';
 import type { IPty } from 'node-pty';
 import { spawn } from 'node-pty';
 
+import { AgentRegistry } from '/@/plugin/agent-registry.js';
+import { WritableConfigurationFile } from '/@/plugin/agent-workspace/writable-configuration-file.js';
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KdnCli } from '/@/plugin/kdn-cli/kdn-cli.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
-import { OpenshellImageBuilder } from '/@/plugin/openshell-cli/openshell-image-builder.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
@@ -85,8 +86,8 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly openshellCli: OpenshellCli,
     @inject(SafeStorageRegistry)
     private readonly safeStorageRegistry: SafeStorageRegistry,
-    @inject(OpenshellImageBuilder)
-    private readonly imageBuilderCli: OpenshellImageBuilder,
+    @inject(AgentRegistry)
+    private readonly agentRegistry: AgentRegistry,
   ) {}
 
   async getCliInfo(): Promise<CliInfo> {
@@ -121,43 +122,51 @@ export class AgentWorkspaceManager implements Disposable {
     }
   }
 
-  private sanitizeImageTag(name: string): string {
-    const sanitized = name
-      .toLowerCase()
-      .replace(/[^a-z0-9-]+/g, '-')
-      .split('-')
-      .filter(Boolean)
-      .join('-');
-    return sanitized || 'workspace';
-  }
-
   private async createOpenshell(options: AgentWorkspaceCreateOptions): Promise<AgentWorkspaceId> {
     const connectionInfo = options.model
       ? this.providerRegistry.getInferenceConnectionCredentials(options.model)
       : undefined;
 
     const modelName = options.model?.split('::')[1];
-    const inference = connectionInfo?.llmMetadataName;
     const endpoint = connectionInfo?.endpoint;
 
     await this.kdnCli.writeWorkspaceConfig(options);
 
-    const sandboxName = options.name ?? basename(options.sourcePath);
-    const imageTag = `kaiden-workspace-${this.sanitizeImageTag(sandboxName)}:latest`;
+    const agent = this.agentRegistry.getAgentRegistration(options.agent);
+    const uploads: Array<{ local: string; remote: string }> = [];
 
-    await this.imageBuilderCli.buildImage(imageTag, {
-      agent: options.agent,
-      model: modelName,
-      inference,
-      endpoint,
-      cwd: options.sourcePath,
-    });
+    if (agent) {
+      const writable = await Promise.all(
+        agent.configurationFiles.map(
+          async (base, i) =>
+            new WritableConfigurationFile(base, await base.read(), join(tmpdir(), `kaiden-config-${Date.now()}-${i}`)),
+        ),
+      );
+
+      await agent.preWorkspaceStart({
+        model: {
+          llmMetadata: connectionInfo?.llmMetadataName ? { name: connectionInfo.llmMetadataName } : undefined,
+          model: { label: modelName ?? '' },
+          endpoint,
+        },
+        configurationFiles: writable,
+      });
+
+      for (const file of writable) {
+        await writeFile(file.localPath, await file.read(), 'utf-8');
+        uploads.push({ local: file.localPath, remote: file.path });
+      }
+    } else {
+      throw new Error(`Unable to create workspace: agent ${options.agent} not registered`);
+    }
+
+    const sandboxName = options.name ?? basename(options.sourcePath);
 
     await this.openshellCli.createSandbox({
       name: sandboxName,
-      from: imageTag,
       providers: options.secrets,
       labels: { 'ai.openkaiden.kaiden.workspace': Buffer.from(options.sourcePath).toString('base64url') },
+      uploads: uploads.length > 0 ? uploads : undefined,
       noTty: true,
       command: ['true'],
     });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -27,6 +27,7 @@ import type { IPty } from 'node-pty';
 import { spawn } from 'node-pty';
 
 import { AgentRegistry } from '/@/plugin/agent-registry.js';
+import { writeWorkspaceConfig } from '/@/plugin/agent-workspace/workspace-config-writer.js';
 import { WritableConfigurationFile } from '/@/plugin/agent-workspace/writable-configuration-file.js';
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
@@ -130,7 +131,7 @@ export class AgentWorkspaceManager implements Disposable {
     const modelName = options.model?.split('::')[1];
     const endpoint = connectionInfo?.endpoint;
 
-    await this.kdnCli.writeWorkspaceConfig(options);
+    const workspace = await writeWorkspaceConfig(options);
 
     const agent = this.agentRegistry.getAgentRegistration(options.agent);
     const uploads: Array<{ local: string; remote: string }> = [];
@@ -150,6 +151,7 @@ export class AgentWorkspaceManager implements Disposable {
           endpoint,
         },
         configurationFiles: writable,
+        workspace,
       });
 
       for (const file of writable) {

--- a/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
@@ -89,10 +89,11 @@ describe('writeWorkspaceConfig', () => {
     expect(parsed.network).toEqual({ mode: 'deny', hosts: ['registry.npmjs.org', 'pypi.org'] });
   });
 
-  test('does not write workspace.json when no skills, network, secrets, mcp, mounts or workspaceConfiguration provided', async () => {
+  test('write empty workspace.json when no skills, network, secrets, mcp, mounts or workspaceConfiguration provided', async () => {
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
     await writeWorkspaceConfig(defaultOptions);
 
-    expect(writeFile).not.toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalled();
   });
 
   test('writes workspace.json with mounts', async () => {

--- a/packages/main/src/plugin/agent-workspace/workspace-config-writer.ts
+++ b/packages/main/src/plugin/agent-workspace/workspace-config-writer.ts
@@ -27,16 +27,13 @@ import type { AgentWorkspaceCreateOptions } from '/@api/agent-workspace-info.js'
 
 export type WorkspaceConfiguration = workspaceComponents['schemas']['WorkspaceConfiguration'];
 
-export async function writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
+export async function writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<WorkspaceConfiguration> {
   const mcpServers = options.mcp?.servers;
   const mcpCommands = options.mcp?.commands;
   const hasSkills = !!options.skills?.length;
   const hasMcp = !!mcpServers?.length || !!mcpCommands?.length;
   const hasWsConfig = !!options.workspaceConfiguration;
   const hasMounts = !!options.mounts?.length;
-  if (!hasSkills && !options.secrets?.length && !options.network && !hasMcp && !hasMounts && !hasWsConfig) {
-    return;
-  }
 
   const configDir = join(options.sourcePath, '.kaiden');
   const configPath = join(configDir, 'workspace.json');
@@ -154,6 +151,7 @@ export async function writeWorkspaceConfig(options: AgentWorkspaceCreateOptions)
   const output = JSON.stringify(existing, undefined, 2) + '\n';
   console.log(`[KdnCli] workspace.json:\n${output}`);
   await writeFile(configPath, output, 'utf-8');
+  return existing;
 }
 
 export async function updateWorkspaceConfig(

--- a/packages/main/src/plugin/agent-workspace/writable-configuration-file.ts
+++ b/packages/main/src/plugin/agent-workspace/writable-configuration-file.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { AgentConfigurationBase, AgentConfigurationFile } from '@openkaiden/api';
+
+export class WritableConfigurationFile implements AgentConfigurationFile {
+  readonly path: string;
+  readonly localPath: string;
+  private content = '';
+
+  constructor(base: AgentConfigurationBase, baseContent: string, localPath: string) {
+    this.path = base.path;
+    this.content = baseContent;
+    this.localPath = localPath;
+  }
+
+  async read(): Promise<string> {
+    return this.content;
+  }
+
+  async update(content: string): Promise<void> {
+    this.content = content;
+  }
+}

--- a/packages/main/src/plugin/kdn-cli/kdn-cli.ts
+++ b/packages/main/src/plugin/kdn-cli/kdn-cli.ts
@@ -143,7 +143,7 @@ export class KdnCli implements SecretCliBackend {
     }
   }
 
-  async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<void> {
+  async writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<WorkspaceConfiguration> {
     return writeWsConfig(options);
   }
 


### PR DESCRIPTION
To test:
- define env variable KAIDEN_OPENSHELL
- create a workspace (excluding Gemini models before #2199 is merged)
- check the OpenCode configuration file inside the sandbox

Fixes #2186

Replace Docker image building logic in AgentWorkspaceManager with agent-driven preWorkspaceStart() hooks. Agents now customize their own configuration files before workspace startup, enabling more flexible and agent-specific setup.

- Add WritableConfigurationFile wrapper for mutable agent config
- Add getAgentRegistration() method to AgentRegistry
- Remove OpenshellImageBuilder dependency from workspace manager
- Upload agent config files to sandbox instead of baking into images