### PR TITLE
feat(renderer): offer inline connection creation when no compatible models exist

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.spec.ts
@@ -24,11 +24,13 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import * as agentsStore from '/@/stores/agents';
 import * as agentWorkspaceRuntimeStore from '/@/stores/agentworkspace-runtime';
+import * as configurationPropertiesStore from '/@/stores/configurationProperties';
+import * as inferenceConnectionSummariesStore from '/@/stores/inference-connection-summaries';
 import * as modelCatalogStore from '/@/stores/model-catalog';
 import * as modelsStore from '/@/stores/models';
 import * as providersStore from '/@/stores/providers';
 import type { AgentInfo } from '/@api/agent-info';
-import type { CatalogModelInfo } from '/@api/model-registry-info';
+import type { CatalogModelInfo, InferenceConnectionSummary } from '/@api/model-registry-info';
 import type { ProviderInfo } from '/@api/provider-info';
 
 import AgentWorkspaceCreateStepAgentModel from './AgentWorkspaceCreateStepAgentModel.svelte';
@@ -39,6 +41,8 @@ vi.mock(import('/@/stores/providers'));
 vi.mock(import('/@/stores/model-catalog'));
 vi.mock(import('/@/stores/models'));
 vi.mock(import('/@/stores/agentworkspace-runtime'));
