### PR TITLE
feat(openclaw): implement agent configuration for workspace preparation

### DIFF
--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -20,7 +20,8 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@openkaiden/api": "workspace:*"
+    "@openkaiden/api": "workspace:*",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "adm-zip": "^0.5.16",

--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -62,9 +62,9 @@ describe('activate', () => {
     await activate(extensionContextMock);
 
     const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-    expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(true);
-    expect(agent.isSupportedModelType!({ name: 'gemini' })).toBe(true);
-    expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBe(false);
+    expect(agent.isSupportedModelType!({ name: 'openai' })).toBeTruthy();
+    expect(agent.isSupportedModelType!({ name: 'gemini' })).toBeTruthy();
+    expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBeFalsy();
   });
 
   test('registers agent with openclaw.json configuration file', async () => {

--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -22,6 +22,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { activate, OPENCLAW_CONFIG_PATH } from './extension';
 
+vi.mock(import('@openkaiden/api'));
+
 const AGENT_DISPOSABLE_MOCK: Disposable = { dispose: vi.fn() };
 
 let extensionContextMock: ExtensionContext;
@@ -76,6 +78,13 @@ describe('activate', () => {
   });
 
   describe('preWorkspaceStart', () => {
+    let agent: ReturnType<typeof vi.mocked<typeof agents.registerAgent>>['mock']['calls'][0][0];
+
+    beforeEach(async () => {
+      await activate(extensionContextMock);
+      agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    });
+
     function createContext(
       configFiles: AgentConfigurationFile[],
       options: {
@@ -92,38 +101,36 @@ describe('activate', () => {
           model: { label: modelLabel },
         },
         configurationFiles: configFiles,
-        workspace: { ...(mcp ? { mcp } : {}) },
+        workspace: { mcp },
       };
     }
 
     function createConfigFile(content = '{}'): AgentConfigurationFile & { updateMock: ReturnType<typeof vi.fn> } {
       const updateMock = vi.fn();
-      const file: AgentConfigurationFile = {
+      return {
         path: OPENCLAW_CONFIG_PATH,
         read: vi.fn().mockResolvedValue(content),
         update: updateMock,
+        updateMock,
       };
-      return Object.assign(file, { updateMock });
+    }
+
+    function writtenConfig(configFile: { updateMock: ReturnType<typeof vi.fn> }): Record<string, unknown> {
+      return JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
     }
 
     test('writes model configuration into openclaw.json', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile]));
 
       expect(configFile.updateMock).toHaveBeenCalledOnce();
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written).toEqual({
         agents: { defaults: { model: 'anthropic/claude-opus-4-6' } },
       });
     });
 
     test('preserves existing configuration fields', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const existingConfig = JSON.stringify({
         agents: { defaults: { model: 'old-model', params: { cacheRetention: 'long' } } },
         other: true,
@@ -131,24 +138,18 @@ describe('activate', () => {
       const configFile = createConfigFile(existingConfig);
       await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'openai/gpt-5.5' }));
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.agents.defaults.model).toBe('openai/gpt-5.5');
       expect(written.agents.defaults.params.cacheRetention).toBe('long');
       expect(written.other).toBe(true);
     });
 
     test('throws on invalid JSON', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile('not valid json');
       await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
     test('throws on non-object JSON', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       for (const nonObject of ['null', '"string"', '123', '[]']) {
         const configFile = createConfigFile(nonObject);
         await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
@@ -156,9 +157,6 @@ describe('activate', () => {
     });
 
     test('does nothing when config file is not in context', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const updateMock = vi.fn();
       const otherFile: AgentConfigurationFile = {
         path: 'some/other/path.json',
@@ -172,9 +170,6 @@ describe('activate', () => {
     });
 
     test('writes remote MCP servers from workspace config', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -184,16 +179,13 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers).toEqual({
         'my-remote': { transport: 'streamable-http', url: 'https://mcp.example.com' },
       });
     });
 
     test('writes remote MCP servers with headers', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -209,7 +201,7 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers).toEqual({
         'authed-server': {
           transport: 'streamable-http',
@@ -220,9 +212,6 @@ describe('activate', () => {
     });
 
     test('writes local MCP commands from workspace config', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -232,16 +221,13 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers).toEqual({
         'my-local': { command: 'npx', args: ['-y', 'my-mcp-server'] },
       });
     });
 
     test('writes local MCP commands with env variables', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -258,7 +244,7 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers).toEqual({
         'github-mcp': {
           command: 'npx',
@@ -269,9 +255,6 @@ describe('activate', () => {
     });
 
     test('writes both remote and local MCP servers together', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -282,7 +265,7 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers).toEqual({
         'remote-one': { transport: 'streamable-http', url: 'https://mcp.example.com' },
         'local-one': { command: 'npx', args: ['my-server'] },
@@ -290,9 +273,6 @@ describe('activate', () => {
     });
 
     test('merges MCP servers with existing mcp.servers config', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const existingConfig = JSON.stringify({
         mcp: { servers: { 'existing-server': { transport: 'streamable-http', url: 'https://existing.example.com' } } },
       });
@@ -305,7 +285,7 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers).toEqual({
         'existing-server': { transport: 'streamable-http', url: 'https://existing.example.com' },
         'new-server': { transport: 'streamable-http', url: 'https://new.example.com' },
@@ -313,36 +293,27 @@ describe('activate', () => {
     });
 
     test('does not write mcp key when workspace has no MCP config', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(createContext([configFile]));
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp).toBeUndefined();
     });
 
     test('preserves existing mcp.servers when workspace has no MCP config', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const existingConfig = JSON.stringify({
         mcp: { servers: { 'existing-server': { command: 'my-server', args: [] } } },
       });
       const configFile = createConfigFile(existingConfig);
       await agent.preWorkspaceStart(createContext([configFile]));
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers).toEqual({
         'existing-server': { command: 'my-server', args: [] },
       });
     });
 
     test('omits headers when remote MCP server has empty headers', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -352,18 +323,14 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers['no-headers']).toEqual({
         transport: 'streamable-http',
         url: 'https://mcp.example.com',
       });
-      expect(written.mcp.servers['no-headers']).not.toHaveProperty('headers');
     });
 
     test('omits env when local MCP command has empty env', async () => {
-      await activate(extensionContextMock);
-      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
-
       const configFile = createConfigFile();
       await agent.preWorkspaceStart(
         createContext([configFile], {
@@ -373,9 +340,8 @@ describe('activate', () => {
         }),
       );
 
-      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      const written = writtenConfig(configFile);
       expect(written.mcp.servers['minimal']).toEqual({ command: 'my-server', args: [] });
-      expect(written.mcp.servers['minimal']).not.toHaveProperty('env');
     });
   });
 });

--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Disposable, ExtensionContext } from '@openkaiden/api';
+import type { AgentConfigurationFile, AgentWorkspaceContext, Disposable, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { activate } from './extension';
+import { activate, OPENCLAW_CONFIG_PATH } from './extension';
 
 const AGENT_DISPOSABLE_MOCK: Disposable = { dispose: vi.fn() };
 
@@ -65,5 +65,317 @@ describe('activate', () => {
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'gemini' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBe(false);
+  });
+
+  test('registers agent with openclaw.json configuration file', async () => {
+    await activate(extensionContextMock);
+
+    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    expect(agent.configurationFiles).toHaveLength(1);
+    expect(agent.configurationFiles[0]!.path).toBe(OPENCLAW_CONFIG_PATH);
+  });
+
+  describe('preWorkspaceStart', () => {
+    function createContext(
+      configFiles: AgentConfigurationFile[],
+      options: {
+        modelLabel?: string;
+        mcp?: {
+          servers?: { name: string; url: string; headers?: Record<string, string> }[];
+          commands?: { name: string; command: string; args?: string[]; env?: Record<string, string> }[];
+        };
+      } = {},
+    ): AgentWorkspaceContext {
+      const { modelLabel = 'anthropic/claude-opus-4-6', mcp } = options;
+      return {
+        model: {
+          model: { label: modelLabel },
+        },
+        configurationFiles: configFiles,
+        workspace: { ...(mcp ? { mcp } : {}) },
+      };
+    }
+
+    function createConfigFile(content = '{}'): AgentConfigurationFile & { updateMock: ReturnType<typeof vi.fn> } {
+      const updateMock = vi.fn();
+      const file: AgentConfigurationFile = {
+        path: OPENCLAW_CONFIG_PATH,
+        read: vi.fn().mockResolvedValue(content),
+        update: updateMock,
+      };
+      return Object.assign(file, { updateMock });
+    }
+
+    test('writes model configuration into openclaw.json', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(configFile.updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written).toEqual({
+        agents: { defaults: { model: 'anthropic/claude-opus-4-6' } },
+      });
+    });
+
+    test('preserves existing configuration fields', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const existingConfig = JSON.stringify({
+        agents: { defaults: { model: 'old-model', params: { cacheRetention: 'long' } } },
+        other: true,
+      });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'openai/gpt-5.5' }));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.agents.defaults.model).toBe('openai/gpt-5.5');
+      expect(written.agents.defaults.params.cacheRetention).toBe('long');
+      expect(written.other).toBe(true);
+    });
+
+    test('throws on invalid JSON', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile('not valid json');
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+    });
+
+    test('throws on non-object JSON', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      for (const nonObject of ['null', '"string"', '123', '[]']) {
+        const configFile = createConfigFile(nonObject);
+        await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+      }
+    });
+
+    test('does nothing when config file is not in context', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const otherFile: AgentConfigurationFile = {
+        path: 'some/other/path.json',
+        read: vi.fn(),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([otherFile]));
+
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    test('writes remote MCP servers from workspace config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'my-remote', url: 'https://mcp.example.com' }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers).toEqual({
+        'my-remote': { transport: 'streamable-http', url: 'https://mcp.example.com' },
+      });
+    });
+
+    test('writes remote MCP servers with headers', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [
+              {
+                name: 'authed-server',
+                url: 'https://mcp.example.com',
+                headers: { Authorization: 'Bearer token123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers).toEqual({
+        'authed-server': {
+          transport: 'streamable-http',
+          url: 'https://mcp.example.com',
+          headers: { Authorization: 'Bearer token123' },
+        },
+      });
+    });
+
+    test('writes local MCP commands from workspace config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'my-local', command: 'npx', args: ['-y', 'my-mcp-server'] }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers).toEqual({
+        'my-local': { command: 'npx', args: ['-y', 'my-mcp-server'] },
+      });
+    });
+
+    test('writes local MCP commands with env variables', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [
+              {
+                name: 'github-mcp',
+                command: 'npx',
+                args: ['@modelcontextprotocol/server-github'],
+                env: { GITHUB_TOKEN: 'ghp_test123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers).toEqual({
+        'github-mcp': {
+          command: 'npx',
+          args: ['@modelcontextprotocol/server-github'],
+          env: { GITHUB_TOKEN: 'ghp_test123' },
+        },
+      });
+    });
+
+    test('writes both remote and local MCP servers together', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'remote-one', url: 'https://mcp.example.com' }],
+            commands: [{ name: 'local-one', command: 'npx', args: ['my-server'] }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers).toEqual({
+        'remote-one': { transport: 'streamable-http', url: 'https://mcp.example.com' },
+        'local-one': { command: 'npx', args: ['my-server'] },
+      });
+    });
+
+    test('merges MCP servers with existing mcp.servers config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const existingConfig = JSON.stringify({
+        mcp: { servers: { 'existing-server': { transport: 'streamable-http', url: 'https://existing.example.com' } } },
+      });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'new-server', url: 'https://new.example.com' }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers).toEqual({
+        'existing-server': { transport: 'streamable-http', url: 'https://existing.example.com' },
+        'new-server': { transport: 'streamable-http', url: 'https://new.example.com' },
+      });
+    });
+
+    test('does not write mcp key when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toBeUndefined();
+    });
+
+    test('preserves existing mcp.servers when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const existingConfig = JSON.stringify({
+        mcp: { servers: { 'existing-server': { command: 'my-server', args: [] } } },
+      });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers).toEqual({
+        'existing-server': { command: 'my-server', args: [] },
+      });
+    });
+
+    test('omits headers when remote MCP server has empty headers', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'no-headers', url: 'https://mcp.example.com', headers: {} }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers['no-headers']).toEqual({
+        transport: 'streamable-http',
+        url: 'https://mcp.example.com',
+      });
+      expect(written.mcp.servers['no-headers']).not.toHaveProperty('headers');
+    });
+
+    test('omits env when local MCP command has empty env', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'minimal', command: 'my-server', args: [], env: {} }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp.servers['minimal']).toEqual({ command: 'my-server', args: [] });
+      expect(written.mcp.servers['minimal']).not.toHaveProperty('env');
+    });
   });
 });

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -46,6 +46,23 @@ const OpenClawConfigSchema = z.looseObject({
   mcp: McpConfigSchema.optional(),
 });
 
