### PR TITLE
feat(api): add skillsFolder field to Agent interface

### DIFF
--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -61,7 +61,7 @@ describe('ClaudeExtension', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
-        destinationSkillsFolder: '.claude/skills',
+        destinationSkillsFolder: '${HOME}/.claude/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -61,7 +61,7 @@ describe('ClaudeExtension', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
-        skillsFolder: expect.any(String),
+        skillsFolder: '.claude/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -61,7 +61,7 @@ describe('ClaudeExtension', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
-        skillsFolder: '.claude/skills',
+        destinationSkillsFolder: '.claude/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -61,6 +61,7 @@ describe('ClaudeExtension', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -63,7 +63,7 @@ export class ClaudeExtension {
       command: 'claude',
       tags: ['Cloud'],
       configurationFiles: [],
-      skillsFolder: '.claude/skills',
+      destinationSkillsFolder: '.claude/skills',
       isSupportedModelType: (type): boolean => type.name === 'anthropic' || type.name === 'vertexai',
       async preWorkspaceStart(): Promise<void> {
         throw new Error('not implemented');

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { Disposable, ExtensionContext } from '@openkaiden/api';
 import { agents, provider } from '@openkaiden/api';
 import type { Container } from 'inversify';
@@ -66,7 +63,7 @@ export class ClaudeExtension {
       command: 'claude',
       tags: ['Cloud'],
       configurationFiles: [],
-      skillsFolder: join(homedir(), '.claude', 'skills'),
+      skillsFolder: '.claude/skills',
       isSupportedModelType: (type): boolean => type.name === 'anthropic' || type.name === 'vertexai',
       async preWorkspaceStart(): Promise<void> {
         throw new Error('not implemented');

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { Disposable, ExtensionContext } from '@openkaiden/api';
 import { agents, provider } from '@openkaiden/api';
 import type { Container } from 'inversify';
@@ -63,6 +66,7 @@ export class ClaudeExtension {
       command: 'claude',
       tags: ['Cloud'],
       configurationFiles: [],
+      skillsFolder: join(homedir(), '.claude', 'skills'),
       isSupportedModelType: (type): boolean => type.name === 'anthropic' || type.name === 'vertexai',
       async preWorkspaceStart(): Promise<void> {
         throw new Error('not implemented');

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -63,7 +63,7 @@ export class ClaudeExtension {
       command: 'claude',
       tags: ['Cloud'],
       configurationFiles: [],
-      destinationSkillsFolder: '.claude/skills',
+      destinationSkillsFolder: '${HOME}/.claude/skills',
       isSupportedModelType: (type): boolean => type.name === 'anthropic' || type.name === 'vertexai',
       async preWorkspaceStart(): Promise<void> {
         throw new Error('not implemented');

--- a/extensions/codex/src/extension.spec.ts
+++ b/extensions/codex/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'Codex',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
-        skillsFolder: '.agents/skills',
+        destinationSkillsFolder: '.agents/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/codex/src/extension.spec.ts
+++ b/extensions/codex/src/extension.spec.ts
@@ -46,6 +46,7 @@ describe('activate', () => {
         name: 'Codex',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/codex/src/extension.spec.ts
+++ b/extensions/codex/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'Codex',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
-        destinationSkillsFolder: '.agents/skills',
+        destinationSkillsFolder: '${HOME}/.agents/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/codex/src/extension.spec.ts
+++ b/extensions/codex/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'Codex',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
-        skillsFolder: expect.any(String),
+        skillsFolder: '.agents/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/codex/src/extension.ts
+++ b/extensions/codex/src/extension.ts
@@ -30,7 +30,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     },
     command: 'codex',
     configurationFiles: [],
-    skillsFolder: '.agents/skills',
+    destinationSkillsFolder: '.agents/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'openai';
     },

--- a/extensions/codex/src/extension.ts
+++ b/extensions/codex/src/extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -30,6 +33,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     },
     command: 'codex',
     configurationFiles: [],
+    skillsFolder: join(homedir(), '.agents', 'skills'),
     isSupportedModelType(type): boolean {
       return type.name === 'openai';
     },

--- a/extensions/codex/src/extension.ts
+++ b/extensions/codex/src/extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -33,7 +30,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     },
     command: 'codex',
     configurationFiles: [],
-    skillsFolder: join(homedir(), '.agents', 'skills'),
+    skillsFolder: '.agents/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'openai';
     },

--- a/extensions/codex/src/extension.ts
+++ b/extensions/codex/src/extension.ts
@@ -30,7 +30,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     },
     command: 'codex',
     configurationFiles: [],
-    destinationSkillsFolder: '.agents/skills',
+    destinationSkillsFolder: '${HOME}/.agents/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'openai';
     },

--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'GitHub Copilot',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { light: './icon_light.png', dark: './icon_dark.png' } }),
-        skillsFolder: expect.any(String),
+        skillsFolder: '.copilot/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'GitHub Copilot',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { light: './icon_light.png', dark: './icon_dark.png' } }),
-        skillsFolder: '.copilot/skills',
+        destinationSkillsFolder: '.copilot/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -46,6 +46,7 @@ describe('activate', () => {
         name: 'GitHub Copilot',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { light: './icon_light.png', dark: './icon_dark.png' } }),
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/copilot/src/extension.spec.ts
+++ b/extensions/copilot/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'GitHub Copilot',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { light: './icon_light.png', dark: './icon_dark.png' } }),
-        destinationSkillsFolder: '.copilot/skills',
+        destinationSkillsFolder: '${HOME}/.copilot/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -40,7 +40,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     acp: { args: ['--acp'] },
     tags: [],
     configurationFiles: [],
