### PR TITLE
fix(openshell): upload all filesystem mounts including broad paths

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { access, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { access, lstat, readFile, rm, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 import type {
   Agent,
@@ -162,6 +163,21 @@ beforeEach(() => {
     get: vi.fn().mockReturnValue(undefined),
   } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
   vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({});
+  vi.mocked(lstat).mockImplementation(async path => {
+    const value = String(path);
+    const isDirectory =
+      value === '/tmp/my-project' ||
+      value.endsWith('shared-lib') ||
+      value.endsWith('skills/github') ||
+      value.endsWith('skills\\github') ||
+      value.endsWith('skills/kubernetes') ||
+      value.endsWith('skills\\kubernetes');
+    return {
+      isDirectory: () => isDirectory,
+      isFile: () => !isDirectory,
+      isSymbolicLink: () => false,
+    } as Awaited<ReturnType<typeof lstat>>;
+  });
   manager = new AgentWorkspaceManager(
     apiSender,
     ipcHandle,
@@ -287,13 +303,15 @@ describe('create – OpenShell mode', () => {
     const options = { ...defaultOptions, secrets: ['my-secret'] };
     await manager.create(options);
 
-    expect(openshellCli.createSandbox).toHaveBeenCalledWith({
-      name: 'my-sandbox',
-      providers: ['my-secret'],
-      labels: { ...encodeWorkspaceLabels('/tmp/my-project'), [AGENT_LABEL]: 'claude' },
-      noTty: true,
-      command: ['true'],
-    });
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'my-sandbox',
+        providers: ['my-secret'],
+        labels: { ...encodeWorkspaceLabels('/tmp/my-project'), [AGENT_LABEL]: 'claude' },
+        noTty: true,
+        command: ['true'],
+      }),
+    );
   });
 
   test('returns { id: sandboxName }', async () => {
@@ -372,16 +390,20 @@ describe('create – OpenShell mode', () => {
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        uploads: [{ local: expect.any(String), remote: '/home/user/.config/agent/config.toml' }],
+        uploads: expect.arrayContaining([
+          { local: expect.any(String), remote: '/home/user/.config/agent/config.toml' },
+        ]),
       }),
     );
   });
 
-  test('does not include uploads when agent has no config files', async () => {
+  test('uploads workspace filesystem even when agent has no config files', async () => {
     await manager.create(defaultOptions);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
-      expect.not.objectContaining({ uploads: expect.anything() }),
+      expect.objectContaining({
+        uploads: expect.arrayContaining([{ local: '/tmp/my-project', remote: '.' }]),
+      }),
     );
   });
 
@@ -399,7 +421,9 @@ describe('create – OpenShell mode', () => {
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        uploads: [{ local: expect.any(String), remote: '/home/user/.config/agent/config.toml' }],
+        uploads: expect.arrayContaining([
+          { local: expect.any(String), remote: '/home/user/.config/agent/config.toml' },
+        ]),
       }),
     );
   });
@@ -414,11 +438,50 @@ describe('create – OpenShell mode', () => {
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        uploads: [
-          { local: '/home/user/.kaiden/skills/github', remote: '.claude/skills/github' },
-          { local: '/home/user/.kaiden/skills/kubernetes', remote: '.claude/skills/kubernetes' },
-        ],
+        uploads: expect.arrayContaining([
+          { local: '/home/user/.kaiden/skills/github', remote: '.claude/skills' },
+          { local: '/home/user/.kaiden/skills/kubernetes', remote: '.claude/skills' },
+        ]),
       }),
+    );
+  });
+
+  test('uploads safe resolved mounts to the openshell sandbox', async () => {
+    await manager.create({
+      ...defaultOptions,
+      mounts: [
+        { host: '$SOURCES/subdir', target: '$SOURCES/subdir', ro: false },
+        { host: '$HOME/.gitconfig', target: '$HOME/.gitconfig', ro: true },
+      ],
+    });
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: expect.arrayContaining([
+          { local: '/tmp/my-project', remote: '.' },
+          { local: resolve('/tmp/my-project', './subdir'), remote: 'subdir' },
+          { local: join(homedir(), '.gitconfig'), remote: '~/.gitconfig' },
+        ]),
+      }),
+    );
+  });
+
+  test('uploads broad host access mounts when creating an openshell sandbox', async () => {
+    await manager.create({
+      ...defaultOptions,
+      mounts: [
+        { host: '$HOME', target: '$HOME', ro: false },
+        { host: '/', target: '/', ro: false },
+      ],
+    });
+
+    const sandboxOptions = vi.mocked(openshellCli.createSandbox).mock.calls[0]?.[0];
+    expect(sandboxOptions?.uploads).toEqual(
+      expect.arrayContaining([
+        { local: '/tmp/my-project', remote: '.' },
+        { local: homedir(), remote: '~' },
+        { local: '/', remote: '/' },
+      ]),
     );
   });
 