+const OpenClawConfigCodec = z.codec(z.string(), OpenClawConfigSchema, {
+  decode: (jsonString, ctx) => {
+    try {
+      return JSON.parse(jsonString);
+    } catch (err: unknown) {
+      ctx.issues.push({
+        code: 'invalid_format',
+        format: 'json',
+        input: jsonString,
+        message: err instanceof Error ? err.message : 'Invalid JSON',
+      });
+      return z.NEVER;
+    }
+  },
+  encode: value => JSON.stringify(value, undefined, 2),
+});
+
 export const OPENCLAW_CONFIG_PATH = '.openclaw/openclaw.json';
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
@@ -77,7 +94,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         return;
       }
 
-      const config = OpenClawConfigSchema.parse(JSON.parse(await configFile.read()));
+      const config = OpenClawConfigCodec.decode(await configFile.read());
 
       config.agents = {
         ...config.agents,
@@ -112,7 +129,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         config.mcp = { ...config.mcp, servers };
       }
 
-      await configFile.update(JSON.stringify(config, undefined, 2));
+      await configFile.update(OpenClawConfigCodec.encode(config));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -16,8 +16,37 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext, ModelType } from '@openkaiden/api';
+import type { AgentWorkspaceContext, ExtensionContext, ModelType } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+import { z } from 'zod';
+
+const OpenClawAgentsSchema = z
+  .looseObject({
+    defaults: z.looseObject({}).catch({}).optional(),
+  })
+  .catch({});
+
+const McpServerEntrySchema = z.looseObject({
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  transport: z.string().optional(),
+  url: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
+type McpServerEntry = z.infer<typeof McpServerEntrySchema>;
+
+const McpConfigSchema = z.looseObject({
+  servers: z.record(z.string(), McpServerEntrySchema).optional(),
+});
+
+const OpenClawConfigSchema = z.looseObject({
+  agents: OpenClawAgentsSchema.optional(),
+  mcp: McpConfigSchema.optional(),
+});
+
+export const OPENCLAW_CONFIG_PATH = '.openclaw/openclaw.json';
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -30,13 +59,60 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     },
     command: 'openclaw',
     acp: { args: ['acp'] },
-    configurationFiles: [],
+    configurationFiles: [
+      {
+        path: OPENCLAW_CONFIG_PATH,
+        async read(): Promise<string> {
+          return '{}';
+        },
+      },
+    ],
     destinationSkillsFolder: '${HOME}/.openclaw/skills',
     isSupportedModelType(type: ModelType): boolean {
       return type.name !== 'vertexai';
     },
-    async preWorkspaceStart(): Promise<void> {
-      throw new Error('not implemented');
+    async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+      const configFile = context.configurationFiles.find(f => f.path === OPENCLAW_CONFIG_PATH);
+      if (!configFile) {
+        return;
+      }
+
+      const config = OpenClawConfigSchema.parse(JSON.parse(await configFile.read()));
+
+      config.agents = {
+        ...config.agents,
+        defaults: {
+          ...(config.agents?.defaults ?? {}),
+          model: context.model.model.label,
+        },
+      };
+
+      const mcpServers = context.workspace.mcp?.servers;
+      const mcpCommands = context.workspace.mcp?.commands;
+
+      if (mcpServers?.length || mcpCommands?.length) {
+        const servers: Record<string, McpServerEntry> = { ...config.mcp?.servers };
+
+        for (const server of mcpServers ?? []) {
+          servers[server.name] = {
+            transport: 'streamable-http',
+            url: server.url,
+            ...(server.headers && Object.keys(server.headers).length > 0 ? { headers: server.headers } : {}),
+          };
+        }
+
+        for (const cmd of mcpCommands ?? []) {
+          servers[cmd.name] = {
+            command: cmd.command,
+            args: cmd.args ?? [],
+            ...(cmd.env && Object.keys(cmd.env).length > 0 ? { env: cmd.env } : {}),
+          };
+        }
+
+        config.mcp = { ...config.mcp, servers };
+      }
+
+      await configFile.update(JSON.stringify(config, undefined, 2));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -22,7 +22,12 @@ import { z } from 'zod';
 
 const OpenClawAgentsSchema = z
   .looseObject({
-    defaults: z.looseObject({}).catch({}).optional(),
+    defaults: z
+      .looseObject({
+        model: z.string().optional(),
+      })
+      .catch({})
+      .optional(),
   })
   .catch({});
 
@@ -55,13 +60,17 @@ const OpenClawConfigCodec = z.codec(z.string(), OpenClawConfigSchema, {
         code: 'invalid_format',
         format: 'json',
         input: jsonString,
-        message: err instanceof Error ? err.message : 'Invalid JSON',
+        message: String(err),
       });
       return z.NEVER;
     }
   },
   encode: value => JSON.stringify(value, undefined, 2),
 });
