### PR TITLE
fix(gemini): add missing workspace property to AgentWorkspaceContextmock

### DIFF
--- a/extensions/gemini/src/extension.spec.ts
+++ b/extensions/gemini/src/extension.spec.ts
@@ -103,6 +103,7 @@ describe('activate', () => {
           model: { label: modelLabel },
         },
         configurationFiles: configFiles,
+        workspace: {},
       };
     }
 


### PR DESCRIPTION
The workspace field became required in AgentWorkspaceContext after b72d6ea3c but the gemini extension test was not updated, breaking typecheck on main.