### PR TITLE
feat(models): wire model selection to semantic router create workflow

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -653,6 +653,7 @@ declare module '@openkaiden/api' {
 
   export interface LLMMetadata {
     name?: string;
+    semanticRouter?: string;
   }
 
   export type InferenceProviderConnection = {

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -29,11 +29,22 @@ const statusMap: Record<string, string> = {
 interface Props {
   models: CatalogModelInfo[];
   selectedKey?: string;
+  selectedKeys?: Set<string>;
+  multiSelect?: boolean;
   showCatalogLink?: boolean;
   onselect?: (model: CatalogModelInfo) => void;
+  ontoggle?: (model: CatalogModelInfo) => void;
 }
 
-let { models, selectedKey = '', showCatalogLink = true, onselect }: Props = $props();
+let {
+  models,
+  selectedKey = '',
+  selectedKeys,
+  multiSelect = false,
+  showCatalogLink = true,
+  onselect,
+  ontoggle,
+}: Props = $props();
 
 let searchTerm = $state('');
 
@@ -44,7 +55,17 @@ let corporateModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m
 let localModels: CatalogModelInfo[] = $derived(displayedModels.filter(m => m.type === 'local'));
 let hasAnyModels: boolean = $derived(cloudModels.length > 0 || corporateModels.length > 0 || localModels.length > 0);
 
-let selectedModel: CatalogModelInfo | undefined = $derived(models.find(m => getKey(m) === selectedKey));
+let selectedModel: CatalogModelInfo | undefined = $derived(
+  multiSelect ? undefined : models.find(m => getKey(m) === selectedKey),
+);
+let selectedCount: number = $derived(
+  multiSelect && selectedKeys ? models.filter(m => selectedKeys.has(getKey(m))).length : 0,
+);
+
+function isSelected(key: string): boolean {
+  if (multiSelect) return selectedKeys?.has(key) ?? false;
+  return selectedKey === key;
+}
 
 function filterBySearch(allModels: CatalogModelInfo[], term: string): CatalogModelInfo[] {
   if (!term.trim()) return allModels;
@@ -129,18 +150,18 @@ function navigateToModels(): void {
               <tbody>
                 {#each catModels as model (getKey(model))}
                   {@const key = getKey(model)}
-                  {@const isSelected = selectedKey === key}
+                  {@const selected = isSelected(key)}
                   <tr
                     role="button"
                     tabindex="0"
                     class="border-b border-(--pd-content-card-border) last:border-b-0 transition-colors
                       cursor-pointer hover:bg-(--pd-content-card-hover-inset-bg)
-                      {isSelected ? 'bg-(--pd-content-card-hover-inset-bg)' : ''}"
-                    onclick={onselect?.bind(undefined, model)}
+                      {selected ? 'bg-(--pd-content-card-hover-inset-bg)' : ''}"
+                    onclick={(multiSelect ? ontoggle : onselect)?.bind(undefined, model)}
                     onkeydown={(e: KeyboardEvent): void => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
-                        onselect?.(model);
+                        (multiSelect ? ontoggle : onselect)?.(model);
                       }
                     }}
                     data-testid="model-row-{model.label}">
@@ -154,14 +175,23 @@ function navigateToModels(): void {
                     <td class="px-3 py-2 text-(--pd-table-body-text)">—</td>
                     <td class="px-3 py-2 text-(--pd-table-body-text)">{model.providerName}</td>
                     <td class="px-3 py-2 text-center">
-                      <input
-                        type="radio"
-                        name="modelSelection"
-                        value={key}
-                        checked={isSelected}
-                        aria-label="Use {model.label}"
-                        onclick={(e: MouseEvent): void => e.stopPropagation()}
-                        onchange={onselect?.bind(undefined, model)} />
+                      {#if multiSelect}
+                        <input
+                          type="checkbox"
+                          checked={selected}
+                          aria-label="Use {model.label}"
+                          onclick={(e: MouseEvent): void => e.stopPropagation()}
+                          onchange={ontoggle?.bind(undefined, model)} />
+                      {:else}
+                        <input
+                          type="radio"
+                          name="modelSelection"
+                          value={key}
+                          checked={selected}
+                          aria-label="Use {model.label}"
+                          onclick={(e: MouseEvent): void => e.stopPropagation()}
+                          onchange={onselect?.bind(undefined, model)} />
+                      {/if}
                     </td>
                   </tr>
                 {/each}
@@ -173,7 +203,11 @@ function navigateToModels(): void {
     {/each}
   </div>
 
-  {#if selectedModel}
+  {#if multiSelect && selectedCount > 0}
+    <p class="text-xs text-(--pd-state-success) mt-4" data-testid="selected-count">
+      {selectedCount} model{selectedCount !== 1 ? 's' : ''} selected
+    </p>
+  {:else if !multiSelect && selectedModel}
     <p class="text-xs text-(--pd-state-success) mt-4" data-testid="selected-model">
       Selected: {selectedModel.label}
     </p>

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
@@ -23,13 +23,28 @@ import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CatalogModelInfo } from '/@/lib/models/models-utils';
+import * as modelCatalogStore from '/@/stores/model-catalog';
 import * as modelsStore from '/@/stores/models';
 import { resetRouterDraft } from '/@/stores/semantic-router-create-draft.svelte';
 
 import SemanticRouterCreate from './SemanticRouterCreate.svelte';
 
 vi.mock(import('/@/navigation'));
+vi.mock(import('/@/stores/model-catalog'));
 vi.mock(import('/@/stores/models'));
+
+const mockCloudModels: CatalogModelInfo[] = [
+  {
+    providerId: 'claude',
+    providerName: 'Anthropic',
+    connectionId: 'conn-0',
+    connectionName: 'Anthropic Cloud',
+    type: 'cloud',
+    llmMetadata: { name: 'anthropic' },
+    label: 'claude-sonnet-4',
+    connectionStatus: 'started',
+  } as CatalogModelInfo,
+];
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -40,17 +55,17 @@ beforeEach(() => {
     listeners: [{ address: '0.0.0.0', port: 8899 }],
     routing: { keywords: [], decisions: [] },
   });
-  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([
-    {
-      providerId: 'gemini',
-      connectionId: 'conn-1',
-      connectionName: 'Gemini',
-      type: 'cloud',
-      label: 'gemini-2.5-pro',
-      connectionStatus: 'started',
-      providerName: 'Gemini',
-    },
-  ]);
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([]);
+  vi.mocked(modelCatalogStore).disabledModels = writable<Set<string>>(new Set());
+  vi.mocked(modelCatalogStore.isModelEnabled).mockImplementation(
+    (disabled: Set<string>, providerId: string, label: string): boolean => !disabled.has(`${providerId}::${label}`),
+  );
+  vi.mocked(modelCatalogStore.modelKey).mockImplementation(
+    (providerId: string, label: string): string => `${providerId}::${label}`,
+  );
+  vi.mocked(modelCatalogStore.modelSelectionKey).mockImplementation(
+    (providerId: string, connectionId: string, label: string): string => `${providerId}::${connectionId}::${label}`,
+  );
 });
 
 describe('basic setup step', () => {
@@ -88,73 +103,142 @@ describe('basic setup step', () => {
   });
 });
 
-describe('step navigation', () => {
-  test('navigates to signals step when Next is clicked', async () => {
+describe('model selection step', () => {
+  test('advances to model selection step when clicking next', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
     render(SemanticRouterCreate);
 
     const nameInput = screen.getByLabelText('Router name');
     await fireEvent.input(nameInput, { target: { value: 'my-router' } });
 
-    const nextBtn = screen.getByRole('button', { name: 'Continue' });
-    await fireEvent.click(nextBtn);
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByText(/Select one or more models/)).toBeInTheDocument();
+  });
+
+  test('continue is disabled when no models are selected', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+    render(SemanticRouterCreate);
+
+    const nameInput = screen.getByLabelText('Router name');
+    await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    const continueBtn = screen.getByRole('button', { name: 'Continue' });
+    expect(continueBtn).toBeDisabled();
+  });
+
+  test('continue is enabled when a model is selected', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+    render(SemanticRouterCreate);
+
+    const nameInput = screen.getByLabelText('Router name');
+    await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+
+    const continueBtn = screen.getByRole('button', { name: 'Continue' });
+    expect(continueBtn).toBeEnabled();
+  });
+
+  test('back button returns to basic setup step', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+    render(SemanticRouterCreate);
+
+    const nameInput = screen.getByLabelText('Router name');
+    await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByText(/Select one or more models/)).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(screen.getByLabelText('Router name')).toBeInTheDocument();
+  });
+});
+
+describe('step navigation', () => {
+  test('navigates to signals step from models step', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+    render(SemanticRouterCreate);
+
+    const nameInput = screen.getByLabelText('Router name');
+    await fireEvent.input(nameInput, { target: { value: 'my-router' } });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     screen.getByText('Signals');
     screen.getByText('Decisions');
   });
 
-  test('Back button appears on step 2 and navigates back', async () => {
-    render(SemanticRouterCreate);
-
-    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
-
-    const nameInput = screen.getByLabelText('Router name');
-    await fireEvent.input(nameInput, { target: { value: 'my-router' } });
-
-    const nextBtn = screen.getByRole('button', { name: 'Continue' });
-    await fireEvent.click(nextBtn);
-
-    const backBtn = screen.getByRole('button', { name: 'Back' });
-    await fireEvent.click(backBtn);
-
-    screen.getByLabelText('Router name');
-  });
-
   test('shows Create button on last step', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
     render(SemanticRouterCreate);
 
     const nameInput = screen.getByLabelText('Router name');
     await fireEvent.input(nameInput, { target: { value: 'my-router' } });
 
-    const nextBtn = screen.getByRole('button', { name: 'Continue' });
-    await fireEvent.click(nextBtn);
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     screen.getByRole('button', { name: 'Create' });
   });
 
   test('step counter updates as steps change', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
     render(SemanticRouterCreate);
 
-    screen.getByText('Step 1 of 2');
+    screen.getByText('Step 1 of 3');
 
     const nameInput = screen.getByLabelText('Router name');
     await fireEvent.input(nameInput, { target: { value: 'my-router' } });
 
-    const nextBtn = screen.getByRole('button', { name: 'Continue' });
-    await fireEvent.click(nextBtn);
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
-    screen.getByText('Step 2 of 2');
+    screen.getByText('Step 2 of 3');
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    screen.getByText('Step 3 of 3');
+  });
+
+  test('back button is not shown on step 1', () => {
+    render(SemanticRouterCreate);
+
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
   });
 });
 
 describe('create flow', () => {
-  test('calls createSemanticRouter on final step', async () => {
+  test('calls createSemanticRouter with selected models on final step', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
     render(SemanticRouterCreate);
 
     const nameInput = screen.getByLabelText('Router name');
     await fireEvent.input(nameInput, { target: { value: 'my-router' } });
 
-    const nextBtn = screen.getByRole('button', { name: 'Continue' });
-    await fireEvent.click(nextBtn);
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     const createBtn = screen.getByRole('button', { name: 'Create' });
     await fireEvent.click(createBtn);
@@ -164,19 +248,40 @@ describe('create flow', () => {
       expect.objectContaining({
         name: 'my-router',
         listeners: expect.arrayContaining([expect.objectContaining({ port: 8899 })]),
-        routing: { keywords: [], decisions: [] },
+        routing: expect.objectContaining({
+          keywords: [],
+          decisions: [
+            {
+              name: 'default',
+              priority: 0,
+              rules: [
+                {
+                  operator: 'OR',
+                  conditions: [],
+                  modelRefs: [
+                    { providerId: 'claude', connectionId: 'conn-0', label: 'claude-sonnet-4', useReasoning: false },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
       }),
     );
   });
 
   test('navigates to semantic routers page after creation', async () => {
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
     render(SemanticRouterCreate);
 
     const nameInput = screen.getByLabelText('Router name');
     await fireEvent.input(nameInput, { target: { value: 'my-router' } });
 
-    const nextBtn = screen.getByRole('button', { name: 'Continue' });
-    await fireEvent.click(nextBtn);
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     const createBtn = screen.getByRole('button', { name: 'Create' });
     await fireEvent.click(createBtn);
@@ -190,14 +295,17 @@ describe('create flow', () => {
 
   test('displays error when createSemanticRouter fails', async () => {
     vi.mocked(window.createSemanticRouter).mockRejectedValueOnce(new Error('duplicate name'));
+    vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
 
     render(SemanticRouterCreate);
 
     const nameInput = screen.getByLabelText('Router name');
     await fireEvent.input(nameInput, { target: { value: 'my-router' } });
 
-    const nextBtn = screen.getByRole('button', { name: 'Continue' });
-    await fireEvent.click(nextBtn);
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     const createBtn = screen.getByRole('button', { name: 'Create' });
     await fireEvent.click(createBtn);
@@ -217,4 +325,10 @@ describe('create flow', () => {
     const { handleNavigation } = await import('/@/navigation');
     expect(handleNavigation).toHaveBeenCalledWith({ page: 'semantic-routers' });
   });
+});
+
+test('shows step counter', () => {
+  render(SemanticRouterCreate);
+
+  expect(screen.getByText('Step 1 of 3')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -49,11 +49,7 @@ let isSignalsStepValid = $derived.by(() => {
 });
 
 let canProceed = $derived(
-  currentStepId === 'basic'
-    ? isBasicStepValid
-    : currentStepId === 'models'
-      ? canProceedModels
-      : isSignalsStepValid,
+  currentStepId === 'basic' ? isBasicStepValid : currentStepId === 'models' ? canProceedModels : isSignalsStepValid,
 );
 
 function buildModelRefs(): Array<{ providerId: string; connectionId: string; label: string; useReasoning: boolean }> {
@@ -84,11 +80,12 @@ function buildConfig(): SemanticRouterConfigInfo {
     listeners: [{ address: d.listenerAddress, port: d.listenerPort, timeout: d.timeout }],
     routing: {
       keywords: d.keywords,
-      decisions: d.decisions.length > 0
-        ? d.decisions
-        : modelRefs.length > 0
-          ? [{ name: 'default', priority: 0, rules: [{ operator: 'OR', conditions: [], modelRefs }] }]
-          : [],
+      decisions:
+        d.decisions.length > 0
+          ? d.decisions
+          : modelRefs.length > 0
+            ? [{ name: 'default', priority: 0, rules: [{ operator: 'OR', conditions: [], modelRefs }] }]
+            : [],
     },
   };
 }

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -210,7 +210,8 @@ function cancel(): void {
             {:else if currentStepId === 'signals'}
               <SemanticRouterCreateStepSignals
                 bind:keywords={routerWizard.draft.keywords}
-                bind:decisions={routerWizard.draft.decisions} />
+                bind:decisions={routerWizard.draft.decisions}
+                availableModels={selectedModels} />
             {/if}
           </div>
 

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -3,6 +3,8 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Input, NumberInput } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
+import type { CatalogModelInfo } from '/@/lib/models/models-utils';
+import SemanticRouterCreateStepModels from '/@/lib/models/SemanticRouterCreateStepModels.svelte';
 import FormPage from '/@/lib/ui/FormPage.svelte';
 import WizardStepper from '/@/lib/ui/WizardStepper.svelte';
 import { handleNavigation } from '/@/navigation';
@@ -14,12 +16,15 @@ import SemanticRouterCreateStepSignals from './SemanticRouterCreateStepSignals.s
 
 const WIZARD_STEPS = [
   { id: 'basic', title: 'Basic setup' },
+  { id: 'models', title: 'Backend models' },
   { id: 'signals', title: 'Signals & decisions' },
 ];
 
 let currentStepIndex = $derived(routerWizard.draft.currentStepIndex);
 let currentStepId = $derived(WIZARD_STEPS[currentStepIndex]?.id ?? '');
 let isLastStep = $derived(currentStepIndex === WIZARD_STEPS.length - 1);
+
+let selectedModels: CatalogModelInfo[] = $state([]);
 
 let error = $state('');
 let creating = $state(false);
@@ -32,6 +37,8 @@ let isBasicStepValid = $derived(
     routerWizard.draft.timeout <= 3600,
 );
 
+let canProceedModels = $derived(selectedModels.length > 0);
+
 let isSignalsStepValid = $derived.by(() => {
   const { keywords, decisions } = routerWizard.draft;
   const allSignalsNamed = keywords.every(k => k.name.trim().length > 0);
@@ -41,7 +48,22 @@ let isSignalsStepValid = $derived.by(() => {
   return allSignalsNamed && allDecisionsNamed && allDecisionsHaveSignal && allDecisionsHaveModel;
 });
 
-let canProceed = $derived(currentStepId === 'basic' ? isBasicStepValid : isSignalsStepValid);
+let canProceed = $derived(
+  currentStepId === 'basic'
+    ? isBasicStepValid
+    : currentStepId === 'models'
+      ? canProceedModels
+      : isSignalsStepValid,
+);
+
+function buildModelRefs(): Array<{ providerId: string; connectionId: string; label: string; useReasoning: boolean }> {
+  return selectedModels.map(m => ({
+    providerId: m.providerId,
+    connectionId: m.connectionId,
+    label: m.label,
+    useReasoning: false,
+  }));
+}
 
 function goBack(): void {
   if (routerWizard.draft.currentStepIndex > 0) {
@@ -55,13 +77,18 @@ function handleStepClick(index: number): void {
 
 function buildConfig(): SemanticRouterConfigInfo {
   const d = $state.snapshot(routerWizard.draft);
+  const modelRefs = buildModelRefs();
   return {
     name: d.name.trim(),
     description: d.description.trim() || undefined,
     listeners: [{ address: d.listenerAddress, port: d.listenerPort, timeout: d.timeout }],
     routing: {
       keywords: d.keywords,
-      decisions: d.decisions,
+      decisions: d.decisions.length > 0
+        ? d.decisions
+        : modelRefs.length > 0
+          ? [{ name: 'default', priority: 0, rules: [{ operator: 'OR', conditions: [], modelRefs }] }]
+          : [],
     },
   };
 }
@@ -181,6 +208,8 @@ function cancel(): void {
                 </p>
               </div>
             </div>
+            {:else if currentStepId === 'models'}
+              <SemanticRouterCreateStepModels bind:selectedModels={selectedModels} />
             {:else if currentStepId === 'signals'}
               <SemanticRouterCreateStepSignals
                 bind:keywords={routerWizard.draft.keywords}
@@ -203,7 +232,7 @@ function cancel(): void {
               {/if}
               <Button onclick={cancel}>Cancel</Button>
               {#if isLastStep}
-                <Button onclick={createRouter} disabled={!isBasicStepValid || !isSignalsStepValid || creating} inProgress={creating}>
+                <Button onclick={createRouter} disabled={!isBasicStepValid || !canProceedModels || !isSignalsStepValid || creating} inProgress={creating}>
                   Create
                 </Button>
               {:else}

--- a/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.spec.ts
@@ -1,0 +1,224 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as modelCatalogStore from '/@/stores/model-catalog';
+import * as modelsStore from '/@/stores/models';
+import type { CatalogModelInfo } from '/@api/model-registry-info';
+
+import SemanticRouterCreateStepModels from './SemanticRouterCreateStepModels.svelte';
+
+vi.mock(import('/@/navigation'));
+vi.mock(import('/@/stores/model-catalog'));
+vi.mock(import('/@/stores/models'));
+
+const mockCloudModels: CatalogModelInfo[] = [
+  {
+    providerId: 'claude',
+    providerName: 'Anthropic',
+    connectionId: 'conn-0',
+    connectionName: 'Anthropic Cloud',
+    type: 'cloud',
+    llmMetadata: { name: 'anthropic' },
+    label: 'claude-sonnet-4',
+    connectionStatus: 'started',
+  } as CatalogModelInfo,
+  {
+    providerId: 'gemini',
+    providerName: 'Gemini',
+    connectionId: 'conn-1',
+    connectionName: 'Gemini Cloud',
+    type: 'cloud',
+    llmMetadata: { name: 'gemini' },
+    label: 'gemini-2.5-pro',
+    connectionStatus: 'started',
+  } as CatalogModelInfo,
+];
+
+const mockLocalModel: CatalogModelInfo = {
+  providerId: 'ollama',
+  providerName: 'Ollama',
+  connectionId: 'conn-2',
+  connectionName: 'Ollama Local',
+  type: 'local',
+  llmMetadata: { name: 'ollama' },
+  label: 'llama3.2:3b',
+  connectionStatus: 'started',
+} as CatalogModelInfo;
+
+const mockSemanticRouterModel: CatalogModelInfo = {
+  providerId: 'router-provider',
+  providerName: 'Router',
+  connectionId: 'conn-3',
+  connectionName: 'Router Conn',
+  type: 'cloud',
+  llmMetadata: { name: 'router', semanticRouter: 'coding-router' },
+  label: 'router-model',
+  connectionStatus: 'started',
+} as CatalogModelInfo;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([]);
+  vi.mocked(modelCatalogStore).disabledModels = writable<Set<string>>(new Set());
+  vi.mocked(modelCatalogStore.isModelEnabled).mockImplementation(
+    (disabled: Set<string>, providerId: string, label: string): boolean => !disabled.has(`${providerId}::${label}`),
+  );
+  vi.mocked(modelCatalogStore.modelKey).mockImplementation(
+    (providerId: string, label: string): string => `${providerId}::${label}`,
+  );
+  vi.mocked(modelCatalogStore.modelSelectionKey).mockImplementation(
+    (providerId: string, connectionId: string, label: string): string => `${providerId}::${connectionId}::${label}`,
+  );
+});
+
+test('renders heading and description', () => {
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.getByText('Backend models')).toBeInTheDocument();
+  expect(screen.getByText(/Select one or more models/)).toBeInTheDocument();
+});
+
+test('shows empty state when no models available', () => {
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.getByTestId('no-models')).toBeInTheDocument();
+});
+
+test('shows cloud models under Cloud category', () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.getByText('Cloud · LLM providers')).toBeInTheDocument();
+  expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
+  expect(screen.getByText('gemini-2.5-pro')).toBeInTheDocument();
+});
+
+test('shows local models under Local category', () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([mockLocalModel]);
+
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.getByText('Local · Ollama & Ramalama')).toBeInTheDocument();
+  expect(screen.getByText('llama3.2:3b')).toBeInTheDocument();
+});
+
+test('filters out models with llmMetadata.semanticRouter defined', () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([...mockCloudModels, mockSemanticRouterModel]);
+
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
+  expect(screen.getByText('gemini-2.5-pro')).toBeInTheDocument();
+  expect(screen.queryByText('router-model')).not.toBeInTheDocument();
+});
+
+test('toggles model selection via checkbox', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  const checkbox = screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' });
+  expect(checkbox).not.toBeChecked();
+
+  await fireEvent.click(checkbox);
+
+  expect(checkbox).toBeChecked();
+  expect(screen.getByTestId('selected-count')).toHaveTextContent('1 model selected');
+});
+
+test('toggles model selection via row click', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  const row = screen.getByTestId('model-row-claude-sonnet-4');
+  await fireEvent.click(row);
+
+  const checkbox = screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' });
+  expect(checkbox).toBeChecked();
+});
+
+test('allows selecting multiple models', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use gemini-2.5-pro' }));
+
+  expect(screen.getByTestId('selected-count')).toHaveTextContent('2 models selected');
+});
+
+test('deselecting a model updates the count', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use gemini-2.5-pro' }));
+
+  expect(screen.getByTestId('selected-count')).toHaveTextContent('2 models selected');
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+
+  expect(screen.getByTestId('selected-count')).toHaveTextContent('1 model selected');
+});
+
+test('search filters model list', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  const searchInput = screen.getByPlaceholderText('Filter models…');
+  await fireEvent.input(searchInput, { target: { value: 'sonnet' } });
+
+  expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
+  expect(screen.queryByText('gemini-2.5-pro')).not.toBeInTheDocument();
+});
+
+test('disabled models are hidden from selection list', () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+  vi.mocked(modelCatalogStore).disabledModels = writable<Set<string>>(new Set(['gemini::gemini-2.5-pro']));
+
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
+  expect(screen.queryByText('gemini-2.5-pro')).not.toBeInTheDocument();
+});
+
+test('Open Models catalog link is visible', () => {
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.getByText('Open Models catalog')).toBeInTheDocument();
+});
+
+test('no selected count shown when nothing selected', () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.queryByTestId('selected-count')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.svelte
@@ -13,13 +13,15 @@ interface Props {
 
 let { selectedModels = $bindable([]) }: Props = $props();
 
-let selectedKeys = new SvelteSet<string>();
+let selectedKeys = new SvelteSet<string>(
+  selectedModels.map(m => modelSelectionKey(m.providerId, m.connectionId, m.label)),
+);
 
 let eligibleModels: CatalogModelInfo[] = $derived.by(() => {
   const enabled = $catalogModels.filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
   const seen: Record<string, boolean> = {};
   return enabled.filter(m => {
-    if (m.llmMetadata?.semanticRouter) return false;
+    if (m.llmMetadata?.semanticRouter !== undefined) return false;
     const key = modelKey(m.providerId, m.label);
     if (seen[key]) return false;
     seen[key] = true;

--- a/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+import { SvelteSet } from 'svelte/reactivity';
+
+import { disabledModels, isModelEnabled, modelKey, modelSelectionKey } from '/@/stores/model-catalog';
+import { catalogModels } from '/@/stores/models';
+
+import type { CatalogModelInfo } from './models-utils';
+import ModelSelectionTable from './ModelSelectionTable.svelte';
+
+interface Props {
+  selectedModels?: CatalogModelInfo[];
+}
+
+let { selectedModels = $bindable([]) }: Props = $props();
+
+let selectedKeys = new SvelteSet<string>();
+
+let eligibleModels: CatalogModelInfo[] = $derived.by(() => {
+  const enabled = $catalogModels.filter(m => isModelEnabled($disabledModels, m.providerId, m.label));
+  const seen: Record<string, boolean> = {};
+  return enabled.filter(m => {
+    if (m.llmMetadata?.semanticRouter) return false;
+    const key = modelKey(m.providerId, m.label);
+    if (seen[key]) return false;
+    seen[key] = true;
+    return true;
+  });
+});
+
+$effect(() => {
+  selectedModels = eligibleModels.filter(m =>
+    selectedKeys.has(modelSelectionKey(m.providerId, m.connectionId, m.label)),
+  );
+});
+
+function toggleModel(model: CatalogModelInfo): void {
+  const key = modelSelectionKey(model.providerId, model.connectionId, model.label);
+  if (selectedKeys.has(key)) {
+    selectedKeys.delete(key);
+  } else {
+    selectedKeys.add(key);
+  }
+}
+</script>
+
+<div>
+  <h2 class="text-lg font-semibold text-(--pd-modal-text) mb-1">Backend models</h2>
+  <p class="text-sm text-(--pd-content-card-text) opacity-60 mb-5">
+    Select one or more models the router can forward requests to. Models that are themselves
+    semantic routers are excluded automatically.
+  </p>
+
+  <ModelSelectionTable
+    models={eligibleModels}
+    multiSelect={true}
+    selectedKeys={selectedKeys}
+    ontoggle={toggleModel} />
+</div>

--- a/packages/renderer/src/lib/models/SemanticRouterCreateStepSignals.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreateStepSignals.spec.ts
@@ -19,15 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CatalogModelInfo } from '/@/lib/models/models-utils';
-import * as modelsStore from '/@/stores/models';
 
 import SemanticRouterCreateStepSignals from './SemanticRouterCreateStepSignals.svelte';
-
-vi.mock(import('/@/stores/models'));
 
 const mockModels: CatalogModelInfo[] = [
   {
@@ -52,25 +48,25 @@ const mockModels: CatalogModelInfo[] = [
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockModels);
+  vi.useFakeTimers({ shouldAdvanceTime: true });
 });
 
 describe('signals section', () => {
   test('renders signals and decisions headers', () => {
-    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [] });
+    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [], availableModels: mockModels });
 
     screen.getByText('Signals');
     screen.getByText('Decisions');
   });
 
   test('shows empty state when no signals defined', () => {
-    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [] });
+    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [], availableModels: mockModels });
 
     screen.getByText('No signals defined yet. Add a keyword signal to get started.');
   });
 
   test('adds a keyword signal when button is clicked', async () => {
-    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [] });
+    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [], availableModels: mockModels });
 
     const addBtn = screen.getByRole('button', { name: /Add keyword signal/i });
     await fireEvent.click(addBtn);
@@ -82,6 +78,7 @@ describe('signals section', () => {
     render(SemanticRouterCreateStepSignals, {
       keywords: [{ name: 'coding_keywords', operator: 'OR', keywords: ['function', 'class'], caseSensitive: false }],
       decisions: [],
+      availableModels: mockModels,
     });
 
     expect(screen.getByDisplayValue('coding_keywords')).toBeInTheDocument();
@@ -93,6 +90,7 @@ describe('signals section', () => {
     render(SemanticRouterCreateStepSignals, {
       keywords: [{ name: 'my-signal', operator: 'OR', keywords: [], caseSensitive: false }],
       decisions: [],
+      availableModels: mockModels,
     });
 
     const closeBtn = screen.getByRole('button', { name: 'Close' });
@@ -105,6 +103,7 @@ describe('signals section', () => {
     render(SemanticRouterCreateStepSignals, {
       keywords: [{ name: 'sig', operator: 'OR', keywords: [], caseSensitive: false }],
       decisions: [],
+      availableModels: mockModels,
     });
 
     const chipInput = screen.getByLabelText('Add keyword');
@@ -118,6 +117,7 @@ describe('signals section', () => {
     render(SemanticRouterCreateStepSignals, {
       keywords: [{ name: 'sig', operator: 'OR', keywords: ['testchip'], caseSensitive: false }],
       decisions: [],
+      availableModels: mockModels,
     });
 
     screen.getByText('testchip');
@@ -132,6 +132,7 @@ describe('signals section', () => {
     render(SemanticRouterCreateStepSignals, {
       keywords: [{ name: 'sig', operator: 'OR', keywords: [], caseSensitive: false }],
       decisions: [],
+      availableModels: mockModels,
     });
 
     const toggle = screen.getByRole('checkbox', { name: 'Toggle operator' });
@@ -143,13 +144,13 @@ describe('signals section', () => {
 
 describe('decisions section', () => {
   test('shows empty state when no decisions defined', () => {
-    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [] });
+    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [], availableModels: mockModels });
 
     screen.getByText('No decisions defined yet. Add a decision to create routing rules.');
   });
 
   test('adds a decision when button is clicked', async () => {
-    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [] });
+    render(SemanticRouterCreateStepSignals, { keywords: [], decisions: [], availableModels: mockModels });
 
     const addBtn = screen.getByRole('button', { name: /Add decision/i });
     await fireEvent.click(addBtn);
@@ -167,6 +168,7 @@ describe('decisions section', () => {
           rules: [{ operator: 'AND', conditions: [], modelRefs: [] }],
         },
       ],
+      availableModels: mockModels,
     });
 
     expect(screen.getByDisplayValue('code-route')).toBeInTheDocument();
@@ -182,6 +184,7 @@ describe('decisions section', () => {
           rules: [{ operator: 'AND', conditions: [], modelRefs: [] }],
         },
       ],
+      availableModels: mockModels,
     });
 
     const closeBtn = screen.getByRole('button', { name: 'Close' });
@@ -203,6 +206,7 @@ describe('decisions section', () => {
           rules: [{ operator: 'AND', conditions: [], modelRefs: [] }],
         },
       ],
+      availableModels: mockModels,
     });
 
     screen.getByRole('checkbox', { name: 'Toggle signal coding_kw' });
@@ -219,12 +223,13 @@ describe('decisions section', () => {
           rules: [{ operator: 'AND', conditions: [], modelRefs: [] }],
         },
       ],
+      availableModels: mockModels,
     });
 
     screen.getByText('Define keyword signals above first.');
   });
 
-  test('renders model select with catalog models', () => {
+  test('renders model select with available models', () => {
     render(SemanticRouterCreateStepSignals, {
       keywords: [],
       decisions: [
@@ -234,6 +239,7 @@ describe('decisions section', () => {
           rules: [{ operator: 'AND', conditions: [], modelRefs: [] }],
         },
       ],
+      availableModels: mockModels,
     });
 
     screen.getByLabelText('Target model');
@@ -249,6 +255,7 @@ describe('decisions section', () => {
           rules: [{ operator: 'AND', conditions: [], modelRefs: [] }],
         },
       ],
+      availableModels: mockModels,
     });
 
     screen.getByText('Enable reasoning mode');

--- a/packages/renderer/src/lib/models/SemanticRouterCreateStepSignals.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreateStepSignals.svelte
@@ -4,17 +4,15 @@ import { Button, Checkbox, CloseButton, Dropdown, Input, NumberInput } from '@po
 
 import type { CatalogModelInfo } from '/@/lib/models/models-utils';
 import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
-import { catalogModels } from '/@/stores/models';
 import type { DecisionConfigDraft, KeywordGroupDraft } from '/@/stores/semantic-router-create-draft.svelte';
 
 interface Props {
   keywords: KeywordGroupDraft[];
   decisions: DecisionConfigDraft[];
+  availableModels: readonly CatalogModelInfo[];
 }
 
-let { keywords = $bindable(), decisions = $bindable() }: Props = $props();
-
-let allModels: readonly CatalogModelInfo[] = $derived($catalogModels);
+let { keywords = $bindable(), decisions = $bindable(), availableModels }: Props = $props();
 
 let keywordNames: string[] = $derived(keywords.map(k => k.name).filter(n => n.trim().length > 0));
 
@@ -70,12 +68,12 @@ function addDecision(): void {
   const defaultConditions = keywordNames.length > 0 ? [{ type: 'keyword' as const, name: keywordNames[0] }] : [];
 
   const defaultModelRefs =
-    allModels.length > 0
+    availableModels.length > 0
       ? [
           {
-            providerId: allModels[0].providerId,
-            connectionId: allModels[0].connectionId ?? '',
-            label: allModels[0].label,
+            providerId: availableModels[0].providerId,
+            connectionId: availableModels[0].connectionId ?? '',
+            label: availableModels[0].label,
             useReasoning: false,
           },
         ]
@@ -127,7 +125,7 @@ function isConditionSelected(decIndex: number, signalName: string): boolean {
 }
 
 function onSelectedModelChanged(decIndex: number, label: string): void {
-  const model = allModels.find(m => m.label === label);
+  const model = availableModels.find(m => m.label === label);
   if (model) selectModel(decIndex, model);
 }
 
@@ -344,7 +342,7 @@ function getSelectedModelLabel(decIndex: number): string {
             <!-- Target model -->
             <div class="pb-3">
               <span class="block text-xs font-semibold text-(--pd-modal-text) pb-1.5">Target model</span>
-              {#if allModels.length === 0}
+              {#if availableModels.length === 0}
                 <p class="text-xs text-(--pd-content-card-text) opacity-50 italic">
                   No models available in the catalog.
                 </p>
@@ -352,7 +350,7 @@ function getSelectedModelLabel(decIndex: number): string {
                 <Dropdown
                   ariaLabel="Target model"
                   value={getSelectedModelLabel(decIdx)}
-                  options={allModels.map(m => ({ label: `${m.label} (${m.providerName})`, value: m.label }))}
+                  options={availableModels.map(m => ({ label: `${m.label} (${m.providerName})`, value: m.label }))}
                   onChange={(val: string): void => onSelectedModelChanged(decIdx, val)} />
               {/if}
             </div>


### PR DESCRIPTION
Add a multi-select model step to the semantic router creation wizard so users can pick backend models from the catalog. Models with llmMetadata.semanticRouter defined are filtered out. Extends ModelSelectionTable with multiSelect support to avoid duplicating the table rendering logic.

https://github.com/user-attachments/assets/03606671-3e51-4a8c-a6d6-d8cf06aa46f6

Closes #2103