### PR TITLE
fix(guided-setup): Claude API key onboarding with Openshell

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -851,12 +851,8 @@ describe('createProvider', () => {
 
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
-      ['provider', 'create', '--name', 'my-openai', '--type', 'openai', '--credential', 'apiKey'],
-      {
-        env: {
-          apiKey: 'sk-123',
-        },
-      },
+      ['provider', 'create', '--name', 'my-openai', '--type', 'openai', '--credential', 'apiKey=sk-123'],
+      undefined,
     );
   });
 
@@ -880,16 +876,11 @@ describe('createProvider', () => {
         '--type',
         'custom',
         '--credential',
-        'apiKey',
+        'apiKey=key-1',
         '--credential',
-        'secret',
+        'secret=sec-2',
       ],
-      {
-        env: {
-          apiKey: 'key-1',
-          secret: 'sec-2',
-        },
-      },
+      undefined,
     );
   });
 
@@ -914,17 +905,13 @@ describe('createProvider', () => {
         '--type',
         'openai',
         '--credential',
-        'apiKey',
+        'apiKey=sk-123',
         '--config',
         'model=gpt-4',
         '--config',
         'temperature=0.7',
       ],
-      {
-        env: {
-          apiKey: 'sk-123',
-        },
-      },
+      undefined,
     );
   });
 
@@ -961,14 +948,10 @@ describe('createProvider', () => {
         '--type',
         'google-vertex-ai',
         '--credential',
-        'GOOGLE_APPLICATION_CREDENTIALS',
+        'GOOGLE_APPLICATION_CREDENTIALS=/path/to/creds.json',
         '--from-gcloud-adc',
       ],
-      {
-        env: {
-          GOOGLE_APPLICATION_CREDENTIALS: '/path/to/creds.json',
-        },
-      },
+      undefined,
     );
   });
 
@@ -986,7 +969,7 @@ describe('createProvider', () => {
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
       ['provider', 'create', '--name', 'my-vertex', '--type', 'google-vertex-ai', '--from-gcloud-adc'],
-      { env: {} },
+      undefined,
     );
   });
 
@@ -1003,7 +986,7 @@ describe('createProvider', () => {
 
     const loggedMessage = logSpy.mock.calls[0]?.[0] as string;
     expect(loggedMessage).not.toContain('sk-secret-123');
-    expect(loggedMessage).toContain('gpt-4');
+    expect(loggedMessage).toContain('apiKey=***');
   });
 
   test('rejects when CLI fails', async () => {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -1002,4 +1002,22 @@ describe('createProvider', () => {
       }),
     ).rejects.toThrow('provider type not supported');
   });