-    skillsFolder: '.copilot/skills',
+    destinationSkillsFolder: '.copilot/skills',
     isSupportedModelType(type): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -40,6 +43,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     acp: { args: ['--acp'] },
     tags: [],
     configurationFiles: [],
+    skillsFolder: join(homedir(), '.copilot', 'skills'),
     isSupportedModelType(type): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -40,7 +40,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     acp: { args: ['--acp'] },
     tags: [],
     configurationFiles: [],
-    destinationSkillsFolder: '.copilot/skills',
+    destinationSkillsFolder: '${HOME}/.copilot/skills',
     isSupportedModelType(type): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/copilot/src/extension.ts
+++ b/extensions/copilot/src/extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -43,7 +40,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     acp: { args: ['--acp'] },
     tags: [],
     configurationFiles: [],
-    skillsFolder: join(homedir(), '.copilot', 'skills'),
+    skillsFolder: '.copilot/skills',
     isSupportedModelType(type): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/cursor/src/extension.spec.ts
+++ b/extensions/cursor/src/extension.spec.ts
@@ -60,7 +60,7 @@ describe('activate', () => {
           icon: { dark: './APP_ICON_2D_DARK.png', light: './APP_ICON_2D_LIGHT.png' },
         }),
         tags: ['Local'],
-        skillsFolder: '.cursor/skills',
+        destinationSkillsFolder: '.cursor/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/cursor/src/extension.spec.ts
+++ b/extensions/cursor/src/extension.spec.ts
@@ -60,7 +60,7 @@ describe('activate', () => {
           icon: { dark: './APP_ICON_2D_DARK.png', light: './APP_ICON_2D_LIGHT.png' },
         }),
         tags: ['Local'],
-        destinationSkillsFolder: '.cursor/skills',
+        destinationSkillsFolder: '${HOME}/.cursor/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/cursor/src/extension.spec.ts
+++ b/extensions/cursor/src/extension.spec.ts
@@ -60,7 +60,7 @@ describe('activate', () => {
           icon: { dark: './APP_ICON_2D_DARK.png', light: './APP_ICON_2D_LIGHT.png' },
         }),
         tags: ['Local'],
-        skillsFolder: expect.any(String),
+        skillsFolder: '.cursor/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/cursor/src/extension.spec.ts
+++ b/extensions/cursor/src/extension.spec.ts
@@ -60,6 +60,7 @@ describe('activate', () => {
           icon: { dark: './APP_ICON_2D_DARK.png', light: './APP_ICON_2D_LIGHT.png' },
         }),
         tags: ['Local'],
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -38,6 +41,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'cursor',
     tags: ['Local'],
     configurationFiles: [],
