### PR TITLE
feat(claude): handle Vertex AI configuration in preWorkspaceStart

### DIFF
--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -377,5 +377,110 @@ describe('ClaudeExtension', () => {
 
       await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
     });
+
+    test('adds Vertex AI environment variables when using vertexai model', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const workspace = {
+        environment: [
+          { name: 'GOOGLE_VERTEX_PROJECT', value: 'my-gcp-project' },
+          { name: 'GOOGLE_VERTEX_LOCATION', value: 'us-east5' },
+        ],
+      };
+
+      const context: AgentWorkspaceContext = {
+        model: {
+          llmMetadata: { name: 'vertexai' },
+          model: { label: 'claude-sonnet-4-20250514' },
+        },
+        configurationFiles: [],
+        workspace,
+      };
+
+      await agent.preWorkspaceStart(context);
+
+      expect(workspace.environment).toContainEqual({ name: 'CLAUDE_CODE_USE_VERTEX', value: '1' });
+      expect(workspace.environment).toContainEqual({ name: 'CLOUD_ML_REGION', value: 'us-east5' });
+      expect(workspace.environment).toContainEqual({ name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: 'my-gcp-project' });
+    });
+
+    test('does not add Vertex AI environment variables for non-vertexai models', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const workspace = {
+        environment: [{ name: 'SOME_OTHER_VAR', value: 'value' }],
+      };
+
+      const context: AgentWorkspaceContext = {
+        model: {
+          llmMetadata: { name: 'anthropic' },
+          model: { label: 'claude-sonnet-4-20250514' },
+        },
+        configurationFiles: [],
+        workspace,
+      };
+
+      await agent.preWorkspaceStart(context);
+
+      expect(workspace.environment).toHaveLength(1);
+      expect(workspace.environment).toEqual([{ name: 'SOME_OTHER_VAR', value: 'value' }]);
+    });
+
+    test('does not add Vertex AI environment variables when Google env vars are missing', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const workspace = {
+        environment: [],
+      };
+
+      const context: AgentWorkspaceContext = {
+        model: {
+          llmMetadata: { name: 'vertexai' },
+          model: { label: 'claude-sonnet-4-20250514' },
+        },
+        configurationFiles: [],
+        workspace,
+      };
+
+      await agent.preWorkspaceStart(context);
+
+      expect(workspace.environment).toHaveLength(0);
+    });
+
+    test('replaces existing Vertex AI environment variables', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const workspace = {
+        environment: [
+          { name: 'GOOGLE_VERTEX_PROJECT', value: 'my-gcp-project' },
+          { name: 'GOOGLE_VERTEX_LOCATION', value: 'us-east5' },
+          { name: 'CLAUDE_CODE_USE_VERTEX', value: '0' },
+          { name: 'CLOUD_ML_REGION', value: 'old-region' },
+        ],
+      };
+
+      const context: AgentWorkspaceContext = {
+        model: {
+          llmMetadata: { name: 'vertexai' },
+          model: { label: 'claude-sonnet-4-20250514' },
+        },
+        configurationFiles: [],
+        workspace,
+      };
+
+      await agent.preWorkspaceStart(context);
+
+      const claudeUseVertex = workspace.environment.filter(e => e.name === 'CLAUDE_CODE_USE_VERTEX');
+      const cloudMlRegion = workspace.environment.filter(e => e.name === 'CLOUD_ML_REGION');
+
+      expect(claudeUseVertex).toHaveLength(1);
+      expect(claudeUseVertex[0]).toEqual({ name: 'CLAUDE_CODE_USE_VERTEX', value: '1' });
+      expect(cloudMlRegion).toHaveLength(1);
+      expect(cloudMlRegion[0]).toEqual({ name: 'CLOUD_ML_REGION', value: 'us-east5' });
+    });
   });
 });

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -120,6 +120,32 @@ export class ClaudeExtension {
       destinationSkillsFolder: '${HOME}/.claude/skills',
       isSupportedModelType: (type): boolean => type.name === 'anthropic' || type.name === 'vertexai',
       async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+        // Handle Vertex AI model configuration
+        if (context.model.llmMetadata?.name === 'vertexai') {
+          const environment = context.workspace.environment ?? [];
+          const googleProject = environment.find(e => e.name === 'GOOGLE_VERTEX_PROJECT')?.value;
+          const googleLocation = environment.find(e => e.name === 'GOOGLE_VERTEX_LOCATION')?.value;
+
+          if (googleProject && googleLocation) {
+            // Add Claude Code-specific environment variables for Vertex AI
+            const claudeEnvVars = [
+              { name: 'CLAUDE_CODE_USE_VERTEX', value: '1' },
+              { name: 'CLOUD_ML_REGION', value: googleLocation },
+              { name: 'ANTHROPIC_VERTEX_PROJECT_ID', value: googleProject },
+            ];
+
+            context.workspace.environment ??= [];
+            for (const envVar of claudeEnvVars) {
+              // Remove existing entry if present
+              const index = context.workspace.environment.findIndex(e => e.name === envVar.name);
+              if (index >= 0) {
+                context.workspace.environment.splice(index, 1);
+              }
+              context.workspace.environment.push(envVar);
+            }
+          }
+        }
+
         const settingsFile = context.configurationFiles.find(f => f.path === CLAUDE_SETTINGS_PATH);
         if (settingsFile) {
           const config = ClaudeSettingsCodec.decode(await settingsFile.read());


### PR DESCRIPTION
## Summary
Update Claude extension to handle Vertex AI-specific workspace configuration when a Vertex AI model is selected. This moves Vertex AI configuration logic from the core (agent-workspace-manager) into the Claude extension's `preWorkspaceStart` method.

## Changes
- Add Vertex AI detection in `preWorkspaceStart` method
- Set `CLAUDE_CODE_USE_VERTEX=1` when using Vertex AI models
- Map `GOOGLE_VERTEX_LOCATION` to `CLOUD_ML_REGION`
- Map `GOOGLE_VERTEX_PROJECT` to `ANTHROPIC_VERTEX_PROJECT_ID`
- Add comprehensive tests for Vertex AI environment variable handling
- Remove obsolete `applyVertexAiConfiguration` workaround from core
- Remove obsolete tests for the old workaround

## How It Works
1. User selects a Vertex AI model with the Claude agent
2. Core's `ensureModelSecret` processes the Vertex AI connection and adds `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION` to the workspace environment
3. Claude extension's `preWorkspaceStart` detects the Vertex AI model type, reads those Google env vars, and adds the Claude-specific env vars
4. Workspace is created with all necessary environment variables for Claude Code to work with Vertex AI

## Test Plan
- [x] All Claude extension tests pass (53 tests)
- [x] All agent-workspace-manager tests pass (121 tests)
- [x] Added 5 new tests for Vertex AI environment variable handling
- [x] Removed 3 obsolete tests for the old workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #2247