### PR TITLE
feat(claude): implement agent configuration for workspace preparation

### DIFF
--- a/extensions/claude/package.json
+++ b/extensions/claude/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.85",
     "@anthropic-ai/sdk": "^0.88.0",
-    "inversify": "^7.7.1"
+    "inversify": "^7.7.1",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@openkaiden/api": "workspace:*",

--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@openkaiden/api';
+import type { AgentConfigurationFile, AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
 import type { Container } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { ClaudeExtension } from '/@/claude-extension';
+import { CLAUDE_JSON_PATH, CLAUDE_SETTINGS_PATH, ClaudeExtension } from '/@/claude-extension';
 import { ClaudeInferenceManager } from '/@/manager/claude-inference-manager';
 import { ClaudeSkillsManager } from '/@/manager/claude-skills-manager';
 
@@ -106,5 +106,276 @@ describe('ClaudeExtension', () => {
     await claudeExtension.deactivate();
     expect(ClaudeSkillsManager.prototype.dispose).toHaveBeenCalled();
     expect(ClaudeInferenceManager.prototype.dispose).toHaveBeenCalled();
+  });
+
+  test('registers agent with configuration files', async () => {
+    await claudeExtension.activate();
+
+    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    expect(agent.configurationFiles).toHaveLength(2);
+    expect(agent.configurationFiles[0]!.path).toBe(CLAUDE_SETTINGS_PATH);
+    expect(agent.configurationFiles[1]!.path).toBe(CLAUDE_JSON_PATH);
+  });
+
+  describe('preWorkspaceStart', () => {
+    function createContext(
+      configFiles: AgentConfigurationFile[],
+      modelLabel = 'claude-sonnet-4-20250514',
+      workspace: AgentWorkspaceContext['workspace'] = {},
+    ): AgentWorkspaceContext {
+      return {
+        model: {
+          model: { label: modelLabel },
+        },
+        configurationFiles: configFiles,
+        workspace,
+      };
+    }
+
+    test('writes model label to settings', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_SETTINGS_PATH,
+        read: vi.fn().mockResolvedValue('{}'),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written).toEqual({ model: 'claude-sonnet-4-20250514' });
+    });
+
+    test('preserves existing config fields', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const existingConfig = JSON.stringify({ existingKey: 'existingValue' });
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_SETTINGS_PATH,
+        read: vi.fn().mockResolvedValue(existingConfig),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile], 'claude-opus-4-20250514'));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.existingKey).toBe('existingValue');
+      expect(written.model).toBe('claude-opus-4-20250514');
+    });
+
+    test('rejects invalid JSON', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_SETTINGS_PATH,
+        read: vi.fn().mockResolvedValue('not valid json'),
+        update: vi.fn(),
+      };
+
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+    });
+
+    test.each(['null', '"string"', '123', '[]'])('rejects non-object JSON: %s', async (payload: string) => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_SETTINGS_PATH,
+        read: vi.fn().mockResolvedValue(payload),
+        update: vi.fn(),
+      };
+
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+    });
+
+    test('does nothing when config file is not in context', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const otherFile: AgentConfigurationFile = {
+        path: 'some/other/path.json',
+        read: vi.fn(),
+        update: vi.fn(),
+      };
+      await agent.preWorkspaceStart(createContext([otherFile]));
+
+      expect(otherFile.read).not.toHaveBeenCalled();
+      expect(otherFile.update).not.toHaveBeenCalled();
+    });
+
+    test('skips onboarding in .claude.json', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue('{}'),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(updateMock).toHaveBeenCalledOnce();
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.hasCompletedOnboarding).toBe(true);
+      expect(written.projects['/sandbox'].hasTrustDialogAccepted).toBe(true);
+    });
+
+    test('writes command MCP servers as stdio in .claude.json', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue('{}'),
+        update: updateMock,
+      };
+
+      const workspace = {
+        mcp: {
+          commands: [{ name: 'playwright', command: 'npx', args: ['-y', '@playwright/mcp'] }],
+        },
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile], undefined, workspace));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.mcpServers).toEqual({
+        playwright: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', '@playwright/mcp'],
+          env: {},
+        },
+      });
+    });
+
+    test('writes URL MCP servers as sse in .claude.json', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue('{}'),
+        update: updateMock,
+      };
+
+      const workspace = {
+        mcp: {
+          servers: [{ name: 'github', url: 'https://api.github.com/mcp', headers: { Authorization: 'Bearer tok' } }],
+        },
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile], undefined, workspace));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.mcpServers).toEqual({
+        github: {
+          type: 'sse',
+          url: 'https://api.github.com/mcp',
+          headers: { Authorization: 'Bearer tok' },
+        },
+      });
+    });
+
+    test('omits headers when empty in URL MCP servers', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue('{}'),
+        update: updateMock,
+      };
+
+      const workspace = {
+        mcp: {
+          servers: [{ name: 'github', url: 'https://api.github.com/mcp' }],
+        },
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile], undefined, workspace));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.mcpServers.github).toEqual({ type: 'sse', url: 'https://api.github.com/mcp' });
+    });
+
+    test('does not set mcpServers when workspace has no MCP config', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue('{}'),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.mcpServers).toBeUndefined();
+    });
+
+    test('.claude.json preserves existing fields', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const existing = JSON.stringify({ projects: { '/workspace': { hasTrustDialogAccepted: true } } });
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue(existing),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.projects['/workspace']).toEqual({ hasTrustDialogAccepted: true });
+      expect(written.hasCompletedOnboarding).toBe(true);
+    });
+
+    test('.claude.json rejects invalid JSON', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue('not valid json'),
+        update: vi.fn(),
+      };
+
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+    });
+
+    test.each([
+      'null',
+      '"string"',
+      '123',
+      '[]',
+    ])('.claude.json rejects non-object JSON: %s', async (payload: string) => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue(payload),
+        update: vi.fn(),
+      };
+
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+    });
   });
 });

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -16,15 +16,56 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Disposable, ExtensionContext } from '@openkaiden/api';
+import type { AgentWorkspaceContext, Disposable, ExtensionContext } from '@openkaiden/api';
 import { agents, provider } from '@openkaiden/api';
 import type { Container } from 'inversify';
