### PR TITLE
feat(openshell): upload selected skills during workspace creation

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -523,6 +523,42 @@ describe('create – OpenShell mode', () => {
     );
   });
 
+  test('uploads selected skills into the agent destination skills folder', async () => {
+    const options = {
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/github', '/home/user/.kaiden/skills/kubernetes'],
+    };
+
+    await manager.create(options);
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: [
+          { local: '/home/user/.kaiden/skills/github', remote: '/sandbox/.claude/skills/github' },
+          { local: '/home/user/.kaiden/skills/kubernetes', remote: '/sandbox/.claude/skills/kubernetes' },
+        ],
+      }),
+    );
+  });
+
+  test('resolves relative destination skills folders under the sandbox home', async () => {
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({
+      ...mockAgent,
+      destinationSkillsFolder: '.agents/skills',
+    });
+
+    await manager.create({
+      ...defaultOptions,
+      skills: ['/home/user/.kaiden/skills/github'],
+    });
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: [{ local: '/home/user/.kaiden/skills/github', remote: '/sandbox/.agents/skills/github' }],
+      }),
+    );
+  });
+
   test('throws when agent is not found in registry', async () => {
     vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue(undefined);
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -534,8 +534,8 @@ describe('create – OpenShell mode', () => {
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
         uploads: [
-          { local: '/home/user/.kaiden/skills/github', remote: '/sandbox/.claude/skills/github' },
-          { local: '/home/user/.kaiden/skills/kubernetes', remote: '/sandbox/.claude/skills/kubernetes' },
+          { local: '/home/user/.kaiden/skills/github', remote: '.claude/skills/github' },
+          { local: '/home/user/.kaiden/skills/kubernetes', remote: '.claude/skills/kubernetes' },
         ],
       }),
     );
@@ -554,7 +554,7 @@ describe('create – OpenShell mode', () => {
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        uploads: [{ local: '/home/user/.kaiden/skills/github', remote: '/sandbox/.agents/skills/github' }],
+        uploads: [{ local: '/home/user/.kaiden/skills/github', remote: '.agents/skills/github' }],
       }),
     );
   });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -52,8 +52,6 @@ import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
 import type { InferenceConnectionCredentials } from '/@api/provider-info.js';
 import type { SecretCreateOptions, SecretValue } from '/@api/secret-info.js';
 
-const OPENSHELL_SANDBOX_HOME = '/sandbox';
-
 /**
  * Manages agent workspaces by delegating to the `kdn` CLI.
  */
