### PR TITLE
fix: check stdout/stderr and augment error message in extractCliError

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -318,6 +318,54 @@ describe('createSandbox', () => {
 
     await expect(openshellCli.createSandbox()).rejects.toThrow('gateway connection refused');
   });
+
+  test('extracts JSON error from stderr on failure', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stderr: JSON.stringify({ error: 'stderr json error' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(openshellCli.createSandbox()).rejects.toThrow('stderr json error');
+  });
+
+  test('prefers stdout JSON error over stderr JSON error', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'stdout error' }),
+      stderr: JSON.stringify({ error: 'stderr error' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(openshellCli.createSandbox()).rejects.toThrow('stdout error');
+  });
+
+  test('augments err.message with raw stderr when not JSON', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      message: 'command failed',
+      stderr: 'permission denied',
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(openshellCli.createSandbox()).rejects.toThrow('command failed (stderr: permission denied)');
+  });
+
+  test('augments err.message with raw stdout when stderr is empty', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      message: 'command failed',
+      stdout: 'unexpected output',
+      stderr: '',
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(openshellCli.createSandbox()).rejects.toThrow('command failed (stdout: unexpected output)');
+  });
 });
 
 describe('listSandboxes', () => {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -79,20 +79,40 @@ export class OpenshellCli {
   }
 
   private extractCliError(err: unknown): string {
-    if (err instanceof Error && 'stdout' in err && typeof (err as RunError).stdout === 'string') {
-      try {
-        const parsed: unknown = JSON.parse((err as RunError).stdout);
-        if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
-          const errorField = (parsed as { error: unknown }).error;
-          if (typeof errorField === 'string' && errorField) {
-            return errorField;
-          }
-        }
-      } catch {
-        // not JSON – fall through
+    if (err instanceof Error && 'stdout' in err) {
+      const runErr = err as RunError;
+
+      const jsonError = this.tryExtractJsonError(runErr.stdout) ?? this.tryExtractJsonError(runErr.stderr);
+      if (jsonError) {
+        return jsonError;
+      }
+
+      if (runErr.stderr?.trim()) {
+        return `${err.message} (stderr: ${runErr.stderr.trim()})`;
+      }
+      if (runErr.stdout?.trim()) {
+        return `${err.message} (stdout: ${runErr.stdout.trim()})`;
       }
     }
     return err instanceof Error ? err.message : String(err);
+  }
+
+  private tryExtractJsonError(output: string | undefined): string | undefined {
+    if (typeof output !== 'string' || !output) {
+      return undefined;
+    }
+    try {
+      const parsed: unknown = JSON.parse(output);
+      if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
+        const errorField = (parsed as { error: unknown }).error;
+        if (typeof errorField === 'string' && errorField) {
+          return errorField;
+        }
+      }
+    } catch {
+      // not JSON
+    }
+    return undefined;
   }
 
   async getVersion(): Promise<string> {


### PR DESCRIPTION
## Summary
- Extract JSON error parsing into a reusable `tryExtractJsonError` helper to avoid duplication
- Extend `extractCliError` to inspect both `stdout` and `stderr` for JSON error payloads
- When JSON parsing fails, augment `err.message` with raw `stderr` or `stdout` content so CLI error details are no longer silently discarded

Fixes #2285

## Test plan
- [x] Existing tests pass (76 total)
- [x] New test: `stderr` contains JSON `{"error": "..."}` → returns that error string
- [x] New test: both `stdout` and `stderr` have JSON errors → `stdout` wins
- [x] New test: raw `stderr` augments `err.message` when not JSON
- [x] New test: raw `stdout` augments `err.message` when `stderr` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)