+
+function nonEmpty(obj: Record<string, string> | undefined): Record<string, string> | undefined {
+  return obj && Object.keys(obj).length > 0 ? obj : undefined;
+}
 
 export const OPENCLAW_CONFIG_PATH = '.openclaw/openclaw.json';
 
@@ -74,6 +83,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       icon: './icon.png',
       logo: './icon.png',
     },
+    tags: ['Local'],
     command: 'openclaw',
     acp: { args: ['acp'] },
     configurationFiles: [
@@ -96,13 +106,8 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
       const config = OpenClawConfigCodec.decode(await configFile.read());
 
-      config.agents = {
-        ...config.agents,
-        defaults: {
-          ...(config.agents?.defaults ?? {}),
-          model: context.model.model.label,
-        },
-      };
+      config.agents ??= {};
+      config.agents.defaults = { ...config.agents.defaults, model: context.model.model.label };
 
       const mcpServers = context.workspace.mcp?.servers;
       const mcpCommands = context.workspace.mcp?.commands;
@@ -114,7 +119,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
           servers[server.name] = {
             transport: 'streamable-http',
             url: server.url,
-            ...(server.headers && Object.keys(server.headers).length > 0 ? { headers: server.headers } : {}),
+            headers: nonEmpty(server.headers),
           };
         }
 