+    skillsFolder: join(homedir(), '.cursor', 'skills'),
     isSupportedModelType(type): boolean {
       return type.name === 'cursor';
     },

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -38,7 +38,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'cursor',
     tags: ['Local'],
     configurationFiles: [],
-    skillsFolder: '.cursor/skills',
+    destinationSkillsFolder: '.cursor/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'cursor';
     },

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -38,7 +38,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'cursor',
     tags: ['Local'],
     configurationFiles: [],
-    destinationSkillsFolder: '.cursor/skills',
+    destinationSkillsFolder: '${HOME}/.cursor/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'cursor';
     },

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -41,7 +38,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'cursor',
     tags: ['Local'],
     configurationFiles: [],
-    skillsFolder: join(homedir(), '.cursor', 'skills'),
+    skillsFolder: '.cursor/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'cursor';
     },

--- a/extensions/gemini/src/extension.spec.ts
+++ b/extensions/gemini/src/extension.spec.ts
@@ -65,7 +65,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
-        skillsFolder: '.gemini/skills',
+        destinationSkillsFolder: '.gemini/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/gemini/src/extension.spec.ts
+++ b/extensions/gemini/src/extension.spec.ts
@@ -65,6 +65,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/gemini/src/extension.spec.ts
+++ b/extensions/gemini/src/extension.spec.ts
@@ -65,7 +65,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
-        destinationSkillsFolder: '.gemini/skills',
+        destinationSkillsFolder: '${HOME}/.gemini/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/gemini/src/extension.spec.ts
+++ b/extensions/gemini/src/extension.spec.ts
@@ -65,7 +65,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
         tags: ['Cloud'],
-        skillsFolder: expect.any(String),
+        skillsFolder: '.gemini/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/gemini/src/extension.ts
+++ b/extensions/gemini/src/extension.ts
@@ -50,7 +50,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
-    destinationSkillsFolder: '.gemini/skills',
+    destinationSkillsFolder: '${HOME}/.gemini/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'gemini';
     },

--- a/extensions/gemini/src/extension.ts
+++ b/extensions/gemini/src/extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents, provider } from '@openkaiden/api';
 
@@ -53,7 +50,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
-    skillsFolder: join(homedir(), '.gemini', 'skills'),
+    skillsFolder: '.gemini/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'gemini';
     },

--- a/extensions/gemini/src/extension.ts
+++ b/extensions/gemini/src/extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents, provider } from '@openkaiden/api';
 
@@ -50,6 +53,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
+    skillsFolder: join(homedir(), '.gemini', 'skills'),
     isSupportedModelType(type): boolean {
       return type.name === 'gemini';
     },

--- a/extensions/gemini/src/extension.ts
+++ b/extensions/gemini/src/extension.ts
@@ -50,7 +50,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
-    skillsFolder: '.gemini/skills',
+    destinationSkillsFolder: '.gemini/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'gemini';
     },

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'Goose',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
-        skillsFolder: '.agents/skills',
+        destinationSkillsFolder: '.agents/skills',
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'Goose',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
-        destinationSkillsFolder: '.agents/skills',
+        destinationSkillsFolder: '${HOME}/.agents/skills',
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'Goose',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
-        skillsFolder: expect.any(String),
+        skillsFolder: '.agents/skills',
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),

