### PR TITLE
chore: update fullsend to v0.23.0

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -44,13 +44,12 @@ jobs:
     if: >-
       github.event_name != 'issue_comment'
       || github.event.comment.user.type != 'Bot'
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@10b62b5510e1c8a22ed08ad0b1061aa346dd1373 # v0.21.0
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@02977ab3c4d68be6646134deef2aa91b59bab0b0 # v0.23.0
     with:
       event_action: ${{ github.event.action }}
       install_mode: per-repo
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
-      fullsend_ai_ref: 10b62b5510e1c8a22ed08ad0b1061aa346dd1373 # v0.21.0
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}


### PR DESCRIPTION
remove the reference parameter b/c now it's no longer required

it'll allow to have dependabot automatically updating the GH action reference

reference: https://github.com/fullsend-ai/fullsend/issues/2683