### PR TITLE
fix(e2e): use mock registry server and harden MCP-01 test

### DIFF
--- a/tests/playwright/src/model/pages/mcp-install-tab-page.ts
+++ b/tests/playwright/src/model/pages/mcp-install-tab-page.ts
@@ -22,12 +22,14 @@ import { BaseTablePage } from './base-table-page';
 
 export class McpInstallTabPage extends BaseTablePage {
   readonly noMcpServersAvailableHeading: Locator;
+  readonly catalogRefreshingIndicator: Locator;
   readonly passwordInput: Locator;
   readonly connectButton: Locator;
 
   constructor(page: Page) {
     super(page, 'mcpServer');
     this.noMcpServersAvailableHeading = this.table.getByRole('heading', { name: 'No MCP servers available' });
+    this.catalogRefreshingIndicator = this.content.getByText(/Loading catalog|Refreshing catalog/);
     this.passwordInput = this.page.getByLabel('password');
     this.connectButton = this.page.getByRole('button', { name: 'Connect' });
   }
@@ -36,13 +38,20 @@ export class McpInstallTabPage extends BaseTablePage {
     await expect(this.table).toBeVisible();
   }
 
+  async waitForCatalogRefresh(timeout: number): Promise<void> {
+    await this.catalogRefreshingIndicator.waitFor({ state: 'visible', timeout: 5_000 }).catch(() => {});
+    await expect(this.catalogRefreshingIndicator).not.toBeVisible({ timeout });
+  }
+
   async verifyServerCountIncreased(initialServerCount: number, timeout = 10_000): Promise<void> {
+    await this.waitForCatalogRefresh(timeout);
     await expect
       .poll(async () => await this.countRowsFromTable(), { timeout: timeout })
       .toBeGreaterThan(initialServerCount);
   }
 
   async verifyServerCountIsRestored(initialServerCount: number, timeout = 10_000): Promise<void> {
+    await this.waitForCatalogRefresh(timeout);
     await expect.poll(async () => await this.countRowsFromTable(), { timeout: timeout }).toBe(initialServerCount);
   }
 

--- a/tests/playwright/src/specs/provider-specs/mcp-smoke.spec.ts
+++ b/tests/playwright/src/specs/provider-specs/mcp-smoke.spec.ts
@@ -15,20 +15,50 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { createServer, type Server } from 'node:http';
+
 import { expect, test } from '/@/fixtures/provider-fixtures';
 import { MCP_SERVERS } from '/@/model/core/types';
 import { waitForNavigationReady } from '/@/utils/app-ready';
 
 const MCP_REGISTRY_EXAMPLE = 'MCP Registry example';
-const MCP_REGISTRY_URL = 'https://registry.modelcontextprotocol.io';
-const SERVER_LIST_UPDATE_TIMEOUT = 180_000;
+const SERVER_LIST_UPDATE_TIMEOUT = 60_000;
 const SERVER_CONNECTION_TIMEOUT = 10_000;
+
+const MOCK_REGISTRY_RESPONSE = JSON.stringify({
+  servers: [
+    { server: { name: 'io.test/mock-server-alpha', description: 'Mock MCP server A', version: '1.0.0' }, _meta: {} },
+    { server: { name: 'io.test/mock-server-beta', description: 'Mock MCP server B', version: '1.0.0' }, _meta: {} },
+  ],
+  metadata: { count: 2 },
+});
 
 test.use({
   mcpServers: process.env[MCP_SERVERS.github.envVarName] ? ['github'] : [],
 });
 
-test.describe('MCP Registry Management', () => {
+test.describe('MCP Registry Management', { tag: '@smoke' }, () => {
+  let server: Server;
+  let mockRegistryUrl: string;
+
+  test.beforeAll(async () => {
+    server = createServer((_, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(MOCK_REGISTRY_RESPONSE);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = server.address() as { port: number };
+    mockRegistryUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  test.afterAll(async () => {
+    await new Promise<void>(resolve => server?.close(() => resolve()) ?? resolve());
+  });
+
   test.beforeEach(async ({ page, navigationBar }) => {
     await waitForNavigationReady(page);
     await navigationBar.navigateToMCPPage();
@@ -43,15 +73,15 @@ test.describe('MCP Registry Management', () => {
     const initialServerCount = await installTab.countRowsFromTable();
 
     await mcpPage.openEditRegistriesTab();
-    await editRegistriesTab.addNewRegistry(MCP_REGISTRY_URL);
-    await editRegistriesTab.ensureRowExists(MCP_REGISTRY_URL);
+    await editRegistriesTab.addNewRegistry(mockRegistryUrl);
+    await editRegistriesTab.ensureRowExists(mockRegistryUrl);
 
     await mcpPage.openInstallTab();
     await installTab.verifyServerCountIncreased(initialServerCount, SERVER_LIST_UPDATE_TIMEOUT);
 
     await mcpPage.openEditRegistriesTab();
-    await editRegistriesTab.removeRegistry(MCP_REGISTRY_URL);
-    await editRegistriesTab.ensureRowDoesNotExist(MCP_REGISTRY_URL);
+    await editRegistriesTab.removeRegistry(mockRegistryUrl);
+    await editRegistriesTab.ensureRowDoesNotExist(mockRegistryUrl);
 
     await mcpPage.openInstallTab();
     await installTab.verifyServerCountIsRestored(initialServerCount, SERVER_LIST_UPDATE_TIMEOUT);


### PR DESCRIPTION
## Summary
- Replace the real MCP registry (`registry.modelcontextprotocol.io`) with a local mock HTTP server to eliminate network flakiness and reduce timeout from 180s to 60s
- Wait for the catalog refresh indicator to appear/disappear before asserting row counts, closing a timing race where assertions could pass vacuously before the catalog started loading
- Enable MCP-01 on PR checks by adding the `@smoke` tag
- Handle mock server `listen` errors to fail fast on port conflicts instead of hanging

## Test plan
- [x] Verified MCP-01 passes on all 10 nightly E2E jobs (macOS, Linux, Windows — dev + prod): [run #28229940393](https://github.com/openkaiden/kaiden/actions/runs/28229940393)
- [x] Confirm MCP-01 runs on PR check workflows with the `@smoke` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)