### PR TITLE
chore: pin acorn dependency to ensure correct parsing for all tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,8 @@
       "tmp-promise>tmp": "^0.2.5",
       "tar": "^7.5.3",
       "cheerio>undici": "^7.18.2",
-      "cpu-features>nan": "^2.25.0"
+      "cpu-features>nan": "^2.25.0",
+      "acorn": "8.17.0"
     },
     "patchedDependencies": {
       "dmg-builder": "patches/dmg-builder.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   tar: ^7.5.3
   cheerio>undici: ^7.18.2
   cpu-features>nan: ^2.25.0
+  acorn: 8.17.0
 
 patchedDependencies:
   dmg-builder:
@@ -2301,7 +2302,7 @@ packages:
   '@sveltejs/acorn-typescript@1.0.9':
     resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
     peerDependencies:
-      acorn: ^8.9.0
+      acorn: 8.17.0
 
   '@sveltejs/opencode@0.1.6':
     resolution: {integrity: sha512-GATPKJdEvZ+JhIhHkXNCyHJEkCimKKI4hhyS06z5/q5ol515JgJruyscCHhfHiARynyIIdsQOSsfvpBLb0HIMg==}
@@ -3032,15 +3033,10 @@ packages:
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+      acorn: 8.17.0
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -9458,9 +9454,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.17.0)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   '@sveltejs/opencode@0.1.6(typescript@5.9.3)':
     dependencies:
@@ -10314,13 +10310,11 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
 
-  acorn@8.15.0: {}
-
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   adm-zip@0.5.16: {}
 
@@ -12135,8 +12129,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
@@ -15470,9 +15464,9 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.17.0)
       '@types/estree': 1.0.8
-      acorn: 8.16.0
+      acorn: 8.17.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
@@ -15588,7 +15582,7 @@ snapshots:
   terser@5.36.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true


### PR DESCRIPTION
avoid parsing errors from dependabot

example:
https://github.com/openkaiden/kaiden/pull/2167
https://github.com/openkaiden/kaiden/pull/2166
https://github.com/openkaiden/kaiden/pull/2165
https://github.com/openkaiden/kaiden/pull/2164

etc.