### PR TITLE
feat(agent-workspace): encode agent label on sandbox creation

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -43,6 +43,7 @@ export type SandboxInfo = z.output<typeof SandboxInfoSchema> & {
 };
 
 export const WORKSPACE_LABEL = 'ai.openkaiden.kaiden.workspace';
+export const AGENT_LABEL = 'ai.openkaiden.kaiden.agent';
 
 export function decodeWorkspaceLabels(labels: Record<string, string>): string | undefined {
   let encoded: string;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -46,7 +46,7 @@ import type { AgentWorkspaceCreateOptions } from '/@api/agent-workspace-info.js'
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
-import { decodeWorkspaceLabels } from '/@api/openshell-gateway-info.js';
+import { AGENT_LABEL, decodeWorkspaceLabels } from '/@api/openshell-gateway-info.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
 import { AgentWorkspaceManager, encodeWorkspaceLabels } from './agent-workspace-manager.js';
@@ -288,14 +288,14 @@ describe('create – OpenShell mode', () => {
     vi.mocked(readFile).mockRejectedValue(mockEnoent());
   });
 
-  test('calls openshellCli.createSandbox with name, providers, and workspace label', async () => {
+  test('calls openshellCli.createSandbox with name, providers, workspace label, and agent label', async () => {
     const options = { ...defaultOptions, secrets: ['my-secret'] };
     await manager.create(options);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith({
       name: 'my-sandbox',
       providers: ['my-secret'],
-      labels: encodeWorkspaceLabels('/tmp/my-project'),
+      labels: { ...encodeWorkspaceLabels('/tmp/my-project'), [AGENT_LABEL]: 'claude' },
       noTty: true,
       command: ['true'],
     });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -48,7 +48,7 @@ import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationNode } from '/@api/configuration/models.js';
 import { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
-import { decodeWorkspaceLabels, WORKSPACE_LABEL } from '/@api/openshell-gateway-info.js';
+import { AGENT_LABEL, decodeWorkspaceLabels, WORKSPACE_LABEL } from '/@api/openshell-gateway-info.js';
 import type { SecretValue } from '/@api/secret-info.js';
 
 const HOME_VARIABLE = '${HOME}';
@@ -193,7 +193,7 @@ export class AgentWorkspaceManager implements Disposable {
       name: sandboxName,
       providers: options.secrets,
       env: env && Object.keys(env).length > 0 ? env : undefined,
-      labels: encodeWorkspaceLabels(options.sourcePath),
+      labels: { ...encodeWorkspaceLabels(options.sourcePath), [AGENT_LABEL]: options.agent },
       uploads: uploads.length > 0 ? uploads : undefined,
       noTty: true,
       command: ['true'],

--- a/packages/renderer/src/lib/agent-workspaces/workspace-utils.ts
+++ b/packages/renderer/src/lib/agent-workspaces/workspace-utils.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { SandboxInfoWithGateway } from '/@/stores/openshell-sandboxes';
+import { AGENT_LABEL } from '/@api/openshell-gateway-info';
 
 export const ACTIVE_GROUP_LABEL = 'Active';
 export const STOPPED_GROUP_LABEL = 'Stopped';
@@ -30,5 +31,5 @@ export function getReferenceTime(sandbox: SandboxInfoWithGateway): string | unde
 }
 
 export function getAgentId(sandbox?: SandboxInfoWithGateway): string | undefined {
-  return sandbox?.labels?.['ai.openkaiden.kaiden.agent'];
+  return sandbox?.labels?.[AGENT_LABEL];
 }


### PR DESCRIPTION
Generalize encodeWorkspaceLabels/decodeWorkspaceLabels into encodeLabel/decodeLabel that accept an arbitrary label key. Add AGENT_LABEL constant and attach it alongside the workspace label when creating OpenShell sandboxes. Update getAgentId to decode the base64url-encoded agent label instead of reading it raw.

Closes https://github.com/openkaiden/kaiden/issues/2286