--- a/extensions/goose/src/extension.spec.ts
+++ b/extensions/goose/src/extension.spec.ts
@@ -46,6 +46,7 @@ describe('activate', () => {
         name: 'Goose',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -31,6 +34,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'goose',
     acp: { args: ['acp'] },
     configurationFiles: [],
+    skillsFolder: join(homedir(), '.agents', 'skills'),
     isSupportedRuntime(runtime): boolean {
       return runtime === 'podman';
     },

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'goose',
     acp: { args: ['acp'] },
     configurationFiles: [],
-    destinationSkillsFolder: '.agents/skills',
+    destinationSkillsFolder: '${HOME}/.agents/skills',
     isSupportedRuntime(runtime): boolean {
       return runtime === 'podman';
     },

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -34,7 +31,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'goose',
     acp: { args: ['acp'] },
     configurationFiles: [],
-    skillsFolder: join(homedir(), '.agents', 'skills'),
+    skillsFolder: '.agents/skills',
     isSupportedRuntime(runtime): boolean {
       return runtime === 'podman';
     },

--- a/extensions/goose/src/extension.ts
+++ b/extensions/goose/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'goose',
     acp: { args: ['acp'] },
     configurationFiles: [],
-    skillsFolder: '.agents/skills',
+    destinationSkillsFolder: '.agents/skills',
     isSupportedRuntime(runtime): boolean {
       return runtime === 'podman';
     },

--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'OpenClaw',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
-        destinationSkillsFolder: '.openclaw/skills',
+        destinationSkillsFolder: '${HOME}/.openclaw/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'OpenClaw',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
-        skillsFolder: '.openclaw/skills',
+        destinationSkillsFolder: '.openclaw/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -46,6 +46,7 @@ describe('activate', () => {
         name: 'OpenClaw',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/openclaw/src/extension.spec.ts
+++ b/extensions/openclaw/src/extension.spec.ts
@@ -46,7 +46,7 @@ describe('activate', () => {
         name: 'OpenClaw',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
-        skillsFolder: expect.any(String),
+        skillsFolder: '.openclaw/skills',
         isSupportedModelType: expect.any(Function),
       }),
     );

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'openclaw',
     acp: { args: ['acp'] },
     configurationFiles: [],
-    skillsFolder: '.openclaw/skills',
+    destinationSkillsFolder: '.openclaw/skills',
     isSupportedModelType(type: ModelType): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'openclaw',
     acp: { args: ['acp'] },
     configurationFiles: [],
-    destinationSkillsFolder: '.openclaw/skills',
+    destinationSkillsFolder: '${HOME}/.openclaw/skills',
     isSupportedModelType(type: ModelType): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { ExtensionContext, ModelType } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -31,6 +34,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'openclaw',
     acp: { args: ['acp'] },
     configurationFiles: [],
+    skillsFolder: join(homedir(), '.openclaw', 'skills'),
     isSupportedModelType(type: ModelType): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/openclaw/src/extension.ts
+++ b/extensions/openclaw/src/extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { ExtensionContext, ModelType } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -34,7 +31,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     command: 'openclaw',
     acp: { args: ['acp'] },
     configurationFiles: [],
-    skillsFolder: join(homedir(), '.openclaw', 'skills'),
+    skillsFolder: '.openclaw/skills',
     isSupportedModelType(type: ModelType): boolean {
       return type.name !== 'vertexai';
     },

--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -49,7 +49,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
         tags: ['Recommended'],
-        skillsFolder: '.opencode/skills',
+        destinationSkillsFolder: '.opencode/skills',
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),

--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -49,6 +49,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
         tags: ['Recommended'],
+        skillsFolder: expect.any(String),
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),

--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -49,7 +49,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
         tags: ['Recommended'],
-        destinationSkillsFolder: '.opencode/skills',
+        destinationSkillsFolder: '${HOME}/.opencode/skills',
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),

--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -49,7 +49,7 @@ describe('activate', () => {
         description: expect.any(String),
         icon: expect.objectContaining({ icon: { dark: './icon_dark.png', light: './icon_light.png' } }),
         tags: ['Recommended'],
-        skillsFolder: expect.any(String),
+        skillsFolder: '.opencode/skills',
         isSupportedModelType: expect.any(Function),
         isSupportedRuntime: expect.any(Function),
       }),
@@ -100,6 +100,7 @@ describe('activate', () => {
           endpoint,
         },
         configurationFiles: configFiles,
+        workspace: {},
       };
     }
 

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -52,7 +52,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
-    skillsFolder: '.opencode/skills',
+    destinationSkillsFolder: '.opencode/skills',
     isSupportedRuntime(): boolean {
       return true;
     },

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -55,7 +52,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
-    skillsFolder: join(homedir(), '.opencode', 'skills'),
+    skillsFolder: '.opencode/skills',
     isSupportedRuntime(): boolean {
       return true;
     },

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 
@@ -52,6 +55,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
+    skillsFolder: join(homedir(), '.opencode', 'skills'),
     isSupportedRuntime(): boolean {
       return true;
     },

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -52,7 +52,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         },
       },
     ],
