### PR TITLE
feat(api): expose workspace configuration in AgentWorkspaceContext

### DIFF
--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -20,6 +20,7 @@
     "publish:next": "pnpm publish  --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version 0.0.1-\"$(date +%s)\""
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^3.0.10"
+    "@ai-sdk/provider": "^3.0.10",
+    "@openkaiden/workspace-configuration": "^0.14.0"
   }
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -42,6 +42,7 @@
 declare module '@openkaiden/api' {
   import type { ProviderV3 as AISDKInferenceProvider } from '@ai-sdk/provider';
   import type { components } from '@openkaiden/mcp-registry-types';
+  import type { components as workspaceConfigComponents } from '@openkaiden/workspace-configuration';
 
   /**
    * The version of Kaiden.
@@ -5560,6 +5561,8 @@ declare module '@openkaiden/api' {
     update(content: string): Promise<void>;
   }
 
+  export type AgentWorkspaceConfiguration = workspaceConfigComponents['schemas']['WorkspaceConfiguration'];
+
   export interface AgentWorkspaceContext {
     readonly model: {
       readonly llmMetadata?: LLMMetadata;
@@ -5567,6 +5570,7 @@ declare module '@openkaiden/api' {
       readonly endpoint?: string;
     };
     readonly configurationFiles: ReadonlyArray<AgentConfigurationFile>;
+    readonly workspace: AgentWorkspaceConfiguration;
   }
 
   export interface Agent {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,9 @@ importers:
       '@ai-sdk/provider':
         specifier: ^3.0.10
         version: 3.0.10
+      '@openkaiden/workspace-configuration':
+        specifier: ^0.14.0
+        version: 0.14.0
 
   packages/preload-webview:
     devDependencies:


### PR DESCRIPTION
## Summary
- Add `readonly workspace: AgentWorkspaceConfiguration` field to `AgentWorkspaceContext` interface
- Import `WorkspaceConfiguration` schema from `@openkaiden/workspace-configuration` in the extension API
- Enables agents to access workspace configuration (mounts, environment, skills, MCP, network, ports, secrets, features) during `preWorkspaceStart`

Fixes #2194

## Test plan
- [x] `pnpm build` compiles successfully
- [x] All agent-registry tests pass (32/32)
- [x] All extension-loader tests pass (112/112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)