### PR TITLE
feat(openshell): enable bind mounts for local gateways

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -125,6 +125,19 @@ export interface OpenshellGatewayStartOptions {
   supervisorImage?: string;
 }
 
+export const GatewayRuntimeInfoSchema = z.looseObject({
+  compute_drivers: z.array(
+    z.looseObject({
+      capabilities: z.looseObject({
+        driver_name: z.string(),
+      }),
+      name: z.string(),
+    }),
+  ),
+});
+
+export type GatewayRuntimeInfo = z.output<typeof GatewayRuntimeInfoSchema>;
+
 export interface GatewaySandboxes {
   gateway: GatewayInfo;
   sandboxes: SandboxInfo[];

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -688,6 +688,26 @@ describe('listGateways', () => {
   });
 });
 
+describe('getGatewayInfo', () => {
+  test('executes gateway info with json output and returns parsed result', async () => {
+    const payload = {
+      compute_drivers: [
+        {
+          capabilities: { driver_name: 'podman', driver_version: '0.0.92' },
+          name: 'podman',
+        },
+      ],
+      status: 'healthy',
+    };
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(payload)));
+
+    const result = await openshellCli.getGatewayInfo();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'info', '-o', 'json'], undefined);
+    expect(result).toEqual(payload);
+  });
+});
+
 describe('listSandboxesForGateway', () => {
   test('lists sandboxes for a specific gateway using -g flag', async () => {
     const gateways = [

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -33,6 +33,8 @@ import {
   type GatewayAddOptions,
   type GatewayInfo,
   GatewayInfoSchema,
+  type GatewayRuntimeInfo,
+  GatewayRuntimeInfoSchema,
   type GatewaySandboxes,
   type OpenshellProfile,
   OpenshellProfileSchema,
@@ -351,6 +353,11 @@ export class OpenshellCli {
   async listGateways(): Promise<GatewayInfo[]> {
     const data = await this.execCLI<unknown>(['gateway', 'list']);
     return z.array(GatewayInfoSchema).parse(data);
+  }
+
+  async getGatewayInfo(): Promise<GatewayRuntimeInfo> {
+    const data = await this.execCLI<unknown>(['gateway', 'info']);
+    return GatewayRuntimeInfoSchema.parse(data);
   }
 
   async checkEndpointStatus(endpoint: string): Promise<boolean> {

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -968,4 +968,29 @@ describe('gateway config generation', () => {
       expect.objectContaining({ detached: false }),
     );
   });
+
+  test('enables bind mounts when a local compute driver is detected', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
+
+    await gateway.start();
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]?.[1] as string;
+    expect(writtenContent).toContain('enable_bind_mounts = true');
+  });
+
+  test('generates config without bind mounts when no driver is available', async () => {
+    vi.mocked(exec.exec).mockImplementation(async (command: string, args?: string[]) => {
+      if (command === 'podman') throw new Error('podman not found');
+      if (command === 'docker') throw new Error('docker not found');
+      if (args?.[0] === '--version') return mockExecResult('openshell-gateway 0.0.69');
+      return mockExecResult('');
+    });
+
+    await gateway.start();
+
+    const writtenContent = vi.mocked(writeFile).mock.calls[0]?.[1] as string;
+    expect(writtenContent).toContain('[openshell.drivers.podman]');
+    expect(writtenContent).not.toContain('enable_bind_mounts');
+    expect(writtenContent).not.toContain('compute_drivers');
+  });
 });

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -83,6 +83,7 @@ const openshellCli = {
   checkEndpointStatus: vi.fn(),
   addGateway: vi.fn(),
   removeGateway: vi.fn(),
+  getGatewayInfo: vi.fn(),
 } as unknown as OpenshellCli;
 
 const directories = {
@@ -971,6 +972,9 @@ describe('gateway config generation', () => {
 
   test('enables bind mounts when a local compute driver is detected', async () => {
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
+    vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({
+      compute_drivers: [{ capabilities: { driver_name: 'podman' }, name: 'podman' }],
+    });
 
     await gateway.start();
 
@@ -979,12 +983,8 @@ describe('gateway config generation', () => {
   });
 
   test('generates config without bind mounts when no driver is available', async () => {
-    vi.mocked(exec.exec).mockImplementation(async (command: string, args?: string[]) => {
-      if (command === 'podman') throw new Error('podman not found');
-      if (command === 'docker') throw new Error('docker not found');
-      if (args?.[0] === '--version') return mockExecResult('openshell-gateway 0.0.69');
-      return mockExecResult('');
-    });
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
+    vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({ compute_drivers: [] });
 
     await gateway.start();
 

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.toml.template
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.toml.template
@@ -1,10 +1,22 @@
 [openshell]
 version = 1
 
+{{#driver}}
+[openshell.gateway]
+compute_drivers = ["{{{driver}}}"]
+
+[openshell.drivers.{{{driver}}}]
+enable_bind_mounts = true
+{{#supervisorImage}}
+supervisor_image = "{{{supervisorImage}}}"
+{{/supervisorImage}}
+{{/driver}}
+{{^driver}}
 [openshell.drivers.podman]
 {{#supervisorImage}}
 supervisor_image = "{{{supervisorImage}}}"
 {{/supervisorImage}}
+{{/driver}}
 
 [openshell.gateway.auth]
 allow_unauthenticated_users = true

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -46,6 +46,8 @@ const STOP_TIMEOUT_MS = 5000;
 const SUPERVISOR_IMAGE_BASE = 'ghcr.io/nvidia/openshell/supervisor';
 const GATEWAY_LOG_FILENAME = 'gateway.log';
 
+type LocalComputeDriver = 'docker' | 'podman';
+
 /**
  * Manages the `openshell-gateway` server binary lifecycle.
  *
@@ -320,6 +322,8 @@ export class OpenshellGateway implements Disposable {
         }
       }
 
+      const driver = await this.detectLocalComputeDriver();
+
       const storageDirectory = join(this.directories.getDataDirectory(), 'openshell-gateway');
       const configPath = join(storageDirectory, 'gateway.toml');
       await this.generateCerts(binaryPath, storageDirectory);
@@ -327,6 +331,7 @@ export class OpenshellGateway implements Disposable {
         supervisorImage: image,
         gatewayDir: storageDirectory,
         q: '"',
+        driver,
       });
 
       await mkdir(storageDirectory, { recursive: true });
@@ -340,6 +345,25 @@ export class OpenshellGateway implements Disposable {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[openshell-gateway] failed to generate gateway config: ${message}`);
       return undefined;
+    }
+  }
+
+  private async detectLocalComputeDriver(): Promise<LocalComputeDriver | undefined> {
+    if (await this.isCommandAvailable('podman')) {
+      return 'podman';
+    }
+    if (await this.isCommandAvailable('docker')) {
+      return 'docker';
+    }
+    return undefined;
+  }
+
+  private async isCommandAvailable(command: string): Promise<boolean> {
+    try {
+      await this.exec.exec(command, ['--version']);
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -349,21 +349,12 @@ export class OpenshellGateway implements Disposable {
   }
 
   private async detectLocalComputeDriver(): Promise<LocalComputeDriver | undefined> {
-    if (await this.isCommandAvailable('podman')) {
-      return 'podman';
-    }
-    if (await this.isCommandAvailable('docker')) {
-      return 'docker';
-    }
-    return undefined;
-  }
-
-  private async isCommandAvailable(command: string): Promise<boolean> {
     try {
-      await this.exec.exec(command, ['--version']);
-      return true;
+      const info = await this.openshellCli.getGatewayInfo();
+      const driver = info.compute_drivers[0]?.capabilities.driver_name;
+      return driver === 'podman' || driver === 'docker' ? driver : undefined;
     } catch {
-      return false;
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## Summary
- detect the local OpenShell compute driver before auto-starting a gateway and pin it in a generated gateway config
- enable bind mounts in the generated Podman or Docker driver config so local gateways are ready for follow-up mount-based sandbox work
- add gateway tests covering driver selection, fallback behavior, generated config contents, and config cleanup

Fixes:  https://github.com/openkaiden/kaiden/issues/2254

Test plan

first stop any existing gateway using openshell
`openshell gateway remove (name default is openshell)`
cleanup the port
`kill $(lsof -t -i :17670)`

start kaiden via pnpm watch

kaiden should have written to local/share/kaiden/openshell-gateway/gateway.toml

which should show how enable_bind_mounts = true and compute_drivers = ["podman"] (or docker). This proves the template renders correctly with driver detection

Now theres a few things I ran into (maybe linux specific) that Kaiden couldnt get the gateway fully operational so heres a way to manually test the config works

Prerequisites: openshell 0.0.76+, podman installed, mTLS certs already provisioned (~/.local/state/openshell/tls/)

  1. Clean up any existing gateway
```
  openshell gateway remove kaiden-local
  kill $(lsof -t -i :17670)
  rm -f ~/.local/share/kaiden/openshell-gateway/gateway.toml
```

  2. Write the config (or let Kaiden generate it)
```
  mkdir -p ~/.local/share/kaiden/openshell-gateway
  cat > ~/.local/share/kaiden/openshell-gateway/gateway.toml << 'EOF'
  [openshell]
  version = 1
  
  [openshell.gateway]
  compute_drivers = ["podman"]

  [openshell.drivers.podman]
  enable_bind_mounts = true
  supervisor_image = "ghcr.io/nvidia/openshell/supervisor:0.0.76"
  EOF

```

  3. Start the gateway with the config
```
  openshell-gateway \
    --config ~/.local/share/kaiden/openshell-gateway/gateway.toml \
    --port 17670 \
    --bind-address 0.0.0.0 &

```
  ▎ Note (Linux only): --bind-address 0.0.0.0 is required because sandbox containers reach the host via host.containers.internal (169.254.1.2), not 
  ▎ 127.0.0.1. On macOS this isn't needed since podman runs in a VM with port forwarding.


  4. Register the gateway
`  openshell gateway add https://127.0.0.1:17670 --name kaiden-local --local`

  5. Create a sandbox with a bind mount
```
  mkdir -p /tmp/bind-test
  echo "hello from host" > /tmp/bind-test/test.txt
  openshell sandbox create --name e2e-bind \
    --driver-config-json '{"podman":{"mounts":[{"type":"bind","source":"/tmp/bind-test","target":"/tmp/bind-test","read_only":false}]}}'
```

  6. Verify the file is mounted inside the sandbox
`  openshell sandbox exec -n e2e-bind -- cat /tmp/bind-test/test.txt`
  # Expected output: hello from host

  Update the file on the host and verify that the change is immediately visible in the sandbox:
```
  echo "updated from host" > /tmp/bind-test/test.txt
  openshell sandbox exec -n e2e-bind -- cat /tmp/bind-test/test.txt
```
  # Expected output: updated from host

  7. Cleanup
`  openshell sandbox delete e2e-bind`
