### PR TITLE
chore(deps): bump openshell from 0.0.57 to 0.0.69

### DIFF
--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenShell",
   "description": "Registers the openshell CLI binary for managing sandboxed workspaces.",
   "version": "0.3.0-next",
-  "openshellVersion": "0.0.57",
+  "openshellVersion": "0.0.69",
   "openshellImageBuilderVersion": "0.9.0",
   "icon": "icon.png",
   "publisher": "kaiden",


### PR DESCRIPTION
## Summary
- Bumps the pinned `openshellVersion` in `extensions/openshell/package.json` from `0.0.57` to `0.0.69`

## Test plan
- [ ] Verify openshell extension builds successfully
- [ ] Verify openshell binary download works with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)