### PR TITLE
feat(codex): add agent configuration and model settings support (#2170)

### DIFF
--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -20,7 +20,9 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@openkaiden/api": "workspace:*"
+    "@openkaiden/api": "workspace:*",
+    "smol-toml": "^1.6.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "adm-zip": "^0.5.16",

--- a/extensions/codex/src/extension.spec.ts
+++ b/extensions/codex/src/extension.spec.ts
@@ -16,11 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Disposable, ExtensionContext } from '@openkaiden/api';
+import type {
+  Agent,
+  AgentConfigurationFile,
+  AgentWorkspaceContext,
+  Disposable,
+  ExtensionContext,
+} from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+import { parse, stringify } from 'smol-toml';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { activate } from './extension';
+import { activate, CODEX_CONFIG_PATH } from './extension';
 
 const AGENT_DISPOSABLE_MOCK: Disposable = { dispose: vi.fn() };
 
@@ -35,6 +42,44 @@ beforeEach(() => {
 
   vi.mocked(agents.registerAgent).mockReturnValue(AGENT_DISPOSABLE_MOCK);
 });
+
+function getRegisteredAgent(): Agent {
+  return vi.mocked(agents.registerAgent).mock.calls[0]![0];
+}
+
+function createContext(
+  configFiles: AgentConfigurationFile[],
+  options: {
+    modelLabel?: string;
+    mcp?: {
+      servers?: { name: string; url: string; headers?: Record<string, string> }[];
+      commands?: { name: string; command: string; args?: string[]; env?: Record<string, string> }[];
+    };
+  } = {},
+): AgentWorkspaceContext {
+  const { modelLabel = 'gpt-4o', mcp } = options;
+  return {
+    model: {
+      model: { label: modelLabel },
+    },
+    configurationFiles: configFiles,
+    workspace: { ...(mcp ? { mcp } : {}) },
+  };
+}
+
+function createConfigFile(content = ''): AgentConfigurationFile & { updateMock: ReturnType<typeof vi.fn> } {
+  const updateMock = vi.fn();
+  const file: AgentConfigurationFile = {
+    path: CODEX_CONFIG_PATH,
+    read: vi.fn().mockResolvedValue(content),
+    update: updateMock,
+  };
+  return Object.assign(file, { updateMock });
+}
+
+function parseWrittenToml(updateMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  return parse(updateMock.mock.calls[0]![0] as string);
+}
 
 describe('activate', () => {
   test('registers codex agent', async () => {
@@ -61,9 +106,273 @@ describe('activate', () => {
   test('registered agent supports only openai model type', async () => {
     await activate(extensionContextMock);
 
-    const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+    const agent = getRegisteredAgent();
     expect(agent.isSupportedModelType!({ name: 'openai' })).toBe(true);
     expect(agent.isSupportedModelType!({ name: 'gemini' })).toBe(false);
     expect(agent.isSupportedModelType!({ name: 'vertexai' })).toBe(false);
+  });
+
+  test('registers agent with config.toml configuration file', async () => {
+    await activate(extensionContextMock);
+
+    const agent = getRegisteredAgent();
+    expect(agent.configurationFiles).toHaveLength(1);
+    expect(agent.configurationFiles[0]!.path).toBe(CODEX_CONFIG_PATH);
+  });
+
+  describe('preWorkspaceStart', () => {
+    test('writes model configuration into config.toml', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      expect(configFile.updateMock).toHaveBeenCalledOnce();
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written).toEqual({ model: 'gpt-4o' });
+    });
+
+    test('preserves existing configuration fields', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const existingConfig = stringify({ model: 'old-model', approval_mode: 'suggest' });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile], { modelLabel: 'o4-mini' }));
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.model).toBe('o4-mini');
+      expect(written.approval_mode).toBe('suggest');
+    });
+
+    test('rejects invalid TOML', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile('not = [valid toml');
+      await expect(agent.preWorkspaceStart(createContext([configFile]))).rejects.toThrow();
+    });
+
+    test('does nothing when config file is not in context', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const updateMock = vi.fn();
+      const otherFile: AgentConfigurationFile = {
+        path: 'some/other/path.toml',
+        read: vi.fn(),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([otherFile]));
+
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    test('writes stdio MCP commands from workspace config', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'my-local', command: 'npx', args: ['-y', 'my-mcp-server'] }],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'my-local': { command: 'npx', args: ['-y', 'my-mcp-server'] },
+      });
+    });
+
+    test('writes stdio MCP commands with env variables', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [
+              {
+                name: 'github-mcp',
+                command: 'npx',
+                args: ['@modelcontextprotocol/server-github'],
+                env: { GITHUB_TOKEN: 'ghp_test123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'github-mcp': {
+          command: 'npx',
+          args: ['@modelcontextprotocol/server-github'],
+          env: { GITHUB_TOKEN: 'ghp_test123' },
+        },
+      });
+    });
+
+    test('writes HTTP MCP servers from workspace config', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'my-remote', url: 'https://mcp.example.com' }],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'my-remote': { url: 'https://mcp.example.com' },
+      });
+    });
+
+    test('writes HTTP MCP servers with headers', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [
+              {
+                name: 'authed-server',
+                url: 'https://mcp.example.com',
+                headers: { Authorization: 'Bearer token123' },
+              },
+            ],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'authed-server': {
+          url: 'https://mcp.example.com',
+          http_headers: { Authorization: 'Bearer token123' },
+        },
+      });
+    });
+
+    test('writes both stdio and HTTP MCP servers together', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'remote-one', url: 'https://mcp.example.com' }],
+            commands: [{ name: 'local-one', command: 'npx', args: ['my-server'] }],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'local-one': { command: 'npx', args: ['my-server'] },
+        'remote-one': { url: 'https://mcp.example.com' },
+      });
+    });
+
+    test('merges MCP servers with existing mcp_servers config', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const existingConfig = stringify({
+        mcp_servers: { 'existing-server': { url: 'https://existing.example.com' } },
+      });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'new-server', url: 'https://new.example.com' }],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'existing-server': { url: 'https://existing.example.com' },
+        'new-server': { url: 'https://new.example.com' },
+      });
+    });
+
+    test('does not write mcp_servers key when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toBeUndefined();
+    });
+
+    test('preserves existing mcp_servers when workspace has no MCP config', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const existingConfig = stringify({
+        mcp_servers: { 'existing-server': { url: 'https://existing.example.com' } },
+      });
+      const configFile = createConfigFile(existingConfig);
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'existing-server': { url: 'https://existing.example.com' },
+      });
+    });
+
+    test('omits http_headers when HTTP MCP server has empty headers', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            servers: [{ name: 'no-headers', url: 'https://mcp.example.com', headers: {} }],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        'no-headers': { url: 'https://mcp.example.com' },
+      });
+    });
+
+    test('omits env when stdio MCP command has empty env', async () => {
+      await activate(extensionContextMock);
+      const agent = getRegisteredAgent();
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          mcp: {
+            commands: [{ name: 'minimal', command: 'my-server', args: [], env: {} }],
+          },
+        }),
+      );
+
+      const written = parseWrittenToml(configFile.updateMock);
+      expect(written.mcp_servers).toEqual({
+        minimal: { command: 'my-server', args: [] },
+      });
+    });
   });
 });

