### PR TITLE
fix(openshell): pass workspace env vars to sandbox create

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -85,7 +85,7 @@ export interface CreateSandboxOptions {
   cpu?: string;
   memory?: string;
   providers?: string[];
-  env?: string[];
+  env?: Record<string, string>;
   labels?: Record<string, string>;
   uploads?: Array<{ local: string; remote: string }>;
   command?: string[];

--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -85,6 +85,7 @@ export interface CreateSandboxOptions {
   cpu?: string;
   memory?: string;
   providers?: string[];
+  env?: string[];
   labels?: Record<string, string>;
   uploads?: Array<{ local: string; remote: string }>;
   command?: string[];

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -441,7 +441,7 @@ describe('create – OpenShell mode', () => {
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        env: ['MISTRAL_API_KEY=provided', 'DEBUG=1'],
+        env: { MISTRAL_API_KEY: 'provided', DEBUG: '1' },
       }),
     );
   });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -428,6 +428,24 @@ describe('create – OpenShell mode', () => {
     });
   });
 
+  test('passes workspace environment variables to sandbox creation', async () => {
+    await manager.create({
+      ...defaultOptions,
+      workspaceConfiguration: {
+        environment: [
+          { name: 'MISTRAL_API_KEY', value: 'provided' },
+          { name: 'DEBUG', value: '1' },
+        ],
+      },
+    });
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: ['MISTRAL_API_KEY=provided', 'DEBUG=1'],
+      }),
+    );
+  });
+
   test('returns { id: sandboxName }', async () => {
     const result = await manager.create(defaultOptions);
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -182,10 +182,14 @@ export class AgentWorkspaceManager implements Disposable {
     }
 
     const sandboxName = options.name ?? basename(options.sourcePath);
+    const env = workspace.environment
+      ?.filter(entry => typeof entry.value === 'string' && entry.value !== '')
+      .map(entry => `${entry.name}=${entry.value}`);
 
     await this.openshellCli.createSandbox({
       name: sandboxName,
       providers: options.secrets,
+      env: env?.length ? env : undefined,
       labels: encodeWorkspaceLabels(options.sourcePath),
       uploads: uploads.length > 0 ? uploads : undefined,
       noTty: true,

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -184,12 +184,15 @@ export class AgentWorkspaceManager implements Disposable {
     const sandboxName = options.name ?? basename(options.sourcePath);
     const env = workspace.environment
       ?.filter(entry => typeof entry.value === 'string' && entry.value !== '')
-      .map(entry => `${entry.name}=${entry.value}`);
+      .reduce<Record<string, string>>((acc, entry) => {
+        acc[entry.name] = entry.value as string;
+        return acc;
+      }, {});
 
     await this.openshellCli.createSandbox({
       name: sandboxName,
       providers: options.secrets,
-      env: env?.length ? env : undefined,
+      env: env && Object.keys(env).length > 0 ? env : undefined,
       labels: encodeWorkspaceLabels(options.sourcePath),
       uploads: uploads.length > 0 ? uploads : undefined,
       noTty: true,

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -247,6 +247,18 @@ describe('createSandbox', () => {
     );
   });
 
+  test('redacts --env values in logs', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ env: { API_KEY: 'sk-secret-123' } });
+
+    const loggedMessage = logSpy.mock.calls[0]?.[0] as string;
+    expect(loggedMessage).not.toContain('sk-secret-123');
+    expect(loggedMessage).toContain('--env');
+    expect(loggedMessage).toContain('***');
+  });
+
   test('places --env flags before -- command separator', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -165,6 +165,19 @@ describe('createSandbox', () => {
     );
   });
 
+  test('includes repeatable --env flags when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({ env: ['API_KEY=sk-test', 'DEBUG=1'] });
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['sandbox', 'create', '--env', 'API_KEY=sk-test', '--env', 'DEBUG=1'],
+      undefined,
+    );
+  });
+
   test('includes --label flags when provided', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
@@ -230,6 +243,22 @@ describe('createSandbox', () => {
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
       ['sandbox', 'create', '--upload', '.agents/skills:.agents/skills', '--', 'bash'],
+      undefined,
+    );
+  });
+
+  test('places --env flags before -- command separator', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createSandbox({
+      env: ['API_KEY=sk-test'],
+      command: ['bash'],
+    });
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['sandbox', 'create', '--env', 'API_KEY=sk-test', '--', 'bash'],
       undefined,
     );
   });

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -169,7 +169,7 @@ describe('createSandbox', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
-    await openshellCli.createSandbox({ env: ['API_KEY=sk-test', 'DEBUG=1'] });
+    await openshellCli.createSandbox({ env: { API_KEY: 'sk-test', DEBUG: '1' } });
 
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
@@ -252,7 +252,7 @@ describe('createSandbox', () => {
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
     await openshellCli.createSandbox({
-      env: ['API_KEY=sk-test'],
+      env: { API_KEY: 'sk-test' },
       command: ['bash'],
     });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -155,7 +155,7 @@ export class OpenshellCli {
     if (options.command?.length) {
       args.push('--', ...options.command);
     }
-    await this.runCli(args);
+    await this.runCli(args, { redact: true });
   }
 
   async listSandboxes(gatewayName?: string): Promise<SandboxInfo[]> {
@@ -318,7 +318,7 @@ export class OpenshellCli {
   }
 
   private redactSensitiveArgs(args: string[]): string[] {
-    const sensitiveFlags = new Set(['--credential', '--config']);
+    const sensitiveFlags = new Set(['--credential', '--config', '--env']);
     return args.map((arg, i) => {
       if (i > 0 && sensitiveFlags.has(args[i - 1]!)) {
         return '***';

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -135,8 +135,8 @@ export class OpenshellCli {
       }
     }
     if (options.env) {
-      for (const env of options.env) {
-        args.push('--env', env);
+      for (const [key, value] of Object.entries(options.env)) {
+        args.push('--env', `${key}=${value}`);
       }
     }
     if (options.labels) {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -134,6 +134,11 @@ export class OpenshellCli {
         args.push('--provider', provider);
       }
     }
+    if (options.env) {
+      for (const env of options.env) {
+        args.push('--env', env);
+      }
+    }
     if (options.labels) {
       for (const [key, value] of Object.entries(options.labels)) {
         args.push('--label', `${key}=${value}`);


### PR DESCRIPTION
Fixes #2246.

## Summary
- pass workspace environment entries through the OpenShell workspace creation path
- add repeatable `--env KEY=VALUE` support to the OpenShell CLI wrapper used by Kaiden
- cover the new wiring with focused unit tests and a local OpenShell smoke test

## Test plan
- [x] `pnpm exec vitest run packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts`
- [x] `openshell sandbox create --name <temp> --from base --env KAIDEN_ENV_VERIFY=works --no-keep --no-tty -- sh -lc 'printf %s "$KAIDEN_ENV_VERIFY"'`

Made with [Cursor](https://cursor.com)