### PR TITLE
fix: split workspace label to respect 63-char limit

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -38,7 +38,43 @@ export const SandboxInfoSchema = z.object({
   resource_version: z.number().optional(),
 });
 
-export type SandboxInfo = z.output<typeof SandboxInfoSchema>;
+export type SandboxInfo = z.output<typeof SandboxInfoSchema> & {
+  sourcePath?: string;
+};
+
+export const WORKSPACE_LABEL = 'ai.openkaiden.kaiden.workspace';
+
+export function decodeWorkspaceLabels(labels: Record<string, string>): string | undefined {
+  let encoded: string;
+  if (WORKSPACE_LABEL in labels) {
+    encoded = labels[WORKSPACE_LABEL]!;
+  } else {
+    const chunks = Object.entries(labels)
+      .flatMap(([key, value]) => {
+        if (!key.startsWith(`${WORKSPACE_LABEL}.`)) {
+          return [];
+        }
+        const suffix = key.slice(WORKSPACE_LABEL.length + 1);
+        if (!/^\d+$/.test(suffix)) {
+          return [];
+        }
+        return [{ index: Number(suffix), value }];
+      })
+      .sort((a, b) => a.index - b.index);
+    if (chunks.length === 0 || chunks.some((chunk, i) => chunk.index !== i)) {
+      return undefined;
+    }
+    encoded = chunks.map(chunk => chunk.value).join('');
+  }
+  try {
+    const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    const binary = atob(base64);
+    const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
 
 export interface CreateSandboxOptions {
   name?: string;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -41,9 +41,10 @@ import type { Exec } from '/@/plugin/util/exec.js';
 import type { AgentWorkspaceCreateOptions, AgentWorkspaceSummary } from '/@api/agent-workspace-info.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationRegistry } from '/@api/configuration/models.js';
+import { decodeWorkspaceLabels } from '/@api/openshell-gateway-info.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
-import { AgentWorkspaceManager } from './agent-workspace-manager.js';
+import { AgentWorkspaceManager, encodeWorkspaceLabels } from './agent-workspace-manager.js';
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('yaml'));
@@ -421,7 +422,7 @@ describe('create – OpenShell mode', () => {
     expect(openshellCli.createSandbox).toHaveBeenCalledWith({
       name: 'my-sandbox',
       providers: ['my-secret'],
-      labels: { 'ai.openkaiden.kaiden.workspace': Buffer.from('/tmp/my-project').toString('base64url') },
+      labels: encodeWorkspaceLabels('/tmp/my-project'),
       noTty: true,
       command: ['true'],
     });
@@ -1635,5 +1636,53 @@ describe('dispose', () => {
     onExitCallback!();
 
     expect(webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('encodeWorkspaceLabels', () => {
+  test('returns single label for short paths', () => {
+    const labels = encodeWorkspaceLabels('/tmp/my-project');
+    expect(Object.keys(labels)).toEqual(['ai.openkaiden.kaiden.workspace']);
+    expect(labels['ai.openkaiden.kaiden.workspace']!.length).toBeLessThanOrEqual(63);
+  });
+
+  test('splits into indexed labels for long paths', () => {
+    const longPath = '/Users/fbricon/Dev/souk/ideas/stock-trading-ai/backend';
+    const labels = encodeWorkspaceLabels(longPath);
+    expect(labels['ai.openkaiden.kaiden.workspace']).toBeUndefined();
+    expect(labels['ai.openkaiden.kaiden.workspace.0']).toBeDefined();
+    expect(labels['ai.openkaiden.kaiden.workspace.1']).toBeDefined();
+    for (const value of Object.values(labels)) {
+      expect(value.length).toBeLessThanOrEqual(63);
+    }
+  });
+});
+
+describe('decodeWorkspaceLabels', () => {
+  test('round-trips a short path', () => {
+    const path = '/tmp/my-project';
+    expect(decodeWorkspaceLabels(encodeWorkspaceLabels(path))).toBe(path);
+  });
+
+  test('round-trips a long path', () => {
+    const path = '/Users/fbricon/Dev/souk/ideas/stock-trading-ai/backend';
+    expect(decodeWorkspaceLabels(encodeWorkspaceLabels(path))).toBe(path);
+  });
+
+  test('returns undefined when no matching labels exist', () => {
+    expect(decodeWorkspaceLabels({ unrelated: 'value' })).toBeUndefined();
+  });
+
+  test('returns undefined for non-numeric chunk suffixes', () => {
+    expect(decodeWorkspaceLabels({ 'ai.openkaiden.kaiden.workspace.foo': 'abc' })).toBeUndefined();
+  });
+
+  test('returns undefined for non-contiguous chunk indices', () => {
+    expect(
+      decodeWorkspaceLabels({
+        'ai.openkaiden.kaiden.workspace.0': 'abc',
+        'ai.openkaiden.kaiden.workspace.2': 'def',
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -49,10 +49,24 @@ import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationNode } from '/@api/configuration/models.js';
 import { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
+import { decodeWorkspaceLabels, WORKSPACE_LABEL } from '/@api/openshell-gateway-info.js';
 import type { InferenceConnectionCredentials } from '/@api/provider-info.js';
 import type { SecretCreateOptions, SecretValue } from '/@api/secret-info.js';
 
 const HOME_VARIABLE = '${HOME}';
+const LABEL_MAX_LENGTH = 63;
+
+export function encodeWorkspaceLabels(sourcePath: string): Record<string, string> {
+  const encoded = Buffer.from(sourcePath).toString('base64url');
+  if (encoded.length <= LABEL_MAX_LENGTH) {
+    return { [WORKSPACE_LABEL]: encoded };
+  }
+  const labels: Record<string, string> = {};
+  for (let i = 0, chunk = 0; i < encoded.length; i += LABEL_MAX_LENGTH, chunk++) {
+    labels[`${WORKSPACE_LABEL}.${chunk}`] = encoded.slice(i, i + LABEL_MAX_LENGTH);
+  }
+  return labels;
+}
 
 /**
  * Manages agent workspaces by delegating to the `kdn` CLI.
@@ -172,7 +186,7 @@ export class AgentWorkspaceManager implements Disposable {
     await this.openshellCli.createSandbox({
       name: sandboxName,
       providers: options.secrets,
-      labels: { 'ai.openkaiden.kaiden.workspace': Buffer.from(options.sourcePath).toString('base64url') },
+      labels: encodeWorkspaceLabels(options.sourcePath),
       uploads: uploads.length > 0 ? uploads : undefined,
       noTty: true,
       command: ['true'],
@@ -503,7 +517,15 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   async listOpenshellSandboxes(): Promise<GatewaySandboxes[]> {
-    return this.openshellCli.listSandboxesPerGateway();
+    const results = await this.openshellCli.listSandboxesPerGateway();
+    for (const entry of results) {
+      for (const sandbox of entry.sandboxes) {
+        if (sandbox.labels) {
+          sandbox.sourcePath = decodeWorkspaceLabels(sandbox.labels);
+        }
+      }
+    }
+    return results;
   }
 
   async deleteOpenshellSandbox(name: string): Promise<void> {

--- a/packages/renderer/src/lib/agent-workspaces/columns/SandboxName.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/columns/SandboxName.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
+
 import type { SandboxInfo } from '/@api/openshell-gateway-info';
 
 interface Props {
@@ -9,6 +11,8 @@ let { object }: Props = $props();
 </script>
 
 <div class="flex flex-col">
-  <div class="text-sm text-[var(--pd-table-body-text)]">{object.name}</div>
+  <Tooltip top tip={object.sourcePath ?? object.name}>
+    <div class="text-sm text-[var(--pd-table-body-text)]">{object.name}</div>
+  </Tooltip>
   <div class="text-xs text-[var(--pd-table-body-text-sub)]">ID: {object.id}</div>
 </div>


### PR DESCRIPTION
The workspace label stores a base64url-encoded source path so it can
be decoded and displayed in the UI. Long paths can exceed the 63-char
label value limit, causing sandbox creation to fail.

Add encodeWorkspaceLabels/decodeWorkspaceLabels functions that use a
single label when the value fits, and split into indexed labels
(workspace.0, workspace.1, ...) when it exceeds the limit.

The decoded workspace path is shown as a tooltip on the sandbox name
in the workspace list.
Closes #2218

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Fred Bricon <fbricon@gmail.com>