+import { z } from 'zod';
 
 import { InversifyBinding } from '/@/inject/inversify-binding';
 import { ClaudeInferenceManager } from '/@/manager/claude-inference-manager';
 import { ClaudeSkillsManager } from '/@/manager/claude-skills-manager';
 
 export const PROVIDER_ID = 'claude';
+export const CLAUDE_SETTINGS_PATH = '.claude/settings.json';
+export const CLAUDE_JSON_PATH = '.claude.json';
+const WORKSPACE_SOURCES_PATH = '/sandbox';
+
+function jsonCodec<T extends z.ZodType>(schema: T): z.ZodCodec<z.ZodString, T> {
+  return z.codec(z.string(), schema, {
+    decode: (jsonString, ctx) => {
+      try {
+        return JSON.parse(jsonString);
+      } catch (err: unknown) {
+        ctx.issues.push({
+          code: 'invalid_format',
+          format: 'json',
+          input: jsonString,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return z.NEVER;
+      }
+    },
+    encode: value => JSON.stringify(value, undefined, 2),
+  });
+}
+
+const ClaudeSettingsCodec = jsonCodec(
+  z.looseObject({
+    model: z.string().optional(),
+  }),
+);
+
+const ClaudeProjectSchema = z.looseObject({
+  hasTrustDialogAccepted: z.boolean().optional(),
+});
+
+const ClaudeJsonCodec = jsonCodec(
+  z.looseObject({
+    hasCompletedOnboarding: z.boolean().optional(),
+    projects: z.record(z.string(), ClaudeProjectSchema).optional(),
+    mcpServers: z.record(z.string(), z.unknown()).optional(),
+  }),
+);
 
 export class ClaudeExtension {
   #extensionContext: ExtensionContext;
@@ -62,11 +103,69 @@ export class ClaudeExtension {
       icon: providerImages,
       command: 'claude',
       tags: ['Cloud'],
-      configurationFiles: [],
+      configurationFiles: [
+        {
+          path: CLAUDE_SETTINGS_PATH,
+          async read(): Promise<string> {
+            return '{}';
+          },
+        },
+        {
+          path: CLAUDE_JSON_PATH,
+          async read(): Promise<string> {
+            return '{}';
+          },
+        },
+      ],
       destinationSkillsFolder: '${HOME}/.claude/skills',
       isSupportedModelType: (type): boolean => type.name === 'anthropic' || type.name === 'vertexai',
-      async preWorkspaceStart(): Promise<void> {
-        throw new Error('not implemented');
+      async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+        const settingsFile = context.configurationFiles.find(f => f.path === CLAUDE_SETTINGS_PATH);
+        if (settingsFile) {
+          const config = ClaudeSettingsCodec.decode(await settingsFile.read());
+          config.model = context.model.model.label;
+          await settingsFile.update(ClaudeSettingsCodec.encode(config));
+        }
+
+        const claudeJsonFile = context.configurationFiles.find(f => f.path === CLAUDE_JSON_PATH);
+        if (claudeJsonFile) {
+          const config = ClaudeJsonCodec.decode(await claudeJsonFile.read());
+          config.hasCompletedOnboarding = true;
+
+          const projects = config.projects ?? {};
+          const project = projects[WORKSPACE_SOURCES_PATH] ?? {};
+          project.hasTrustDialogAccepted = true;
+          projects[WORKSPACE_SOURCES_PATH] = project;
+          config.projects = projects;
+
+          const mcpServers = context.workspace.mcp?.servers;
+          const mcpCommands = context.workspace.mcp?.commands;
+
+          if (mcpServers?.length || mcpCommands?.length) {
+            const servers: Record<string, unknown> = config.mcpServers ?? {};
+
+            for (const cmd of mcpCommands ?? []) {
+              servers[cmd.name] = {
+                type: 'stdio',
+                command: cmd.command,
+                args: cmd.args ?? [],
+                env: cmd.env ?? {},
+              };
+            }
+
+            for (const srv of mcpServers ?? []) {
+              const entry: Record<string, unknown> = { type: 'sse', url: srv.url };
+              if (srv.headers && Object.keys(srv.headers).length > 0) {
+                entry['headers'] = srv.headers;
+              }
+              servers[srv.name] = entry;
+            }
+
+            config.mcpServers = servers;
+          }
+
+          await claudeJsonFile.update(ClaudeJsonCodec.encode(config));
+        }
       },
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
       inversify:
         specifier: ^7.7.1
         version: 7.11.0(reflect-metadata@0.2.2)
+      zod:
+        specifier: ^4.3.5
+        version: 4.4.3
     devDependencies:
       '@openkaiden/api':
         specifier: workspace:*


### PR DESCRIPTION
Replaces the configurationFiles and preWorkspaceStart stubs with a real implementation, mirroring the Cursor extension pattern.
Uses zod codecs for unified JSON parsing and schema validation.

Configuration files:
  - .claude/settings.json: writes model label
  - .claude.json: skips onboarding (hasCompletedOnboarding, trust dialog
      for /sandbox), configures MCP servers (stdio for commands, sse for
      URL-based), mirroring kdn claude.go
Both files preserve existing fields and reject invalid/non-object JSON.

There are 2 caveats for now:

- we can't automatically trust the openshell injected ANTHROPIC_API_KEY, as it looks like 
> ANTHROPIC_API_KEY=openshell:resolve:env:v16994155543811787309_ANTHROPIC_API_KEY

and .claude.json needs to look like

```
"customApiKeyResponses": {
      "approved": [
        "09_ANTHROPIC_API_KEY"
      ],
      "rejected": []
    },
```
So we can't predict which value to approve. I tried storing "_ANTHROPIC_API_KEY" but it didn't work

- vertex ai provider is not recognized at this point

Fixes #2169