+
+  test('redacts credential values from thrown CLI errors', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(
+      mockRunError({
+        stderr: 'failed to create provider with credential apiKey=sk-secret-123',
+      }),
+    );
+
+    await expect(
+      openshellCli.createProvider({
+        name: 'my-openai',
+        type: 'openai',
+        credentials: { apiKey: 'sk-secret-123' },
+      }),
+    ).rejects.toThrow('failed to create provider with credential apiKey=***');
+  });
 });

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -79,17 +79,27 @@ export class OpenshellCli {
   }
 
   private extractCliError(err: unknown): string {
-    if (err instanceof Error && 'stdout' in err && typeof (err as RunError).stdout === 'string') {
-      try {
-        const parsed: unknown = JSON.parse((err as RunError).stdout);
-        if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
-          const errorField = (parsed as { error: unknown }).error;
-          if (typeof errorField === 'string' && errorField) {
-            return errorField;
+    if (err instanceof Error && 'stdout' in err) {
+      const runErr = err as RunError;
+      if (typeof runErr.stdout === 'string' && runErr.stdout.trim()) {
+        try {
+          const parsed: unknown = JSON.parse(runErr.stdout);
+          if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
+            const errorField = (parsed as { error: unknown }).error;
+            if (typeof errorField === 'string' && errorField) {
+              return errorField;
+            }
           }
+        } catch {
+          // not JSON – fall through
         }
-      } catch {
-        // not JSON – fall through
+      }
+
+      const stderr = typeof runErr.stderr === 'string' ? runErr.stderr.trim() : '';
+      const stdout = typeof runErr.stdout === 'string' ? runErr.stdout.trim() : '';
+      const cliOutput = stderr || stdout;
+      if (cliOutput) {
+        return cliOutput;
       }
     }
     return err instanceof Error ? err.message : String(err);
@@ -317,10 +327,8 @@ export class OpenshellCli {
       throw new Error('credentials must not be empty');
     }
     const args = ['provider', 'create', '--name', options.name, '--type', options.type];
-    const env: Record<string, string> = {};
     for (const [key, value] of Object.entries(options.credentials)) {
-      env[key] = value;
-      args.push('--credential', key);
+      args.push('--credential', `${key}=${value}`);
     }
     if (options.flags) {
       for (const flag of options.flags) {
@@ -332,7 +340,7 @@ export class OpenshellCli {
         args.push('--config', `${key}=${value}`);
       }
     }
-    await this.runCli(args, { env });
+    await this.runCli(args, { redact: true });
   }
 
   // ── helpers ───────────────────────────────────────────────────────
@@ -354,6 +362,10 @@ export class OpenshellCli {
     const sensitiveFlags = new Set(['--credential', '--config', '--env']);
     return args.map((arg, i) => {
       if (i > 0 && sensitiveFlags.has(args[i - 1]!)) {
+        const separatorIndex = arg.indexOf('=');
+        if (separatorIndex > 0) {
+          return `${arg.slice(0, separatorIndex + 1)}***`;
+        }
         return '***';
       }
       return arg;

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -105,6 +105,24 @@ export class OpenshellCli {
     return err instanceof Error ? err.message : String(err);
   }
 
+  private redactSensitiveText(text: string, args: string[]): string {
+    const sensitiveFlags = new Set(['--credential', '--config', '--env']);
+    let redacted = text;
+    for (let i = 0; i < args.length; i++) {
+      if (i === 0 || !sensitiveFlags.has(args[i - 1]!)) {
+        continue;
+      }
+      const separatorIndex = args[i]!.indexOf('=');
+      if (separatorIndex > 0) {
+        const value = args[i]!.slice(separatorIndex + 1);
+        if (value) {
+          redacted = redacted.replaceAll(value, '***');
+        }
+      }
+    }
+    return redacted;
+  }
+
   async getVersion(): Promise<string> {
     const cliPath = this.getCliPath();
     try {
@@ -352,7 +370,7 @@ export class OpenshellCli {
     try {
       await this.exec.exec(cliPath, args, options?.env ? { env: options.env } : undefined);
     } catch (err: unknown) {
-      const detail = this.extractCliError(err);
+      const detail = this.redactSensitiveText(this.extractCliError(err), args);
       console.error(`openshell failed: ${cliPath} ${displayArgs.join(' ')} — ${detail}`);
       throw new Error(detail);
     }

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -189,6 +189,7 @@ describe('beforeAdvance callback', () => {
     const result = await onboarding.beforeAdvance!();
 
     expect(result).toBe(true);
+    expect(onboarding.workspaceSetting.defaultAgentSettings?.claude?.workspaceConfiguration?.secrets).toBeUndefined();
   });
 
   test('returns false and shows error when inference connection fails', async () => {

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts
@@ -157,7 +157,11 @@ describe('beforeAdvance callback', () => {
     expect(window.createSecret).toHaveBeenCalledWith({
       name: 'anthropic',
       type: 'anthropic',
-      value: 'sk-ant-test-key',
+      value: {
+        credentials: {
+          ANTHROPIC_API_KEY: 'sk-ant-test-key',
+        },
+      },
     });
     expect(window.createInferenceProviderConnection).toHaveBeenCalledWith(
       'claude-internal-1',
@@ -202,8 +206,12 @@ describe('beforeAdvance callback', () => {
     expect(screen.getByText('invalid apiKey')).toBeInTheDocument();
   });
 
-  test('returns false and shows error when secret creation fails', async () => {
-    vi.mocked(window.createSecret).mockRejectedValue(new Error('vault locked'));
+  test('continues when secret creation fails but inference connection succeeds', async () => {
+    vi.mocked(window.createSecret).mockRejectedValue(new Error('gateway unavailable'));
+    vi.mocked(fetchProviders).mockImplementation(async () => {
+      stubClaudeProvider({ withModels: true });
+      return [] as ProviderInfo[];
+    });
 
     renderPanel();
 
@@ -213,8 +221,8 @@ describe('beforeAdvance callback', () => {
 
     const result = await onboarding.beforeAdvance!();
 
-    expect(result).toBe(false);
-    expect(screen.getByText(/vault locked/)).toBeInTheDocument();
+    expect(result).toBe(true);
+    expect(onboarding.workspaceSetting.defaultAgentSettings?.claude?.workspaceConfiguration?.secrets).toBeUndefined();
   });
 });
 

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -48,7 +48,8 @@ async function storeOpenshellProvider(trimmedKey: string): Promise<boolean> {
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('already exists')) {
-      return true;
+      console.warn('Openshell provider already exists with unknown format, skipping workspace secret registration');
+      return false;
     }
     console.warn('Failed to store openshell provider during onboarding:', msg);
     return false;

--- a/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
+++ b/packages/renderer/src/lib/guided-setup/panels/ClaudePanel.svelte
@@ -33,6 +33,28 @@ let existingConnection = $derived(
 );
 let alreadyConnected = $derived(!!existingConnection);
 
+async function storeOpenshellProvider(trimmedKey: string): Promise<boolean> {
+  try {
+    await window.createSecret({
+      name: secretType,
+      type: secretType,
+      value: {
+        credentials: {
+          ANTHROPIC_API_KEY: trimmedKey,
+        },
+      },
+    });
+    return true;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('already exists')) {
+      return true;
+    }
+    console.warn('Failed to store openshell provider during onboarding:', msg);
+    return false;
+  }
+}
+
 async function validate(): Promise<boolean> {
   if (alreadyConnected) {
     return true;
@@ -45,23 +67,10 @@ async function validate(): Promise<boolean> {
     return false;
   }
 
-  if (!apiKey.trim()) {
+  const trimmedKey = apiKey.trim();
+  if (!trimmedKey) {
     errorMessage = 'Please enter your Anthropic API key.';
     return false;
-  }
-
-  try {
-    await window.createSecret({
-      name: secretType,
-      type: secretType,
-      value: apiKey.trim(),
-    });
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes('already exists')) {
-      errorMessage = `Failed to store secret: ${msg}`;
-      return false;
-    }
   }
 
   try {
@@ -69,7 +78,7 @@ async function validate(): Promise<boolean> {
     const noop = (): void => {};
     await window.createInferenceProviderConnection(
       claudeProvider.internalId,
-      { 'claude.factory.apiKey': apiKey.trim() },
+      { 'claude.factory.apiKey': trimmedKey },
       loggerKey,
       noop,
       undefined,
@@ -78,16 +87,20 @@ async function validate(): Promise<boolean> {
 
     await fetchProviders();
 
+    const secretStored = await storeOpenshellProvider(trimmedKey);
+
     if (onboarding) {
       const agentSettings = onboarding.workspaceSetting.defaultAgentSettings?.[onboarding.agent] ?? {};
       onboarding.workspaceSetting.defaultAgentSettings ??= {};
       onboarding.workspaceSetting.defaultAgentSettings[onboarding.agent] = agentSettings;
-      agentSettings.workspaceConfiguration ??= {};
-      agentSettings.workspaceConfiguration.secrets ??= [];
-      agentSettings.workspaceConfiguration.secrets = agentSettings.workspaceConfiguration.secrets.filter(
-        secret => secret !== secretType,
-      );
-      agentSettings.workspaceConfiguration.secrets.push(secretType);
+      if (secretStored) {
+        agentSettings.workspaceConfiguration ??= {};
+        agentSettings.workspaceConfiguration.secrets ??= [];
+        agentSettings.workspaceConfiguration.secrets = agentSettings.workspaceConfiguration.secrets.filter(
+          secret => secret !== secretType,
+        );
+        agentSettings.workspaceConfiguration.secrets.push(secretType);
+      }
     }
     return true;
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Fix guided setup Claude API key storage by passing a `SecretValue` record with `ANTHROPIC_API_KEY`, which Openshell expects for the `anthropic` provider type.
- Validate the inference connection before storing the Openshell provider, and allow onboarding to continue when gateway secret storage is unavailable.
- Pass provider credentials inline to `openshell provider create` and surface CLI stderr/stdout in error messages.

Fixes #2287

## Test plan
- [x] `pnpm exec vitest run --project=renderer packages/renderer/src/lib/guided-setup/panels/ClaudePanel.spec.ts`
- [x] `pnpm exec vitest run --project=main packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts`
- [x] Manual: run guided setup, enter a valid Anthropic API key for Claude Code, and confirm onboarding advances
- [x] Manual: verify `openshell provider list` shows the `anthropic` provider when the gateway is healthy


Made with [Cursor](https://cursor.com)