### PR TITLE
fix(container): conditionally use --all-providers based on Podman version

### DIFF
--- a/extensions/container/packages/extension/package.json
+++ b/extensions/container/packages/extension/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "inversify": "^7.7.1",
     "dockerode": "^4.0.7",
+    "semver": "^7.7.3",
     "stream-json": "^1.9.1",
     "zod": "^4.1.11"
   },

--- a/extensions/container/packages/extension/src/helper/socket-finder/_socket-finder-module.ts
+++ b/extensions/container/packages/extension/src/helper/socket-finder/_socket-finder-module.ts
@@ -25,9 +25,12 @@ import { DockerSocketLinuxFinder } from './docker/docker-linux-finder';
 import { DockerSocketMacOSFinder } from './docker/docker-macos-finder';
 import { PodmanSocketLinuxFinder } from './podman/podman-linux-finder';
 import { PodmanSocketMacOSFinder } from './podman/podman-macos-finder';
+import { PodmanVersionDetector } from './podman/podman-version-detector';
 import { PodmanSocketWindowsFinder } from './podman/podman-windows-finder';
 
 const socketFinderModule = new ContainerModule(options => {
+  options.bind(PodmanVersionDetector).toSelf().inSingletonScope();
+
   if (env.isMac) {
     options.bind<PodmanSocketMacOSFinder>(PodmanSocketMacOSFinder).toSelf().inSingletonScope();
     options.bind<DockerSocketMacOSFinder>(DockerSocketMacOSFinder).toSelf().inSingletonScope();

--- a/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-macos-finder.spec.ts
+++ b/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-macos-finder.spec.ts
@@ -22,22 +22,34 @@ import { resolve } from 'node:path';
 
 import type { RunResult } from '@openkaiden/api';
 import { process } from '@openkaiden/api';
+import { Container } from 'inversify';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanSocketMacOSFinder } from './podman-macos-finder';
+import { PodmanVersionDetector } from './podman-version-detector';
 
 vi.mock(import('node:fs'));
 vi.mock(import('node:os'));
 vi.mock(import('node:path'));
 vi.mock(import('@openkaiden/api'));
 
-beforeEach(() => {
+const versionDetectorMock = {
+  getMajorVersion: vi.fn(),
+} as unknown as PodmanVersionDetector;
+
+let finder: PodmanSocketMacOSFinder;
+
+beforeEach(async () => {
   vi.resetAllMocks();
+  vi.mocked(versionDetectorMock.getMajorVersion).mockResolvedValue(6);
+
+  const container = new Container();
+  container.bind(PodmanSocketMacOSFinder).toSelf().inSingletonScope();
+  container.bind(PodmanVersionDetector).toConstantValue(versionDetectorMock);
+  finder = await container.getAsync(PodmanSocketMacOSFinder);
 });
 
 test('findPaths returns empty array when socket does not exist', async () => {
-  const finder = new PodmanSocketMacOSFinder();
-
   vi.mocked(homedir).mockReturnValue('/home/user');
   vi.mocked(resolve).mockReturnValue('/home/user/.local/share/containers/podman/machine/podman.sock');
   vi.mocked(existsSync).mockReturnValue(false);
@@ -49,8 +61,8 @@ test('findPaths returns empty array when socket does not exist', async () => {
   expect(process.exec).not.toHaveBeenCalled();
 });
 
-test('findPaths returns socket path when socket exists and machine is running', async () => {
-  const finder = new PodmanSocketMacOSFinder();
+test('findPaths returns socket path with --all-providers on podman 5', async () => {
+  vi.mocked(versionDetectorMock.getMajorVersion).mockResolvedValue(5);
 
   const socketPath = '/home/user/.local/share/containers/podman/machine/podman.sock';
   vi.mocked(homedir).mockReturnValue('/home/user');
@@ -67,9 +79,25 @@ test('findPaths returns socket path when socket exists and machine is running', 
   expect(process.exec).toHaveBeenCalledWith('podman', ['machine', 'ls', '--all-providers', '--format', 'json']);
 });
 
-test('findPaths returns empty array when socket exists but no machines are running', async () => {
-  const finder = new PodmanSocketMacOSFinder();
+test('findPaths returns socket path without --all-providers on podman 6', async () => {
+  vi.mocked(versionDetectorMock.getMajorVersion).mockResolvedValue(6);
 
+  const socketPath = '/home/user/.local/share/containers/podman/machine/podman.sock';
+  vi.mocked(homedir).mockReturnValue('/home/user');
+  vi.mocked(resolve).mockReturnValue(socketPath);
+  vi.mocked(existsSync).mockReturnValue(true);
+
+  const machineListOutput = JSON.stringify([{ Name: 'podman-machine-default', VMType: 'qemu', Running: true }]);
+
+  vi.mocked(process.exec).mockResolvedValue({ stdout: machineListOutput, stderr: '' } as RunResult);
+
+  const result = await finder.findPaths();
+
+  expect(result).toEqual([socketPath]);
+  expect(process.exec).toHaveBeenCalledWith('podman', ['machine', 'ls', '--format', 'json']);
+});
+
+test('findPaths returns empty array when socket exists but no machines are running', async () => {
   const socketPath = '/home/user/.local/share/containers/podman/machine/podman.sock';
   vi.mocked(homedir).mockReturnValue('/home/user');
   vi.mocked(resolve).mockReturnValue(socketPath);
@@ -85,8 +113,6 @@ test('findPaths returns empty array when socket exists but no machines are runni
 });
 
 test('findPaths returns socket path when multiple machines exist and at least one is running', async () => {
-  const finder = new PodmanSocketMacOSFinder();
-
   const socketPath = '/home/user/.local/share/containers/podman/machine/podman.sock';
   vi.mocked(homedir).mockReturnValue('/home/user');
   vi.mocked(resolve).mockReturnValue(socketPath);
@@ -106,8 +132,6 @@ test('findPaths returns socket path when multiple machines exist and at least on
 });
 
 test('findPaths returns empty array when socket exists but machine list is empty', async () => {
-  const finder = new PodmanSocketMacOSFinder();
-
   const socketPath = '/home/user/.local/share/containers/podman/machine/podman.sock';
   vi.mocked(homedir).mockReturnValue('/home/user');
   vi.mocked(resolve).mockReturnValue(socketPath);

--- a/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-macos-finder.ts
+++ b/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-macos-finder.ts
@@ -21,16 +21,20 @@ import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 
 import { process } from '@openkaiden/api';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import type { SocketFinder } from '/@/api/socket-finder';
 import {
   type PodmanMachineListInfo,
   zodPodmanMachineList,
 } from '/@/helper/socket-finder/podman/podman-machine-list-info';
+import { PodmanVersionDetector } from '/@/helper/socket-finder/podman/podman-version-detector';
 
 @injectable()
 export class PodmanSocketMacOSFinder implements SocketFinder {
+  @inject(PodmanVersionDetector)
+  private readonly versionDetector: PodmanVersionDetector;
+
   async findPaths(): Promise<string[]> {
     // socket path is at $HOME/.local/share/containers/podman/machine/podman.sock
     const socketPath = resolve(homedir(), '.local/share/containers/podman/machine/podman.sock');
@@ -41,8 +45,13 @@ export class PodmanSocketMacOSFinder implements SocketFinder {
     }
 
     try {
-      // on macOS, run the command to list podman machines with the providers
-      const { stdout } = await process.exec('podman', ['machine', 'ls', '--all-providers', '--format', 'json']);
+      const majorVersion = await this.versionDetector.getMajorVersion();
+      const args = ['machine', 'ls'];
+      if (majorVersion < 6) {
+        args.push('--all-providers');
+      }
+      args.push('--format', 'json');
+      const { stdout } = await process.exec('podman', args);
 
       // use zod to parse the output
       const machines: PodmanMachineListInfo = zodPodmanMachineList.parse(JSON.parse(stdout));

--- a/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-version-detector.spec.ts
+++ b/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-version-detector.spec.ts
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RunResult } from '@openkaiden/api';
+import { env, process } from '@openkaiden/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { PodmanVersionDetector } from './podman-version-detector';
+
+vi.mock(import('@openkaiden/api'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('getMajorVersion returns 5 for podman 5.x', async () => {
+  const detector = new PodmanVersionDetector();
+
+  vi.mocked(env).isWindows = false;
+  vi.mocked(process.exec).mockResolvedValue({ stdout: 'podman version 5.3.1', stderr: '' } as RunResult);
+
+  const version = await detector.getMajorVersion();
+
+  expect(version).toBe(5);
+  expect(process.exec).toHaveBeenCalledWith('podman', ['--version']);
+});
+
+test('getMajorVersion returns 6 for podman 6.x', async () => {
+  const detector = new PodmanVersionDetector();
+
+  vi.mocked(env).isWindows = false;
+  vi.mocked(process.exec).mockResolvedValue({ stdout: 'podman version 6.0.0', stderr: '' } as RunResult);
+
+  const version = await detector.getMajorVersion();
+
+  expect(version).toBe(6);
+});
+
+test('getMajorVersion uses podman.exe on Windows', async () => {
+  const detector = new PodmanVersionDetector();
+
+  vi.mocked(env).isWindows = true;
+  vi.mocked(process.exec).mockResolvedValue({ stdout: 'podman version 5.2.0', stderr: '' } as RunResult);
+
+  const version = await detector.getMajorVersion();
+
+  expect(version).toBe(5);
+  expect(process.exec).toHaveBeenCalledWith('podman.exe', ['--version']);
+});
+
+test('getMajorVersion defaults to 6 when exec fails', async () => {
+  const detector = new PodmanVersionDetector();
+
+  vi.mocked(env).isWindows = false;
+  vi.mocked(process.exec).mockRejectedValue(new Error('podman not found'));
+
+  const version = await detector.getMajorVersion();
+
+  expect(version).toBe(6);
+});
+
+test('getMajorVersion defaults to 6 when output cannot be parsed', async () => {
+  const detector = new PodmanVersionDetector();
+
+  vi.mocked(env).isWindows = false;
+  vi.mocked(process.exec).mockResolvedValue({ stdout: 'unexpected output', stderr: '' } as RunResult);
+
+  const version = await detector.getMajorVersion();
+
+  expect(version).toBe(6);
+});
+
+test('getMajorVersion caches the result', async () => {
+  const detector = new PodmanVersionDetector();
+
+  vi.mocked(env).isWindows = false;
+  vi.mocked(process.exec).mockResolvedValue({ stdout: 'podman version 5.3.1', stderr: '' } as RunResult);
+
+  await detector.getMajorVersion();
+  const version = await detector.getMajorVersion();
+
+  expect(version).toBe(5);
+  expect(process.exec).toHaveBeenCalledTimes(1);
+});

--- a/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-version-detector.ts
+++ b/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-version-detector.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { env, process } from '@openkaiden/api';
+import { injectable } from 'inversify';
+import { coerce, major } from 'semver';
+
+@injectable()
+export class PodmanVersionDetector {
+  #cachedMajorVersion: number | undefined;
+
+  async getMajorVersion(): Promise<number> {
+    if (this.#cachedMajorVersion !== undefined) {
+      return this.#cachedMajorVersion;
+    }
+
+    try {
+      const binary = env.isWindows ? 'podman.exe' : 'podman';
+      const { stdout } = await process.exec(binary, ['--version']);
+      // output is like "podman version X.Y.Z"
+      const version = coerce(stdout.trim());
+      if (version) {
+        this.#cachedMajorVersion = major(version);
+        return this.#cachedMajorVersion;
+      }
+    } catch (error: unknown) {
+      console.debug('PodmanVersionDetector: unable to detect podman version', error);
+    }
+
+    // default to 6 (newest behavior, no --all-providers)
+    this.#cachedMajorVersion = 6;
+    return this.#cachedMajorVersion;
+  }
+}

--- a/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-windows-finder.spec.ts
+++ b/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-windows-finder.spec.ts
@@ -18,19 +18,31 @@
 
 import type { RunResult } from '@openkaiden/api';
 import { process } from '@openkaiden/api';
+import { Container } from 'inversify';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { PodmanVersionDetector } from './podman-version-detector';
 import { PodmanSocketWindowsFinder } from './podman-windows-finder';
 
 vi.mock(import('@openkaiden/api'));
 
-beforeEach(() => {
+const versionDetectorMock = {
+  getMajorVersion: vi.fn(),
+} as unknown as PodmanVersionDetector;
+
+let finder: PodmanSocketWindowsFinder;
+
+beforeEach(async () => {
   vi.resetAllMocks();
+  vi.mocked(versionDetectorMock.getMajorVersion).mockResolvedValue(5);
+
+  const container = new Container();
+  container.bind(PodmanSocketWindowsFinder).toSelf().inSingletonScope();
+  container.bind(PodmanVersionDetector).toConstantValue(versionDetectorMock);
+  finder = await container.getAsync(PodmanSocketWindowsFinder);
 });
 
 test('findPaths returns empty array when socket does not exist', async () => {
-  const finder = new PodmanSocketWindowsFinder();
-
   const machineListOutput = JSON.stringify([]);
 
   vi.mocked(process.exec).mockResolvedValue({ stdout: machineListOutput, stderr: '' } as RunResult);
@@ -41,8 +53,8 @@ test('findPaths returns empty array when socket does not exist', async () => {
   expect(process.exec).toHaveBeenCalledWith('podman.exe', ['machine', 'ls', '--all-providers', '--format', 'json']);
 });
 
-test('findPaths returns socket path when socket exists and machine is running', async () => {
-  const finder = new PodmanSocketWindowsFinder();
+test('findPaths returns socket path with --all-providers on podman 5', async () => {
+  vi.mocked(versionDetectorMock.getMajorVersion).mockResolvedValue(5);
 
   const machineListOutput = JSON.stringify([{ Name: 'podman-machine-default', VMType: 'qemu', Running: true }]);
 
@@ -54,9 +66,20 @@ test('findPaths returns socket path when socket exists and machine is running', 
   expect(process.exec).toHaveBeenCalledWith('podman.exe', ['machine', 'ls', '--all-providers', '--format', 'json']);
 });
 
-test('findPaths returns empty array when socket exists but no machines are running', async () => {
-  const finder = new PodmanSocketWindowsFinder();
+test('findPaths returns socket path without --all-providers on podman 6', async () => {
+  vi.mocked(versionDetectorMock.getMajorVersion).mockResolvedValue(6);
 
+  const machineListOutput = JSON.stringify([{ Name: 'podman-machine-default', VMType: 'qemu', Running: true }]);
+
+  vi.mocked(process.exec).mockResolvedValue({ stdout: machineListOutput, stderr: '' } as RunResult);
+
+  const result = await finder.findPaths();
+
+  expect(result).toEqual(['\\\\.\\pipe\\podman-machine-default']);
+  expect(process.exec).toHaveBeenCalledWith('podman.exe', ['machine', 'ls', '--format', 'json']);
+});
+
+test('findPaths returns empty array when socket exists but no machines are running', async () => {
   const machineListOutput = JSON.stringify([{ Name: 'podman-machine-default', VMType: 'qemu', Running: false }]);
 
   vi.mocked(process.exec).mockResolvedValue({ stdout: machineListOutput, stderr: '' } as RunResult);
@@ -67,8 +90,6 @@ test('findPaths returns empty array when socket exists but no machines are runni
 });
 
 test('findPaths returns socket path when multiple machines exist and at least one is running', async () => {
-  const finder = new PodmanSocketWindowsFinder();
-
   const machineListOutput = JSON.stringify([
     { Name: 'machine-1', VMType: 'qemu', Running: false },
     { Name: 'machine-2', VMType: 'qemu', Running: true },
@@ -83,8 +104,6 @@ test('findPaths returns socket path when multiple machines exist and at least on
 });
 
 test('findPaths returns empty array when socket exists but machine list is empty', async () => {
-  const finder = new PodmanSocketWindowsFinder();
-
   const machineListOutput = JSON.stringify([]);
 
   vi.mocked(process.exec).mockResolvedValue({ stdout: machineListOutput, stderr: '' } as RunResult);

--- a/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-windows-finder.ts
+++ b/extensions/container/packages/extension/src/helper/socket-finder/podman/podman-windows-finder.ts
@@ -17,27 +17,30 @@
  ***********************************************************************/
 
 import { process } from '@openkaiden/api';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import type { SocketFinder } from '/@/api/socket-finder';
 import {
   type PodmanMachineListInfo,
   zodPodmanMachineList,
 } from '/@/helper/socket-finder/podman/podman-machine-list-info';
+import { PodmanVersionDetector } from '/@/helper/socket-finder/podman/podman-version-detector';
 
 // on Windows, npipe are stored in \\.\pipe\ with for example \\.\pipe\podman-machine-default for the default machine
 @injectable()
 export class PodmanSocketWindowsFinder implements SocketFinder {
+  @inject(PodmanVersionDetector)
+  private readonly versionDetector: PodmanVersionDetector;
+
   async findPaths(): Promise<string[]> {
     try {
-      // run the command to list podman machines with the providers
-      const { stdout: machineListOutput } = await process.exec('podman.exe', [
-        'machine',
-        'ls',
-        '--all-providers',
-        '--format',
-        'json',
-      ]);
+      const majorVersion = await this.versionDetector.getMajorVersion();
+      const args = ['machine', 'ls'];
+      if (majorVersion < 6) {
+        args.push('--all-providers');
+      }
+      args.push('--format', 'json');
+      const { stdout: machineListOutput } = await process.exec('podman.exe', args);
 
       // use zod to parse the output
       const machines: PodmanMachineListInfo = zodPodmanMachineList.parse(JSON.parse(machineListOutput));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       inversify:
         specifier: ^7.7.1
         version: 7.11.0(reflect-metadata@0.2.2)
+      semver:
+        specifier: ^7.7.3
+        version: 7.8.5
       stream-json:
         specifier: ^1.9.1
         version: 1.9.1
@@ -6951,11 +6954,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -8322,7 +8320,7 @@ snapshots:
   '@commitlint/is-ignored@20.4.1':
     dependencies:
       '@commitlint/types': 20.4.0
-      semver: 7.8.4
+      semver: 7.8.5
 
   '@commitlint/lint@20.4.2':
     dependencies:
@@ -8526,7 +8524,7 @@ snapshots:
       node-api-version: 0.2.1
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.8.4
+      semver: 7.8.5
       tar: 7.5.15
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -8545,7 +8543,7 @@ snapshots:
       node-gyp: 11.5.0
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.15
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -9932,7 +9930,7 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.8.4
+      semver: 7.8.5
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -9947,7 +9945,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.8.4
+      semver: 7.8.5
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -9962,7 +9960,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3
       minimatch: 10.2.4
-      semver: 7.8.4
+      semver: 7.8.5
       tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -9994,7 +9992,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       eslint: 9.39.3(jiti@2.6.1)
       eslint-scope: 5.1.1
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10008,7 +10006,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       eslint: 9.39.3(jiti@2.6.1)
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10414,7 +10412,7 @@ snapshots:
       minimatch: 10.0.3
       plist: 3.1.0
       resedit: 1.7.2
-      semver: 7.8.4
+      semver: 7.8.5
       tar: 7.5.15
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
@@ -11573,7 +11571,7 @@ snapshots:
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
-      semver: 7.7.3
+      semver: 7.7.4
       tiny-typed-emitter: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -11904,7 +11902,7 @@ snapshots:
       postcss: 8.5.6
       postcss-load-config: 3.1.4(postcss@8.5.6)
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
-      semver: 7.7.3
+      semver: 7.8.5
       svelte-eslint-parser: 1.5.1(svelte@5.47.0)
     optionalDependencies:
       svelte: 5.47.0
@@ -11930,7 +11928,7 @@ snapshots:
       pluralize: 8.0.0
       regexp-tree: 0.1.27
       regjsparser: 0.13.0
-      semver: 7.7.3
+      semver: 7.8.5
       strip-indent: 4.1.1
 
   eslint-scope@5.1.1:
@@ -12534,7 +12532,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.8.4
+      semver: 7.8.5
       serialize-error: 7.0.1
     optional: true
 
@@ -12868,7 +12866,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   is-callable@1.2.7: {}
 
@@ -13370,7 +13368,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -14031,11 +14029,11 @@ snapshots:
 
   node-abi@3.92.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   node-abi@4.26.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   node-addon-api@1.7.2:
     optional: true
@@ -14044,7 +14042,7 @@ snapshots:
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   node-domexception@1.0.0: {}
 
@@ -14070,7 +14068,7 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
-      semver: 7.8.4
+      semver: 7.8.5
       tar: 7.5.15
       tinyglobby: 0.2.16
       which: 5.0.0
@@ -14899,8 +14897,6 @@ snapshots:
 
   semver@7.7.4: {}
 
-  semver@7.8.4: {}
-
   semver@7.8.5: {}
 
   send@0.19.0:
@@ -15036,7 +15032,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   slash@3.0.0: {}
 
@@ -15337,7 +15333,7 @@ snapshots:
       postcss: 8.5.6
       postcss-scss: 4.0.9(postcss@8.5.6)
       postcss-selector-parser: 7.1.0
-      semver: 7.7.3
+      semver: 7.8.5
     optionalDependencies:
       svelte: 5.47.0
 


### PR DESCRIPTION
Podman 6 removed the --all-providers flag from `podman machine ls`. Detect the installed Podman major version and only pass the flag on Podman 5, omitting it for Podman 6+.

Fixes https://github.com/openkaiden/kaiden/issues/1389