-    destinationSkillsFolder: '.opencode/skills',
+    destinationSkillsFolder: '${HOME}/.opencode/skills',
     isSupportedRuntime(): boolean {
       return true;
     },

--- a/packages/api/src/agent-info.ts
+++ b/packages/api/src/agent-info.ts
@@ -31,7 +31,7 @@ export interface AgentInfo {
   command: string;
   acp?: AcpConfigurationInfo;
   baseImage?: string;
-  skillsFolder: string;
+  destinationSkillsFolder: string;
   supportedModelTypes?: ReadonlyArray<ModelType>;
   supportedRuntimes?: ReadonlyArray<Runtime>;
 }

--- a/packages/api/src/agent-info.ts
+++ b/packages/api/src/agent-info.ts
@@ -31,6 +31,7 @@ export interface AgentInfo {
   command: string;
   acp?: AcpConfigurationInfo;
   baseImage?: string;
+  skillsFolder: string;
   supportedModelTypes?: ReadonlyArray<ModelType>;
   supportedRuntimes?: ReadonlyArray<Runtime>;
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5583,6 +5583,10 @@ declare module '@openkaiden/api' {
     readonly acp?: AcpConfiguration;
     readonly configurationFiles: ReadonlyArray<AgentConfigurationBase>;
     readonly baseImage?: string;
+    /**
+     * If relative path taken as relative to home folder of the sandbox user or
+     * ${HOME}/path1/path2
+     */
     readonly destinationSkillsFolder: string;
     isSupportedModelType?(type: ModelType): boolean | Promise<boolean>;
     isSupportedRuntime?(runtime: Runtime): boolean | Promise<boolean>;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5583,7 +5583,7 @@ declare module '@openkaiden/api' {
     readonly acp?: AcpConfiguration;
     readonly configurationFiles: ReadonlyArray<AgentConfigurationBase>;
     readonly baseImage?: string;
-    readonly skillsFolder: string;
+    readonly destinationSkillsFolder: string;
     isSupportedModelType?(type: ModelType): boolean | Promise<boolean>;
     isSupportedRuntime?(runtime: Runtime): boolean | Promise<boolean>;
     preWorkspaceStart(context: AgentWorkspaceContext): Promise<void>;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5583,6 +5583,7 @@ declare module '@openkaiden/api' {
     readonly acp?: AcpConfiguration;
     readonly configurationFiles: ReadonlyArray<AgentConfigurationBase>;
     readonly baseImage?: string;
+    readonly skillsFolder: string;
     isSupportedModelType?(type: ModelType): boolean | Promise<boolean>;
     isSupportedRuntime?(runtime: Runtime): boolean | Promise<boolean>;
     preWorkspaceStart(context: AgentWorkspaceContext): Promise<void>;

--- a/packages/main/src/plugin/agent-registry.spec.ts
+++ b/packages/main/src/plugin/agent-registry.spec.ts
@@ -52,7 +52,7 @@ function createAgent(overrides?: Partial<Agent>): Agent {
     description: 'A test agent',
     command: 'test-cmd',
     configurationFiles: [],
-    skillsFolder: '/home/test/.test-agent/skills',
+    destinationSkillsFolder: '/home/test/.test-agent/skills',
     async preWorkspaceStart(): Promise<void> {
       throw new Error('not implemented');
     },
@@ -347,7 +347,7 @@ describe('AgentRegistry', () => {
         command: 'test-cmd',
         acp: undefined,
         baseImage: undefined,
-        skillsFolder: '/home/test/.test-agent/skills',
+        destinationSkillsFolder: '/home/test/.test-agent/skills',
         supportedModelTypes: undefined,
         supportedRuntimes: undefined,
       });
@@ -404,11 +404,11 @@ describe('AgentRegistry', () => {
 
     test('passes through skillsFolder', async () => {
       const agent = createAgent({
-        skillsFolder: '/home/user/.claude/skills',
+        destinationSkillsFolder: '/home/user/.claude/skills',
       });
 
       const info = await agentRegistry.toAgentInfo(agent);
-      expect(info.skillsFolder).toBe('/home/user/.claude/skills');
+      expect(info.destinationSkillsFolder).toBe('/home/user/.claude/skills');
     });
 
     test('includes icon and tags', async () => {

--- a/packages/main/src/plugin/agent-registry.spec.ts
+++ b/packages/main/src/plugin/agent-registry.spec.ts
@@ -52,6 +52,7 @@ function createAgent(overrides?: Partial<Agent>): Agent {
     description: 'A test agent',
     command: 'test-cmd',
     configurationFiles: [],
+    skillsFolder: '/home/test/.test-agent/skills',
     async preWorkspaceStart(): Promise<void> {
       throw new Error('not implemented');
     },
@@ -346,6 +347,7 @@ describe('AgentRegistry', () => {
         command: 'test-cmd',
         acp: undefined,
         baseImage: undefined,
+        skillsFolder: '/home/test/.test-agent/skills',
         supportedModelTypes: undefined,
         supportedRuntimes: undefined,
       });
@@ -398,6 +400,15 @@ describe('AgentRegistry', () => {
 
       const info = await agentRegistry.toAgentInfo(agent);
       expect(info.supportedRuntimes).toEqual(['podman']);
+    });
+
+    test('passes through skillsFolder', async () => {
+      const agent = createAgent({
+        skillsFolder: '/home/user/.claude/skills',
+      });
+
+      const info = await agentRegistry.toAgentInfo(agent);
+      expect(info.skillsFolder).toBe('/home/user/.claude/skills');
     });
 
     test('includes icon and tags', async () => {

--- a/packages/main/src/plugin/agent-registry.ts
+++ b/packages/main/src/plugin/agent-registry.ts
@@ -115,7 +115,7 @@ export class AgentRegistry {
       command: agent.command,
       acp: agent.acp,
       baseImage: agent.baseImage,
-      skillsFolder: agent.skillsFolder,
+      destinationSkillsFolder: agent.destinationSkillsFolder,
       supportedModelTypes,
       supportedRuntimes,
     };

--- a/packages/main/src/plugin/agent-registry.ts
+++ b/packages/main/src/plugin/agent-registry.ts
@@ -115,6 +115,7 @@ export class AgentRegistry {
       command: agent.command,
       acp: agent.acp,
       baseImage: agent.baseImage,
+      skillsFolder: agent.skillsFolder,
       supportedModelTypes,
       supportedRuntimes,
     };

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -398,6 +398,7 @@ describe('create – OpenShell mode', () => {
     description: 'Test agent',
     command: 'claude',
     configurationFiles: [],
+    skillsFolder: '.claude/skills',
     async preWorkspaceStart(): Promise<void> {},
   };
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -398,7 +398,7 @@ describe('create – OpenShell mode', () => {
     description: 'Test agent',
     command: 'claude',
     configurationFiles: [],
-    skillsFolder: '.claude/skills',
+    destinationSkillsFolder: '.claude/skills',
     async preWorkspaceStart(): Promise<void> {},
   };
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -398,7 +398,7 @@ describe('create – OpenShell mode', () => {
     description: 'Test agent',
     command: 'claude',
     configurationFiles: [],
-    destinationSkillsFolder: '.claude/skills',
+    destinationSkillsFolder: '${HOME}/.claude/skills',
     async preWorkspaceStart(): Promise<void> {},
   };
 

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -2115,7 +2115,7 @@ test('registerAgent', async () => {
     description: 'An agent for testing',
     command: 'my-agent',
     configurationFiles: [],
-    skillsFolder: '/home/test/.my-agent/skills',
+    destinationSkillsFolder: '/home/test/.my-agent/skills',
     async preWorkspaceStart(): Promise<void> {
       throw new Error('not implemented');
     },

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -2115,6 +2115,7 @@ test('registerAgent', async () => {
     description: 'An agent for testing',
     command: 'my-agent',
     configurationFiles: [],
+    skillsFolder: '/home/test/.my-agent/skills',
     async preWorkspaceStart(): Promise<void> {
       throw new Error('not implemented');
     },

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -96,7 +96,7 @@ beforeEach(() => {
       description: 'Open-source agent.',
       command: 'opencode',
       tags: ['Recommended'],
-      skillsFolder: '/home/test/.opencode/skills',
+      destinationSkillsFolder: '/home/test/.opencode/skills',
       supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
     },
     {
@@ -105,7 +105,7 @@ beforeEach(() => {
       description: 'Anthropic Claude.',
       command: 'claude',
       tags: ['Cloud'],
-      skillsFolder: '/home/test/.claude/skills',
+      destinationSkillsFolder: '/home/test/.claude/skills',
       supportedModelTypes: [{ name: 'anthropic' }],
     },
     {
@@ -113,7 +113,7 @@ beforeEach(() => {
       name: 'Goose',
       description: 'Autonomous coding agent.',
       command: 'goose',
-      skillsFolder: '/home/test/.agents/skills',
+      destinationSkillsFolder: '/home/test/.agents/skills',
       supportedRuntimes: ['podman'],
       supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
     },

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -96,6 +96,7 @@ beforeEach(() => {
       description: 'Open-source agent.',
       command: 'opencode',
       tags: ['Recommended'],
+      skillsFolder: '/home/test/.opencode/skills',
       supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
     },
     {
@@ -104,6 +105,7 @@ beforeEach(() => {
       description: 'Anthropic Claude.',
       command: 'claude',
       tags: ['Cloud'],
+      skillsFolder: '/home/test/.claude/skills',
       supportedModelTypes: [{ name: 'anthropic' }],
     },
     {
@@ -111,6 +113,7 @@ beforeEach(() => {
       name: 'Goose',
       description: 'Autonomous coding agent.',
       command: 'goose',
+      skillsFolder: '/home/test/.agents/skills',
       supportedRuntimes: ['podman'],
       supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
     },

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
@@ -73,7 +73,7 @@ const mockAgentInfos: AgentInfo[] = [
     description: 'Open-source agent.',
     command: 'opencode',
     tags: ['Recommended'],
-    skillsFolder: '/home/test/.opencode/skills',
+    destinationSkillsFolder: '/home/test/.opencode/skills',
     supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
   },
   {
@@ -82,7 +82,7 @@ const mockAgentInfos: AgentInfo[] = [
     description: 'Anthropic Claude.',
     command: 'claude',
     tags: ['Cloud'],
-    skillsFolder: '/home/test/.claude/skills',
+    destinationSkillsFolder: '/home/test/.claude/skills',
     supportedModelTypes: [{ name: 'anthropic' }],
   },
   {
@@ -90,7 +90,7 @@ const mockAgentInfos: AgentInfo[] = [
     name: 'Claude on Vertex AI',
     description: 'Claude via Vertex AI.',
     command: 'claude',
-    skillsFolder: '/home/test/.claude/skills',
+    destinationSkillsFolder: '/home/test/.claude/skills',
     supportedModelTypes: [{ name: 'vertexai' }],
   },
   {
@@ -98,7 +98,7 @@ const mockAgentInfos: AgentInfo[] = [
     name: 'Cursor',
     description: 'AI code editor.',
     command: 'cursor',
-    skillsFolder: '/home/test/.cursor/skills',
+    destinationSkillsFolder: '/home/test/.cursor/skills',
     supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
   },
   {
@@ -106,7 +106,7 @@ const mockAgentInfos: AgentInfo[] = [
     name: 'Goose',
     description: 'Autonomous coding agent.',
     command: 'goose',
-    skillsFolder: '/home/test/.agents/skills',
+    destinationSkillsFolder: '/home/test/.agents/skills',
     supportedRuntimes: ['podman'],
     supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
   },
@@ -407,14 +407,14 @@ test('recommended agent is sorted first regardless of other tags', () => {
       description: 'Cloud tag.',
       command: 'cloud',
       tags: ['Cloud'],
-      skillsFolder: '/home/test/.cloud/skills',
+      destinationSkillsFolder: '/home/test/.cloud/skills',
     },
     {
       id: 'no-tag',
       name: 'No Tag Agent',
       description: 'No tags.',
       command: 'no-tag',
-      skillsFolder: '/home/test/.no-tag/skills',
+      destinationSkillsFolder: '/home/test/.no-tag/skills',
     },
     {
       id: 'recommended',
@@ -422,7 +422,7 @@ test('recommended agent is sorted first regardless of other tags', () => {
       description: 'Recommended.',
       command: 'recommended',
       tags: ['Recommended'],
-      skillsFolder: '/home/test/.recommended/skills',
+      destinationSkillsFolder: '/home/test/.recommended/skills',
     },
   ];
   vi.mocked(agentsStore).agentInfos = writable<AgentInfo[]>(agents);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
@@ -73,6 +73,7 @@ const mockAgentInfos: AgentInfo[] = [
     description: 'Open-source agent.',
     command: 'opencode',
     tags: ['Recommended'],
+    skillsFolder: '/home/test/.opencode/skills',
     supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
   },
   {
@@ -81,6 +82,7 @@ const mockAgentInfos: AgentInfo[] = [
     description: 'Anthropic Claude.',
     command: 'claude',
     tags: ['Cloud'],
+    skillsFolder: '/home/test/.claude/skills',
     supportedModelTypes: [{ name: 'anthropic' }],
   },
   {
@@ -88,6 +90,7 @@ const mockAgentInfos: AgentInfo[] = [
     name: 'Claude on Vertex AI',
     description: 'Claude via Vertex AI.',
     command: 'claude',
+    skillsFolder: '/home/test/.claude/skills',
     supportedModelTypes: [{ name: 'vertexai' }],
   },
   {
@@ -95,6 +98,7 @@ const mockAgentInfos: AgentInfo[] = [
     name: 'Cursor',
     description: 'AI code editor.',
     command: 'cursor',
+    skillsFolder: '/home/test/.cursor/skills',
     supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
   },
   {
@@ -102,6 +106,7 @@ const mockAgentInfos: AgentInfo[] = [
     name: 'Goose',
     description: 'Autonomous coding agent.',
     command: 'goose',
+    skillsFolder: '/home/test/.agents/skills',
     supportedRuntimes: ['podman'],
     supportedModelTypes: [{ name: 'anthropic' }, { name: 'openai' }, { name: 'ollama' }, { name: 'gemini' }],
   },
@@ -396,14 +401,28 @@ test('Claude on Vertex AI shows only Vertex AI models', async () => {
 
 test('recommended agent is sorted first regardless of other tags', () => {
   const agents: AgentInfo[] = [
-    { id: 'cloud', name: 'Cloud Agent', description: 'Cloud tag.', command: 'cloud', tags: ['Cloud'] },
-    { id: 'no-tag', name: 'No Tag Agent', description: 'No tags.', command: 'no-tag' },
+    {
+      id: 'cloud',
+      name: 'Cloud Agent',
+      description: 'Cloud tag.',
+      command: 'cloud',
+      tags: ['Cloud'],
+      skillsFolder: '/home/test/.cloud/skills',
+    },
+    {
+      id: 'no-tag',
+      name: 'No Tag Agent',
+      description: 'No tags.',
+      command: 'no-tag',
+      skillsFolder: '/home/test/.no-tag/skills',
+    },
     {
       id: 'recommended',
       name: 'Recommended Agent',
       description: 'Recommended.',
       command: 'recommended',
       tags: ['Recommended'],
+      skillsFolder: '/home/test/.recommended/skills',
     },
   ];
   vi.mocked(agentsStore).agentInfos = writable<AgentInfo[]>(agents);


### PR DESCRIPTION
## Summary
- Add a required `skillsFolder` property to the `Agent` and `AgentInfo` types so the core can copy skills to the correct agent-specific directory during workspace creation
- Update `AgentRegistry.toAgentInfo()` to pass `skillsFolder` through
- Update all 8 agent extensions (claude, codex, copilot, cursor, gemini, goose, openclaw, opencode) to provide their `skillsFolder` path

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:main` passes (agent-registry + extension-loader tests)
- [x] `pnpm run test:extensions` passes (all 8 agent extension tests)
- [x] Renderer workspace-create tests pass

Fixes #2207

🤖 Generated with [Claude Code](https://claude.com/claude-code)