### PR TITLE
feat(secrets): tie openshell provider lifecycle to inference connections

### DIFF
--- a/extensions/claude/src/manager/claude-inference-manager.spec.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.spec.ts
@@ -324,6 +324,22 @@ describe('factory', () => {
       apiKey: 'dummyKey',
     });
   });
+
+  test('should rollback saved config if registration fails', async () => {
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockImplementation(() => {
+      throw new Error('registration boom');
+    });
+
+    await expect(
+      create({
+        'claude.factory.apiKey': 'dummyKey',
+      }),
+    ).rejects.toThrow('registration boom');
+
+    expect(SECRET_STORAGE_MOCK.delete).toHaveBeenCalledWith('claude:fake-uuid-1:token');
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('claude.connection._type', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('claude.connection.ANTHROPIC_API_KEY', undefined);
+  });
 });
 
 describe('connection delete lifecycle', () => {

--- a/extensions/claude/src/manager/claude-inference-manager.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.ts
@@ -189,8 +189,13 @@ export class ClaudeInferenceManager {
 
     await this.setConnectionConfiguration(connection, token);
 
-    const connectionDisposable = this.claudeProvider.registerInferenceProviderConnection(connection);
-    this.connections.set(id, connectionDisposable);
+    try {
+      const connectionDisposable = this.claudeProvider.registerInferenceProviderConnection(connection);
+      this.connections.set(id, connectionDisposable);
+    } catch (err: unknown) {
+      await this.clearConnectionConfiguration(connection);
+      throw err;
+    }
   }
 
   private async getAnthropicModels(token: string, baseURL: string): Promise<Array<{ label: string }>> {

--- a/extensions/claude/src/manager/claude-inference-manager.ts
+++ b/extensions/claude/src/manager/claude-inference-manager.ts
@@ -187,10 +187,10 @@ export class ClaudeInferenceManager {
       },
     };
 
+    await this.setConnectionConfiguration(connection, token);
+
     const connectionDisposable = this.claudeProvider.registerInferenceProviderConnection(connection);
     this.connections.set(id, connectionDisposable);
-
-    await this.setConnectionConfiguration(connection, token);
   }
 
   private async getAnthropicModels(token: string, baseURL: string): Promise<Array<{ label: string }>> {

--- a/extensions/cursor/src/manager/cursor-inference-manager.spec.ts
+++ b/extensions/cursor/src/manager/cursor-inference-manager.spec.ts
@@ -207,6 +207,22 @@ describe('factory', () => {
       credentials: expect.any(Function),
     });
   });
+
+  test('should rollback saved config if registration fails', async () => {
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockImplementation(() => {
+      throw new Error('registration boom');
+    });
+
+    await expect(
+      create({
+        'cursor.factory.apiKey': 'dummyKey',
+      }),
+    ).rejects.toThrow('registration boom');
+
+    expect(SECRET_STORAGE_MOCK.delete).toHaveBeenCalledWith('cursor:fake-uuid-1:token');
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('cursor.connection._type', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('cursor.connection.token', undefined);
+  });
 });
 
 describe('connection delete lifecycle', () => {

--- a/extensions/cursor/src/manager/cursor-inference-manager.ts
+++ b/extensions/cursor/src/manager/cursor-inference-manager.ts
@@ -173,10 +173,10 @@ export class CursorInferenceManager {
       },
     };
 
+    await this.setConnectionConfiguration(connection, token);
+
     const connectionDisposable = this.cursorProvider.registerInferenceProviderConnection(connection);
     this.connections.set(id, connectionDisposable);
-
-    await this.setConnectionConfiguration(connection, token);
   }
 
   private async getCursorModels(token: string): Promise<Array<{ label: string }>> {

--- a/extensions/cursor/src/manager/cursor-inference-manager.ts
+++ b/extensions/cursor/src/manager/cursor-inference-manager.ts
@@ -175,8 +175,13 @@ export class CursorInferenceManager {
 
     await this.setConnectionConfiguration(connection, token);
 
-    const connectionDisposable = this.cursorProvider.registerInferenceProviderConnection(connection);
-    this.connections.set(id, connectionDisposable);
+    try {
+      const connectionDisposable = this.cursorProvider.registerInferenceProviderConnection(connection);
+      this.connections.set(id, connectionDisposable);
+    } catch (err: unknown) {
+      await this.clearConnectionConfiguration(connection);
+      throw err;
+    }
   }
 
   private async getCursorModels(token: string): Promise<Array<{ label: string }>> {

--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -299,6 +299,22 @@ describe('factory', () => {
       credentials: expect.any(Function),
     });
   });
+
+  test('should rollback saved config if registration fails', async () => {
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockImplementation(() => {
+      throw new Error('registration boom');
+    });
+
+    await expect(
+      create({
+        'gemini.factory.apiKey': 'dummyKey',
+      }),
+    ).rejects.toThrow('registration boom');
+
+    expect(SAFE_STORAGE_MOCK.delete).toHaveBeenCalledWith('gemini:fake-uuid-1:token');
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection._type', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.GEMINI_API_KEY', undefined);
+  });
 });
 
 describe('connection delete lifecycle', () => {

--- a/extensions/gemini/src/gemini.ts
+++ b/extensions/gemini/src/gemini.ts
@@ -186,10 +186,10 @@ export class Gemini implements Disposable {
       },
     };
 
+    await this.setConnectionConfiguration(connection, token);
+
     const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
     this.connections.set(id, connectionDisposable);
-
-    await this.setConnectionConfiguration(connection, token);
   }
 
   private async getGeminiModels(token: string): Promise<Array<{ label: string }>> {

--- a/extensions/gemini/src/gemini.ts
+++ b/extensions/gemini/src/gemini.ts
@@ -188,8 +188,13 @@ export class Gemini implements Disposable {
 
     await this.setConnectionConfiguration(connection, token);
 
-    const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
-    this.connections.set(id, connectionDisposable);
+    try {
+      const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
+      this.connections.set(id, connectionDisposable);
+    } catch (err: unknown) {
+      await this.clearConnectionConfiguration(connection);
+      throw err;
+    }
   }
 
   private async getGeminiModels(token: string): Promise<Array<{ label: string }>> {

--- a/extensions/mistral/src/manager/mistral-inference-manager.spec.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.spec.ts
@@ -242,6 +242,22 @@ describe('factory', () => {
       credentials: expect.any(Function),
     });
   });
