### PR TITLE
feat: configure MCP servers in OpenCode agent preWorkspaceStart

### DIFF
--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -90,9 +90,17 @@ describe('activate', () => {
   describe('preWorkspaceStart', () => {
     function createContext(
       configFiles: AgentConfigurationFile[],
-      options: { modelLabel?: string; provider?: string; endpoint?: string } = {},
+      options: {
+        modelLabel?: string;
+        provider?: string;
+        endpoint?: string;
+        mcp?: {
+          servers?: { name: string; url: string; headers?: Record<string, string> }[];
+          commands?: { name: string; command: string; args?: string[]; env?: Record<string, string> }[];
+        };
+      } = {},
     ): AgentWorkspaceContext {
-      const { modelLabel = 'gpt-4o', provider, endpoint } = options;
+      const { modelLabel = 'gpt-4o', provider, endpoint, mcp } = options;
       return {
         model: {
           model: { label: modelLabel },
@@ -100,7 +108,7 @@ describe('activate', () => {
           endpoint,
         },
         configurationFiles: configFiles,
-        workspace: {},
+        workspace: { ...(mcp ? { mcp } : {}) },
       };
     }
 
@@ -299,6 +307,212 @@ describe('activate', () => {
       await agent.preWorkspaceStart(createContext([otherFile]));
 
       expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    test('writes remote MCP servers from workspace config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'my-remote', url: 'https://mcp.example.com' }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toEqual({
+        'my-remote': { type: 'remote', url: 'https://mcp.example.com', enabled: true },
+      });
+    });
+
+    test('writes remote MCP servers with headers as environment', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [
+              {
+                name: 'authed-server',
+                url: 'https://mcp.example.com',
+                headers: { Authorization: 'Bearer token123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toEqual({
+        'authed-server': {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+          enabled: true,
+          environment: { Authorization: 'Bearer token123' },
+        },
+      });
+    });
+
+    test('writes local MCP commands from workspace config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'my-local', command: 'npx', args: ['-y', 'my-mcp-server'] }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toEqual({
+        'my-local': { type: 'local', command: ['npx', '-y', 'my-mcp-server'], enabled: true },
+      });
+    });
+
+    test('writes local MCP commands with env variables as environment', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [
+              {
+                name: 'github-mcp',
+                command: 'npx',
+                args: ['@modelcontextprotocol/server-github'],
+                env: { GITHUB_TOKEN: 'ghp_test123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toEqual({
+        'github-mcp': {
+          type: 'local',
+          command: ['npx', '@modelcontextprotocol/server-github'],
+          enabled: true,
+          environment: { GITHUB_TOKEN: 'ghp_test123' },
+        },
+      });
+    });
+
+    test('writes both remote and local MCP servers together', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'remote-one', url: 'https://mcp.example.com' }],
+            commands: [{ name: 'local-one', command: 'npx', args: ['my-server'] }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toEqual({
+        'remote-one': { type: 'remote', url: 'https://mcp.example.com', enabled: true },
+        'local-one': { type: 'local', command: ['npx', 'my-server'], enabled: true },
+      });
+    });
+
+    test('merges MCP servers with existing MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const existingConfig = JSON.stringify({
+        mcp: { 'existing-server': { type: 'remote', url: 'https://existing.example.com', enabled: true } },
+      });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'new-server', url: 'https://new.example.com' }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toEqual({
+        'existing-server': { type: 'remote', url: 'https://existing.example.com', enabled: true },
+        'new-server': { type: 'remote', url: 'https://new.example.com', enabled: true },
+      });
+    });
+
+    test('does not write mcp key when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toBeUndefined();
+    });
+
+    test('preserves existing MCP entries when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const existingConfig = JSON.stringify({
+        mcp: { 'existing-server': { type: 'remote', url: 'https://existing.example.com', enabled: true } },
+      });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp).toEqual({
+        'existing-server': { type: 'remote', url: 'https://existing.example.com', enabled: true },
+      });
+    });
+
+    test('omits environment when remote MCP server has empty headers', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'no-headers', url: 'https://mcp.example.com', headers: {} }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp['no-headers']).toEqual({ type: 'remote', url: 'https://mcp.example.com', enabled: true });
+      expect(written.mcp['no-headers']).not.toHaveProperty('environment');
+    });
+
+    test('omits environment when local MCP command has empty env', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'minimal', command: 'my-server', args: [], env: {} }],
+          },
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.mcp['minimal']).toEqual({ type: 'local', command: ['my-server'], enabled: true });
+      expect(written.mcp['minimal']).not.toHaveProperty('environment');
     });
   });
 });

--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -328,7 +328,7 @@ describe('activate', () => {
       });
     });
 
-    test('writes remote MCP servers with headers as environment', async () => {
+    test('writes remote MCP servers with headers', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
 
@@ -353,7 +353,7 @@ describe('activate', () => {
           type: 'remote',
           url: 'https://mcp.example.com',
           enabled: true,
-          environment: { Authorization: 'Bearer token123' },
+          headers: { Authorization: 'Bearer token123' },
         },
       });
     });
