### PR TITLE
fix(cli): include path in convertToCliToolInfo

### DIFF
--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -535,6 +535,7 @@ suite('cli module', () => {
       displayName: 'tool-display-name',
       markdownDescription: 'markdown description',
       images: {},
+      path: '/usr/bin/tool-name',
     };
     const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
     const cliToolInfo = cliToolRegistry['convertToCliToolInfo'](newCliTool);
@@ -544,5 +545,6 @@ suite('cli module', () => {
     expect(cliToolInfo.displayName).equals(newCliTool.displayName);
     expect(cliToolInfo.markdownDescription).equals(newCliTool.markdownDescription);
     expect(cliToolInfo.version).equals(newCliTool.version);
+    expect(cliToolInfo.path).equals(newCliTool.path);
   });
 });

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -184,6 +184,7 @@ export class CliToolRegistry {
       markdownDescription: cliTool.markdownDescription,
       images: cliTool.images,
       version: cliTool.version,
+      path: cliTool.path,
       extensionInfo: {
         id: cliTool.extensionInfo.id,
         label: cliTool.extensionInfo.label,


### PR DESCRIPTION
Cherry-pick from acddd55e143d9833bd7dff607ea3c33777a0c904

This change was originally implemented in podman-desktop/podman-desktop and is being brought into openkaiden/kaiden.

## Description
Adds the \`path\` property to the CLI tool information returned by \`convertToCliToolInfo\`. This ensures that when CLI tools are converted to the extension API format, their file system path is preserved and available to consumers.

## Changes
- Added \`path\` property to \`convertToCliToolInfo\` function in \`cli-tool-registry.ts\`
- Updated unit tests in \`cli-tool-registry.spec.ts\` to verify the path is included in the conversion output

## Original PR
- podman-desktop/podman-desktop#18044
- Fixes podman-desktop/podman-desktop#18040