### PR TITLE
refactor(gemini): use zod to validate parsed settings.json

### DIFF
--- a/extensions/gemini/package.json
+++ b/extensions/gemini/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@ai-sdk/google": "^3.0.81",
     "@google/genai": "^1.25.0",
-    "@openkaiden/api": "workspace:*"
+    "@openkaiden/api": "workspace:*",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "mkdirp": "^3.0.1",

--- a/extensions/gemini/src/extension.spec.ts
+++ b/extensions/gemini/src/extension.spec.ts
@@ -155,40 +155,30 @@ describe('activate', () => {
       '123',
       'true',
       '[1, 2]',
-    ])('falls back to empty config when parsed JSON is non-object: %s', async (payload: string) => {
+    ])('rejects non-object JSON: %s', async (payload: string) => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
 
-      const updateMock = vi.fn();
       const configFile: AgentConfigurationFile = {
         path: GEMINI_SETTINGS_PATH,
         read: vi.fn().mockResolvedValue(payload),
-        update: updateMock,
+        update: vi.fn(),
       };
 
-      await agent.preWorkspaceStart(createContext([configFile]));
-
-      expect(updateMock).toHaveBeenCalledOnce();
-      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
-      expect(written.model.name).toBe('gemini-2.5-pro');
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
-    test('handles invalid JSON by starting with empty config', async () => {
+    test('rejects invalid JSON', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
 
-      const updateMock = vi.fn();
       const configFile: AgentConfigurationFile = {
         path: GEMINI_SETTINGS_PATH,
         read: vi.fn().mockResolvedValue('not valid json'),
-        update: updateMock,
+        update: vi.fn(),
       };
 
-      await agent.preWorkspaceStart(createContext([configFile]));
-
-      expect(updateMock).toHaveBeenCalledOnce();
-      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
-      expect(written.model.name).toBe('gemini-2.5-pro');
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
 
     test('does nothing when config file is not in context', async () => {

--- a/extensions/gemini/src/extension.ts
+++ b/extensions/gemini/src/extension.ts
@@ -18,10 +18,13 @@
 
 import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents, provider } from '@openkaiden/api';
+import { z } from 'zod';
 
 import { Gemini } from './gemini';
 
 export const GEMINI_SETTINGS_PATH = '.gemini/settings.json';
+
+const GeminiSettingsSchema = z.record(z.string(), z.unknown()).catch({});
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   console.log('starting gemini extension');
@@ -60,17 +63,14 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       }
 
       const content = await configFile.read();
-      let config: Record<string, unknown>;
+      let parsed: unknown;
       try {
-        const parsed: unknown = JSON.parse(content);
-        config =
-          typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
-            ? (parsed as Record<string, unknown>)
-            : {};
+        parsed = JSON.parse(content);
       } catch {
-        config = {};
+        parsed = {};
       }
 
+      const config = GeminiSettingsSchema.parse(parsed);
       const modelName = context.model.model.label;
       config['model'] = {
         name: modelName,

--- a/extensions/gemini/src/extension.ts
+++ b/extensions/gemini/src/extension.ts
@@ -24,7 +24,9 @@ import { Gemini } from './gemini';
 
 export const GEMINI_SETTINGS_PATH = '.gemini/settings.json';
 
-const GeminiSettingsSchema = z.record(z.string(), z.unknown()).catch({});
+const GeminiSettingsSchema = z.looseObject({
+  model: z.looseObject({ name: z.string() }).optional(),
+});
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   console.log('starting gemini extension');
@@ -62,19 +64,9 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         return;
       }
 
-      const content = await configFile.read();
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(content);
-      } catch {
-        parsed = {};
-      }
-
-      const config = GeminiSettingsSchema.parse(parsed);
+      const config = GeminiSettingsSchema.parse(JSON.parse(await configFile.read()));
       const modelName = context.model.model.label;
-      config['model'] = {
-        name: modelName,
-      };
+      config.model = { name: modelName };
 
       await configFile.update(JSON.stringify(config, undefined, 2));
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,9 @@ importers:
       '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
+      zod:
+        specifier: ^4.3.5
+        version: 4.4.3
     devDependencies:
       mkdirp:
         specifier: ^3.0.1
@@ -9130,8 +9133,8 @@ snapshots:
   '@mistralai/mistralai@2.2.0':
     dependencies:
       ws: 8.19.0
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16325,7 +16328,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-    optional: true
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
Replaces manual typeof/Array.isArray guards with a Zod schema for parsing the configuration file in preWorkspaceStart, aligning with the project's established validation pattern.