@@ -122,11 +127,12 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
           servers[cmd.name] = {
             command: cmd.command,
             args: cmd.args ?? [],
-            ...(cmd.env && Object.keys(cmd.env).length > 0 ? { env: cmd.env } : {}),
+            env: nonEmpty(cmd.env),
           };
         }
 
-        config.mcp = { ...config.mcp, servers };
+        config.mcp ??= {};
+        config.mcp.servers = servers;
       }
 
       await configFile.update(OpenClawConfigCodec.encode(config));

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -375,6 +375,21 @@ describe('create – OpenShell mode', () => {
     expect(result).toEqual({ id: 'my-project' });
   });
 
+  test('passes agent baseImage as from option to createSandbox', async () => {
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({
+      ...mockAgent,
+      baseImage: 'registry.example.com/agent-base:v1',
+    });
+
+    await manager.create(defaultOptions);
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'registry.example.com/agent-base:v1',
+      }),
+    );
+  });
+
   test('calls agent.preWorkspaceStart with correct context', async () => {
     const preWorkspaceStart = vi.fn();
     vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({ ...mockAgent, preWorkspaceStart });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -216,6 +216,7 @@ export class AgentWorkspaceManager implements Disposable {
     try {
       await this.openshellCli.createSandbox({
         name: sandboxName,
+        from: agent.baseImage,
         providers: options.secrets,
         env: env && Object.keys(env).length > 0 ? env : undefined,
         labels: { ...encodeWorkspaceLabels(options.sourcePath), [AGENT_LABEL]: options.agent },

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -414,7 +414,6 @@ export class ExtensionLoader implements IAsyncDisposable {
         'kaiden.openai',
         'kaiden.codex',
         'kaiden.copilot',
-        'kaiden.openclaw',
         'kaiden.goose',
         'kaiden.gemini',
         'kaiden.cursor',

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -414,6 +414,7 @@ export class ExtensionLoader implements IAsyncDisposable {
         'kaiden.openai',
         'kaiden.codex',
         'kaiden.copilot',
+        'kaiden.openclaw',
         'kaiden.goose',
         'kaiden.gemini',
         'kaiden.cursor',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,6 +741,9 @@ importers:
       '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       adm-zip:
         specifier: ^0.5.16


### PR DESCRIPTION
## Summary
- Replaces the `configurationFiles` and `preWorkspaceStart` stubs with a real implementation that writes the selected model into `openclaw.json` at `agents.defaults.model`, preserving existing configuration fields.

Fixes #2175

## Testing

Before testing you'll need to set the baseImage property locally in extensions/openclaw/src/extension.ts:
baseImage: 'quay.io/bmahabir/openkaiden/openshell-openclaw:latest',

Besides testing openclaw tui try asserting the mcp and skill are there

for mcp

```
sandbox@sandbox-openclawer:~$ openclaw mcp show
(node:115) [UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental, expect them to change at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:122) [UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental, expect them to change at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
│
◇  

OpenClaw 2026.6.11 (e085fa1) — Type the command with confidence—nature will provide the stack trace if needed.

OpenClaw-managed MCP servers (/sandbox/.openclaw/openclaw.json):
{
  "ai.openkaiden.registry/playwright": {
    "command": "npx",
    "args": [
      "@playwright/mcp@0.0.73"
    ]
  }
}
sandbox@sandbox-openclawer:~$ 
```

For skills

```

sandbox@sandbox-openclawer:~$ openclaw skills list
✓ ready       │ summarize-changes        │ Summarizes the uncommitted changes in your git repository and flags anything risky.            │ openclaw-managed │

```



