### PR TITLE
chore: initialize fullsend per-repo installation

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -68,7 +68,7 @@ jobs:
           || github.event.comment.author_association == 'CONTRIBUTOR'
           || github.event.comment.user.login == github.event.issue.user.login
         )
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
This PR adds the fullsend scaffold files for per-repo installation.

Merge this PR to activate fullsend workflows.