--- a/extensions/codex/src/extension.ts
+++ b/extensions/codex/src/extension.ts
@@ -16,8 +16,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext } from '@openkaiden/api';
+import type { AgentWorkspaceContext, ExtensionContext } from '@openkaiden/api';
 import { agents } from '@openkaiden/api';
+import { parse, stringify } from 'smol-toml';
+import { z } from 'zod';
+
+export const CODEX_CONFIG_PATH = '.codex/config.toml';
+
+const McpServerEntrySchema = z.looseObject({
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  url: z.string().optional(),
+  http_headers: z.record(z.string(), z.string()).optional(),
+});
+
+const CodexConfigSchema = z.looseObject({
+  model: z.string().optional(),
+  mcp_servers: z.record(z.string(), McpServerEntrySchema).optional(),
+});
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
@@ -29,13 +46,58 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       logo: { dark: './icon.png', light: './icon.png' },
     },
     command: 'codex',
-    configurationFiles: [],
+    configurationFiles: [
+      {
+        path: CODEX_CONFIG_PATH,
+        async read(): Promise<string> {
+          return '';
+        },
+      },
+    ],
     destinationSkillsFolder: '${HOME}/.agents/skills',
     isSupportedModelType(type): boolean {
       return type.name === 'openai';
     },
-    async preWorkspaceStart(): Promise<void> {
-      throw new Error('not implemented');
+    async preWorkspaceStart(context: AgentWorkspaceContext): Promise<void> {
+      const configFile = context.configurationFiles.find(f => f.path === CODEX_CONFIG_PATH);
+      if (!configFile) {
+        return;
+      }
+
+      const raw = await configFile.read();
+      const config = CodexConfigSchema.parse(raw ? parse(raw) : {});
+
+      config.model = context.model.model.label;
+
+      const mcpServers = context.workspace.mcp?.servers;
+      const mcpCommands = context.workspace.mcp?.commands;
+
+      if (mcpServers?.length || mcpCommands?.length) {
+        const servers = config.mcp_servers ?? {};
+
+        for (const cmd of mcpCommands ?? []) {
+          const entry: Record<string, unknown> = {
+            command: cmd.command,
+            args: cmd.args ?? [],
+          };
+          if (cmd.env && Object.keys(cmd.env).length > 0) {
+            entry['env'] = cmd.env;
+          }
+          servers[cmd.name] = entry;
+        }
+
+        for (const srv of mcpServers ?? []) {
+          const entry: Record<string, unknown> = { url: srv.url };
+          if (srv.headers && Object.keys(srv.headers).length > 0) {
+            entry['http_headers'] = srv.headers;
+          }
+          servers[srv.name] = entry;
+        }
+
+        config.mcp_servers = servers;
+      }
+
+      await configFile.update(stringify(config));
     },
   });
   extensionContext.subscriptions.push(disposable);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,12 @@ importers:
       '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       adm-zip:
         specifier: ^0.5.16


### PR DESCRIPTION
Implement preWorkspaceStart for the Codex extension, writing model and MCP server configuration into .codex/config.toml using smol-toml for TOML serialization and Zod for schema validation.

Closes #2170