+
+  test('should rollback saved config if registration fails', async () => {
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockImplementation(() => {
+      throw new Error('registration boom');
+    });
+
+    await expect(
+      create({
+        'mistral.factory.apiKey': 'dummyKey',
+      }),
+    ).rejects.toThrow('registration boom');
+
+    expect(SECRET_STORAGE_MOCK.delete).toHaveBeenCalledWith('mistral:fake-uuid-1:token');
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('mistral.connection._type', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('mistral.connection.token', undefined);
+  });
 });
 
 describe('connection delete lifecycle', () => {

--- a/extensions/mistral/src/manager/mistral-inference-manager.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.ts
@@ -165,8 +165,13 @@ export class MistralInferenceManager {
 
     await this.setConnectionConfiguration(connection, token);
 
-    const connectionDisposable = this.mistralProvider.registerInferenceProviderConnection(connection);
-    this.connections.set(id, connectionDisposable);
+    try {
+      const connectionDisposable = this.mistralProvider.registerInferenceProviderConnection(connection);
+      this.connections.set(id, connectionDisposable);
+    } catch (err: unknown) {
+      await this.clearConnectionConfiguration(connection);
+      throw err;
+    }
   }
 
   private async getMistralModels(token: string): Promise<Array<{ label: string }>> {

--- a/extensions/mistral/src/manager/mistral-inference-manager.ts
+++ b/extensions/mistral/src/manager/mistral-inference-manager.ts
@@ -163,10 +163,10 @@ export class MistralInferenceManager {
       },
     };
 
+    await this.setConnectionConfiguration(connection, token);
+
     const connectionDisposable = this.mistralProvider.registerInferenceProviderConnection(connection);
     this.connections.set(id, connectionDisposable);
-
-    await this.setConnectionConfiguration(connection, token);
   }
 
   private async getMistralModels(token: string): Promise<Array<{ label: string }>> {

--- a/extensions/openai-compatible/src/openAI.spec.ts
+++ b/extensions/openai-compatible/src/openAI.spec.ts
@@ -210,6 +210,23 @@ describe('factory', () => {
     expect(call.models).toEqual([{ label: 'gpt-4o' }, { label: 'gpt-4.1' }]);
     expect(call.credentials()).toEqual({ 'openai:tokens': 'dummyKey' });
   });
+
+  test('should rollback saved config if registration fails', async () => {
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockImplementation(() => {
+      throw new Error('registration boom');
+    });
+
+    await expect(
+      create({
+        'openai.factory.apiKey': 'dummyKey',
+        'openai.factory.baseURL': 'http://localhost:11434/v1',
+      }),
+    ).rejects.toThrow('registration boom');
+
+    expect(SECRET_STORAGE_MOCK.delete).toHaveBeenCalledWith('openai:fake-uuid-1:token');
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('openai.connection._type', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('openai.connection.OPENAI_API_KEY', undefined);
+  });
 });
 
 describe('connection delete lifecycle', () => {

--- a/extensions/openai-compatible/src/openAI.ts
+++ b/extensions/openai-compatible/src/openAI.ts
@@ -208,8 +208,13 @@ export class OpenAI implements Disposable {
 
     await this.setConnectionConfiguration(connection, token);
 
-    const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
-    this.connections.set(id, connectionDisposable);
+    try {
+      const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
+      this.connections.set(id, connectionDisposable);
+    } catch (err: unknown) {
+      await this.clearConnectionConfiguration(connection);
+      throw err;
+    }
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {

--- a/extensions/openai-compatible/src/openAI.ts
+++ b/extensions/openai-compatible/src/openAI.ts
@@ -206,10 +206,10 @@ export class OpenAI implements Disposable {
       },
     };
 
+    await this.setConnectionConfiguration(connection, token);
+
     const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
     this.connections.set(id, connectionDisposable);
-
-    await this.setConnectionConfiguration(connection, token);
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {

--- a/extensions/openshift-ai/src/openshiftai.spec.ts
+++ b/extensions/openshift-ai/src/openshiftai.spec.ts
@@ -263,6 +263,49 @@ describe('factory', () => {
     ];
     expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify(expected));
   });
+
+  test('should rollback saved config if registration fails', async () => {
+    listClusterCustomObjectMock.mockResolvedValue({
+      items: [{ metadata: { name: 'test-project' } }],
+    });
+    listNamespacedCustomObjectMock.mockResolvedValue({
+      items: [
+        {
+          metadata: { name: 'my-model' },
+          spec: { predictor: { model: { runtime: 'vllm' } } },
+          status: { url: 'https://my-model.example.com' },
+        },
+      ],
+    });
+    listNamespacedSecretMock.mockResolvedValue({
+      items: [
+        {
+          metadata: { annotations: { 'kubernetes.io/service-account.name': 'vllm-sa' } },
+          data: { token: Buffer.from('serviceToken').toString('base64') },
+        },
+      ],
+    });
+
+    fetchMock.mockResolvedValue({
+      status: 200,
+      json: async () => ({ data: [{ id: 'llama-3' }] }),
+    });
+
+    vi.mocked(PROVIDER_MOCK.registerInferenceProviderConnection).mockImplementation(() => {
+      throw new Error('registration boom');
+    });
+
+    await expect(
+      create({
+        'openshiftai.factory.url': 'https://api.cluster.example.com:6443',
+        'openshiftai.factory.token': 'dummyToken',
+      }),
+    ).rejects.toThrow('registration boom');
+
+    expect(SECRET_STORAGE_MOCK.delete).toHaveBeenCalledWith('openshiftai:fake-uuid-1:token');
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('openshiftai.connection._type', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('openshiftai.connection.token', undefined);
+  });
 });
 
 describe('restoreConnections', () => {

--- a/extensions/openshift-ai/src/openshiftai.ts
+++ b/extensions/openshift-ai/src/openshiftai.ts
@@ -298,8 +298,13 @@ export class OpenShiftAI implements Disposable {
 
     await this.setConnectionConfiguration(connection, stored);
 
-    const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
-    this.connections.set(stored.id, connectionDisposable);
+    try {
+      const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
+      this.connections.set(stored.id, connectionDisposable);
+    } catch (err: unknown) {
+      await this.clearConnectionConfiguration(connection);
+      throw err;
+    }
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {

--- a/extensions/openshift-ai/src/openshiftai.ts
+++ b/extensions/openshift-ai/src/openshiftai.ts
@@ -296,10 +296,10 @@ export class OpenShiftAI implements Disposable {
       },
     };
 
+    await this.setConnectionConfiguration(connection, stored);
+
     const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
     this.connections.set(stored.id, connectionDisposable);
-
-    await this.setConnectionConfiguration(connection, stored);
   }
 
   private async inferenceFactory(params: { [p: string]: unknown }): Promise<void> {

--- a/extensions/vertex-ai/src/vertex-ai.spec.ts
+++ b/extensions/vertex-ai/src/vertex-ai.spec.ts
@@ -509,8 +509,8 @@ describe('factory', () => {
       }),
     ).rejects.toThrow('registration boom');
 
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledTimes(2);
-    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(2, CONNECTIONS_KEY, '[]');
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledTimes(3);
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenNthCalledWith(3, CONNECTIONS_KEY, '[]');
   });
 
   test('should reject duplicate connection for same project and region', async () => {

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -382,7 +382,6 @@ export class VertexAi implements Disposable {
       await this.clearConnectionConfiguration(connection);
       throw err;
     }
-
   }
 
   /**

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -373,16 +373,16 @@ export class VertexAi implements Disposable {
       },
     };
 
-    const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
-    this.connections.set(id, connectionDisposable);
+    await this.setConnectionConfiguration(connection, config);
 
     try {
-      await this.setConnectionConfiguration(connection, config);
-    } catch (error) {
-      connectionDisposable.dispose();
-      this.connections.delete(id);
-      throw error;
+      const connectionDisposable = this.provider.registerInferenceProviderConnection(connection);
+      this.connections.set(id, connectionDisposable);
+    } catch (err: unknown) {
+      await this.clearConnectionConfiguration(connection);
+      throw err;
     }
+
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1155,9 +1155,11 @@ declare module '@openkaiden/api' {
   }
   export interface RegisterInferenceConnectionEvent {
     providerId: string;
+    connection: InferenceProviderConnection;
   }
   export interface UnregisterInferenceConnectionEvent {
     providerId: string;
+    connection: InferenceProviderConnection;
   }
   export interface RegisterRagConnectionEvent {
     providerId: string;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -19,12 +19,7 @@
 import { access, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type {
-  Agent,
-  AgentWorkspaceConfiguration,
-  FileSystemWatcher,
-  InferenceProviderConnection,
-} from '@openkaiden/api';
+import type { Agent, AgentWorkspaceConfiguration, FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import type { IPty } from 'node-pty';
 import { spawn } from 'node-pty';
@@ -37,7 +32,6 @@ import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
-import type { SafeStorageRegistry, SecretStorageWrapper } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import type { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type { Task } from '/@/plugin/tasks/tasks.js';
@@ -134,18 +128,8 @@ const providerRegistry = {
 const secretManager = {
   create: vi.fn(),
   init: vi.fn(),
+  getSecretForModel: vi.fn(),
 } as unknown as SecretManager;
-
-const extensionStorageMock = {
-  get: vi.fn(),
-  store: vi.fn(),
-  delete: vi.fn(),
-  onDidChange: vi.fn(),
-} as unknown as SecretStorageWrapper;
-
-const safeStorageRegistry = {
-  getExtensionStorage: vi.fn().mockReturnValue(extensionStorageMock),
-} as unknown as SafeStorageRegistry;
 
 function mockEnoent(): NodeJS.ErrnoException {
   const err: NodeJS.ErrnoException = new Error('ENOENT');
@@ -166,7 +150,6 @@ beforeEach(() => {
     get: vi.fn().mockReturnValue(undefined),
   } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
   vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({});
-  vi.mocked(safeStorageRegistry.getExtensionStorage).mockReturnValue(extensionStorageMock);
   manager = new AgentWorkspaceManager(
     apiSender,
     ipcHandle,
@@ -177,7 +160,6 @@ beforeEach(() => {
     providerRegistry,
     secretManager,
     openshellCli,
-    safeStorageRegistry,
     agentRegistry,
   );
   manager.init();
@@ -551,131 +533,15 @@ describe('create – OpenShell mode', () => {
     await expect(manager.create(options)).rejects.toThrow('policy update failed');
   });
 
-  // Environment variable merging tests
-  test('merges single credentials config key and passes to createProvider', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.vertex-ai',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'vertex-ai.connection._type') return 'google-vertex-ai';
-        if (key === 'vertex-ai.connection._flags') return ['--from-gcloud-adc'];
-        if (key === 'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS') return 'vertex-ai:conn-1:token';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_PROJECT') return 'test-project';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'vertex-ai.connection._type': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        hidden: true,
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection._flags': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_PROJECT': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('/path/to/creds.json');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-sandbox-google-vertex-ai' });
+  test('attaches secret to sandbox when getSecretForModel returns a secret', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'vertex-ai-conn-1', type: 'vertex-ai' });
 
     const options = { ...defaultOptions, model: 'vertexai::claude-sonnet-4::' };
     await manager.create(options);
 
-    expect(secretManager.create).toHaveBeenCalledWith(
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        value: expect.objectContaining({
-          config: {
-            GOOGLE_VERTEX_PROJECT: 'test-project',
-          },
-        }),
-      }),
-    );
-  });
-
-  test('merges multiple cfredentials config key and passes to createProvider', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.vertex-ai',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'vertex-ai.connection._type') return 'google-vertex-ai';
-        if (key === 'vertex-ai.connection._flags') return ['--from-gcloud-adc'];
-        if (key === 'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS') return 'vertex-ai:conn-1:token';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_PROJECT') return 'multi-var-project';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_LOCATION') return 'us-east5';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'vertex-ai.connection._type': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        hidden: true,
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection._flags': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_PROJECT': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_LOCATION': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('/path/to/creds.json');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-sandbox-google-vertex-ai' });
-
-    const options = { ...defaultOptions, model: 'vertexai::claude-sonnet-4::' };
-    await manager.create(options);
-
-    expect(secretManager.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        value: expect.objectContaining({
-          config: {
-            GOOGLE_VERTEX_PROJECT: 'multi-var-project',
-            GOOGLE_VERTEX_LOCATION: 'us-east5',
-          },
-        }),
+        providers: expect.arrayContaining(['vertex-ai-conn-1']),
       }),
     );
   });
@@ -710,67 +576,16 @@ describe('create – OpenShell mode', () => {
     expect(call!.env).not.toHaveProperty('EMPTY_VAR');
   });
 
-  test('appends credentials config key to proivider create', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.vertex-ai',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'vertex-ai.connection._type') return 'google-vertex-ai';
-        if (key === 'vertex-ai.connection._flags') return ['--from-gcloud-adc'];
-        if (key === 'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS') return 'vertex-ai:conn-1:token';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_PROJECT') return 'append-project';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'vertex-ai.connection._type': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        hidden: true,
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection._flags': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_PROJECT': {
-        title: 'Vertex AI',
-        parentId: 'vertexai',
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('/path/to/creds.json');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-sandbox-google-vertex-ai' });
-    vi.spyOn(configWriter, 'writeWorkspaceConfig').mockResolvedValue({
-      environment: [{ name: 'EXISTING_VAR', value: 'existing-value' }],
-    } as AgentWorkspaceConfiguration);
+  test('calls setInference during create when secret type requires it', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'vertex-ai-conn-1', type: 'vertex-ai' });
 
     const options = { ...defaultOptions, model: 'vertexai::claude-sonnet-4::' };
     await manager.create(options);
 
-    expect(secretManager.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        value: expect.objectContaining({
-          config: {
-            GOOGLE_VERTEX_PROJECT: 'append-project',
-          },
-        }),
-      }),
-    );
+    expect(openshellCli.setInference).toHaveBeenCalledWith({
+      provider: 'vertex-ai-conn-1',
+      model: 'claude-sonnet-4',
+    });
   });
 
   test('does not pass env when all environment values are filtered out', async () => {
@@ -968,119 +783,36 @@ describe('ensureModelSecret', () => {
     } as AgentWorkspaceCreateOptions;
     await manager.ensureModelSecret(options);
 
-    expect(providerRegistry.getInferenceConnectionCredentials).not.toHaveBeenCalled();
-    expect(secretManager.create).not.toHaveBeenCalled();
+    expect(secretManager.getSecretForModel).not.toHaveBeenCalled();
   });
 
-  test('skips when connection cannot be resolved', async () => {
-    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue(undefined);
+  test('skips when no model is provided', async () => {
+    const options = { ...baseOptions };
+    await manager.ensureModelSecret(options);
+
+    expect(secretManager.getSecretForModel).not.toHaveBeenCalled();
+  });
+
+  test('skips when getSecretForModel returns undefined (no registered provider)', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue(undefined);
 
     const options = { ...baseOptions, model: 'unknown::model::' };
     await manager.ensureModelSecret(options);
 
-    expect(secretManager.create).not.toHaveBeenCalled();
+    expect(options.secrets).toBeUndefined();
   });
 
-  test('skips when credentials map is empty (local provider)', async () => {
-    vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
-      credentials: {},
-      llmMetadataName: 'ollama',
-      endpoint: 'http://localhost:11434/v1',
-    });
-
-    const options = { ...baseOptions, model: 'ollama::llama3::http://localhost:11434/v1' };
-    await manager.ensureModelSecret(options);
-
-    expect(secretManager.create).not.toHaveBeenCalled();
-  });
-
-  test('creates secret from connection config when _type and password property exist', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.cursor',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'cursor.connection._type') return 'cursor';
-        if (key === 'cursor.connection.token') return 'cursor:conn-1:token';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'cursor.connection._type': {
-        title: 'Cursor',
-        parentId: 'cursor',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: {
-          id: 'kaiden.cursor',
-        },
-      },
-      'cursor.connection.token': {
-        title: 'Cursor',
-        parentId: 'cursor',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        hidden: true,
-        extension: {
-          id: 'kaiden.cursor',
-        },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('actual-api-key');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-token' });
+  test('adds secret name to options.secrets when found', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'cursor-conn-123', type: 'cursor' });
 
     const options = { ...baseOptions, model: 'cursor::gpt-4o::https://api.cursor.com' };
     await manager.ensureModelSecret(options);
 
-    expect(safeStorageRegistry.getExtensionStorage).toHaveBeenCalledWith('kaiden.cursor');
-    expect(extensionStorageMock.get).toHaveBeenCalledWith('cursor:conn-1:token');
-    expect(secretManager.create).toHaveBeenCalledWith({
-      name: 'my-workspace-cursor',
-      type: 'cursor',
-      value: {
-        credentials: {
-          token: 'actual-api-key',
-        },
-      },
-    });
-    expect(options.secrets).toContain('my-workspace-cursor');
-    expect(providerRegistry.getInferenceConnectionCredentials).not.toHaveBeenCalled();
+    expect(options.secrets).toContain('cursor-conn-123');
   });
 
-  test('does not call setInference when no flags are present', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.cursor',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'cursor.connection._type') return 'cursor';
-        if (key === 'cursor.connection.token') return 'cursor:conn-1:token';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'cursor.connection._type': {
-        title: 'Cursor',
-        parentId: 'cursor',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.cursor' },
-      },
-      'cursor.connection.token': {
-        title: 'Cursor',
-        parentId: 'cursor',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        hidden: true,
-        extension: { id: 'kaiden.cursor' },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('actual-api-key');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-cursor' });
+  test('does not call setInference when secret type is not in SET_INFERENCE_TYPES', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'cursor-conn-123', type: 'cursor' });
 
     const options = { ...baseOptions, model: 'cursor::gpt-4o::https://api.cursor.com' };
     await manager.ensureModelSecret(options);
@@ -1088,302 +820,16 @@ describe('ensureModelSecret', () => {
     expect(openshellCli.setInference).not.toHaveBeenCalled();
   });
 
-  test('does call create secret when _type exists but secret value is not found', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.cursor',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'cursor.connection._type') return 'cursor';
-        if (key === 'cursor.connection.token') return 'cursor:conn-1:token';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'cursor.connection._type': {
-        title: 'Cursor',
-        parentId: 'cursor',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: {
-          id: 'kaiden.cursor',
-        },
-      },
-      'cursor.connection.token': {
-        title: 'Cursor',
-        parentId: 'cursor',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        hidden: true,
-        extension: {
-          id: 'kaiden.cursor',
-        },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue(undefined);
-
-    const options = { ...baseOptions, model: 'cursor::gpt-4o::' };
-    await manager.ensureModelSecret(options);
-
-    expect(secretManager.create).toHaveBeenCalled();
-    expect(providerRegistry.getInferenceConnectionCredentials).not.toHaveBeenCalled();
-  });
-
-  test('derives secret name from sourcePath when name is omitted (config path)', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.mistral',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'mistral.connection._type') return 'mistral';
-        if (key === 'mistral.connection.token') return 'mistral:conn-1:token';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'mistral.connection._type': {
-        title: 'Mistral',
-        parentId: 'mistral',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: {
-          id: 'kaiden.mistral',
-        },
-      },
-      'mistral.connection.token': {
-        title: 'Mistral',
-        parentId: 'mistral',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        hidden: true,
-        extension: {
-          id: 'kaiden.mistral',
-        },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('mistral-key');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-project-token' });
-
-    const options: AgentWorkspaceCreateOptions = {
-      sourcePath: '/tmp/my-project',
-      agent: 'coder',
-      model: 'mistral::mistral-large::',
-    };
-    await manager.ensureModelSecret(options);
-
-    expect(secretManager.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'my-project-mistral' }));
-  });
-
-  test('creates secret with config and flags for Vertex AI config-based path', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.vertex-ai',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'vertex-ai.connection._type') return 'google-vertex-ai';
-        if (key === 'vertex-ai.connection._flags') return '--from-gcloud-adc';
-        if (key === 'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS') return 'vertex-ai:conn-1:token';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_PROJECT') return 'my-gcp-project';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_LOCATION') return 'us-east5';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'vertex-ai.connection._type': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection._flags': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_PROJECT': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_LOCATION': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('/path/to/creds.json');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-google-vertex-ai' });
-
-    const options = { ...baseOptions, model: 'vertexai::claude-sonnet-4-20250514::' };
-    const environment = await manager.ensureModelSecret(options);
-
-    expect(secretManager.create).toHaveBeenCalledWith({
-      name: 'my-workspace-google-vertex-ai',
-      type: 'google-vertex-ai',
-      value: {
-        config: {
-          GOOGLE_VERTEX_LOCATION: 'us-east5',
-          GOOGLE_VERTEX_PROJECT: 'my-gcp-project',
-        },
-        credentials: {},
-        env: {
-          GOOGLE_APPLICATION_CREDENTIALS: '/path/to/creds.json',
-        },
-        flags: ['--from-gcloud-adc'],
-      },
-    });
-    expect(options.secrets).toContain('my-workspace-google-vertex-ai');
-    expect(environment).toEqual({});
-    expect(providerRegistry.getInferenceConnectionCredentials).not.toHaveBeenCalled();
-  });
-
-  test('calls setInference when flags are present', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.vertex-ai',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'vertex-ai.connection._type') return 'google-vertex-ai';
-        if (key === 'vertex-ai.connection._flags') return '--from-gcloud-adc';
-        if (key === 'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS') return 'vertex-ai:conn-1:token';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'vertex-ai.connection._type': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection._flags': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('/path/to/creds.json');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-google-vertex-ai' });
+  test('calls setInference when secret type is in SET_INFERENCE_TYPES', async () => {
+    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'vertex-ai-conn-123', type: 'vertex-ai' });
 
     const options = { ...baseOptions, model: 'vertexai::claude-sonnet-4-20250514::' };
     await manager.ensureModelSecret(options);
 
     expect(openshellCli.setInference).toHaveBeenCalledWith({
-      provider: 'my-workspace-google-vertex-ai',
+      provider: 'vertex-ai-conn-123',
       model: 'claude-sonnet-4-20250514',
     });
-  });
-
-  test('passes _flags array through unchanged when value is string[]', async () => {
-    const mockConnection = { id: 'conn-1', sdk: {}, models: [] } as unknown as InferenceProviderConnection;
-    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
-      connection: mockConnection,
-      extensionId: 'kaiden.vertex-ai',
-    });
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === 'vertex-ai.connection._type') return 'google-vertex-ai';
-        if (key === 'vertex-ai.connection._flags') return ['--flag-one', '--flag-two'];
-        if (key === 'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS') return 'vertex-ai:conn-1:token';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_PROJECT') return 'my-gcp-project';
-        if (key === 'vertex-ai.connection.GOOGLE_VERTEX_LOCATION') return 'us-east5';
-        return undefined;
-      }),
-    } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({
-      'vertex-ai.connection._type': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection._flags': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_APPLICATION_CREDENTIALS': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        format: 'password',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_PROJECT': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-      'vertex-ai.connection.GOOGLE_VERTEX_LOCATION': {
-        title: 'Vertex AI',
-        parentId: 'vertex-ai',
-        scope: 'InferenceProviderConnection',
-        hidden: true,
-        extension: { id: 'kaiden.vertex-ai' },
-      },
-    });
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('/path/to/creds.json');
-    vi.mocked(secretManager.create).mockResolvedValue({ name: 'my-workspace-google-vertex-ai' });
-
-    const options = { ...baseOptions, model: 'vertexai::claude-sonnet-4-20250514::' };
-    const environment = await manager.ensureModelSecret(options);
-
-    expect(secretManager.create).toHaveBeenCalledWith({
-      name: 'my-workspace-google-vertex-ai',
-      type: 'google-vertex-ai',
-      value: {
-        config: {
-          GOOGLE_VERTEX_LOCATION: 'us-east5',
-          GOOGLE_VERTEX_PROJECT: 'my-gcp-project',
-        },
-        credentials: {},
-        env: {
-          GOOGLE_APPLICATION_CREDENTIALS: '/path/to/creds.json',
-        },
-        flags: ['--flag-one', '--flag-two'],
-      },
-    });
-    expect(environment).toEqual({});
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -19,7 +19,14 @@
 import { access, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { Agent, AgentWorkspaceConfiguration, FileSystemWatcher } from '@openkaiden/api';
+import type {
+  Agent,
+  AgentWorkspaceConfiguration,
+  AISDKInferenceProvider,
+  Configuration,
+  FileSystemWatcher,
+  ProviderConnectionStatus,
+} from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import type { IPty } from 'node-pty';
 import { spawn } from 'node-pty';
@@ -31,6 +38,7 @@ import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { ProviderImpl } from '/@/plugin/provider-impl.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
@@ -38,7 +46,7 @@ import type { Task } from '/@/plugin/tasks/tasks.js';
 import type { Exec } from '/@/plugin/util/exec.js';
 import type { AgentWorkspaceCreateOptions } from '/@api/agent-workspace-info.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IConfigurationRegistry } from '/@api/configuration/models.js';
+import type { IConfigurationPropertyRecordedSchema, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
 import { AGENT_LABEL, decodeWorkspaceLabels } from '/@api/openshell-gateway-info.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
@@ -123,12 +131,14 @@ const configurationRegistry = {
 const providerRegistry = {
   getInferenceConnectionCredentials: vi.fn(),
   getInferenceConnection: vi.fn(),
+  getProvider: vi.fn(),
 } as unknown as ProviderRegistry;
 
 const secretManager = {
   create: vi.fn(),
   init: vi.fn(),
   getSecretForModel: vi.fn(),
+  getConnectionProperties: vi.fn(),
 } as unknown as SecretManager;
 
 function mockEnoent(): NodeJS.ErrnoException {
@@ -252,6 +262,7 @@ describe('create – OpenShell mode', () => {
     agent: 'claude',
     runtime: 'podman',
     name: 'my-sandbox',
+    model: 'ramalama::granite-4.6::',
   };
 
   const mockAgent: Agent = {
@@ -296,7 +307,11 @@ describe('create – OpenShell mode', () => {
   });
 
   test('derives sandbox name from sourcePath basename when name is omitted', async () => {
-    const options: AgentWorkspaceCreateOptions = { sourcePath: '/tmp/my-project', agent: 'claude' };
+    const options: AgentWorkspaceCreateOptions = {
+      sourcePath: '/tmp/my-project',
+      agent: 'claude',
+      model: 'ramalama::granite-4::',
+    };
     const result = await manager.create(options);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(expect.objectContaining({ name: 'my-project' }));
@@ -578,6 +593,31 @@ describe('create – OpenShell mode', () => {
 
   test('calls setInference during create when secret type requires it', async () => {
     vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'vertex-ai-conn-1', type: 'vertex-ai' });
+    vi.mocked(secretManager.getConnectionProperties).mockReturnValue({
+      config: {} as Configuration,
+      connectionProperties: [['kaiden.vertexai._flags', {} as IConfigurationPropertyRecordedSchema]],
+    });
+    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
+      connection: {
+        name: 'vertexai',
+        id: 'vertexai',
+        type: 'cloud',
+        sdk: {} as AISDKInferenceProvider,
+        credentials: (): Record<string, string> => {
+          return {};
+        },
+        status: (): ProviderConnectionStatus => 'started',
+        models: [
+          {
+            label: 'claude-sonnet-4',
+          },
+        ],
+      },
+      providerId: 'kaiden.vertexai',
+    });
+    vi.mocked(providerRegistry.getProvider).mockReturnValue({
+      extensionId: 'kaiden.vertexai',
+    } as ProviderImpl);
 
     const options = { ...defaultOptions, model: 'vertexai::claude-sonnet-4::' };
     await manager.create(options);
@@ -818,18 +858,6 @@ describe('ensureModelSecret', () => {
     await manager.ensureModelSecret(options);
 
     expect(openshellCli.setInference).not.toHaveBeenCalled();
-  });
-
-  test('calls setInference when secret type is in SET_INFERENCE_TYPES', async () => {
-    vi.mocked(secretManager.getSecretForModel).mockResolvedValue({ name: 'vertex-ai-conn-123', type: 'vertex-ai' });
-
-    const options = { ...baseOptions, model: 'vertexai::claude-sonnet-4-20250514::' };
-    await manager.ensureModelSecret(options);
-
-    expect(openshellCli.setInference).toHaveBeenCalledWith({
-      provider: 'vertex-ai-conn-123',
-      model: 'claude-sonnet-4-20250514',
-    });
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -114,8 +114,8 @@ export class AgentWorkspaceManager implements Disposable {
         await rm(configPath, { force: true });
       }
 
-      const credentialsEnvironment = await this.ensureModelSecret(options);
-      const workspaceId = await this.createOpenshell(options, credentialsEnvironment);
+      const secretName = await this.ensureModelSecret(options);
+      const workspaceId = await this.createOpenshell(options, secretName);
       this.apiSender.send('agent-workspace-update');
       task.status = 'success';
       return workspaceId;
@@ -131,25 +131,18 @@ export class AgentWorkspaceManager implements Disposable {
 
   private async createOpenshell(
     options: AgentWorkspaceCreateOptions,
-    credentialsEnvironment: Record<string, string>,
+    secretName: string | undefined,
   ): Promise<AgentWorkspaceId> {
-    const connectionInfo = options.model
-      ? this.providerRegistry.getInferenceConnectionCredentials(options.model)
-      : undefined;
+    if (options.model === undefined) {
+      throw new Error(`Can't start workspace without model`);
+    }
+    const connectionInfo = this.providerRegistry.getInferenceConnectionCredentials(options.model);
 
-    const modelName = options.model?.split('::')[1];
+    const modelName = options.model?.split('::')[1] ?? '';
     const rawEndpoint = connectionInfo?.endpoint ?? options.model?.split('::')[2] ?? undefined;
     const endpoint = rawEndpoint ? rewriteLocalhostUrl(rawEndpoint) : undefined;
 
     const workspace = await writeWorkspaceConfig(options);
-    workspace.environment ??= [];
-    Object.entries(credentialsEnvironment).forEach(([key, value]) => {
-      workspace.environment?.push({
-        name: key,
-        value,
-      });
-    });
-
     const agent = this.agentRegistry.getAgentRegistration(options.agent);
     const uploads: Array<{ local: string; remote: string }> = [];
 
@@ -180,6 +173,21 @@ export class AgentWorkspaceManager implements Disposable {
       uploads.push(...skillUploads);
     } else {
       throw new Error(`Unable to create workspace: agent ${options.agent} not registered`);
+    }
+
+    if (secretName !== undefined) {
+      const connection = this.providerRegistry.getInferenceConnection(options.model);
+      if (connection) {
+        const provider = this.providerRegistry.getProvider(connection?.providerId);
+        const { connectionProperties } = this.secretManager.getConnectionProperties(connection.connection, provider);
+        const hasFlags = connectionProperties.find(([fullKey]) => fullKey.endsWith('._flags'));
+        if (hasFlags) {
+          await this.openshellCli.setInference({
+            provider: secretName,
+            model: modelName,
+          });
+        }
+      }
     }
 
     const sandboxName = options.name ?? basename(options.sourcePath);
@@ -297,36 +305,25 @@ export class AgentWorkspaceManager implements Disposable {
    * the provider type is unknown, or secrets were already explicitly
    * configured (e.g. by the onboarding flow via workspaceConfiguration).
    */
-  async ensureModelSecret(options: AgentWorkspaceCreateOptions): Promise<Record<string, string>> {
+  async ensureModelSecret(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
     if (!options.model) {
-      return {};
+      return undefined;
     }
 
     if (options.workspaceConfiguration?.secrets?.length) {
-      return {};
+      return undefined;
     }
 
     return this.ensureModelSecretFromConfig(options);
   }
 
-  private static readonly SET_INFERENCE_TYPES = new Set(['vertex-ai', 'openshiftai']);
-
-  private async ensureModelSecretFromConfig(options: AgentWorkspaceCreateOptions): Promise<Record<string, string>> {
-    const environment: Record<string, string> = {};
-
+  private async ensureModelSecretFromConfig(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
     const secret = await this.secretManager.getSecretForModel(options.model!);
-    if (!secret) return environment;
-
-    if (AgentWorkspaceManager.SET_INFERENCE_TYPES.has(secret.type)) {
-      await this.openshellCli.setInference({
-        provider: secret.name,
-        model: options.model!.split('::')[1]!,
-      });
-    }
+    if (!secret) return undefined;
 
     options.secrets = [...new Set([...(options.secrets ?? []), secret.name])];
 
-    return environment;
+    return secret.name;
   }
 
   async remove(id: string): Promise<AgentWorkspaceId> {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -295,15 +295,8 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   /**
-   * If the selected model's provider connection holds a single credential
-   * entry (assumed to be an API key), create a matching kdn vault secret
-   * and attach it to the workspace options so the CLI can inject it at
-   * runtime.
-   *
-   * Silently skips when: no model is selected, the connection cannot be
-   * resolved, credentials are empty or multi-valued (e.g. Vertex AI ADC),
-   * the provider type is unknown, or secrets were already explicitly
-   * configured (e.g. by the onboarding flow via workspaceConfiguration).
+   * Return the secret related to the inference connection linked to the
+   * model. Return undefined if there is no secret associated with this connection
    */
   async ensureModelSecret(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
     if (!options.model) {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -129,10 +129,7 @@ export class AgentWorkspaceManager implements Disposable {
     }
   }
 
-  private async createOpenshell(
-    options: AgentWorkspaceCreateOptions,
-    secretName: string | undefined,
-  ): Promise<AgentWorkspaceId> {
+  private async createOpenshell(options: AgentWorkspaceCreateOptions, secretName?: string): Promise<AgentWorkspaceId> {
     if (options.model === undefined) {
       throw new Error(`Can't start workspace without model`);
     }
@@ -297,7 +294,7 @@ export class AgentWorkspaceManager implements Disposable {
   /**
    * Return the secret related to the inference connection linked to the
    * model. Return undefined if there is no secret associated with this connection
-   */
+·   */
   async ensureModelSecret(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
     if (!options.model) {
       return undefined;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -38,7 +38,6 @@ import {
   rewriteLocalhostUrl,
 } from '/@/plugin/openshell-cli/openshell-network-policy.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
-import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { AgentWorkspaceSettings } from '/@api/agent-workspace/agent-workspace-settings.js';
@@ -53,7 +52,6 @@ import type { IConfigurationNode } from '/@api/configuration/models.js';
 import { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { GatewaySandboxes, PolicyUpdateOptions } from '/@api/openshell-gateway-info.js';
 import { AGENT_LABEL, decodeWorkspaceLabels, WORKSPACE_LABEL } from '/@api/openshell-gateway-info.js';
-import type { SecretValue } from '/@api/secret-info.js';
 
 const HOME_VARIABLE = '${HOME}';
 const LABEL_MAX_LENGTH = 63;
@@ -101,8 +99,6 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly secretManager: SecretManager,
     @inject(OpenshellCli)
     private readonly openshellCli: OpenshellCli,
-    @inject(SafeStorageRegistry)
-    private readonly safeStorageRegistry: SafeStorageRegistry,
     @inject(AgentRegistry)
     private readonly agentRegistry: AgentRegistry,
   ) {}
@@ -313,86 +309,22 @@ export class AgentWorkspaceManager implements Disposable {
     return this.ensureModelSecretFromConfig(options);
   }
 
+  private static readonly SET_INFERENCE_TYPES = new Set(['vertex-ai', 'openshiftai']);
+
   private async ensureModelSecretFromConfig(options: AgentWorkspaceCreateOptions): Promise<Record<string, string>> {
     const environment: Record<string, string> = {};
 
-    const info = this.providerRegistry.getInferenceConnection(options.model!);
-    if (!info) return environment;
+    const secret = await this.secretManager.getSecretForModel(options.model!);
+    if (!secret) return environment;
 
-    const config = this.configurationRegistry.getConfiguration(undefined, info.connection);
-    const allProperties = this.configurationRegistry.getConfigurationProperties();
-
-    const connectionProperties = Object.entries(allProperties)
-      .filter(([, schema]) => {
-        const scope = schema.scope;
-        return Array.isArray(scope)
-          ? scope.includes('InferenceProviderConnection')
-          : scope === 'InferenceProviderConnection';
-      })
-      .filter(([_, schema]) => schema.extension?.id === info.extensionId);
-
-    const typeEntry = connectionProperties.find(([fullKey]) => fullKey.endsWith('_type'));
-    if (!typeEntry) return environment;
-
-    const typeShortKey = typeEntry[0];
-    const secretType = config.get<string>(typeShortKey);
-    if (!secretType) return environment;
-
-    const flagsEntry = connectionProperties.find(([fullKey]) => fullKey.endsWith('._flags'));
-    const flagsRaw = flagsEntry ? config.get<string | string[]>(flagsEntry[0]) : undefined;
-    const flagsValue = flagsRaw ? (Array.isArray(flagsRaw) ? flagsRaw : [flagsRaw]) : undefined;
-    const workspaceName = options.name ?? basename(options.sourcePath);
-
-    const configKeys = connectionProperties.filter(
-      ([fullKey, _schema]) => !fullKey.endsWith('._type') && !fullKey.endsWith('._flags'),
-    );
-
-    const extensionStorage = this.safeStorageRegistry.getExtensionStorage(info.extensionId);
-
-    const value: SecretValue = { credentials: {} };
-    if (flagsValue) {
-      value.flags = flagsValue;
-    }
-    for (const [propertyName, schema] of configKeys) {
-      const secretRefName = config.get<string>(propertyName);
-      if (!secretRefName) continue;
-
-      const actualValue = schema.format === 'password' ? await extensionStorage.get(secretRefName) : secretRefName;
-      if (!actualValue) continue;
-
-      const shortPropertyName = propertyName.split('.').pop()!;
-      if (flagsValue === undefined) {
-        if (schema.format === 'password') {
-          value.credentials[shortPropertyName] = actualValue;
-        } else {
-          value.config ??= {};
-          value.config[shortPropertyName] = actualValue;
-        }
-      } else {
-        if (schema.format === 'password') {
-          value.env ??= {};
-          value.env[shortPropertyName] = actualValue;
-        } else {
-          value.config ??= {};
-          value.config[shortPropertyName] = actualValue;
-        }
-      }
-    }
-
-    const secretName = `${workspaceName}-${secretType}`;
-    await this.secretManager.create({
-      name: secretName,
-      type: secretType,
-      value: value,
-    });
-    if (flagsValue !== undefined) {
+    if (AgentWorkspaceManager.SET_INFERENCE_TYPES.has(secret.type)) {
       await this.openshellCli.setInference({
-        provider: secretName,
+        provider: secret.name,
         model: options.model!.split('::')[1]!,
       });
     }
 
-    options.secrets = [...new Set([...(options.secrets ?? []), secretName])];
+    options.secrets = [...new Set([...(options.secrets ?? []), secret.name])];
 
     return environment;
   }

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1786,7 +1786,7 @@ export class ProviderRegistry {
   ): void {
     this.connectionLifecycleContexts.set(inferenceProviderConnection, new LifecycleContextImpl());
     this.apiSender.send('provider-register-inference-connection', { name: inferenceProviderConnection.name });
-    this._onDidRegisterInferenceConnection.fire({ providerId: provider.id });
+    this._onDidRegisterInferenceConnection.fire({ providerId: provider.id, connection: inferenceProviderConnection });
   }
 
   onDidRegisterRagConnectionCallback(provider: ProviderImpl, ragProviderConnection: RagProviderConnection): void {
@@ -1855,7 +1855,7 @@ export class ProviderRegistry {
     inferenceProviderConnection: InferenceProviderConnection,
   ): void {
     this.apiSender.send('provider-unregister-inference-connection', { name: inferenceProviderConnection.name });
-    this._onDidUnregisterKubernetesConnection.fire({ providerId: provider.id });
+    this._onDidUnregisterInferenceConnection.fire({ providerId: provider.id, connection: inferenceProviderConnection });
   }
 
   onDidUnregisterRagConnectionCallback(provider: ProviderImpl, ragProviderConnection: RagProviderConnection): void {
@@ -2283,9 +2283,7 @@ export class ProviderRegistry {
     return undefined;
   }
 
-  getInferenceConnection(
-    modelId: string,
-  ): { connection: InferenceProviderConnection; extensionId: string } | undefined {
+  getInferenceConnection(modelId: string): { connection: InferenceProviderConnection; providerId: string } | undefined {
     const [metadataName = '', modelLabel = '', endpoint = ''] = modelId.split('::');
 
     for (const provider of this.providers.values()) {
@@ -2297,7 +2295,7 @@ export class ProviderRegistry {
           connEndpoint === endpoint &&
           connection.models.some(m => m.label === modelLabel)
         ) {
-          return { connection, extensionId: provider.extensionId };
+          return { connection, providerId: provider.id };
         }
       }
     }

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -16,15 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { FileSystemWatcher } from '@openkaiden/api';
+import type { FileSystemWatcher, InferenceProviderConnection, RegisterInferenceConnectionEvent } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import type { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import type { Exec } from '/@/plugin/util/exec.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { SecretCreateOptions } from '/@api/secret-info.js';
 
 import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
@@ -42,6 +45,36 @@ const ipcHandle: IPCHandle = vi.fn();
 const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
 const openshellAdapter = new OpenshellSecretAdapter(openshellCli);
 
+let registerInferenceCallback: ((event: RegisterInferenceConnectionEvent) => void) | undefined;
+let unregisterInferenceCallback:
+  | ((event: { providerId: string; connection: InferenceProviderConnection }) => void)
+  | undefined;
+
+const providerRegistry = {
+  onDidRegisterInferenceConnection: vi.fn((cb: (event: RegisterInferenceConnectionEvent) => void) => {
+    registerInferenceCallback = cb;
+  }),
+  onDidUnregisterInferenceConnection: vi.fn(
+    (cb: (event: { providerId: string; connection: InferenceProviderConnection }) => void) => {
+      unregisterInferenceCallback = cb;
+    },
+  ),
+  getInferenceConnection: vi.fn(),
+} as unknown as ProviderRegistry;
+
+const extensionStorageMock = {
+  get: vi.fn(),
+} as unknown as ReturnType<SafeStorageRegistry['getExtensionStorage']>;
+
+const configurationRegistry = {
+  getConfiguration: vi.fn(),
+  getConfigurationProperties: vi.fn(),
+} as unknown as IConfigurationRegistry;
+
+const safeStorageRegistry = {
+  getExtensionStorage: vi.fn().mockReturnValue(extensionStorageMock),
+} as unknown as SafeStorageRegistry;
+
 const mockWatcher = {
   onDidChange: vi.fn(),
   onDidCreate: vi.fn(),
@@ -54,8 +87,18 @@ const filesystemMonitoring = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  registerInferenceCallback = undefined;
+  unregisterInferenceCallback = undefined;
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
-  manager = new SecretManager(apiSender, ipcHandle, openshellAdapter);
+  vi.mocked(safeStorageRegistry.getExtensionStorage).mockReturnValue(extensionStorageMock);
+  manager = new SecretManager(
+    apiSender,
+    ipcHandle,
+    openshellAdapter,
+    providerRegistry,
+    configurationRegistry,
+    safeStorageRegistry,
+  );
   manager.init();
 });
 
@@ -70,6 +113,11 @@ describe('init', () => {
 
   test('registers IPC handler for remove', () => {
     expect(ipcHandle).toHaveBeenCalledWith('secret-manager:remove', expect.any(Function));
+  });
+
+  test('subscribes to inference connection events', () => {
+    expect(providerRegistry.onDidRegisterInferenceConnection).toHaveBeenCalled();
+    expect(providerRegistry.onDidUnregisterInferenceConnection).toHaveBeenCalled();
   });
 });
 
@@ -86,8 +134,18 @@ describe('openshellAdapter', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    registerInferenceCallback = undefined;
+    unregisterInferenceCallback = undefined;
     vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
-    manager = new SecretManager(apiSender, ipcHandle, openshellAdapter);
+    vi.mocked(safeStorageRegistry.getExtensionStorage).mockReturnValue(extensionStorageMock);
+    manager = new SecretManager(
+      apiSender,
+      ipcHandle,
+      openshellAdapter,
+      providerRegistry,
+      configurationRegistry,
+      safeStorageRegistry,
+    );
     manager.init();
   });
 
@@ -150,5 +208,151 @@ describe('openshellAdapter', () => {
     await manager.remove('my-openai');
 
     expect(apiSender.send).toHaveBeenCalledWith('secret-manager-update');
+  });
+});
+
+describe('inference connection lifecycle', () => {
+  const mockConnection: InferenceProviderConnection = {
+    id: 'conn-123',
+    name: 'test-connection',
+    type: 'cloud',
+    sdk: {} as InferenceProviderConnection['sdk'],
+    status: () => 'started',
+    models: [{ label: 'model-1' }],
+    credentials: () => ({ token: 'secret-token' }),
+  };
+
+  function setupConfigMocks(secretType: string, flags?: string): void {
+    const properties = {
+      'cursor.connection._type': {
+        scope: 'InferenceProviderConnection',
+        extension: { id: 'kaiden.cursor' },
+        title: 'Cursor',
+        parentId: 'cursor',
+      },
+      'cursor.connection.token': {
+        scope: 'InferenceProviderConnection',
+        extension: { id: 'kaiden.cursor' },
+        format: 'password',
+        title: 'Cursor',
+        parentId: 'cursor',
+      },
+    } as Record<string, Record<string, unknown>>;
+    if (flags) {
+      properties['cursor.connection._flags'] = {
+        scope: 'InferenceProviderConnection',
+        extension: { id: 'kaiden.cursor' },
+        title: 'Cursor',
+        parentId: 'cursor',
+      };
+    }
+
+    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(
+      properties as unknown as ReturnType<typeof configurationRegistry.getConfigurationProperties>,
+    );
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string) => {
+        if (key === 'cursor.connection._type') return secretType;
+        if (key === 'cursor.connection.token') return 'cursor:conn-123:token';
+        if (key === 'cursor.connection._flags') return flags;
+        return undefined;
+      }),
+      has: vi.fn(),
+      update: vi.fn(),
+    } as unknown as ReturnType<typeof configurationRegistry.getConfiguration>);
+
+    vi.mocked(extensionStorageMock.get).mockResolvedValue('actual-api-key');
+    vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
+  }
+
+  test('creates openshell provider on inference connection register', async () => {
+    setupConfigMocks('cursor');
+
+    registerInferenceCallback!({
+      providerId: 'kaiden.cursor',
+      connection: mockConnection,
+    });
+
+    await vi.waitFor(() => {
+      expect(openshellCli.createProvider).toHaveBeenCalledWith({
+        name: 'kaiden.cursor-conn-123',
+        type: 'cursor',
+        credentials: { token: 'actual-api-key' },
+      });
+    });
+  });
+
+  test('deletes openshell provider on inference connection unregister', async () => {
+    setupConfigMocks('cursor');
+
+    registerInferenceCallback!({
+      providerId: 'kaiden.cursor',
+      connection: mockConnection,
+    });
+
+    await vi.waitFor(() => {
+      expect(openshellCli.createProvider).toHaveBeenCalled();
+    });
+
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'kaiden.cursor-conn-123', type: 'cursor' }]);
+    vi.mocked(openshellCli.deleteProvider).mockResolvedValue(undefined);
+
+    unregisterInferenceCallback!({
+      providerId: 'kaiden.cursor',
+      connection: mockConnection,
+    });
+
+    await vi.waitFor(() => {
+      expect(openshellCli.deleteProvider).toHaveBeenCalledWith('kaiden.cursor-conn-123');
+    });
+  });
+
+  test('skips creation when no _type config property exists', async () => {
+    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({});
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+      get: vi.fn(() => undefined),
+      has: vi.fn(),
+      update: vi.fn(),
+    } as unknown as ReturnType<typeof configurationRegistry.getConfiguration>);
+
+    registerInferenceCallback!({
+      providerId: 'kaiden.ramalama',
+      connection: mockConnection,
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(openshellCli.createProvider).not.toHaveBeenCalled();
+  });
+
+  test('getSecretForModel returns SecretInfo matching by name', async () => {
+    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
+      connection: mockConnection,
+      providerId: 'kaiden.cursor',
+    });
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([
+      { name: 'other-provider', type: 'other' },
+      { name: 'kaiden.cursor-conn-123', type: 'cursor' },
+    ]);
+
+    const secret = await manager.getSecretForModel('cursor::model-1::');
+    expect(secret).toEqual({ name: 'kaiden.cursor-conn-123', type: 'cursor' });
+  });
+
+  test('getSecretForModel returns undefined for unknown model', async () => {
+    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue(undefined);
+
+    const secret = await manager.getSecretForModel('unknown::model::');
+    expect(secret).toBeUndefined();
+  });
+
+  test('getSecretForModel returns correct type for vertex-ai provider', async () => {
+    vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
+      connection: mockConnection,
+      providerId: 'kaiden.vertex-ai',
+    });
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'kaiden.vertex-ai-conn-123', type: 'vertex-ai' }]);
+
+    const secret = await manager.getSecretForModel('vertexai::model-1::');
+    expect(secret).toEqual({ name: 'kaiden.vertex-ai-conn-123', type: 'vertex-ai' });
   });
 });

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -23,6 +23,7 @@ import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { ProviderImpl } from '/@/plugin/provider-impl.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import type { Exec } from '/@/plugin/util/exec.js';
@@ -32,7 +33,6 @@ import type { SecretCreateOptions } from '/@api/secret-info.js';
 
 import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
 import { SecretManager } from './secret-manager.js';
