### PR TITLE
chore: initialize fullsend per-repo installation

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -25,15 +25,15 @@ permissions:
   packages: read
   pull-requests: write
 
-#on:
-#  issues:
-#    types: [opened, edited, labeled]
-#  issue_comment:
-#    types: [created]
-#  pull_request_target:
-#    types: [opened, synchronize, ready_for_review, closed]
-#  pull_request_review:
-#    types: [submitted]
+on:
+  issues:
+    types: [opened, edited, labeled]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, closed]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   dispatch:


### PR DESCRIPTION
This PR adds the fullsend scaffold files for per-repo installation.

Merge this PR to activate fullsend workflows.