### PR TITLE
fix(workspaces): restore agent count in workspace list page

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.spec.ts
@@ -19,11 +19,16 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { SandboxInfoWithGateway } from '/@/stores/openshell-sandboxes';
+import { AGENT_LABEL } from '/@api/openshell-gateway-info';
 
 import AgentWorkspaceStatCards from './AgentWorkspaceStatCards.svelte';
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
 
 function makeSandbox(overrides: Partial<SandboxInfoWithGateway> = {}): SandboxInfoWithGateway {
   return {
@@ -35,23 +40,23 @@ function makeSandbox(overrides: Partial<SandboxInfoWithGateway> = {}): SandboxIn
   };
 }
 
-test('should display count of unique configured agents', () => {
+test('should display count of unique configured agents', async () => {
   const sandboxes: SandboxInfoWithGateway[] = [
-    makeSandbox({ id: 'sb-1', labels: { 'ai.openkaiden.kaiden.agent': 'coder-v1' } }),
-    makeSandbox({ id: 'sb-2', labels: { 'ai.openkaiden.kaiden.agent': 'coder-v1' } }),
-    makeSandbox({ id: 'sb-3', labels: { 'ai.openkaiden.kaiden.agent': 'reviewer-v2' } }),
+    makeSandbox({ id: 'sb-1', labels: { [AGENT_LABEL]: 'coder-v1' } }),
+    makeSandbox({ id: 'sb-2', labels: { [AGENT_LABEL]: 'coder-v1' } }),
+    makeSandbox({ id: 'sb-3', labels: { [AGENT_LABEL]: 'reviewer-v2' } }),
     makeSandbox({ id: 'sb-4' }),
   ];
 
   render(AgentWorkspaceStatCards, { sandboxes });
 
   const agentCard = screen.getByText('Configured Agents').parentElement!;
-  expect(agentCard).toHaveTextContent('2');
+  await vi.waitFor(() => expect(agentCard).toHaveTextContent('2'));
 });
 
-test('should display 0 configured agents when no labels present', () => {
+test('should display 0 configured agents when no labels present', async () => {
   render(AgentWorkspaceStatCards, { sandboxes: [makeSandbox()] });
 
   const agentCard = screen.getByText('Configured Agents').parentElement!;
-  expect(agentCard).toHaveTextContent('0');
+  await vi.waitFor(() => expect(agentCard).toHaveTextContent('0'));
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { SandboxInfoWithGateway } from '/@/stores/openshell-sandboxes';
+
+import AgentWorkspaceStatCards from './AgentWorkspaceStatCards.svelte';
+
+function makeSandbox(overrides: Partial<SandboxInfoWithGateway> = {}): SandboxInfoWithGateway {
+  return {
+    id: 'sb-1',
+    name: 'test',
+    gatewayName: 'kaiden',
+    phase: 'Unknown',
+    ...overrides,
+  };
+}
+
+test('should display count of unique configured agents', () => {
+  const sandboxes: SandboxInfoWithGateway[] = [
+    makeSandbox({ id: 'sb-1', labels: { 'ai.openkaiden.kaiden.agent': 'coder-v1' } }),
+    makeSandbox({ id: 'sb-2', labels: { 'ai.openkaiden.kaiden.agent': 'coder-v1' } }),
+    makeSandbox({ id: 'sb-3', labels: { 'ai.openkaiden.kaiden.agent': 'reviewer-v2' } }),
+    makeSandbox({ id: 'sb-4' }),
+  ];
+
+  render(AgentWorkspaceStatCards, { sandboxes });
+
+  const agentCard = screen.getByText('Configured Agents').parentElement!;
+  expect(agentCard).toHaveTextContent('2');
+});
+
+test('should display 0 configured agents when no labels present', () => {
+  render(AgentWorkspaceStatCards, { sandboxes: [makeSandbox()] });
+
+  const agentCard = screen.getByText('Configured Agents').parentElement!;
+  expect(agentCard).toHaveTextContent('0');
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.svelte
@@ -4,7 +4,8 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import Card from '/@/lib/components/Card.svelte';
 import type { SandboxInfoWithGateway } from '/@/stores/openshell-sandboxes';
-import { AGENT_LABEL } from '/@api/openshell-gateway-info';
+
+import { getAgentId } from './workspace-utils';
 
 interface Props {
   sandboxes: SandboxInfoWithGateway[];
@@ -16,7 +17,7 @@ const activeSandboxCount = $derived(
   sandboxes.filter(s => s.phase.toLowerCase() === 'ready' || s.phase.toLowerCase() === 'running').length,
 );
 
-const configuredAgentCount = $derived(new Set(sandboxes.map(s => s.labels?.[AGENT_LABEL]).filter(Boolean)).size);
+const configuredAgentCount = $derived(new Set(sandboxes.map(getAgentId).filter(Boolean)).size);
 </script>
 
 <div class="grid grid-cols-3 gap-3.5 mb-5">

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceStatCards.svelte
@@ -4,6 +4,7 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import Card from '/@/lib/components/Card.svelte';
 import type { SandboxInfoWithGateway } from '/@/stores/openshell-sandboxes';
+import { AGENT_LABEL } from '/@api/openshell-gateway-info';
 
 interface Props {
   sandboxes: SandboxInfoWithGateway[];
@@ -14,6 +15,8 @@ let { sandboxes }: Props = $props();
 const activeSandboxCount = $derived(
   sandboxes.filter(s => s.phase.toLowerCase() === 'ready' || s.phase.toLowerCase() === 'running').length,
 );
+
+const configuredAgentCount = $derived(new Set(sandboxes.map(s => s.labels?.[AGENT_LABEL]).filter(Boolean)).size);
 </script>
 
 <div class="grid grid-cols-3 gap-3.5 mb-5">
@@ -42,7 +45,7 @@ const activeSandboxCount = $derived(
       <Icon icon={faRobot} size="1.1x" />
     </div>
     <div class="flex flex-col">
-      <span class="text-4xl font-bold text-[var(--pd-content-text)]">{0}</span>
+      <span class="text-4xl font-bold text-[var(--pd-content-text)]">{configuredAgentCount}</span>
       <span class="text-base text-[var(--pd-content-text)] opacity-60">Configured Agents</span>
     </div>
   </Card>


### PR DESCRIPTION
## Summary
- Compute the "Configured Agents" count by deriving unique agent IDs from the `ai.openkaiden.kaiden.agent` label across sandboxes, replacing the hardcoded `0`
- Add unit tests for the stat card agent count

Fixes: #2302

## Test plan
- [x] Unit tests pass (`AgentWorkspaceStatCards.spec.ts`)
- [x] Typecheck passes with 0 errors
- [ ] Verify the "Configured Agents" card shows correct unique count in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)