### PR TITLE
feat(workspaces): allow provider URL access from OpenShell sandboxes

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -435,7 +435,7 @@ describe('create – OpenShell mode', () => {
     expect(openshellCli.createSandbox).not.toHaveBeenCalled();
   });
 
-  test('calls policyUpdate twice for deny mode with hosts: remove then add', async () => {
+  test('calls policyUpdate with one endpoint per call for deny mode with hosts', async () => {
     const options = {
       ...defaultOptions,
       network: { mode: 'deny' as const, hosts: ['registry.npmjs.org', 'pypi.python.org'] },
@@ -775,6 +775,125 @@ describe('create – OpenShell mode', () => {
 
     const call = vi.mocked(openshellCli.createSandbox).mock.calls[0]![0];
     expect(call!.env).toBeUndefined();
+  });
+
+  test('applies model endpoint policy when model has an endpoint', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { api_key: 'sk-test' },
+      llmMetadataName: 'openai',
+      endpoint: 'https://api.example.com/v1',
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-sandbox-openai' });
+
+    const options = { ...defaultOptions, model: 'openai::gpt-4o::https://api.example.com/v1' };
+    await manager.create(options);
+
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith({
+      sandboxName: 'my-sandbox',
+      removeRule: 'kdn-model',
+    });
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith({
+      sandboxName: 'my-sandbox',
+      ruleName: 'kdn-model',
+      addEndpoints: ['api.example.com:443'],
+      binary: '/**',
+      wait: true,
+    });
+  });
+
+  test('rewrites localhost model endpoint to host.openshell.internal', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: {},
+      llmMetadataName: 'ollama',
+      endpoint: 'http://localhost:11434/v1',
+    });
+
+    const options = { ...defaultOptions, model: 'ollama::qwen3::http://localhost:11434/v1' };
+    await manager.create(options);
+
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith({
+      sandboxName: 'my-sandbox',
+      ruleName: 'kdn-model',
+      addEndpoints: ['host.openshell.internal:11434'],
+      binary: '/**',
+      wait: true,
+    });
+  });
+
+  test('does not apply model policy when no model is configured', async () => {
+    await manager.create(defaultOptions);
+
+    expect(openshellCli.policyUpdate).not.toHaveBeenCalled();
+  });
+
+  test('does not apply model policy when model has no endpoint', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { api_key: 'sk-test' },
+      llmMetadataName: 'anthropic',
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-sandbox-anthropic' });
+
+    const options = { ...defaultOptions, model: 'anthropic::claude-sonnet-4-20250514' };
+    await manager.create(options);
+
+    expect(openshellCli.policyUpdate).not.toHaveBeenCalledWith(expect.objectContaining({ removeRule: 'kdn-model' }));
+  });
+
+  test('extracts endpoint from model ID when connectionInfo is unavailable', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue(undefined);
+
+    const options = { ...defaultOptions, model: 'ollama::qwen3:0.6b::http://localhost:11434/v1' };
+    await manager.create(options);
+
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith({
+      sandboxName: 'my-sandbox',
+      ruleName: 'kdn-model',
+      addEndpoints: ['host.openshell.internal:11434'],
+      binary: '/**',
+      wait: true,
+    });
+  });
+
+  test('swallows errors on model policy remove-only operation', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: {},
+      llmMetadataName: 'ollama',
+      endpoint: 'http://localhost:11434/v1',
+    });
+    vi.mocked(openshellCli.policyUpdate).mockImplementation(async op => {
+      if (op.removeRule === 'kdn-model' && !op.addEndpoints) {
+        throw new Error('rule not found');
+      }
+    });
+
+    const options = { ...defaultOptions, model: 'ollama::qwen3::http://localhost:11434/v1' };
+    await expect(manager.create(options)).resolves.toEqual({ id: 'my-sandbox' });
+  });
+
+  test('applies both network and model policies together', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: { api_key: 'sk-test' },
+      llmMetadataName: 'openai',
+      endpoint: 'https://api.openai.com/v1',
+    });
+    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-sandbox-openai' });
+
+    const options = {
+      ...defaultOptions,
+      model: 'openai::gpt-4o::https://api.openai.com/v1',
+      network: { mode: 'deny' as const, hosts: ['registry.npmjs.org'] },
+    };
+
+    await manager.create(options);
+
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith(expect.objectContaining({ removeRule: 'kdn-network' }));
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ ruleName: 'kdn-network', addEndpoints: expect.any(Array) }),
+    );
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith(expect.objectContaining({ removeRule: 'kdn-model' }));
+    expect(openshellCli.policyUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ ruleName: 'kdn-model', addEndpoints: ['api.openai.com:443'] }),
+    );
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -802,6 +802,8 @@ describe('create – OpenShell mode', () => {
   });
 
   test('rewrites localhost model endpoint to host.openshell.internal', async () => {
+    const preWorkspaceStart = vi.fn();
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue({ ...mockAgent, preWorkspaceStart });
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: {},
       llmMetadataName: 'ollama',
@@ -811,6 +813,13 @@ describe('create – OpenShell mode', () => {
     const options = { ...defaultOptions, model: 'ollama::qwen3::http://localhost:11434/v1' };
     await manager.create(options);
 
+    expect(preWorkspaceStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({
+          endpoint: 'http://host.openshell.internal:11434/v1',
+        }),
+      }),
+    );
     expect(openshellCli.policyUpdate).toHaveBeenCalledWith({
       sandboxName: 'my-sandbox',
       ruleName: 'kdn-model',

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -870,6 +870,23 @@ describe('create – OpenShell mode', () => {
     await expect(manager.create(options)).resolves.toEqual({ id: 'my-sandbox' });
   });
 
+  test('deletes sandbox when model policy add fails', async () => {
+    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
+      credentials: {},
+      llmMetadataName: 'ollama',
+      endpoint: 'http://localhost:11434/v1',
+    });
+    vi.mocked(openshellCli.policyUpdate).mockImplementation(async op => {
+      if (op.ruleName === 'kdn-model' && op.addEndpoints) {
+        throw new Error('policy add failed');
+      }
+    });
+
+    const options = { ...defaultOptions, model: 'ollama::qwen3::http://localhost:11434/v1' };
+    await expect(manager.create(options)).rejects.toThrow('policy add failed');
+    expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('my-sandbox');
+  });
+
   test('applies both network and model policies together', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { api_key: 'sk-test' },

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -50,7 +50,7 @@ import type {
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationNode } from '/@api/configuration/models.js';
 import { IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
+import type { GatewaySandboxes, PolicyUpdateOptions } from '/@api/openshell-gateway-info.js';
 import { AGENT_LABEL, decodeWorkspaceLabels, WORKSPACE_LABEL } from '/@api/openshell-gateway-info.js';
 import type { SecretValue } from '/@api/secret-info.js';
 
@@ -205,44 +205,43 @@ export class AgentWorkspaceManager implements Disposable {
     const finalNetwork = workspace.network;
     if (finalNetwork) {
       const operations = buildNetworkPolicyOperations(sandboxName, finalNetwork);
-      for (const op of operations) {
-        if (op.removeRule && !op.addEndpoints) {
-          try {
-            await this.openshellCli.policyUpdate(op);
-          } catch {
-            // Rule may not exist on a fresh sandbox — ignore, matching kdn behavior
-          }
-        } else {
-          try {
-            await this.openshellCli.policyUpdate(op);
-          } catch (err) {
-            try {
-              await this.openshellCli.deleteSandbox(sandboxName);
-            } catch {
-              // best-effort rollback; preserve original failure
-            }
-            throw err;
-          }
-        }
-      }
+      await this.applyPolicyOperations(sandboxName, operations);
     }
 
     if (endpoint) {
       const modelOps = buildModelPolicyOperations(sandboxName, endpoint);
-      for (const op of modelOps) {
-        if (op.removeRule && !op.addEndpoints) {
-          try {
-            await this.openshellCli.policyUpdate(op);
-          } catch {
-            // Rule may not exist on a fresh sandbox — ignore
-          }
-        } else {
-          await this.openshellCli.policyUpdate(op);
-        }
-      }
+      await this.applyPolicyOperations(sandboxName, modelOps);
     }
 
     return { id: sandboxName };
+  }
+
+  /**
+   * Applies a sequence of policy operations to a sandbox, rolling back
+   * (deleting the sandbox) if any add-endpoint operation fails.
+   */
+  private async applyPolicyOperations(sandboxName: string, operations: PolicyUpdateOptions[]): Promise<void> {
+    for (const op of operations) {
+      if (op.removeRule && !op.addEndpoints) {
+        try {
+          await this.openshellCli.policyUpdate(op);
+        } catch {
+          // Rule may not exist on a fresh sandbox — ignore
+        }
+        continue;
+      }
+
+      try {
+        await this.openshellCli.policyUpdate(op);
+      } catch (err) {
+        try {
+          await this.openshellCli.deleteSandbox(sandboxName);
+        } catch {
+          // best-effort rollback; preserve original failure
+        }
+        throw err;
+      }
+    }
   }
 
   async checkWorkspaceConfigExists(sourcePath: string): Promise<boolean> {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -32,7 +32,10 @@ import { WritableConfigurationFile } from '/@/plugin/agent-workspace/writable-co
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
-import { buildNetworkPolicyOperations } from '/@/plugin/openshell-cli/openshell-network-policy.js';
+import {
+  buildModelPolicyOperations,
+  buildNetworkPolicyOperations,
+} from '/@/plugin/openshell-cli/openshell-network-policy.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
@@ -138,7 +141,7 @@ export class AgentWorkspaceManager implements Disposable {
       : undefined;
 
     const modelName = options.model?.split('::')[1];
-    const endpoint = connectionInfo?.endpoint;
+    const endpoint = connectionInfo?.endpoint ?? options.model?.split('::')[2] ?? undefined;
 
     const workspace = await writeWorkspaceConfig(options);
     workspace.environment ??= [];
@@ -220,6 +223,21 @@ export class AgentWorkspaceManager implements Disposable {
             }
             throw err;
           }
+        }
+      }
+    }
+
+    if (endpoint) {
+      const modelOps = buildModelPolicyOperations(sandboxName, endpoint);
+      for (const op of modelOps) {
+        if (op.removeRule && !op.addEndpoints) {
+          try {
+            await this.openshellCli.policyUpdate(op);
+          } catch {
+            // Rule may not exist on a fresh sandbox — ignore
+          }
+        } else {
+          await this.openshellCli.policyUpdate(op);
         }
       }
     }

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -35,6 +35,7 @@ import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import {
   buildModelPolicyOperations,
   buildNetworkPolicyOperations,
+  rewriteLocalhostUrl,
 } from '/@/plugin/openshell-cli/openshell-network-policy.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
@@ -141,7 +142,8 @@ export class AgentWorkspaceManager implements Disposable {
       : undefined;
 
     const modelName = options.model?.split('::')[1];
-    const endpoint = connectionInfo?.endpoint ?? options.model?.split('::')[2] ?? undefined;
+    const rawEndpoint = connectionInfo?.endpoint ?? options.model?.split('::')[2] ?? undefined;
+    const endpoint = rawEndpoint ? rewriteLocalhostUrl(rawEndpoint) : undefined;
 
     const workspace = await writeWorkspaceConfig(options);
     workspace.environment ??= [];

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
@@ -191,6 +191,17 @@ describe('parseModelEndpoint', () => {
   test('returns undefined for empty string', () => {
     expect(parseModelEndpoint('')).toBeUndefined();
   });
+
+  test('returns undefined for unknown scheme without explicit port', () => {
+    expect(parseModelEndpoint('ftp://files.example.com/data')).toBeUndefined();
+  });
+
+  test('parses unknown scheme when explicit port is provided', () => {
+    expect(parseModelEndpoint('ftp://files.example.com:2121/data')).toEqual({
+      host: 'files.example.com',
+      port: 2121,
+    });
+  });
 });
 
 describe('buildModelPolicyOperations', () => {

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
@@ -18,7 +18,14 @@
 
 import { describe, expect, test } from 'vitest';
 
-import { buildNetworkPolicyEndpoints, buildNetworkPolicyOperations } from './openshell-network-policy.js';
+import {
+  buildModelPolicyOperations,
+  buildNetworkPolicyEndpoints,
+  buildNetworkPolicyOperations,
+  OPENSHELL_CONTAINER_HOST,
+  parseModelEndpoint,
+  rewriteLocalhostUrl,
+} from './openshell-network-policy.js';
 
 describe('buildNetworkPolicyEndpoints', () => {
   test('returns undefined for mode allow', () => {
@@ -84,7 +91,7 @@ describe('buildNetworkPolicyOperations', () => {
     expect(ops[0]).toEqual({ sandboxName: 'my-sandbox', removeRule: 'kdn-network' });
   });
 
-  test('returns remove then add operations for deny mode with hosts', () => {
+  test('returns remove then one add per endpoint for deny mode with hosts', () => {
     const ops = buildNetworkPolicyOperations('my-sandbox', {
       mode: 'deny',
       hosts: ['registry.npmjs.org'],
@@ -113,6 +120,128 @@ describe('buildNetworkPolicyOperations', () => {
       mode: 'deny',
       hosts: ['example.com'],
     });
+
+    expect(ops[0]!.sandboxName).toBe('test-sandbox');
+    expect(ops[1]!.sandboxName).toBe('test-sandbox');
+  });
+});
+
+describe('rewriteLocalhostUrl', () => {
+  test('rewrites localhost to host.openshell.internal', () => {
+    expect(rewriteLocalhostUrl('http://localhost:11434/v1')).toBe(`http://${OPENSHELL_CONTAINER_HOST}:11434/v1`);
+  });
+
+  test('rewrites 127.0.0.1 to host.openshell.internal', () => {
+    expect(rewriteLocalhostUrl('http://127.0.0.1:11434/v1')).toBe(`http://${OPENSHELL_CONTAINER_HOST}:11434/v1`);
+  });
+
+  test('rewrites 0.0.0.0 to host.openshell.internal', () => {
+    expect(rewriteLocalhostUrl('http://0.0.0.0:8080/v1')).toBe(`http://${OPENSHELL_CONTAINER_HOST}:8080/v1`);
+  });
+
+  test('does not rewrite external URLs', () => {
+    expect(rewriteLocalhostUrl('https://api.example.com/v1')).toBe('https://api.example.com/v1');
+  });
+
+  test('returns invalid strings unchanged', () => {
+    expect(rewriteLocalhostUrl('not-a-url')).toBe('not-a-url');
+  });
+});
+
+describe('parseModelEndpoint', () => {
+  test('parses HTTPS URL with default port', () => {
+    expect(parseModelEndpoint('https://api.example.com/v1')).toEqual({
+      host: 'api.example.com',
+      port: 443,
+    });
+  });
+
+  test('parses HTTP URL with default port', () => {
+    expect(parseModelEndpoint('http://api.example.com/v1')).toEqual({
+      host: 'api.example.com',
+      port: 80,
+    });
+  });
+
+  test('parses URL with explicit port', () => {
+    expect(parseModelEndpoint('https://api.example.com:8443/v1')).toEqual({
+      host: 'api.example.com',
+      port: 8443,
+    });
+  });
+
+  test('rewrites localhost and parses', () => {
+    expect(parseModelEndpoint('http://localhost:11434/v1')).toEqual({
+      host: OPENSHELL_CONTAINER_HOST,
+      port: 11434,
+    });
+  });
+
+  test('rewrites 127.0.0.1 and parses', () => {
+    expect(parseModelEndpoint('http://127.0.0.1:11434/v1')).toEqual({
+      host: OPENSHELL_CONTAINER_HOST,
+      port: 11434,
+    });
+  });
+
+  test('returns undefined for invalid URL', () => {
+    expect(parseModelEndpoint('not-a-url')).toBeUndefined();
+  });
+
+  test('returns undefined for empty string', () => {
+    expect(parseModelEndpoint('')).toBeUndefined();
+  });
+});
+
+describe('buildModelPolicyOperations', () => {
+  test('returns remove then add for external endpoint', () => {
+    const ops = buildModelPolicyOperations('my-sandbox', 'https://api.example.com/v1');
+
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toEqual({ sandboxName: 'my-sandbox', removeRule: 'kdn-model' });
+    expect(ops[1]).toEqual({
+      sandboxName: 'my-sandbox',
+      ruleName: 'kdn-model',
+      addEndpoints: ['api.example.com:443'],
+      binary: '/**',
+      wait: true,
+    });
+  });
+
+  test('rewrites localhost endpoint to host.openshell.internal', () => {
+    const ops = buildModelPolicyOperations('my-sandbox', 'http://localhost:11434/v1');
+
+    expect(ops).toHaveLength(2);
+    expect(ops[1]).toEqual({
+      sandboxName: 'my-sandbox',
+      ruleName: 'kdn-model',
+      addEndpoints: [`${OPENSHELL_CONTAINER_HOST}:11434`],
+      binary: '/**',
+      wait: true,
+    });
+  });
+
+  test('rewrites 127.0.0.1 endpoint to host.openshell.internal', () => {
+    const ops = buildModelPolicyOperations('my-sandbox', 'http://127.0.0.1:11434/v1');
+
+    expect(ops[1]!.addEndpoints).toEqual([`${OPENSHELL_CONTAINER_HOST}:11434`]);
+  });
+
+  test('returns remove-only for invalid endpoint', () => {
+    const ops = buildModelPolicyOperations('my-sandbox', 'not-a-url');
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ sandboxName: 'my-sandbox', removeRule: 'kdn-model' });
+  });
+
+  test('uses explicit port from URL', () => {
+    const ops = buildModelPolicyOperations('my-sandbox', 'https://api.example.com:8443/v1');
+
+    expect(ops[1]!.addEndpoints).toEqual(['api.example.com:8443']);
+  });
+
+  test('uses the provided sandbox name', () => {
+    const ops = buildModelPolicyOperations('test-sandbox', 'https://api.example.com/v1');
 
     expect(ops[0]!.sandboxName).toBe('test-sandbox');
     expect(ops[1]!.sandboxName).toBe('test-sandbox');

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
@@ -123,6 +123,11 @@ export type OpenshellPolicy = z.output<typeof OpenshellPolicySchema>;
 // ── Policy endpoint builder ───────────────────────────────────────
 
 const NETWORK_RULE_NAME = 'kdn-network';
+const MODEL_RULE_NAME = 'kdn-model';
+
+export const OPENSHELL_CONTAINER_HOST = 'host.openshell.internal';
+
+const LOCALHOST_ALIASES = ['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'];
 
 export function buildNetworkPolicyEndpoints(network: NetworkConfiguration): string[] | undefined {
   if (network.mode === 'allow') {
@@ -163,4 +168,94 @@ export function buildNetworkPolicyOperations(
   }
 
   return operations;
+}
+
+// ── Model endpoint policy ─────────────────────────────────────────
+
+export interface ModelEndpoint {
+  host: string;
+  port: number;
+}
+
+/**
+ * Rewrites localhost URLs to {@link OPENSHELL_CONTAINER_HOST} so the
+ * sandbox can reach host-local model servers (e.g. Ollama).
+ */
+export function rewriteLocalhostUrl(rawUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+
+  if (!LOCALHOST_ALIASES.includes(parsed.hostname.toLowerCase())) {
+    return rawUrl;
+  }
+
+  parsed.hostname = OPENSHELL_CONTAINER_HOST;
+  return parsed.toString();
+}
+
+/**
+ * Extracts host and port from an inference endpoint URL. Localhost
+ * aliases are rewritten to {@link OPENSHELL_CONTAINER_HOST}.
+ */
+export function parseModelEndpoint(endpoint: string): ModelEndpoint | undefined {
+  const rewritten = rewriteLocalhostUrl(endpoint);
+  let parsed: URL;
+  try {
+    parsed = new URL(rewritten);
+  } catch {
+    return undefined;
+  }
+
+  if (!parsed.hostname) {
+    return undefined;
+  }
+
+  let port: number;
+  if (parsed.port) {
+    port = Number(parsed.port);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      return undefined;
+    }
+  } else {
+    if (parsed.protocol === 'https:') {
+      port = 443;
+    } else if (parsed.protocol === 'http:') {
+      port = 80;
+    } else {
+      return undefined;
+    }
+  }
+
+  return { host: parsed.hostname, port };
+}
+
+/**
+ * Builds {@link PolicyUpdateOptions} to allow the sandbox to reach
+ * the model inference endpoint. Follows the pattern from the issue:
+ * `openshell policy update <sandbox> --add-endpoint <host>:<port> --binary '**'`
+ */
+export function buildModelPolicyOperations(sandboxName: string, endpoint: string): PolicyUpdateOptions[] {
+  const removeOp: PolicyUpdateOptions = {
+    sandboxName,
+    removeRule: MODEL_RULE_NAME,
+  };
+
+  const parsed = parseModelEndpoint(endpoint);
+  if (!parsed) {
+    return [removeOp];
+  }
+
+  const addOp: PolicyUpdateOptions = {
+    sandboxName,
+    ruleName: MODEL_RULE_NAME,
+    addEndpoints: [`${parsed.host}:${parsed.port}`],
+    binary: '/**',
+    wait: true,
+  };
+
+  return [removeOp, addOp];
 }


### PR DESCRIPTION
Adds a model endpoint policy (kdn-model) to the OpenShell sandbox creation flow so inference endpoints (including localhost servers like Ollama) are reachable from the sandbox. Localhost URLs are rewritten to host.openshell.internal. Also fixes a pre-existing bug in the network policy builder that batched multiple --add-endpoint flags with --rule-name, which the OpenShell CLI rejects — endpoints are now sent one per call.

Closes #2220