### PR TITLE
feat: configurable openshell binary resolution priority

### DIFF
--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -24,6 +24,16 @@
           "default": "",
           "description": "Custom path to OpenShell binary (Default is blank)"
         },
+        "openshell.binary.resolution": {
+          "type": "string",
+          "enum": [
+            "bundled",
+            "system"
+          ],
+          "scope": "DEFAULT",
+          "default": "bundled",
+          "description": "Binary resolution priority: 'bundled' prefers the embedded binary over system PATH (default); 'system' prefers binaries found in system PATH."
+        },
         "openshell.imageBuilder.binary.path": {
           "type": "string",
           "format": "file",

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -27,12 +27,16 @@
         "openshell.binary.resolution": {
           "type": "string",
           "enum": [
-            "bundled",
-            "system"
+            "bundled,storage,system",
+            "bundled,system,storage",
+            "storage,bundled,system",
+            "storage,system,bundled",
+            "system,bundled,storage",
+            "system,storage,bundled"
           ],
           "scope": "DEFAULT",
-          "default": "bundled",
-          "description": "Binary resolution priority: 'bundled' prefers the embedded binary over system PATH (default); 'system' prefers binaries found in system PATH."
+          "default": "bundled,storage,system",
+          "description": "Binary resolution priority order. Custom config path is always checked first regardless of this setting."
         },
         "openshell.imageBuilder.binary.path": {
           "type": "string",

--- a/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
@@ -126,11 +126,20 @@ describe('OpenshellCliManager', () => {
       Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
     });
 
-    test('prefers extension storage over bundled resource', async () => {
+    test('prefers extension storage over bundled resource when resolution is storage,bundled,system', async () => {
       const storageBinPath = `${STORAGE_PATH}/bin/openshell`;
       const bundledPath = '/resources/openshell/openshell';
 
       Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
+
+      vi.mocked(configuration.getConfiguration).mockReturnValue({
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key === 'binary.resolution') return 'storage,bundled,system';
+          return undefined;
+        }),
+        has: vi.fn(),
+        update: vi.fn(),
+      } as never);
 
       vi.mocked(existsSync).mockImplementation((p: PathLike) => {
         const s = String(p);
@@ -157,14 +166,14 @@ describe('OpenshellCliManager', () => {
       Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
     });
 
-    test('prefers system PATH over bundled resource when resolution is system', async () => {
+    test('prefers system PATH over bundled resource when resolution is system,bundled,storage', async () => {
       const bundledPath = '/resources/openshell/openshell';
 
       Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
 
       vi.mocked(configuration.getConfiguration).mockReturnValue({
         get: vi.fn().mockImplementation((key: string) => {
-          if (key === 'binary.resolution') return 'system';
+          if (key === 'binary.resolution') return 'system,bundled,storage';
           return undefined;
         }),
         has: vi.fn(),

--- a/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
@@ -157,6 +157,44 @@ describe('OpenshellCliManager', () => {
       Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
     });
 
+    test('prefers system PATH over bundled resource when resolution is system', async () => {
+      const bundledPath = '/resources/openshell/openshell';
+
+      Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
+
+      vi.mocked(configuration.getConfiguration).mockReturnValue({
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key === 'binary.resolution') return 'system';
+          return undefined;
+        }),
+        has: vi.fn(),
+        update: vi.fn(),
+      } as never);
+
+      vi.mocked(existsSync).mockImplementation((p: PathLike) => {
+        return String(p) === bundledPath;
+      });
+
+      vi.mocked(extensionProcess.exec).mockImplementation(async (cmd: string, args?: string[]) => {
+        if (cmd === 'openshell' && args?.[0] === '--version') {
+          return { stdout: 'openshell 0.0.1', stderr: '', command: cmd };
+        }
+        if (cmd === 'which') {
+          return { stdout: '/usr/local/bin/openshell\n', stderr: '', command: cmd };
+        }
+        throw new Error(`unexpected exec: ${cmd}`);
+      });
+
+      const manager = createManager();
+      await manager.init();
+
+      expect(manager.getRegisteredPath()).toBe('/usr/local/bin/openshell');
+      // bundled binary should NOT have been version-checked because system PATH was found first
+      expect(extensionProcess.exec).not.toHaveBeenCalledWith(bundledPath, expect.anything());
+
+      Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
+    });
+
     test('prefers custom config path over all others', async () => {
       const customPath = '/custom/openshell';
 

--- a/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
@@ -1,0 +1,186 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import type { PathLike } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+
+import { cli, configuration, process as extensionProcess } from '@openkaiden/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { OpenshellCliManager } from './openshell-cli-manager';
+
+vi.mock(import('node:fs'));
+vi.mock(import('@openkaiden/api'));
+
+const STORAGE_PATH = '/fake/storage';
+const EXTENSION_URI = '/fake/extension';
+
+function createManager(): OpenshellCliManager {
+  const manager = new OpenshellCliManager();
+  Object.defineProperty(manager, 'extensionContext', {
+    value: {
+      extensionUri: { fsPath: EXTENSION_URI },
+      storagePath: STORAGE_PATH,
+      subscriptions: [],
+    },
+    writable: false,
+  });
+  return manager;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(readFileSync).mockReturnValue(
+    JSON.stringify({ openshellVersion: '0.1.0', openshellImageBuilderVersion: '0.1.0' }),
+  );
+
+  vi.mocked(configuration.getConfiguration).mockReturnValue({
+    get: vi.fn().mockReturnValue(undefined),
+    has: vi.fn(),
+    update: vi.fn(),
+  } as never);
+
+  vi.mocked(cli.createCliTool).mockReturnValue({
+    registerInstaller: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    updateVersion: vi.fn(),
+    dispose: vi.fn(),
+  } as never);
+
+  // default: no binary exists anywhere
+  vi.mocked(existsSync).mockReturnValue(false);
+});
+
+describe('OpenshellCliManager', () => {
+  describe('binary discovery priority', () => {
+    test('prefers bundled resource over system PATH', async () => {
+      const bundledPath = '/resources/openshell/openshell';
+
+      Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
+
+      vi.mocked(existsSync).mockImplementation((p: PathLike) => {
+        return String(p) === bundledPath;
+      });
+
+      // bundled binary returns a version
+      vi.mocked(extensionProcess.exec).mockImplementation(async (cmd: string) => {
+        if (cmd === bundledPath) {
+          return { stdout: 'openshell 0.2.0', stderr: '', command: cmd };
+        }
+        // system PATH binary would also work — but should not be reached
+        if (cmd === 'openshell') {
+          return { stdout: 'openshell 0.0.1', stderr: '', command: cmd };
+        }
+        throw new Error(`unexpected exec: ${cmd}`);
+      });
+
+      const manager = createManager();
+      await manager.init();
+
+      expect(manager.getRegisteredPath()).toBe(bundledPath);
+      // system PATH lookup (bare `openshell`) must NOT have been called
+      expect(extensionProcess.exec).not.toHaveBeenCalledWith('openshell', expect.anything());
+      // only the bundled binary should have been version-checked
+      expect(extensionProcess.exec).toHaveBeenCalledWith(bundledPath, ['--version']);
+
+      Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
+    });
+
+    test('falls back to system PATH when no bundled resource exists', async () => {
+      Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
+
+      // no binary exists on disk
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      // system PATH binary responds
+      vi.mocked(extensionProcess.exec).mockImplementation(async (cmd: string, args?: string[]) => {
+        if (cmd === 'openshell' && args?.[0] === '--version') {
+          return { stdout: 'openshell 0.0.1', stderr: '', command: cmd };
+        }
+        if (cmd === 'which') {
+          return { stdout: '/usr/local/bin/openshell\n', stderr: '', command: cmd };
+        }
+        throw new Error(`unexpected exec: ${cmd}`);
+      });
+
+      const manager = createManager();
+      await manager.init();
+
+      expect(manager.getRegisteredPath()).toBe('/usr/local/bin/openshell');
+
+      Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
+    });
+
+    test('prefers extension storage over bundled resource', async () => {
+      const storageBinPath = `${STORAGE_PATH}/bin/openshell`;
+      const bundledPath = '/resources/openshell/openshell';
+
+      Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
+
+      vi.mocked(existsSync).mockImplementation((p: PathLike) => {
+        const s = String(p);
+        return s === storageBinPath || s === bundledPath;
+      });
+
+      vi.mocked(extensionProcess.exec).mockImplementation(async (cmd: string) => {
+        if (cmd === storageBinPath) {
+          return { stdout: 'openshell 0.3.0', stderr: '', command: cmd };
+        }
+        if (cmd === bundledPath) {
+          return { stdout: 'openshell 0.2.0', stderr: '', command: cmd };
+        }
+        throw new Error(`unexpected exec: ${cmd}`);
+      });
+
+      const manager = createManager();
+      await manager.init();
+
+      expect(manager.getRegisteredPath()).toBe(storageBinPath);
+      // bundled binary should not have been checked
+      expect(extensionProcess.exec).not.toHaveBeenCalledWith(bundledPath, expect.anything());
+
+      Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
+    });
+
+    test('prefers custom config path over all others', async () => {
+      const customPath = '/custom/openshell';
+
+      vi.mocked(configuration.getConfiguration).mockReturnValue({
+        get: vi.fn().mockReturnValue(customPath),
+        has: vi.fn(),
+        update: vi.fn(),
+      } as never);
+
+      vi.mocked(existsSync).mockImplementation((p: PathLike) => {
+        return String(p) === customPath;
+      });
+
+      vi.mocked(extensionProcess.exec).mockImplementation(async (cmd: string) => {
+        if (cmd === customPath) {
+          return { stdout: 'openshell 0.5.0', stderr: '', command: cmd };
+        }
+        throw new Error(`unexpected exec: ${cmd}`);
+      });
+
+      const manager = createManager();
+      await manager.init();
+
+      expect(manager.getRegisteredPath()).toBe(customPath);
+    });
+  });
+});

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -128,6 +128,10 @@ export class OpenshellCliManager implements Disposable {
     const binaryName = extensionApi.env.isWindows ? `${binaryBaseName}.exe` : binaryBaseName;
     const localBinaryPath = join(binDir, binaryName);
 
+    console.log(
+      `[${binaryBaseName}] discovery order: custom config → extension storage (${localBinaryPath}) → bundled resources → system PATH`,
+    );
+
     const customPath = extensionApi.configuration.getConfiguration('openshell').get<string>(configKey) ?? undefined;
     if (customPath && existsSync(customPath)) {
       const version = await this.getVersion(customPath);
@@ -147,23 +151,26 @@ export class OpenshellCliManager implements Disposable {
       console.warn(`[${binaryBaseName}] binary exists at ${localBinaryPath} but failed to report a version`);
     }
 
-    const systemResult = await this.findOnPath(binaryBaseName);
-    if (systemResult) {
-      console.log(`[${binaryBaseName}] binary found in system PATH`);
-      return { path: systemResult.path, version: systemResult.version, installationSource: 'external' };
-    }
-
     const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
     if (resourcesPath) {
       const bundledBinaryPath = join(resourcesPath, resourceSubdir, binaryName);
+      console.log(`[${binaryBaseName}] checking bundled resources at ${bundledBinaryPath}`);
       if (existsSync(bundledBinaryPath)) {
         const version = await this.getVersion(bundledBinaryPath);
         if (version) {
-          console.log(`[${binaryBaseName}] binary found in bundled resources`);
+          console.log(`[${binaryBaseName}] binary found in bundled resources at ${bundledBinaryPath}`);
           return { path: bundledBinaryPath, version, installationSource: 'extension' };
         }
         console.warn(`[${binaryBaseName}] bundled binary at ${bundledBinaryPath} failed to report a version`);
       }
+    } else {
+      console.log(`[${binaryBaseName}] no resourcesPath set, skipping bundled resources check`);
+    }
+
+    const systemResult = await this.findOnPath(binaryBaseName);
+    if (systemResult) {
+      console.log(`[${binaryBaseName}] binary found in system PATH at ${systemResult.path}`);
+      return { path: systemResult.path, version: systemResult.version, installationSource: 'external' };
     }
 
     return undefined;

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -128,8 +128,12 @@ export class OpenshellCliManager implements Disposable {
     const binaryName = extensionApi.env.isWindows ? `${binaryBaseName}.exe` : binaryBaseName;
     const localBinaryPath = join(binDir, binaryName);
 
+    const resolutionPriority =
+      extensionApi.configuration.getConfiguration('openshell').get<string>('binary.resolution') ?? 'bundled';
+    const laterSteps =
+      resolutionPriority === 'system' ? 'system PATH → bundled resources' : 'bundled resources → system PATH';
     console.log(
-      `[${binaryBaseName}] discovery order: custom config → extension storage (${localBinaryPath}) → bundled resources → system PATH`,
+      `[${binaryBaseName}] discovery order: custom config → extension storage (${localBinaryPath}) → ${laterSteps}`,
     );
 
     const customPath = extensionApi.configuration.getConfiguration('openshell').get<string>(configKey) ?? undefined;
@@ -151,6 +155,28 @@ export class OpenshellCliManager implements Disposable {
       console.warn(`[${binaryBaseName}] binary exists at ${localBinaryPath} but failed to report a version`);
     }
 
+    if (resolutionPriority === 'system') {
+      const systemResult = await this.discoverFromSystemPath(binaryBaseName);
+      if (systemResult) return systemResult;
+
+      const bundledResult = await this.discoverFromBundledResources(binaryBaseName, binaryName, resourceSubdir);
+      if (bundledResult) return bundledResult;
+    } else {
+      const bundledResult = await this.discoverFromBundledResources(binaryBaseName, binaryName, resourceSubdir);
+      if (bundledResult) return bundledResult;
+
+      const systemResult = await this.discoverFromSystemPath(binaryBaseName);
+      if (systemResult) return systemResult;
+    }
+
+    return undefined;
+  }
+
+  private async discoverFromBundledResources(
+    binaryBaseName: string,
+    binaryName: string,
+    resourceSubdir: string,
+  ): Promise<BinaryDiscoveryResult | undefined> {
     const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
     if (resourcesPath) {
       const bundledBinaryPath = join(resourcesPath, resourceSubdir, binaryName);
@@ -166,13 +192,15 @@ export class OpenshellCliManager implements Disposable {
     } else {
       console.log(`[${binaryBaseName}] no resourcesPath set, skipping bundled resources check`);
     }
+    return undefined;
+  }
 
+  private async discoverFromSystemPath(binaryBaseName: string): Promise<BinaryDiscoveryResult | undefined> {
     const systemResult = await this.findOnPath(binaryBaseName);
     if (systemResult) {
       console.log(`[${binaryBaseName}] binary found in system PATH at ${systemResult.path}`);
       return { path: systemResult.path, version: systemResult.version, installationSource: 'external' };
     }
-
     return undefined;
   }
 

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -128,13 +128,11 @@ export class OpenshellCliManager implements Disposable {
     const binaryName = extensionApi.env.isWindows ? `${binaryBaseName}.exe` : binaryBaseName;
     const localBinaryPath = join(binDir, binaryName);
 
-    const resolutionPriority =
-      extensionApi.configuration.getConfiguration('openshell').get<string>('binary.resolution') ?? 'bundled';
-    const laterSteps =
-      resolutionPriority === 'system' ? 'system PATH → bundled resources' : 'bundled resources → system PATH';
-    console.log(
-      `[${binaryBaseName}] discovery order: custom config → extension storage (${localBinaryPath}) → ${laterSteps}`,
-    );
+    const resolutionOrder =
+      extensionApi.configuration.getConfiguration('openshell').get<string>('binary.resolution') ??
+      'bundled,storage,system';
+    const sources = resolutionOrder.split(',');
+    console.log(`[${binaryBaseName}] discovery order: custom config → ${sources.join(' → ')}`);
 
     const customPath = extensionApi.configuration.getConfiguration('openshell').get<string>(configKey) ?? undefined;
     if (customPath && existsSync(customPath)) {
@@ -146,6 +144,29 @@ export class OpenshellCliManager implements Disposable {
       console.warn(`[${binaryBaseName}] custom binary at ${customPath} failed to report a version`);
     }
 
+    for (const source of sources) {
+      let result: BinaryDiscoveryResult | undefined;
+      switch (source) {
+        case 'storage':
+          result = await this.discoverFromExtensionStorage(binaryBaseName, localBinaryPath);
+          break;
+        case 'bundled':
+          result = await this.discoverFromBundledResources(binaryBaseName, binaryName, resourceSubdir);
+          break;
+        case 'system':
+          result = await this.discoverFromSystemPath(binaryBaseName);
+          break;
+      }
+      if (result) return result;
+    }
+
+    return undefined;
+  }
+
+  private async discoverFromExtensionStorage(
+    binaryBaseName: string,
+    localBinaryPath: string,
+  ): Promise<BinaryDiscoveryResult | undefined> {
     if (existsSync(localBinaryPath)) {
       const version = await this.getVersion(localBinaryPath);
       if (version) {
@@ -154,21 +175,6 @@ export class OpenshellCliManager implements Disposable {
       }
       console.warn(`[${binaryBaseName}] binary exists at ${localBinaryPath} but failed to report a version`);
     }
-
-    if (resolutionPriority === 'system') {
-      const systemResult = await this.discoverFromSystemPath(binaryBaseName);
-      if (systemResult) return systemResult;
-
-      const bundledResult = await this.discoverFromBundledResources(binaryBaseName, binaryName, resourceSubdir);
-      if (bundledResult) return bundledResult;
-    } else {
-      const bundledResult = await this.discoverFromBundledResources(binaryBaseName, binaryName, resourceSubdir);
-      if (bundledResult) return bundledResult;
-
-      const systemResult = await this.discoverFromSystemPath(binaryBaseName);
-      if (systemResult) return systemResult;
-    }
-
     return undefined;
   }
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { existsSync } from 'node:fs';
+
 import type { RunError, RunResult } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -26,6 +28,7 @@ import type { CliToolInfo } from '/@api/cli-tool-info.js';
 
 import { OpenshellCli } from './openshell-cli.js';
 
+vi.mock(import('node:fs'));
 vi.mock(import('/@/plugin/util/exec.js'));
 
 const OPENSHELL_CLI_PATH = '/usr/local/bin/openshell';
@@ -65,13 +68,30 @@ describe('getCliPath', () => {
     expect(openshellCli.getCliPath()).toBe(OPENSHELL_CLI_PATH);
   });
 
-  test('falls back to openshell when no CLI tool is registered', () => {
+  test('falls back to bundled binary when no CLI tool is registered', () => {
     vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([]);
-    expect(openshellCli.getCliPath()).toBe('openshell');
+    Object.defineProperty(process, 'resourcesPath', { value: '/app/resources', configurable: true });
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    expect(openshellCli.getCliPath()).toBe('/app/resources/openshell/openshell');
+
+    Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
   });
 
-  test('falls back to openshell when tool has no path', () => {
+  test('falls back to bundled binary when tool has no path', () => {
     vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([{ name: 'openshell' }] as unknown as CliToolInfo[]);
+    Object.defineProperty(process, 'resourcesPath', { value: '/app/resources', configurable: true });
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    expect(openshellCli.getCliPath()).toBe('/app/resources/openshell/openshell');
+
+    Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
+  });
+
+  test('falls back to bare openshell when no registry and no bundled binary', () => {
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([]);
+    Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
+
     expect(openshellCli.getCliPath()).toBe('openshell');
   });
 });
@@ -253,7 +273,9 @@ describe('createSandbox', () => {
 
     await openshellCli.createSandbox({ env: { API_KEY: 'sk-secret-123' } });
 
-    const loggedMessage = logSpy.mock.calls[0]?.[0] as string;
+    const executingLog = logSpy.mock.calls.find(c => String(c[0]).startsWith('Executing:'));
+    expect(executingLog).toBeDefined();
+    const loggedMessage = executingLog![0] as string;
     expect(loggedMessage).not.toContain('sk-secret-123');
     expect(loggedMessage).toContain('--env');
     expect(loggedMessage).toContain('***');
@@ -1083,7 +1105,9 @@ describe('createProvider', () => {
       config: { model: 'gpt-4' },
     });
 
-    const loggedMessage = logSpy.mock.calls[0]?.[0] as string;
+    const executingLog = logSpy.mock.calls.find(c => String(c[0]).startsWith('Executing:'));
+    expect(executingLog).toBeDefined();
+    const loggedMessage = executingLog![0] as string;
     expect(loggedMessage).not.toContain('sk-secret-123');
     expect(loggedMessage).toContain('gpt-4');
   });

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -75,12 +75,8 @@ export class OpenshellCli {
   ) {}
 
   getCliPath(): string {
-    console.log('[openshell] getting CLI path');
-
     const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
-    console.log('[openshell] found CLI tool info:', tool);
     if (tool?.path) {
-      console.log('[openshell] using CLI path from registry:', tool.path);
       return tool.path;
     }
 
@@ -88,12 +84,10 @@ export class OpenshellCli {
     if (resourcesPath) {
       const bundledPath = join(resourcesPath, 'openshell', 'openshell');
       if (existsSync(bundledPath)) {
-        console.log(`[openshell] CLI not in registry yet, using bundled binary at ${bundledPath}`);
         return bundledPath;
       }
     }
 
-    console.warn('[openshell] CLI path not found in registry, falling back to default "openshell"');
     return 'openshell';
   }
 
@@ -407,9 +401,7 @@ export class OpenshellCli {
   }
 
   private async execCLI<T>(args: string[], options?: RunOptions): Promise<T> {
-    console.log(`[openshell] executing CLI command: ${args.join(' ')}`);
     const cliPath = this.getCliPath();
-    console.log(`[openshell] CLI path: ${cliPath}`);
     const fullArgs = [...args, '-o', 'json'];
     try {
       const result = await this.exec.exec(cliPath, fullArgs, options);

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
 import type { RunError, RunOptions } from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 import z from 'zod';
@@ -72,10 +75,25 @@ export class OpenshellCli {
   ) {}
 
   getCliPath(): string {
+    console.log('[openshell] getting CLI path');
+
     const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
+    console.log('[openshell] found CLI tool info:', tool);
     if (tool?.path) {
+      console.log('[openshell] using CLI path from registry:', tool.path);
       return tool.path;
     }
+
+    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+    if (resourcesPath) {
+      const bundledPath = join(resourcesPath, 'openshell', 'openshell');
+      if (existsSync(bundledPath)) {
+        console.log(`[openshell] CLI not in registry yet, using bundled binary at ${bundledPath}`);
+        return bundledPath;
+      }
+    }
+
+    console.warn('[openshell] CLI path not found in registry, falling back to default "openshell"');
     return 'openshell';
   }
 
@@ -389,7 +407,9 @@ export class OpenshellCli {
   }
 
   private async execCLI<T>(args: string[], options?: RunOptions): Promise<T> {
+    console.log(`[openshell] executing CLI command: ${args.join(' ')}`);
     const cliPath = this.getCliPath();
+    console.log(`[openshell] CLI path: ${cliPath}`);
     const fullArgs = [...args, '-o', 'json'];
     try {
       const result = await this.exec.exec(cliPath, fullArgs, options);


### PR DESCRIPTION
Fixes #2309

## Summary
- Fix bundled openshell binary being shadowed by an outdated system-installed version in packaged Electron builds
- Add `openshell.binary.resolution` setting to control the full discovery order between bundled resources, extension storage, and system PATH (6 permutations available as a dropdown in Settings > OpenShell)
- Default order: `bundled,storage,system` — custom config path is always checked first regardless
- Remove debug console traces from `openshell-cli.ts`

## Test plan
- [x] `cd extensions/openshell && pnpm test` — all 26 tests pass
- [x] Verified default order prefers bundled over storage and system PATH
- [x] Verified `system,bundled,storage` order prefers system PATH over bundled
- [x] Verified `storage,bundled,system` order prefers extension storage over bundled
- [x] Verified custom config path always wins regardless of resolution setting