### PR TITLE
chore: initialize fullsend per-repo installation

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -6,11 +6,6 @@
 version: "1"
 roles:
     - triage
-    - coder
-    - review
-    - fix
-    - retro
-    - prioritize
 create_issues:
     allow_targets:
         repos:


### PR DESCRIPTION
This PR adds the fullsend scaffold files for per-repo installation.

Merge this PR to activate fullsend workflows.