@@ -435,7 +498,7 @@ describe('create – OpenShell mode', () => {
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        uploads: [{ local: '/home/user/.kaiden/skills/github', remote: '.agents/skills/github' }],
+        uploads: expect.arrayContaining([{ local: '/home/user/.kaiden/skills/github', remote: '.agents/skills' }]),
       }),
     );
   });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { access, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, lstat, readFile, rm, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
-import { basename, join, posix } from 'node:path';
+import { basename, isAbsolute, join, posix, resolve } from 'node:path';
 
 import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
@@ -52,6 +52,10 @@ import { AGENT_LABEL, decodeWorkspaceLabels, WORKSPACE_LABEL } from '/@api/opens
 
 const HOME_VARIABLE = '${HOME}';
 const LABEL_MAX_LENGTH = 63;
+const SOURCES_VARIABLE = '$SOURCES';
+const MOUNT_HOME_PREFIX = '$HOME';
+
+type OpenshellUpload = { local: string; remote: string };
 
 export function encodeWorkspaceLabels(sourcePath: string): Record<string, string> {
   const encoded = Buffer.from(sourcePath).toString('base64url');
@@ -138,7 +142,7 @@ export class AgentWorkspaceManager implements Disposable {
 
     const workspace = await writeWorkspaceConfig(options);
     const agent = this.agentRegistry.getAgentRegistration(options.agent);
-    const uploads: Array<{ local: string; remote: string }> = [];
+    const uploads: OpenshellUpload[] = [];
 
     if (agent) {
       const writable = await Promise.all(
@@ -184,6 +188,8 @@ export class AgentWorkspaceManager implements Disposable {
       }
     }
 
+    uploads.push(...(await this.buildOpenshellFilesystemUploads(options.sourcePath, workspace)));
+
     const sandboxName = options.name ?? basename(options.sourcePath);
     const env = workspace.environment
       ?.filter(entry => typeof entry.value === 'string' && entry.value !== '')
@@ -191,6 +197,7 @@ export class AgentWorkspaceManager implements Disposable {
         acc[entry.name] = entry.value as string;
         return acc;
       }, {});
+    const dedupedUploads = this.dedupeOpenshellUploads(uploads);
 
     const t0 = performance.now();
 
@@ -207,7 +214,7 @@ export class AgentWorkspaceManager implements Disposable {
         providers: options.secrets,
         env: env && Object.keys(env).length > 0 ? env : undefined,
         labels: { ...encodeWorkspaceLabels(options.sourcePath), [AGENT_LABEL]: options.agent },
-        uploads: uploads.length > 0 ? uploads : undefined,
+        uploads: dedupedUploads.length > 0 ? dedupedUploads : undefined,
         noTty: true,
         command: ['true'],
         policy: policyFile,
@@ -242,10 +249,7 @@ export class AgentWorkspaceManager implements Disposable {
     }
   }
 
-  private buildOpenshellSkillUploads(
-    skills: string[] | undefined,
-    destinationSkillsFolder: string,
-  ): Array<{ local: string; remote: string }> {
+  private buildOpenshellSkillUploads(skills: string[] | undefined, destinationSkillsFolder: string): OpenshellUpload[] {
     if (!skills?.length) {
       return [];
     }
@@ -253,8 +257,96 @@ export class AgentWorkspaceManager implements Disposable {
     const remoteBase = this.resolveOpenshellSkillsDestination(destinationSkillsFolder);
     return skills.map(skillPath => ({
       local: skillPath,
-      remote: posix.join(remoteBase, basename(skillPath)),
+      remote: remoteBase,
     }));
+  }
+
+  private async buildOpenshellFilesystemUploads(
+    sourcePath: string,
+    workspace: AgentWorkspaceConfiguration,
+  ): Promise<OpenshellUpload[]> {
+    const uploads: OpenshellUpload[] = [{ local: sourcePath, remote: '.' }];
+
+    for (const mount of workspace.mounts ?? []) {
+      const local = this.resolveHostPath(mount.host, sourcePath);
+      const remote = this.resolveOpenshellSandboxPath(mount.target, sourcePath);
+      if (!local || !remote) {
+        continue;
+      }
+      const resolvedRemote = await this.resolveUploadRemotePath(local, remote);
+      uploads.push({ local, remote: resolvedRemote });
+    }
+    return uploads;
+  }
+
+  private async resolveUploadRemotePath(local: string, remote: string): Promise<string> {
+    try {
+      const stats = await lstat(local);
+      if (stats.isDirectory()) {
+        const localBase = basename(local);
+        if (localBase !== '' && posix.basename(remote) === localBase) {
+          return posix.dirname(remote);
+        }
+      }
+    } catch {
+      // Leave remote unchanged when the local path cannot be inspected.
+    }
+    return remote;
+  }
+
+  private resolveHostPath(path: string, sourcePath: string): string | undefined {
+    if (path === SOURCES_VARIABLE) {
+      return sourcePath;
+    }
+    if (path.startsWith(`${SOURCES_VARIABLE}/`)) {
+      return resolve(sourcePath, path.slice(SOURCES_VARIABLE.length + 1));
+    }
+    if (path === MOUNT_HOME_PREFIX) {
+      return homedir();
+    }
+    if (path.startsWith(`${MOUNT_HOME_PREFIX}/`)) {
+      return resolve(homedir(), path.slice(MOUNT_HOME_PREFIX.length + 1));
+    }
+    if (path.startsWith('~/')) {
+      return resolve(homedir(), path.slice(2));
+    }
+    if (isAbsolute(path)) {
+      return path;
+    }
+    return undefined;
+  }
+
+  private resolveOpenshellSandboxPath(path: string, _sourcePath: string): string | undefined {
+    if (path === SOURCES_VARIABLE) {
+      return '.';
+    }
+    if (path.startsWith(`${SOURCES_VARIABLE}/`)) {
+      return path.slice(SOURCES_VARIABLE.length + 1);
+    }
+    if (path === MOUNT_HOME_PREFIX) {
+      return '~';
+    }
+    if (path.startsWith(`${MOUNT_HOME_PREFIX}/`)) {
+      return posix.join('~', path.slice(MOUNT_HOME_PREFIX.length + 1));
+    }
+    if (path.startsWith('/')) {
+      return path;
+    }
+    return undefined;
+  }
+
+  private dedupeOpenshellUploads(uploads: OpenshellUpload[]): OpenshellUpload[] {
+    const deduped: OpenshellUpload[] = [];
+    const seen = new Set<string>();
+    for (const upload of uploads) {
+      const key = `${upload.local}\u0000${upload.remote}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      deduped.push(upload);
+    }
+    return deduped;
   }
 
   private resolveOpenshellSkillsDestination(destinationSkillsFolder: string): string {


### PR DESCRIPTION
## Summary

- Removes the `isBroadOpenshellHostPath` filter that was silently skipping `$HOME` and `/` mounts during OpenShell sandbox creation
- All workspace file access options (Home Directory, Full System Access, Custom Paths) now work correctly with OpenShell via `--upload`
- OpenShell bind mounts are not reliably supported yet

Fixes #2253

  Setup

  1. Have a project directory with some files (e.g. ~/projects/test-app)
  2. Launch Kaiden, create a workspace pointing at that directory
  
  ## Manual Test Plan

  ### Setup
  - Have a project directory with some files (e.g. `~/projects/test-app`)
  - Launch Kaiden, select Claude as the agent

  ### Test Cases

  - [ ] **Source directory uploads** — Create workspace with no custom mounts. Verify: `openshell sandbox exec -- ls -la` shows your project files in the
  working directory.
  - [ ] **Custom mount with $HOME path** — Create workspace with custom mount `$HOME/Downloads` → `$HOME/Downloads`. Verify: `openshell sandbox exec -- ls
  -la '~/Downloads'` shows your Downloads contents.
  - [ ] **Custom mount with $SOURCES subdir** — Create workspace with custom mount `$SOURCES/src` → `$SOURCES/src`. Verify: `openshell sandbox exec -- ls
  src/` shows your project's src files.
  - [ ] **Skills upload** — Create workspace with skills selected. Verify: `openshell sandbox exec -- ls .claude/skills/` shows the selected skill
  directories.
  - [ ] **Claude config uploaded** — Verify: `openshell sandbox exec -- cat .claude.json` shows onboarding completed and trust accepted.
  
  

https://github.com/user-attachments/assets/50a3e96c-1aa2-4186-b991-776b36a3d45e