@@ -479,7 +479,7 @@ describe('activate', () => {
       });
     });
 
-    test('omits environment when remote MCP server has empty headers', async () => {
+    test('omits headers when remote MCP server has empty headers', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
 
@@ -494,7 +494,7 @@ describe('activate', () => {
 
       const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
       expect(written.mcp['no-headers']).toEqual({ type: 'remote', url: 'https://mcp.example.com', enabled: true });
-      expect(written.mcp['no-headers']).not.toHaveProperty('environment');
+      expect(written.mcp['no-headers']).not.toHaveProperty('headers');
     });
 
     test('omits environment when local MCP command has empty env', async () => {

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -34,9 +34,20 @@ const ProviderEntrySchema = z.looseObject({
   models: z.record(z.string(), ModelEntrySchema).default({}),
 });
 
+const McpEntrySchema = z.looseObject({
+  type: z.enum(['remote', 'local']),
+  url: z.string().optional(),
+  command: z.array(z.string()).optional(),
+  enabled: z.boolean(),
+  environment: z.record(z.string(), z.string()).optional(),
+});
+
+type McpEntry = z.infer<typeof McpEntrySchema>;
+
 const OpenCodeConfigSchema = z.looseObject({
   model: z.string().optional(),
   provider: z.record(z.string(), ProviderEntrySchema).optional(),
+  mcp: z.record(z.string(), McpEntrySchema).optional(),
 });
 
 const NATIVE_PROVIDERS = new Set(['anthropic', 'mistral', 'google']);
@@ -104,6 +115,33 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
         }
       } else {
         config.model = modelName;
+      }
+
+      const mcpServers = context.workspace.mcp?.servers;
+      const mcpCommands = context.workspace.mcp?.commands;
+
+      if (mcpServers?.length || mcpCommands?.length) {
+        const mcp: Record<string, McpEntry> = { ...config.mcp };
+
+        for (const server of mcpServers ?? []) {
+          mcp[server.name] = {
+            type: 'remote',
+            url: server.url,
+            enabled: true,
+            ...(server.headers && Object.keys(server.headers).length > 0 ? { environment: server.headers } : {}),
+          };
+        }
+
+        for (const cmd of mcpCommands ?? []) {
+          mcp[cmd.name] = {
+            type: 'local',
+            command: [cmd.command, ...(cmd.args ?? [])],
+            enabled: true,
+            ...(cmd.env && Object.keys(cmd.env).length > 0 ? { environment: cmd.env } : {}),
+          };
+        }
+
+        config.mcp = mcp;
       }
 
       await configFile.update(JSON.stringify(config, undefined, 2));

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -40,6 +40,7 @@ const McpEntrySchema = z.looseObject({
   command: z.array(z.string()).optional(),
   enabled: z.boolean(),
   environment: z.record(z.string(), z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 type McpEntry = z.infer<typeof McpEntrySchema>;
@@ -128,7 +129,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
             type: 'remote',
             url: server.url,
             enabled: true,
-            ...(server.headers && Object.keys(server.headers).length > 0 ? { environment: server.headers } : {}),
+            ...(server.headers && Object.keys(server.headers).length > 0 ? { headers: server.headers } : {}),
           };
         }
 

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -34,14 +34,20 @@ const ProviderEntrySchema = z.looseObject({
   models: z.record(z.string(), ModelEntrySchema).default({}),
 });
 
-const McpEntrySchema = z.looseObject({
-  type: z.enum(['remote', 'local']),
-  url: z.string().optional(),
-  command: z.array(z.string()).optional(),
-  enabled: z.boolean(),
-  environment: z.record(z.string(), z.string()).optional(),
-  headers: z.record(z.string(), z.string()).optional(),
-});
+const McpEntrySchema = z.discriminatedUnion('type', [
+  z.looseObject({
+    type: z.literal('remote'),
+    url: z.string(),
+    enabled: z.boolean(),
+    headers: z.record(z.string(), z.string()).optional(),
+  }),
+  z.looseObject({
+    type: z.literal('local'),
+    command: z.array(z.string()),
+    enabled: z.boolean(),
+    environment: z.record(z.string(), z.string()).optional(),
+  }),
+]);
 
 type McpEntry = z.infer<typeof McpEntrySchema>;
 


### PR DESCRIPTION
## Summary
- Translate workspace MCP servers (remote) and commands (local) into OpenCode's native `mcp` config format during the `preWorkspaceStart` hook
- Add `McpEntrySchema` with typed fields (`type`, `url`, `command`, `enabled`, `environment`) to validate the OpenCode MCP config
- Merge workspace MCP entries with any existing MCP config in `opencode.json`

Fixes #2232

## Test plan
- [x] Unit tests for remote MCP servers (with and without headers)
- [x] Unit tests for local MCP commands (with and without args/env)
- [x] Unit tests for mixed remote + local servers
- [x] Unit tests for merging with existing MCP config
- [x] Unit tests for edge cases (empty headers/env omitted, no MCP preserves existing)
- [x] All 26 tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)