-import { ProviderImpl } from '/@/plugin/provider-impl.js';
 
 vi.mock(import('/@/plugin/openshell-cli/openshell-cli.js'));
 
@@ -264,6 +264,7 @@ describe('inference connection lifecycle', () => {
     } as unknown as ReturnType<typeof configurationRegistry.getConfiguration>);
 
     vi.mocked(extensionStorageMock.get).mockResolvedValue('actual-api-key');
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
     vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
     vi.mocked(providerRegistry.getProvider).mockReturnValue({
       extensionId: 'kaiden.cursor',
@@ -285,6 +286,20 @@ describe('inference connection lifecycle', () => {
         credentials: { token: 'actual-api-key' },
       });
     });
+  });
+
+  test('skips creation when provider with same name already exists', async () => {
+    setupConfigMocks('cursor');
+
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'kaiden.cursor-conn-123', type: 'cursor' }]);
+
+    registerInferenceCallback!({
+      providerId: 'kaiden.cursor',
+      connection: mockConnection,
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(openshellCli.createProvider).not.toHaveBeenCalled();
   });
 
   test('deletes openshell provider on inference connection unregister', async () => {

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -32,6 +32,7 @@ import type { SecretCreateOptions } from '/@api/secret-info.js';
 
 import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
 import { SecretManager } from './secret-manager.js';
+import { ProviderImpl } from '/@/plugin/provider-impl.js';
 
 vi.mock(import('/@/plugin/openshell-cli/openshell-cli.js'));
 
@@ -60,6 +61,7 @@ const providerRegistry = {
     },
   ),
   getInferenceConnection: vi.fn(),
+  getProvider: vi.fn(),
 } as unknown as ProviderRegistry;
 
 const extensionStorageMock = {
@@ -263,6 +265,9 @@ describe('inference connection lifecycle', () => {
 
     vi.mocked(extensionStorageMock.get).mockResolvedValue('actual-api-key');
     vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
+    vi.mocked(providerRegistry.getProvider).mockReturnValue({
+      extensionId: 'kaiden.cursor',
+    } as unknown as ProviderImpl);
   }
 
   test('creates openshell provider on inference connection register', async () => {

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -16,16 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { RegisterInferenceConnectionEvent, UnregisterInferenceConnectionEvent } from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
+import { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type {
   SecretCliBackend,
   SecretCreateOptions,
   SecretInfo,
   SecretName,
   SecretService,
+  SecretValue,
 } from '/@api/secret-info.js';
 
 import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
@@ -43,6 +48,12 @@ export class SecretManager {
     private readonly ipcHandle: IPCHandle,
     @inject(OpenshellSecretAdapter)
     private readonly openshellAdapter: OpenshellSecretAdapter,
+    @inject(ProviderRegistry)
+    private readonly providerRegistry: ProviderRegistry,
+    @inject(IConfigurationRegistry)
+    private readonly configurationRegistry: IConfigurationRegistry,
+    @inject(SafeStorageRegistry)
+    private readonly safeStorageRegistry: SafeStorageRegistry,
   ) {}
 
   private get cli(): SecretCliBackend {
@@ -69,7 +80,112 @@ export class SecretManager {
     return this.cli.listServices();
   }
 
+  async getSecretForModel(modelId: string): Promise<SecretInfo | undefined> {
+    const info = this.providerRegistry.getInferenceConnection(modelId);
+    if (!info) return undefined;
+
+    const expectedName = `${info.providerId}-${info.connection.id}`;
+    const secrets = await this.list();
+    return secrets.find(s => s.name === expectedName);
+  }
+
+  private async onInferenceConnectionRegistered(event: RegisterInferenceConnectionEvent): Promise<void> {
+    const connection = event.connection;
+    const providerId = event.providerId;
+
+    const config = this.configurationRegistry.getConfiguration(undefined, connection);
+    const allProperties = this.configurationRegistry.getConfigurationProperties();
+
+    const connectionProperties = Object.entries(allProperties)
+      .filter(([, schema]) => {
+        const scope = schema.scope;
+        return Array.isArray(scope)
+          ? scope.includes('InferenceProviderConnection')
+          : scope === 'InferenceProviderConnection';
+      })
+      .filter(([_, schema]) => schema.extension?.id === providerId);
+
+    const typeEntry = connectionProperties.find(([fullKey]) => fullKey.endsWith('_type'));
+    if (!typeEntry) return;
+
+    const secretType = config.get<string>(typeEntry[0]);
+    if (!secretType) return;
+
+    const flagsEntry = connectionProperties.find(([fullKey]) => fullKey.endsWith('._flags'));
+    const flagsRaw = flagsEntry ? config.get<string | string[]>(flagsEntry[0]) : undefined;
+    const flagsValue = flagsRaw ? (Array.isArray(flagsRaw) ? flagsRaw : [flagsRaw]) : undefined;
+
+    const configKeys = connectionProperties.filter(
+      ([fullKey, _schema]) => !fullKey.endsWith('._type') && !fullKey.endsWith('._flags'),
+    );
+
+    const extensionStorage = this.safeStorageRegistry.getExtensionStorage(providerId);
+
+    const value: SecretValue = { credentials: {} };
+    if (flagsValue) {
+      value.flags = flagsValue;
+    }
+    for (const [propertyName, schema] of configKeys) {
+      const secretRefName = config.get<string>(propertyName);
+      if (!secretRefName) continue;
+
+      const actualValue = schema.format === 'password' ? await extensionStorage.get(secretRefName) : secretRefName;
+      if (!actualValue) continue;
+
+      const shortPropertyName = propertyName.split('.').pop()!;
+      if (flagsValue === undefined) {
+        if (schema.format === 'password') {
+          value.credentials[shortPropertyName] = actualValue;
+        } else {
+          value.config ??= {};
+          value.config[shortPropertyName] = actualValue;
+        }
+      } else {
+        if (schema.format === 'password') {
+          value.env ??= {};
+          value.env[shortPropertyName] = actualValue;
+        } else {
+          value.config ??= {};
+          value.config[shortPropertyName] = actualValue;
+        }
+      }
+    }
+
+    const secretName = `${providerId}-${connection.id}`;
+
+    await this.create({
+      name: secretName,
+      type: secretType,
+      value: value,
+    });
+  }
+
+  private async onInferenceConnectionUnregistered(event: UnregisterInferenceConnectionEvent): Promise<void> {
+    const expectedName = `${event.providerId}-${event.connection.id}`;
+    const secrets = await this.list();
+    const secret = secrets.find(s => s.name === expectedName);
+    if (secret) {
+      try {
+        await this.remove(secret.name);
+      } catch (err: unknown) {
+        console.warn(`Failed to delete openshell provider ${secret.name}:`, err);
+      }
+    }
+  }
+
   init(): void {
+    this.providerRegistry.onDidRegisterInferenceConnection(event => {
+      this.onInferenceConnectionRegistered(event).catch((err: unknown) => {
+        console.error('Failed to create openshell provider for inference connection:', err);
+      });
+    });
+
+    this.providerRegistry.onDidUnregisterInferenceConnection(event => {
+      this.onInferenceConnectionUnregistered(event).catch((err: unknown) => {
+        console.error('Failed to delete openshell provider for inference connection:', err);
+      });
+    });
+
     this.ipcHandle(
       'secret-manager:create',
       async (_listener: unknown, options: SecretCreateOptions): Promise<SecretName> => {

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -154,6 +154,9 @@ export class SecretManager {
 
     const secretName = `${providerId}-${connection.id}`;
 
+    const existingSecrets = await this.list();
+    if (existingSecrets.some(s => s.name === secretName)) return;
+
     await this.create({
       name: secretName,
       type: secretType,

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -92,6 +92,7 @@ export class SecretManager {
   private async onInferenceConnectionRegistered(event: RegisterInferenceConnectionEvent): Promise<void> {
     const connection = event.connection;
     const providerId = event.providerId;
+    const provider = this.providerRegistry.getProvider(providerId);
 
     const config = this.configurationRegistry.getConfiguration(undefined, connection);
     const allProperties = this.configurationRegistry.getConfigurationProperties();
@@ -103,7 +104,7 @@ export class SecretManager {
           ? scope.includes('InferenceProviderConnection')
           : scope === 'InferenceProviderConnection';
       })
-      .filter(([_, schema]) => schema.extension?.id === providerId);
+      .filter(([_, schema]) => schema.extension?.id === provider.extensionId);
 
     const typeEntry = connectionProperties.find(([fullKey]) => fullKey.endsWith('_type'));
     if (!typeEntry) return;
@@ -119,7 +120,7 @@ export class SecretManager {
       ([fullKey, _schema]) => !fullKey.endsWith('._type') && !fullKey.endsWith('._flags'),
     );
 
-    const extensionStorage = this.safeStorageRegistry.getExtensionStorage(providerId);
+    const extensionStorage = this.safeStorageRegistry.getExtensionStorage(provider.extensionId);
 
     const value: SecretValue = { credentials: {} };
     if (flagsValue) {

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -16,14 +16,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { RegisterInferenceConnectionEvent, UnregisterInferenceConnectionEvent } from '@openkaiden/api';
+import type {
+  Configuration,
+  InferenceProviderConnection,
+  RegisterInferenceConnectionEvent,
+  UnregisterInferenceConnectionEvent,
+} from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
+import { ProviderImpl } from '/@/plugin/provider-impl.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { IConfigurationRegistry } from '/@api/configuration/models.js';
+import { IConfigurationPropertyRecordedSchema, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type {
   SecretCliBackend,
   SecretCreateOptions,
@@ -93,18 +99,7 @@ export class SecretManager {
     const connection = event.connection;
     const providerId = event.providerId;
     const provider = this.providerRegistry.getProvider(providerId);
-
-    const config = this.configurationRegistry.getConfiguration(undefined, connection);
-    const allProperties = this.configurationRegistry.getConfigurationProperties();
-
-    const connectionProperties = Object.entries(allProperties)
-      .filter(([, schema]) => {
-        const scope = schema.scope;
-        return Array.isArray(scope)
-          ? scope.includes('InferenceProviderConnection')
-          : scope === 'InferenceProviderConnection';
-      })
-      .filter(([_, schema]) => schema.extension?.id === provider.extensionId);
+    const { config, connectionProperties } = this.getConnectionProperties(connection, provider);
 
     const typeEntry = connectionProperties.find(([fullKey]) => fullKey.endsWith('_type'));
     if (!typeEntry) return;
@@ -162,6 +157,24 @@ export class SecretManager {
       type: secretType,
       value: value,
     });
+  }
+
+  public getConnectionProperties(
+    connection: InferenceProviderConnection,
+    provider: ProviderImpl,
+  ): { config: Configuration; connectionProperties: [string, IConfigurationPropertyRecordedSchema][] } {
+    const config = this.configurationRegistry.getConfiguration(undefined, connection);
+    const allProperties = this.configurationRegistry.getConfigurationProperties();
+
+    const connectionProperties = Object.entries(allProperties)
+      .filter(([, schema]) => {
+        const scope = schema.scope;
+        return Array.isArray(scope)
+          ? scope.includes('InferenceProviderConnection')
+          : scope === 'InferenceProviderConnection';
+      })
+      .filter(([_, schema]) => schema.extension?.id === provider.extensionId);
+    return { config, connectionProperties };
   }
 
   private async onInferenceConnectionUnregistered(event: UnregisterInferenceConnectionEvent): Promise<void> {


### PR DESCRIPTION
## Summary

- Move openshell provider create/delete from workspace creation into `SecretManager`, driven by inference connection register/unregister events
- Workspace creation now looks up the existing provider by name (`providerId-connectionId`) instead of creating one on the fly, eliminating the duplicate-provider error when recreating a workspace
- Fix bug: wrong emitter in `onDidUnregisterInferenceConnectionCallback` (was firing Kubernetes instead of inference)
- Reorder extension lifecycle: set config before registering the connection so the centralized listener has configuration available when the event fires
- Enrich register/unregister events with the `connection` object
- `ProviderRegistry.getInferenceConnection` now returns `providerId` instead of `extensionId`

## Test plan

- [x] TypeScript compiles with no errors across all modified packages
- [x] All 140 tests pass in `secret-manager/` and `agent-workspace/`
- [x] All 228 tests pass including `provider-registry.spec.ts`
- [ ] Manual: create an inference connection, verify openshell provider is created. Delete connection, verify provider is deleted. Create workspace, verify it attaches the existing provider. Recreate workspace, verify no duplicate error.

Fixes #2303

🤖 Generated with [Claude Code](https://claude.com/claude-code)