### PR TITLE
fix: add missing .cdix build step to openshell extension

### DIFF
--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -35,7 +35,7 @@
     }
   },
   "scripts": {
-    "build": "vite build && tsx ./scripts/download.ts --all && tsx ./scripts/download-image-builder.ts --all",
+    "build": "vite build && node ./scripts/build.js && tsx ./scripts/download.ts --all && tsx ./scripts/download-image-builder.ts --all",
     "download": "tsx ./scripts/download.ts",
     "download:all": "tsx ./scripts/download.ts --all",
     "download:image-builder": "tsx ./scripts/download-image-builder.ts",
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@openkaiden/api": "workspace:*",
+    "mkdirp": "^3.0.1",
     "tsx": "^4.19.4",
     "vite": "^7.1.2",
     "vitest": "^4.0.10"

--- a/extensions/openshell/scripts/build.js
+++ b/extensions/openshell/scripts/build.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+const AdmZip = require('adm-zip');
+const path = require('path');
+const packageJson = require('../package.json');
+const fs = require('fs');
+const { mkdirp } = require('mkdirp');
+
+const destFile = path.resolve(__dirname, `../${packageJson.name}.cdix`);
+const builtinDirectory = path.resolve(__dirname, '../builtin');
+const unzippedDirectory = path.resolve(builtinDirectory, `${packageJson.name}.cdix`);
+// remove the .cdix file before zipping
+if (fs.existsSync(destFile)) {
+  fs.rmSync(destFile);
+}
+// remove the builtin folder before zipping
+if (fs.existsSync(builtinDirectory)) {
+  fs.rmSync(builtinDirectory, { recursive: true, force: true });
+}
+
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
+zip.writeZip(destFile);
+
+// create unzipped built-in
+mkdirp(unzippedDirectory).then(() => {
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -786,6 +786,9 @@ importers:
       '@openkaiden/api':
         specifier: workspace:*
         version: link:../../packages/extension-api
+      mkdirp:
+        specifier: ^3.0.1
+        version: 3.0.1
       tsx:
         specifier: ^4.19.4
         version: 4.20.3


### PR DESCRIPTION
Fixes #2313

## Summary
- Add `scripts/build.js` to the openshell extension (identical to other extensions like gemini) to create the `.cdix` bundle under `builtin/`
- Update the `build` script in `package.json` to run `node ./scripts/build.js` after `vite build`
- Add `mkdirp` devDependency (required by `build.js`)

Without this, the openshell extension never loads in production builds — electron-builder only includes `extensions/**/builtin/*.cdix/**` and no `.cdix` was being generated.

## Test plan
- [x] Run `cd extensions/openshell && node ./scripts/build.js` — creates `builtin/openshell.cdix/` with `package.json`, `dist/`, etc.