@@ -207,22 +205,18 @@ export class AgentWorkspaceManager implements Disposable {
 
   private resolveOpenshellSkillsDestination(destinationSkillsFolder: string): string {
     if (destinationSkillsFolder === '${HOME}') {
-      return OPENSHELL_SANDBOX_HOME;
+      return '.';
     }
 
     if (destinationSkillsFolder.startsWith('${HOME}/')) {
-      return posix.join(OPENSHELL_SANDBOX_HOME, destinationSkillsFolder.slice('${HOME}/'.length));
+      return destinationSkillsFolder.slice('${HOME}/'.length);
     }
 
     if (destinationSkillsFolder.startsWith('~/')) {
-      return posix.join(OPENSHELL_SANDBOX_HOME, destinationSkillsFolder.slice(2));
+      return destinationSkillsFolder.slice(2);
     }
 
-    if (destinationSkillsFolder.startsWith('/')) {
-      return destinationSkillsFolder;
-    }
-
-    return posix.join(OPENSHELL_SANDBOX_HOME, destinationSkillsFolder);
+    return destinationSkillsFolder;
   }
 
   /**

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -18,7 +18,7 @@
 
 import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, join, posix } from 'node:path';
 
 import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
@@ -51,6 +51,8 @@ import { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
 import type { InferenceConnectionCredentials } from '/@api/provider-info.js';
 import type { SecretCreateOptions, SecretValue } from '/@api/secret-info.js';
+
+const OPENSHELL_SANDBOX_HOME = '/sandbox';
 
 /**
  * Manages agent workspaces by delegating to the `kdn` CLI.
@@ -158,6 +160,9 @@ export class AgentWorkspaceManager implements Disposable {
         await writeFile(file.localPath, await file.read(), 'utf-8');
         uploads.push({ local: file.localPath, remote: file.path });
       }
+
+      const skillUploads = this.buildOpenshellSkillUploads(options.skills, agent.destinationSkillsFolder);
+      uploads.push(...skillUploads);
     } else {
       throw new Error(`Unable to create workspace: agent ${options.agent} not registered`);
     }
@@ -183,6 +188,41 @@ export class AgentWorkspaceManager implements Disposable {
     } catch {
       return false;
     }
+  }
+
+  private buildOpenshellSkillUploads(
+    skills: string[] | undefined,
+    destinationSkillsFolder: string,
+  ): Array<{ local: string; remote: string }> {
+    if (!skills?.length) {
+      return [];
+    }
+
+    const remoteBase = this.resolveOpenshellSkillsDestination(destinationSkillsFolder);
+    return skills.map(skillPath => ({
+      local: skillPath,
+      remote: posix.join(remoteBase, basename(skillPath)),
+    }));
+  }
+
+  private resolveOpenshellSkillsDestination(destinationSkillsFolder: string): string {
+    if (destinationSkillsFolder === '${HOME}') {
+      return OPENSHELL_SANDBOX_HOME;
+    }
+
+    if (destinationSkillsFolder.startsWith('${HOME}/')) {
+      return posix.join(OPENSHELL_SANDBOX_HOME, destinationSkillsFolder.slice('${HOME}/'.length));
+    }
+
+    if (destinationSkillsFolder.startsWith('~/')) {
+      return posix.join(OPENSHELL_SANDBOX_HOME, destinationSkillsFolder.slice(2));
+    }
+
+    if (destinationSkillsFolder.startsWith('/')) {
+      return destinationSkillsFolder;
+    }
+
+    return posix.join(OPENSHELL_SANDBOX_HOME, destinationSkillsFolder);
   }
 
   /**

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -52,6 +52,8 @@ import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
 import type { InferenceConnectionCredentials } from '/@api/provider-info.js';
 import type { SecretCreateOptions, SecretValue } from '/@api/secret-info.js';
 
+const HOME_VARIABLE = '${HOME}';
+
 /**
  * Manages agent workspaces by delegating to the `kdn` CLI.
  */
@@ -204,16 +206,18 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   private resolveOpenshellSkillsDestination(destinationSkillsFolder: string): string {
-    if (destinationSkillsFolder === '${HOME}') {
+    if (destinationSkillsFolder === HOME_VARIABLE) {
       return '.';
     }
 
-    if (destinationSkillsFolder.startsWith('${HOME}/')) {
-      return destinationSkillsFolder.slice('${HOME}/'.length);
+    for (const str of [`${HOME_VARIABLE}/`, '~/']) {
+      if (destinationSkillsFolder.startsWith(str)) {
+        return destinationSkillsFolder.slice(str.length);
+      }
     }
 
-    if (destinationSkillsFolder.startsWith('~/')) {
-      return destinationSkillsFolder.slice(2);
+    if (destinationSkillsFolder.includes('..')) {
+      throw new Error(`Invalid destination skills folder: ${destinationSkillsFolder}`);
     }
 
     return destinationSkillsFolder;


### PR DESCRIPTION
## Summary
- upload selected workspace skills into each agent's destination skills folder when creating native OpenShell sandboxes
- resolve `${HOME}`, `~/`, relative, and absolute destination skills paths into the sandbox paths used by OpenShell
- add OpenShell workspace tests covering skill upload mapping for both `${HOME}`-based and relative destination folders

Fixes #2208

## Test plan
- [x] `pnpm exec vitest run packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts`


Made with [Cursor](https://cursor.com)