### PR TITLE
ci: use frozen lockfile for dependency installation in all CI jobs

### DIFF
--- a/.github/workflows/e2e-test-job.yaml
+++ b/.github/workflows/e2e-test-job.yaml
@@ -92,8 +92,8 @@ jobs:
           node-version: 24.15.0
           cache: 'pnpm'
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Get Playwright version and cache path
         id: playwright-info

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -121,8 +121,8 @@ jobs:
         run: |
           sed -i -r -e "s/SEGMENT_KEY = '.*'/SEGMENT_KEY = '${{ secrets.SEGMENT_WRITE_KEY }}'/" packages/main/src/plugin/telemetry/telemetry.ts
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Install flatpak on Linux
         if: ${{ matrix.os=='ubuntu-24.04' }}

--- a/.github/workflows/npmjs-publish.yaml
+++ b/.github/workflows/npmjs-publish.yaml
@@ -96,7 +96,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Show publish parameters
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -49,8 +49,8 @@ jobs:
           node-version: 24.15.0
           cache: 'pnpm'
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run Build
         timeout-minutes: 20
@@ -99,8 +99,8 @@ jobs:
           node-version: 24.15.0
           cache: 'pnpm'
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Install flatpak
         run: |
@@ -148,8 +148,8 @@ jobs:
           node-version: 24.15.0
           cache: 'pnpm'
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run Build
         timeout-minutes: 40
@@ -180,8 +180,8 @@ jobs:
           node-version: 24.15.0
           cache: 'pnpm'
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run linter
         run: pnpm lint:check
@@ -214,8 +214,8 @@ jobs:
           node-version: 24.15.0
           cache: 'pnpm'
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run typecheck
         run: pnpm typecheck
@@ -244,8 +244,8 @@ jobs:
           node-version: 24.15.0
           cache: 'pnpm'
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
         # run the unit tests with coverage on ubuntu
       - name: Run unit tests with coverage

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,8 +171,8 @@ jobs:
         run: |
           jq --arg key "${{ secrets.SEGMENT_WRITE_KEY }}" '.telemetry.key = $key' product.json > product.json.tmp && rm product.json && mv product.json.tmp product.json
 
-      - name: Execute pnpm
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Install flatpak on Linux
         if: ${{ matrix.os=='ubuntu-24.04' }}


### PR DESCRIPTION
Replace all `pnpm install` calls in GitHub Actions workflows with
`pnpm install --frozen-lockfile`, ensuring CI jobs never modify
pnpm-lock.yaml. This mirrors `npm ci` behavior.

Rename install steps to 'Install dependencies' for consistency.

Migration to pnpm 11 will allow us to use `pnpm ci` eventually.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