+vi.mock(import('/@/stores/inference-connection-summaries'));
+vi.mock(import('/@/stores/configurationProperties'));
 
 function buildCatalogModels(providers: ProviderInfo[]): CatalogModelInfo[] {
   const result: CatalogModelInfo[] = [];
@@ -174,6 +178,10 @@ beforeEach(() => {
   vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([]);
   vi.mocked(agentWorkspaceRuntimeStore).agentWorkspaceRuntime = writable<string>('podman');
   vi.mocked(modelCatalogStore).disabledModels = writable<Set<string>>(new Set());
+  vi.mocked(inferenceConnectionSummariesStore).inferenceConnectionSummariesData = writable<
+    Readonly<InferenceConnectionSummary[]>
+  >([]);
+  vi.mocked(configurationPropertiesStore).configurationProperties = writable([]);
   vi.mocked(modelCatalogStore.isModelEnabled).mockImplementation(
     (disabled: Set<string>, providerId: string, label: string): boolean => !disabled.has(`${providerId}::${label}`),
   );
@@ -224,7 +232,7 @@ test('shows empty state when no providers configured', async () => {
 
   await fireEvent.click(screen.getByText('OpenCode'));
 
-  expect(screen.getByText(/No model sources match/i)).toBeInTheDocument();
+  expect(screen.getByTestId('no-providers-available')).toBeInTheDocument();
 });
 
 test('shows cloud models under Cloud category', async () => {
@@ -345,6 +353,8 @@ test('disabled models are hidden from selection list', async () => {
 });
 
 test('Open Models catalog link visible when agent selected', async () => {
+  setProviders([mockAnthropicProvider]);
+
   render(AgentWorkspaceCreateStepAgentModel);
 
   await fireEvent.click(screen.getByText('OpenCode'));

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -5,8 +5,9 @@ import { untrack } from 'svelte';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 import type { ModelInfo } from '/@/lib/chat/components/model-info';
+import { getCompatibleModels } from '/@/lib/models/compatible-connections';
+import CompatibleConnectionGate from '/@/lib/models/CompatibleConnectionGate.svelte';
 import type { CatalogModelInfo } from '/@/lib/models/models-utils';
-import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
 import { agentInfos } from '/@/stores/agents';
 import { agentWorkspaceRuntime } from '/@/stores/agentworkspace-runtime';
 import { disabledModels, isModelEnabled, modelKey, modelSelectionKey } from '/@/stores/model-catalog';
@@ -41,21 +42,16 @@ let allModels: CatalogModelInfo[] = $derived.by(() => {
   });
 });
 
-let agentFilteredModels: CatalogModelInfo[] = $derived(filterByAgent(allModels, selectedAgent));
+let selectedAgentInfo = $derived($agentInfos.find(a => a.id === selectedAgent));
+let agentFilteredModels: CatalogModelInfo[] = $derived(
+  getCompatibleModels(allModels, selectedAgentInfo?.supportedModelTypes),
+);
 
-let selectedAgentLabel: string = $derived($agentInfos.find(a => a.id === selectedAgent)?.name ?? 'the selected agent');
+let selectedAgentLabel: string = $derived(selectedAgentInfo?.name ?? 'the selected agent');
 
 let selectedKey: string = $derived(
   selectedModel ? modelSelectionKey(selectedModel.providerId, selectedModel.connectionId, selectedModel.label) : '',
 );
-
-function filterByAgent(models: CatalogModelInfo[], agent: string): CatalogModelInfo[] {
-  if (!agent) return models;
-  const info = $agentInfos.find(a => a.id === agent);
-  if (!info?.supportedModelTypes || info.supportedModelTypes.length === 0) return models;
-  const typeNames = new Set(info.supportedModelTypes.map(t => t.name));
-  return models.filter(m => m.llmMetadata?.name !== undefined && typeNames.has(m.llmMetadata.name));
-}
 
 function handleModelSelect(model: CatalogModelInfo): void {
   selectedModel = model;
@@ -139,8 +135,9 @@ $effect(() => {
         here. Disabled rows cannot be selected; the table is filtered to models that fit the agent you picked above.
       </p>
 
-      <ModelSelectionTable
-        models={agentFilteredModels}
+      <CompatibleConnectionGate
+        models={allModels}
+        supportedModelTypes={selectedAgentInfo?.supportedModelTypes}
         selectedKey={selectedKey}
         onselect={handleModelSelect} />
     </div>

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepAgentModel.svelte
@@ -42,7 +42,7 @@ let allModels: CatalogModelInfo[] = $derived.by(() => {
   });
 });
 
-let selectedAgentInfo = $derived($agentInfos.find(a => a.id === selectedAgent));
+let selectedAgentInfo = $derived(filteredAgents.find(a => a.id === selectedAgent));
 let agentFilteredModels: CatalogModelInfo[] = $derived(
   getCompatibleModels(allModels, selectedAgentInfo?.supportedModelTypes),
 );

--- a/packages/renderer/src/lib/coding-agents/CodingAgentDetail.spec.ts
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentDetail.spec.ts
@@ -83,9 +83,9 @@ beforeEach(() => {
   vi.mocked(modelCatalogStore.modelSelectionKey).mockImplementation(
     (providerId: string, connectionId: string, label: string): string => `${providerId}::${connectionId}::${label}`,
   );
-  (window as unknown as Record<string, unknown>).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
-  (window as unknown as Record<string, unknown>).updateConfigurationValue = vi.fn().mockResolvedValue(undefined);
-  (window as unknown as Record<string, unknown>).showMessageBox = vi.fn().mockResolvedValue({ response: 0 });
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
+  vi.mocked(window.updateConfigurationValue).mockResolvedValue(undefined);
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 });
 
 test('renders agent name and description', () => {
@@ -107,7 +107,7 @@ test('shows empty state when no models and no unconfigured connections', () => {
   expect(screen.getByTestId('no-providers-available')).toBeInTheDocument();
 });
 
-test('shows inline connection creation after clicking provider button', async () => {
+test('auto-selects single provider and shows form immediately', () => {
   vi.mocked(inferenceConnectionSummariesStore).inferenceConnectionSummariesData = writable<
     Readonly<InferenceConnectionSummary[]>
   >([
@@ -136,10 +136,6 @@ test('shows inline connection creation after clicking provider button', async ()
   render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
 
   expect(screen.getByTestId('no-models-create-connection')).toBeInTheDocument();
-  expect(screen.queryByTestId('inline-connection-form')).not.toBeInTheDocument();
-
-  await fireEvent.click(screen.getByLabelText('Select Anthropic'));
-
   expect(screen.getByTestId('inline-connection-form')).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/coding-agents/CodingAgentDetail.spec.ts
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentDetail.spec.ts
@@ -1,0 +1,220 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as configurationPropertiesStore from '/@/stores/configurationProperties';
+import * as inferenceConnectionSummariesStore from '/@/stores/inference-connection-summaries';
+import * as modelCatalogStore from '/@/stores/model-catalog';
+import * as modelsStore from '/@/stores/models';
+import * as providersStore from '/@/stores/providers';
+import type { AgentInfo } from '/@api/agent-info';
+import type { CatalogModelInfo, InferenceConnectionSummary } from '/@api/model-registry-info';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import CodingAgentDetail from './CodingAgentDetail.svelte';
+
+vi.mock(import('/@/stores/models'));
+vi.mock(import('/@/stores/model-catalog'));
+vi.mock(import('/@/stores/providers'));
+vi.mock(import('/@/stores/inference-connection-summaries'));
+vi.mock(import('/@/stores/configurationProperties'));
+
+const mockAgentInfo: AgentInfo = {
+  id: 'opencode',
+  name: 'OpenCode',
+  description: 'Open-source coding agent.',
+  command: 'opencode',
+  tags: ['Recommended', 'Cloud'],
+  destinationSkillsFolder: '/home/test/.opencode/skills',
+  supportedModelTypes: [{ name: 'anthropic' }, { name: 'ollama' }],
+};
+
+const mockAnthropicModel: CatalogModelInfo = {
+  providerId: 'claude',
+  providerName: 'Anthropic',
+  connectionId: 'conn-0',
+  connectionName: 'Anthropic Cloud',
+  type: 'cloud',
+  llmMetadata: { name: 'anthropic' },
+  label: 'claude-sonnet-4',
+  connectionStatus: 'started',
+};
+
+const mockOllamaModel: CatalogModelInfo = {
+  providerId: 'ollama',
+  providerName: 'Ollama',
+  connectionId: 'conn-1',
+  connectionName: 'Ollama Local',
+  type: 'local',
+  llmMetadata: { name: 'ollama' },
+  label: 'llama3.2:3b',
+  connectionStatus: 'started',
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.resetAllMocks();
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([]);
+  vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([]);
+  vi.mocked(inferenceConnectionSummariesStore).inferenceConnectionSummariesData = writable<
+    Readonly<InferenceConnectionSummary[]>
+  >([]);
+  vi.mocked(configurationPropertiesStore).configurationProperties = writable([]);
+  vi.mocked(modelCatalogStore.modelSelectionKey).mockImplementation(
+    (providerId: string, connectionId: string, label: string): string => `${providerId}::${connectionId}::${label}`,
+  );
+  (window as unknown as Record<string, unknown>).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
+  (window as unknown as Record<string, unknown>).updateConfigurationValue = vi.fn().mockResolvedValue(undefined);
+  (window as unknown as Record<string, unknown>).showMessageBox = vi.fn().mockResolvedValue({ response: 0 });
+});
+
+test('renders agent name and description', () => {
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  expect(screen.getByText('OpenCode')).toBeInTheDocument();
+  expect(screen.getByText('Open-source coding agent.')).toBeInTheDocument();
+});
+
+test('renders agent tags', () => {
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  expect(screen.getByText('Recommended · Cloud')).toBeInTheDocument();
+});
+
+test('shows empty state when no models and no unconfigured connections', () => {
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  expect(screen.getByTestId('no-providers-available')).toBeInTheDocument();
+});
+
+test('shows inline connection creation after clicking provider button', async () => {
+  vi.mocked(inferenceConnectionSummariesStore).inferenceConnectionSummariesData = writable<
+    Readonly<InferenceConnectionSummary[]>
+  >([
+    {
+      providerName: 'Anthropic',
+      providerId: 'claude',
+      providerInternalId: 'claude-internal',
+      connectionId: '',
+      connectionType: 'cloud',
+      llmMetadata: { name: 'anthropic' },
+      status: 'not-configured',
+      modelCount: 0,
+      creationDisplayName: 'Create Anthropic connection',
+      configurable: true,
+    },
+  ]);
+  vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([
+    {
+      id: 'claude',
+      name: 'Anthropic',
+      internalId: 'claude-internal',
+      status: 'not-started',
+    } as unknown as ProviderInfo,
+  ]);
+
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  expect(screen.getByTestId('no-models-create-connection')).toBeInTheDocument();
+  expect(screen.queryByTestId('inline-connection-form')).not.toBeInTheDocument();
+
+  await fireEvent.click(screen.getByLabelText('Select Anthropic'));
+
+  expect(screen.getByTestId('inline-connection-form')).toBeInTheDocument();
+});
+
+test('shows model selection table when compatible models exist', () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([mockAnthropicModel, mockOllamaModel]);
+
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
+  expect(screen.getByText('llama3.2:3b')).toBeInTheDocument();
+});
+
+test('shows provider picker when multiple unconfigured connections', () => {
+  vi.mocked(inferenceConnectionSummariesStore).inferenceConnectionSummariesData = writable<
+    Readonly<InferenceConnectionSummary[]>
+  >([
+    {
+      providerName: 'Anthropic',
+      providerId: 'claude',
+      providerInternalId: 'claude-internal',
+      connectionId: '',
+      connectionType: 'cloud',
+      llmMetadata: { name: 'anthropic' },
+      status: 'not-configured',
+      modelCount: 0,
+      creationDisplayName: 'Create Anthropic connection',
+      configurable: true,
+    },
+    {
+      providerName: 'Ollama',
+      providerId: 'ollama',
+      providerInternalId: 'ollama-internal',
+      connectionId: '',
+      connectionType: 'local',
+      llmMetadata: { name: 'ollama' },
+      status: 'not-configured',
+      modelCount: 0,
+      creationDisplayName: 'Create Ollama connection',
+      configurable: true,
+    },
+  ]);
+  vi.mocked(providersStore).providerInfos = writable<ProviderInfo[]>([
+    {
+      id: 'claude',
+      name: 'Anthropic',
+      internalId: 'claude-internal',
+      status: 'not-started',
+    } as unknown as ProviderInfo,
+    { id: 'ollama', name: 'Ollama', internalId: 'ollama-internal', status: 'not-started' } as unknown as ProviderInfo,
+  ]);
+
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  expect(screen.getByTestId('provider-picker')).toBeInTheDocument();
+  expect(screen.getByLabelText('Select Anthropic')).toBeInTheDocument();
+  expect(screen.getByLabelText('Select Ollama')).toBeInTheDocument();
+});
+
+test('save button disabled when no changes', () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([mockAnthropicModel]);
+
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  const saveBtn = screen.getByRole('button', { name: 'Save' });
+  expect(saveBtn).toBeDisabled();
+});
+
+test('selecting model enables save', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([mockAnthropicModel]);
+
+  render(CodingAgentDetail, { props: { agentInfo: mockAgentInfo } });
+
+  const radio = screen.getByRole('radio', { name: 'Use claude-sonnet-4' });
+  await fireEvent.click(radio);
+
+  const saveBtn = screen.getByRole('button', { name: 'Save' });
+  expect(saveBtn).toBeEnabled();
+});

--- a/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
+++ b/packages/renderer/src/lib/coding-agents/CodingAgentDetail.svelte
@@ -4,10 +4,9 @@ import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
-import type { CatalogModelInfo, InferenceConnectionSummary } from '/@/lib/models/models-utils';
-import ModelSelectionTable from '/@/lib/models/ModelSelectionTable.svelte';
-import ProviderConnectionTiles from '/@/lib/models/ProviderConnectionTiles.svelte';
-import { inferenceConnectionSummariesData } from '/@/stores/inference-connection-summaries';
+import { getCompatibleModels } from '/@/lib/models/compatible-connections';
+import CompatibleConnectionGate from '/@/lib/models/CompatibleConnectionGate.svelte';
+import type { CatalogModelInfo } from '/@/lib/models/models-utils';
 import { modelSelectionKey } from '/@/stores/model-catalog';
 import { catalogModels } from '/@/stores/models';
 import type { AgentInfo } from '/@api/agent-info';
@@ -19,23 +18,8 @@ interface Props {
 
 let { agentInfo }: Props = $props();
 
-let compatibleModels: CatalogModelInfo[] = $derived.by(() => {
-  const types = agentInfo.supportedModelTypes;
-  if (types === undefined) return $catalogModels.slice();
-  if (types.length === 0) return [];
-  const typeNames = new Set(types.map(t => t.name));
-  return $catalogModels.filter(m => m.llmMetadata?.name !== undefined && typeNames.has(m.llmMetadata.name));
-});
-
+let compatibleModels: CatalogModelInfo[] = $derived(getCompatibleModels($catalogModels, agentInfo.supportedModelTypes));
 let hasModels = $derived(compatibleModels.length > 0);
-
-let configurableConnections: InferenceConnectionSummary[] = $derived.by(() => {
-  const all: InferenceConnectionSummary[] = $inferenceConnectionSummariesData.slice();
-  if (agentInfo.supportedModelTypes === undefined) return all;
-  const compatibleProviderIds = new Set(compatibleModels.map(m => m.providerId));
-  if (compatibleProviderIds.size === 0) return all;
-  return all.filter(c => compatibleProviderIds.has(c.providerId));
-});
 
 let savedModelKey = $state('');
 let selectedModelKey = $state('');
@@ -133,23 +117,19 @@ function getAgentSubtitle(agent: AgentInfo): string {
   </div>
 
   <div class="px-8 pb-8 flex-1">
-    {#if configurableConnections.length > 0}
-      <div class="mb-4">
-        <ProviderConnectionTiles connections={configurableConnections} />
-      </div>
-    {/if}
+    <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
+      <h2 class="text-sm font-semibold text-(--pd-content-card-text) mb-1">Default model</h2>
+      <p class="text-xs text-(--pd-content-card-text) opacity-60 mb-4">
+        Select the default model for this agent. You can override per workspace later.
+      </p>
 
-    {#if hasModels}
-      <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
-        <h2 class="text-sm font-semibold text-(--pd-content-card-text) mb-1">Default model</h2>
-        <p class="text-xs text-(--pd-content-card-text) opacity-60 mb-4">
-          Select the default model for this agent. You can override per workspace later.
-        </p>
-        <ModelSelectionTable
-          models={compatibleModels}
-          selectedKey={selectedModelKey}
-          onselect={selectModel} />
+      <CompatibleConnectionGate
+        models={$catalogModels}
+        supportedModelTypes={agentInfo.supportedModelTypes}
+        selectedKey={selectedModelKey}
+        onselect={selectModel} />
 
+      {#if hasModels}
         <div class="flex items-center justify-end gap-3 mt-6 pt-4 border-t border-(--pd-content-divider)">
           <span class="text-xs text-(--pd-content-card-text) opacity-60 mr-auto">
             {hasChanges ? 'You have unsaved changes' : ''}
@@ -159,28 +139,7 @@ function getAgentSubtitle(agent: AgentInfo): string {
             {saving ? 'Saving…' : 'Save'}
           </Button>
         </div>
-      </div>
-    {:else if configurableConnections.length === 0}
-      <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
-        <div class="flex flex-col items-center text-center py-6">
-          <Icon icon={faTerminal} size="2em" class="text-(--pd-content-card-text) opacity-40 mb-4" />
-          <h2 class="text-base font-semibold text-(--pd-content-card-text) mb-2">No models or providers available</h2>
-          <p class="text-sm text-(--pd-content-card-text) opacity-60 max-w-md">
-            Install a compatible provider extension, then return here to select a model.
-          </p>
-        </div>
-      </div>
-    {:else}
-      <div class="rounded-xl border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-6">
-        <div class="flex flex-col items-center text-center py-6">
-          <Icon icon={faTerminal} size="2em" class="text-(--pd-content-card-text) opacity-40 mb-4" />
-          <h2 class="text-base font-semibold text-(--pd-content-card-text) mb-2">No compatible models found</h2>
-          <p class="text-sm text-(--pd-content-card-text) opacity-60 max-w-md">
-            Your providers are connected but no compatible models are available yet.
-            Check the provider settings above or install a model that supports this agent.
-          </p>
-        </div>
-      </div>
-    {/if}
+      {/if}
+    </div>
   </div>
 </div>

--- a/packages/renderer/src/lib/models/CompatibleConnectionGate.svelte
+++ b/packages/renderer/src/lib/models/CompatibleConnectionGate.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+import { faPlug } from '@fortawesome/free-solid-svg-icons';
+import type { ModelType } from '@openkaiden/api';
+import { Button } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import PreferencesConnectionCreationRendering from '/@/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte';
+import { configurationProperties } from '/@/stores/configurationProperties';
+import { inferenceConnectionSummariesData } from '/@/stores/inference-connection-summaries';
+import { providerInfos } from '/@/stores/providers';
+import type { CatalogModelInfo } from '/@api/model-registry-info';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import { getCompatibleModels, getCompatibleUnconfiguredConnections } from './compatible-connections';
+import ModelSelectionTable from './ModelSelectionTable.svelte';
+
+interface Props {
+  models: readonly CatalogModelInfo[];
+  supportedModelTypes: readonly ModelType[] | undefined;
+  selectedKey?: string;
+  onselect?: (model: CatalogModelInfo) => void;
+}
+
+let { models, supportedModelTypes, selectedKey = '', onselect }: Props = $props();
+
+let compatibleModels = $derived(getCompatibleModels(models, supportedModelTypes));
+let hasModels = $derived(compatibleModels.length > 0);
+
+let unconfiguredConnections = $derived(
+  getCompatibleUnconfiguredConnections($inferenceConnectionSummariesData, supportedModelTypes),
+);
+
+let selectedProviderInternalId: string | undefined = $state(undefined);
+
+let activeProviderInternalId = $derived(selectedProviderInternalId);
+
+let activeProviderInfo: ProviderInfo | undefined = $derived(
+  activeProviderInternalId ? $providerInfos.find(p => p.internalId === activeProviderInternalId) : undefined,
+);
+
+let inProgress = $state(false);
+
+function selectProvider(internalId: string): void {
+  selectedProviderInternalId = internalId;
+}
+</script>
+
+{#if hasModels}
+  <ModelSelectionTable
+    models={compatibleModels}
+    {selectedKey}
+    {onselect} />
+{:else if unconfiguredConnections.length > 0}
+  <div class="flex flex-col gap-4" data-testid="no-models-create-connection">
+    <div class="flex flex-col items-center text-center py-4">
+      <Icon icon={faPlug} size="2em" class="text-(--pd-content-card-text) opacity-40 mb-3" />
+      <h3 class="text-sm font-semibold text-(--pd-content-card-text) mb-1">No compatible models available</h3>
+      <p class="text-xs text-(--pd-content-card-text) opacity-60 max-w-sm">
+        Create a compatible connection to make models available for this agent.
+      </p>
+    </div>
+
+    <div class="flex flex-wrap gap-3 justify-center" data-testid="provider-picker">
+      {#each unconfiguredConnections as connection (connection.providerId)}
+        {@const isActive = activeProviderInternalId === connection.providerInternalId}
+        <Button
+          type={isActive ? 'primary' : 'secondary'}
+          aria-label="Select {connection.providerName}"
+          onclick={selectProvider.bind(undefined, connection.providerInternalId)}>
+          {connection.creationDisplayName || connection.providerName}
+        </Button>
+      {/each}
+    </div>
+
+    {#if activeProviderInfo}
+      {#key activeProviderInternalId}
+        <div class="rounded-lg border border-(--pd-content-card-border) bg-(--pd-content-card-bg) p-4" data-testid="inline-connection-form">
+          <PreferencesConnectionCreationRendering
+            providerInfo={activeProviderInfo}
+            properties={$configurationProperties}
+            propertyScope="InferenceProviderConnectionFactory"
+            callback={window.createInferenceProviderConnection}
+            disableEmptyScreen={true}
+            hideCloseButton={true}
+            bind:inProgress={inProgress} />
+        </div>
+      {/key}
+    {/if}
+  </div>
+{:else}
+  <div class="flex flex-col items-center text-center py-6" data-testid="no-providers-available">
+    <Icon icon={faPlug} size="2em" class="text-(--pd-content-card-text) opacity-40 mb-3" />
+    <h3 class="text-sm font-semibold text-(--pd-content-card-text) mb-1">No compatible models or providers</h3>
+    <p class="text-xs text-(--pd-content-card-text) opacity-60 max-w-sm">
+      Install a compatible provider extension, then return here to select a model.
+    </p>
+  </div>
+{/if}

--- a/packages/renderer/src/lib/models/CompatibleConnectionGate.svelte
+++ b/packages/renderer/src/lib/models/CompatibleConnectionGate.svelte
@@ -32,7 +32,12 @@ let unconfiguredConnections = $derived(
 
 let selectedProviderInternalId: string | undefined = $state(undefined);
 
-let activeProviderInternalId = $derived(selectedProviderInternalId);
+let autoSelectedProvider = $derived.by((): string | undefined => {
+  if (unconfiguredConnections.length === 1) return unconfiguredConnections[0]!.providerInternalId;
+  return undefined;
+});
+
+let activeProviderInternalId = $derived(selectedProviderInternalId ?? autoSelectedProvider);
 
 let activeProviderInfo: ProviderInfo | undefined = $derived(
   activeProviderInternalId ? $providerInfos.find(p => p.internalId === activeProviderInternalId) : undefined,

--- a/packages/renderer/src/lib/models/compatible-connections.spec.ts
+++ b/packages/renderer/src/lib/models/compatible-connections.spec.ts
@@ -1,0 +1,167 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import type { CatalogModelInfo, InferenceConnectionSummary } from '/@api/model-registry-info';
+
+import { getCompatibleModels, getCompatibleUnconfiguredConnections } from './compatible-connections';
+
+const anthropicSummary: InferenceConnectionSummary = {
+  providerName: 'Anthropic',
+  providerId: 'claude',
+  providerInternalId: 'claude-internal',
+  connectionId: '',
+  connectionType: 'cloud',
+  llmMetadata: { name: 'anthropic' },
+  status: 'not-configured',
+  modelCount: 0,
+  creationDisplayName: 'Create Anthropic connection',
+  configurable: true,
+};
+
+const ollamaSummary: InferenceConnectionSummary = {
+  providerName: 'Ollama',
+  providerId: 'ollama',
+  providerInternalId: 'ollama-internal',
+  connectionId: '',
+  connectionType: 'local',
+  llmMetadata: { name: 'ollama' },
+  status: 'not-configured',
+  modelCount: 0,
+  creationDisplayName: 'Create Ollama connection',
+  configurable: true,
+};
+
+const connectedSummary: InferenceConnectionSummary = {
+  providerName: 'OpenAI',
+  providerId: 'openai',
+  providerInternalId: 'openai-internal',
+  connectionId: 'conn-1',
+  connectionType: 'cloud',
+  llmMetadata: { name: 'openai' },
+  status: 'started',
+  modelCount: 3,
+  creationDisplayName: 'Create OpenAI connection',
+  configurable: true,
+};
+
+const nonConfigurableSummary: InferenceConnectionSummary = {
+  providerName: 'Custom',
+  providerId: 'custom',
+  providerInternalId: 'custom-internal',
+  connectionId: '',
+  connectionType: 'cloud',
+  llmMetadata: { name: 'anthropic' },
+  status: 'not-configured',
+  modelCount: 0,
+  creationDisplayName: '',
+  configurable: false,
+};
+
+describe('getCompatibleUnconfiguredConnections', () => {
+  test('returns empty when supportedModelTypes is undefined', () => {
+    const result = getCompatibleUnconfiguredConnections([anthropicSummary, ollamaSummary], undefined);
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty when supportedModelTypes is empty', () => {
+    const result = getCompatibleUnconfiguredConnections([anthropicSummary, ollamaSummary], []);
+    expect(result).toEqual([]);
+  });
+
+  test('filters to matching unconfigured connections', () => {
+    const result = getCompatibleUnconfiguredConnections(
+      [anthropicSummary, ollamaSummary, connectedSummary],
+      [{ name: 'anthropic' }],
+    );
+    expect(result).toEqual([anthropicSummary]);
+  });
+
+  test('excludes already connected providers', () => {
+    const result = getCompatibleUnconfiguredConnections([connectedSummary], [{ name: 'openai' }]);
+    expect(result).toEqual([]);
+  });
+
+  test('excludes non-configurable providers', () => {
+    const result = getCompatibleUnconfiguredConnections([nonConfigurableSummary], [{ name: 'anthropic' }]);
+    expect(result).toEqual([]);
+  });
+
+  test('returns multiple matching connections', () => {
+    const result = getCompatibleUnconfiguredConnections(
+      [anthropicSummary, ollamaSummary],
+      [{ name: 'anthropic' }, { name: 'ollama' }],
+    );
+    expect(result).toEqual([anthropicSummary, ollamaSummary]);
+  });
+
+  test('excludes connections with undefined llmMetadata', () => {
+    const noMetadata: InferenceConnectionSummary = {
+      ...anthropicSummary,
+      llmMetadata: undefined,
+    };
+    const result = getCompatibleUnconfiguredConnections([noMetadata], [{ name: 'anthropic' }]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getCompatibleModels', () => {
+  const anthropicModel: CatalogModelInfo = {
+    providerId: 'claude',
+    providerName: 'Anthropic',
+    connectionId: 'conn-0',
+    connectionName: 'Anthropic Cloud',
+    type: 'cloud',
+    llmMetadata: { name: 'anthropic' },
+    label: 'claude-sonnet-4',
+    connectionStatus: 'started',
+  };
+
+  const ollamaModel: CatalogModelInfo = {
+    providerId: 'ollama',
+    providerName: 'Ollama',
+    connectionId: 'conn-1',
+    connectionName: 'Ollama Local',
+    type: 'local',
+    llmMetadata: { name: 'ollama' },
+    label: 'llama3.2:3b',
+    connectionStatus: 'started',
+  };
+
+  test('returns all models when supportedModelTypes is undefined', () => {
+    const result = getCompatibleModels([anthropicModel, ollamaModel], undefined);
+    expect(result).toEqual([anthropicModel, ollamaModel]);
+  });
+
+  test('returns empty when supportedModelTypes is empty', () => {
+    const result = getCompatibleModels([anthropicModel, ollamaModel], []);
+    expect(result).toEqual([]);
+  });
+
+  test('filters to matching models', () => {
+    const result = getCompatibleModels([anthropicModel, ollamaModel], [{ name: 'anthropic' }]);
+    expect(result).toEqual([anthropicModel]);
+  });
+
+  test('excludes models with undefined llmMetadata', () => {
+    const noMetadata = { ...anthropicModel, llmMetadata: undefined };
+    const result = getCompatibleModels([noMetadata], [{ name: 'anthropic' }]);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/renderer/src/lib/models/compatible-connections.ts
+++ b/packages/renderer/src/lib/models/compatible-connections.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ModelType } from '@openkaiden/api';
+
+import type { CatalogModelInfo, InferenceConnectionSummary } from '/@api/model-registry-info';
+
+export function getCompatibleUnconfiguredConnections(
+  summaries: readonly InferenceConnectionSummary[],
+  supportedModelTypes: readonly ModelType[] | undefined,
+): InferenceConnectionSummary[] {
+  if (!supportedModelTypes || supportedModelTypes.length === 0) return [];
+  const typeNames = new Set(supportedModelTypes.map(t => t.name));
+  return summaries.filter(
+    c =>
+      c.configurable &&
+      c.status === 'not-configured' &&
+      c.llmMetadata?.name !== undefined &&
+      typeNames.has(c.llmMetadata.name),
+  );
+}
+
+export function getCompatibleModels(
+  models: readonly CatalogModelInfo[],
+  supportedModelTypes: readonly ModelType[] | undefined,
+): CatalogModelInfo[] {
+  if (supportedModelTypes === undefined) return models.slice();
+  if (supportedModelTypes.length === 0) return [];
+  const typeNames = new Set(supportedModelTypes.map(t => t.name));
+  return models.filter(m => m.llmMetadata?.name !== undefined && typeNames.has(m.llmMetadata.name));
+}


### PR DESCRIPTION
When an agent has no compatible models available, the UI now shows compatible unconfigured providers as selectable buttons and renders the connection creation form inline — removing the need to navigate away to Preferences. ProviderConnectionTiles removed from agent detail.

https://github.com/user-attachments/assets/49e5936b-c1c3-47c6-b69d-63f058fd285c


https://github.com/user-attachments/assets/083e1475-f0d1-4fcd-8603-08de33045b94



Closes #2129