### PR TITLE
feat(openshell): use bundled binaries with VM driver and setup TLS

### DIFF
--- a/extensions/openshell/src/openshell-download.spec.ts
+++ b/extensions/openshell/src/openshell-download.spec.ts
@@ -121,19 +121,18 @@ describe('downloadOpenshellBinaries', () => {
       const cwd = opts.cwd ?? '';
       fileMap.set(normPath(path.join(cwd, 'openshell')), true);
       fileMap.set(normPath(path.join(cwd, 'openshell-gateway')), true);
-      fileMap.set(normPath(path.join(cwd, 'openshell-sandbox')), true);
       fileMap.set(normPath(path.join(cwd, 'openshell-driver-vm')), true);
     });
 
     await downloadOpenshellBinaries('0.0.55', 'linux', 'x64', '/output', digests);
 
-    expect(vi.mocked(tar.extract)).toHaveBeenCalledTimes(4);
+    expect(vi.mocked(tar.extract)).toHaveBeenCalledTimes(3);
     expect(writeFile).toHaveBeenCalledWith(
       expect.stringContaining('.openshell-version'),
       '0.0.55-linux-x64',
       expect.any(Object),
     );
-    expect(chmod).toHaveBeenCalledTimes(4);
+    expect(chmod).toHaveBeenCalledTimes(3);
   });
 
   test('throws on checksum mismatch', async () => {

--- a/extensions/openshell/src/openshell-download.ts
+++ b/extensions/openshell/src/openshell-download.ts
@@ -61,11 +61,6 @@ const ASSET_MAP: Record<string, AssetSpec[]> = {
       binaryName: 'openshell-gateway',
     },
     {
-      component: 'openshell-sandbox',
-      assetName: 'openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz',
-      binaryName: 'openshell-sandbox',
-    },
-    {
       component: 'openshell-driver-vm',
       assetName: 'openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz',
       binaryName: 'openshell-driver-vm',
@@ -77,11 +72,6 @@ const ASSET_MAP: Record<string, AssetSpec[]> = {
       component: 'openshell-gateway',
       assetName: 'openshell-gateway-aarch64-unknown-linux-gnu.tar.gz',
       binaryName: 'openshell-gateway',
-    },
-    {
-      component: 'openshell-sandbox',
-      assetName: 'openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz',
-      binaryName: 'openshell-sandbox',
     },
     {
       component: 'openshell-driver-vm',

--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -111,14 +111,6 @@ export interface GatewayAddOptions {
   local?: boolean;
 }
 
-export interface OpenshellGatewayStartOptions {
-  port?: number;
-  bindAddress?: string;
-  disableTls?: boolean;
-  /** Skip CLI registration when restarting an already-registered gateway. */
-  skipRegistration?: boolean;
-}
-
 export interface GatewaySandboxes {
   gateway: GatewayInfo;
   sandboxes: SandboxInfo[];

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -18,23 +18,25 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { existsSync } from 'node:fs';
 
 import type { RunResult } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
-import type { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { Proxy } from '/@/plugin/proxy.js';
 import { Exec } from '/@/plugin/util/exec.js';
 import type { CliToolInfo } from '/@api/cli-tool-info.js';
-import type { GatewayInfo } from '/@api/openshell-gateway-info.js';
 
 import { OpenshellGateway } from './openshell-gateway.js';
 
 vi.mock(import('node:child_process'));
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
 vi.mock(import('/@/plugin/util/exec.js'));
 
 const { spawn } = await import('node:child_process');
+const { writeFile, mkdir } = await import('node:fs/promises');
 
 const GATEWAY_BINARY = '/usr/local/bin/openshell-gateway';
 const CLI_BINARY = '/usr/local/bin/openshell';
@@ -60,88 +62,62 @@ const cliToolRegistry = {
   getCliToolInfos: vi.fn(),
 } as unknown as CliToolRegistry;
 
-const openshellCli = {
-  listGateways: vi.fn(),
-  selectGateway: vi.fn(),
-} as unknown as OpenshellCli;
-
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
     { name: 'openshell-gateway', path: GATEWAY_BINARY },
     { name: 'openshell', path: CLI_BINARY },
   ] as unknown as CliToolInfo[]);
-  gateway = new OpenshellGateway(exec, cliToolRegistry, openshellCli);
+  vi.mocked(mkdir).mockResolvedValue(undefined);
+  vi.mocked(writeFile).mockResolvedValue(undefined);
+  gateway = new OpenshellGateway(exec, cliToolRegistry);
 });
 
 describe('init', () => {
-  test('skips auto-start when existing gateway is healthy and already active', async () => {
+  test('bootstraps TLS and starts gateway when certs do not exist', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const existingGateways: GatewayInfo[] = [
-      { name: 'local-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
-    ];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await gateway.init();
-
-    expect(openshellCli.listGateways).toHaveBeenCalled();
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://127.0.0.1:8443']);
-    expect(spawn).not.toHaveBeenCalled();
-    expect(openshellCli.selectGateway).not.toHaveBeenCalled();
-  });
-
-  test('selects healthy gateway when it is not active', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const existingGateways: GatewayInfo[] = [{ name: 'kaiden-alt', endpoint: 'http://127.0.0.1:18080', active: false }];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await gateway.init();
-
-    expect(openshellCli.selectGateway).toHaveBeenCalledWith('kaiden-alt');
-    expect(spawn).not.toHaveBeenCalled();
-  });
-
-  test('auto-starts local gateway when no gateways exist and port is free', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
+    // generate-certs succeeds, then health check fails (not running), then waitForReady succeeds, then register succeeds
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(''))
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValue(mockExecResult(''));
 
     await gateway.init();
 
-    expect(spawn).toHaveBeenCalledWith(
+    expect(exec.exec).toHaveBeenCalledWith(
       GATEWAY_BINARY,
-      expect.arrayContaining(['--port', '17670']),
-      expect.objectContaining({ detached: false }),
+      expect.arrayContaining(['generate-certs', '--output-dir', expect.stringContaining('tls')]),
     );
+    expect(spawn).toHaveBeenCalled();
   });
 
-  test('reuses orphan gateway when port is already healthy', async () => {
+  test('skips TLS bootstrap when certs already exist', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+    vi.mocked(existsSync).mockReturnValue(true);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('not healthy')).mockResolvedValue(mockExecResult(''));
+
+    await gateway.init();
+
+    expect(exec.exec).not.toHaveBeenCalledWith(GATEWAY_BINARY, expect.arrayContaining(['generate-certs']));
+  });
+
+  test('skips start when gateway is already healthy', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
     await gateway.init();
 
     expect(spawn).not.toHaveBeenCalled();
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
-      'gateway',
-      'add',
-      'http://127.0.0.1:17670',
-      '--local',
-      '--name',
-      'kaiden-local',
-    ]);
   });
 
-  test('skips auto-start when discovery fails and binary is not registered', async () => {
+  test('skips when gateway binary is not registered', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('CLI not found'));
     vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
       { name: 'openshell', path: CLI_BINARY },
     ] as unknown as CliToolInfo[]);
@@ -151,89 +127,14 @@ describe('init', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  test('auto-starts when discovery fails but binary is available and port is free', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('no gateway configured'));
-    const proc = createMockChildProcess();
-    vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
-
-    await gateway.init();
-
-    expect(spawn).toHaveBeenCalledWith(
-      GATEWAY_BINARY,
-      expect.arrayContaining(['--port', '17670']),
-      expect.objectContaining({ detached: false }),
-    );
-  });
-
-  test('returns without spawning when at least one gateway is healthy among multiple', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const gateways: GatewayInfo[] = [
-      { name: 'gw-stopped', endpoint: 'http://127.0.0.1:8080', active: false },
-      { name: 'gw-healthy', endpoint: 'http://127.0.0.1:9090', active: true },
-    ];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    vi.mocked(exec.exec)
-      .mockRejectedValueOnce(new Error('connection refused'))
-      .mockResolvedValueOnce(mockExecResult(''));
+  test('returns gracefully when TLS bootstrap fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('generate-certs failed'));
 
     await gateway.init();
 
     expect(spawn).not.toHaveBeenCalled();
-  });
-
-  test('creates new gateway when existing gateways are unreachable', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    const gateways: GatewayInfo[] = [{ name: 'broken-gw', endpoint: 'http://127.0.0.1:19999', active: true }];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    const proc = createMockChildProcess();
-    vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec)
-      .mockRejectedValueOnce(new Error('connection refused'))
-      .mockRejectedValueOnce(new Error('connection refused'))
-      .mockResolvedValue(mockExecResult(''));
-
-    await gateway.init();
-
-    expect(spawn).toHaveBeenCalledWith(
-      GATEWAY_BINARY,
-      expect.arrayContaining(['--port', '17670']),
-      expect.objectContaining({ detached: false }),
-    );
-  });
-
-  test('does not pass --gateway-insecure for https endpoints during health check', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const gateways: GatewayInfo[] = [
-      { name: 'tls-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
-    ];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await gateway.init();
-
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://127.0.0.1:8443']);
-  });
-
-  test('skips remote gateways during init and auto-starts local', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    const gateways: GatewayInfo[] = [{ name: 'remote-gw', endpoint: 'https://gw.example.com', active: true }];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    const proc = createMockChildProcess();
-    vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
-
-    await gateway.init();
-
-    expect(exec.exec).not.toHaveBeenCalledWith(
-      CLI_BINARY,
-      expect.arrayContaining(['--gateway-endpoint', 'https://gw.example.com']),
-    );
-    expect(spawn).toHaveBeenCalled();
   });
 });
 
@@ -251,8 +152,9 @@ describe('getGatewayBinaryPath', () => {
 });
 
 describe('start', () => {
-  test('spawns the gateway process with default args', async () => {
+  test('spawns gateway with --config and TLS env', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
@@ -261,43 +163,59 @@ describe('start', () => {
 
     expect(spawn).toHaveBeenCalledWith(
       GATEWAY_BINARY,
-      ['--port', '17670', '--bind-address', '127.0.0.1', '--disable-tls'],
-      expect.objectContaining({ detached: false }),
+      ['--config', expect.stringContaining('gateway.toml')],
+      expect.objectContaining({
+        detached: false,
+        env: expect.objectContaining({
+          OPENSHELL_LOCAL_TLS_DIR: expect.stringContaining('tls'),
+        }),
+      }),
     );
   });
 
-  test('spawns with custom port and address', async () => {
+  test('does not pass --disable-tls', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
 
-    await gateway.start({ port: 9999, bindAddress: '0.0.0.0' });
+    await gateway.start();
 
-    expect(spawn).toHaveBeenCalledWith(
-      GATEWAY_BINARY,
-      ['--port', '9999', '--bind-address', '0.0.0.0', '--disable-tls'],
-      expect.objectContaining({ detached: false }),
-    );
+    const spawnArgs = vi.mocked(spawn).mock.calls[0]![1] as string[];
+    expect(spawnArgs).not.toContain('--disable-tls');
   });
 
-  test('skips --disable-tls when disableTls is false', async () => {
+  test('writes gateway config with VM driver', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
 
-    await gateway.start({ disableTls: false });
+    await gateway.start();
 
-    expect(spawn).toHaveBeenCalledWith(
-      GATEWAY_BINARY,
-      ['--port', '17670', '--bind-address', '127.0.0.1'],
-      expect.objectContaining({ detached: false }),
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('gateway.toml'),
+      expect.stringContaining('compute_drivers = ["vm"]'),
     );
+  });
+
+  test('skips writing config when it already exists', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(true);
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+
+    await gateway.start();
+
+    expect(writeFile).not.toHaveBeenCalled();
   });
 
   test('skips if already running', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
@@ -316,24 +234,22 @@ describe('start', () => {
     await expect(gateway.start()).rejects.toThrow('openshell-gateway binary not registered');
   });
 
-  test('performs health check with openshell status', async () => {
+  test('health checks use https without --gateway-insecure', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
     await gateway.start();
 
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
-      'status',
-      '--gateway-endpoint',
-      'http://127.0.0.1:17670',
-      '--gateway-insecure',
-    ]);
+    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://127.0.0.1:17670']);
+    expect(exec.exec).not.toHaveBeenCalledWith(CLI_BINARY, expect.arrayContaining(['--gateway-insecure']));
   });
 
-  test('registers gateway with CLI after health check passes', async () => {
+  test('registers gateway as kaiden over https', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
@@ -343,29 +259,18 @@ describe('start', () => {
     expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
       'gateway',
       'add',
-      'http://127.0.0.1:17670',
+      'https://127.0.0.1:17670',
       '--local',
       '--name',
-      'kaiden-local',
+      'kaiden',
     ]);
-  });
-
-  test('skips registerWithCli when skipRegistration is true', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const proc = createMockChildProcess();
-    vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await gateway.start({ skipRegistration: true });
-
-    expect(spawn).toHaveBeenCalled();
-    expect(exec.exec).not.toHaveBeenCalledWith(CLI_BINARY, expect.arrayContaining(['gateway', 'add']));
   });
 
   test('stops the spawned process when waitForReady fails', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
@@ -393,6 +298,7 @@ describe('start', () => {
 describe('stop', () => {
   test('sends SIGTERM to running process', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
@@ -418,6 +324,7 @@ describe('isRunning', () => {
 
   test('returns true when process is running', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
@@ -431,6 +338,7 @@ describe('isRunning', () => {
 describe('dispose', () => {
   test('stops the gateway process', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(existsSync).mockReturnValue(false);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -18,100 +18,111 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 import type { Disposable } from '@openkaiden/api';
 import { inject, injectable, preDestroy } from 'inversify';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
-import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { Exec } from '/@/plugin/util/exec.js';
-import type { OpenshellGatewayStartOptions } from '/@api/openshell-gateway-info.js';
 
 const DEFAULT_PORT = 17670;
 const DEFAULT_BIND_ADDRESS = '127.0.0.1';
 const HEALTH_CHECK_INTERVAL_MS = 1000;
 const MAX_HEALTH_CHECK_ATTEMPTS = 30;
 const STOP_TIMEOUT_MS = 5000;
+const GATEWAY_NAME = 'kaiden';
 
-/**
- * Manages the `openshell-gateway` server binary lifecycle.
- *
- * On {@link init}, discovers existing gateways via the CLI. If a healthy
- * gateway is found it is selected. Otherwise, auto-starts a new local
- * gateway by spawning the `openshell-gateway` binary, waiting for it to
- * become healthy, and registering it with the CLI.
- */
+const GATEWAY_CONFIG = `[openshell]
+version = 1
+
+[openshell.gateway]
+bind_address = "${DEFAULT_BIND_ADDRESS}:${DEFAULT_PORT}"
+compute_drivers = ["vm"]
+`;
+
 @injectable()
 export class OpenshellGateway implements Disposable {
   #gatewayProcess: ChildProcess | undefined;
-  #port: number = DEFAULT_PORT;
-  #bindAddress: string = DEFAULT_BIND_ADDRESS;
+  #tlsDir: string;
+  #configDir: string;
 
   constructor(
     @inject(Exec)
     private readonly exec: Exec,
     @inject(CliToolRegistry)
     private readonly cliToolRegistry: CliToolRegistry,
-    @inject(OpenshellCli)
-    private readonly openshellCli: OpenshellCli,
-  ) {}
+  ) {
+    const home = homedir();
+    this.#tlsDir = join(home, '.local', 'state', 'openshell', 'tls');
+    this.#configDir = join(home, '.local', 'state', 'openshell', 'config');
+  }
 
   async init(): Promise<void> {
-    try {
-      const gateways = await this.openshellCli.listGateways();
-      const localGateways = gateways.filter(gw => gw.type === 'local' || this.isLocalEndpoint(gw.endpoint));
-      if (localGateways.length > 0) {
-        for (const gw of localGateways) {
-          if (await this.isEndpointHealthy(gw.endpoint)) {
-            if (!gw.active) {
-              await this.openshellCli.selectGateway(gw.name);
-            }
-            console.log(`[openshell-gateway] gateway '${gw.name}' is healthy and selected`);
-            return;
-          }
-        }
-        console.warn('[openshell-gateway] local gateway(s) defined but none reachable');
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[openshell-gateway] failed to discover gateways: ${message}`);
+    const gatewayBinaryPath = this.getGatewayBinaryPath();
+    if (!gatewayBinaryPath) {
+      console.warn('[openshell-gateway] gateway binary not registered, skipping');
+      return;
     }
 
-    const binaryPath = this.getGatewayBinaryPath();
-    if (!binaryPath) {
-      console.warn('[openshell-gateway] no existing gateways and binary not registered, skipping auto-start');
+    try {
+      await this.bootstrapTls(gatewayBinaryPath);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[openshell-gateway] TLS bootstrap failed: ${message}`);
       return;
     }
 
     if (await this.isEndpointHealthy()) {
-      console.log('[openshell-gateway] found healthy gateway on default port, registering');
-      await this.registerWithCli();
+      console.log('[openshell-gateway] gateway is already healthy');
       return;
     }
 
-    console.log('[openshell-gateway] no existing gateways found, auto-starting local gateway');
+    console.log('[openshell-gateway] starting local gateway with VM driver');
     await this.start();
   }
 
-  private async isEndpointHealthy(endpoint?: string): Promise<boolean> {
-    const target = endpoint ?? `http://${this.#bindAddress}:${this.#port}`;
-    const cliPath = this.getCliPath();
-    const args = ['status', '--gateway-endpoint', target];
-    if (target.startsWith('http://')) {
-      args.push('--gateway-insecure');
+  private async bootstrapTls(gatewayBinaryPath: string): Promise<void> {
+    if (this.isTlsBootstrapped()) {
+      console.log('[openshell-gateway] TLS already bootstrapped');
+      return;
     }
-    try {
-      await this.exec.exec(cliPath, args);
-      return true;
-    } catch {
-      return false;
-    }
+
+    console.log('[openshell-gateway] bootstrapping TLS certificates');
+    await this.exec.exec(gatewayBinaryPath, [
+      'generate-certs',
+      '--output-dir',
+      this.#tlsDir,
+      '--server-san',
+      'host.openshell.internal',
+    ]);
+    console.log(`[openshell-gateway] TLS certificates generated in ${this.#tlsDir}`);
   }
 
-  private isLocalEndpoint(endpoint: string): boolean {
+  private isTlsBootstrapped(): boolean {
+    return (
+      existsSync(join(this.#tlsDir, 'ca.crt')) &&
+      existsSync(join(this.#tlsDir, 'server', 'tls.crt')) &&
+      existsSync(join(this.#tlsDir, 'server', 'tls.key')) &&
+      existsSync(join(this.#tlsDir, 'client', 'tls.crt')) &&
+      existsSync(join(this.#tlsDir, 'client', 'tls.key')) &&
+      existsSync(join(this.#tlsDir, 'jwt', 'signing.pem')) &&
+      existsSync(join(this.#tlsDir, 'jwt', 'public.pem'))
+    );
+  }
+
+  private async isEndpointHealthy(): Promise<boolean> {
+    const cliPath = this.getCliPath();
     try {
-      const url = new URL(endpoint);
-      return ['127.0.0.1', 'localhost', '::1'].includes(url.hostname);
+      await this.exec.exec(cliPath, [
+        'status',
+        '--gateway-endpoint',
+        `https://${DEFAULT_BIND_ADDRESS}:${DEFAULT_PORT}`,
+      ]);
+      return true;
     } catch {
       return false;
     }
@@ -127,7 +138,7 @@ export class OpenshellGateway implements Disposable {
     return tool?.path ?? 'openshell';
   }
 
-  async start(options?: OpenshellGatewayStartOptions): Promise<void> {
+  async start(): Promise<void> {
     if (this.#gatewayProcess) {
       console.log('[openshell-gateway] already running, skipping start');
       return;
@@ -138,22 +149,19 @@ export class OpenshellGateway implements Disposable {
       throw new Error('openshell-gateway binary not registered in CLI tool registry');
     }
 
-    const previousPort = this.#port;
-    const previousBindAddress = this.#bindAddress;
+    await this.writeGatewayConfig();
 
-    if (options?.port !== undefined) {
-      this.#port = options.port;
-    }
-    if (options?.bindAddress !== undefined) {
-      this.#bindAddress = options.bindAddress;
-    }
-
-    const args = this.buildArgs(options?.disableTls ?? true);
+    const configPath = join(this.#configDir, 'gateway.toml');
+    const args = ['--config', configPath];
     console.log(`[openshell-gateway] starting: ${binaryPath} ${args.join(' ')}`);
 
     this.#gatewayProcess = spawn(binaryPath, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,
+      env: {
+        ...process.env,
+        OPENSHELL_LOCAL_TLS_DIR: this.#tlsDir,
+      },
     });
 
     this.#gatewayProcess.stdout?.on('data', (data: Buffer) => {
@@ -180,13 +188,9 @@ export class OpenshellGateway implements Disposable {
       await this.stop().catch((stopErr: unknown) => {
         console.warn('[openshell-gateway] failed to stop after startup error:', stopErr);
       });
-      this.#port = previousPort;
-      this.#bindAddress = previousBindAddress;
       throw err;
     }
-    if (!options?.skipRegistration) {
-      await this.registerWithCli();
-    }
+    await this.registerWithCli();
   }
 
   async stop(): Promise<void> {
@@ -225,18 +229,18 @@ export class OpenshellGateway implements Disposable {
     this.stop().catch((err: unknown) => console.error('[openshell-gateway] failed to stop: ', err));
   }
 
-  private buildArgs(disableTls: boolean): string[] {
-    const args: string[] = [];
-    args.push('--port', String(this.#port));
-    args.push('--bind-address', this.#bindAddress);
-    if (disableTls) {
-      args.push('--disable-tls');
+  private async writeGatewayConfig(): Promise<void> {
+    const configPath = join(this.#configDir, 'gateway.toml');
+    if (existsSync(configPath)) {
+      return;
     }
-    return args;
+    await mkdir(this.#configDir, { recursive: true });
+    await writeFile(configPath, GATEWAY_CONFIG);
+    console.log(`[openshell-gateway] gateway config written to ${configPath}`);
   }
 
   private async waitForReady(): Promise<void> {
-    const endpoint = `http://${this.#bindAddress}:${this.#port}`;
+    const endpoint = `https://${DEFAULT_BIND_ADDRESS}:${DEFAULT_PORT}`;
     console.log(`[openshell-gateway] waiting for server at ${endpoint}`);
 
     const cliPath = this.getCliPath();
@@ -246,7 +250,7 @@ export class OpenshellGateway implements Disposable {
       }
 
       try {
-        await this.exec.exec(cliPath, ['status', '--gateway-endpoint', endpoint, '--gateway-insecure']);
+        await this.exec.exec(cliPath, ['status', '--gateway-endpoint', endpoint]);
         console.log('[openshell-gateway] server is ready');
         return;
       } catch {
@@ -260,11 +264,11 @@ export class OpenshellGateway implements Disposable {
   }
 
   private async registerWithCli(): Promise<void> {
-    const endpoint = `http://${this.#bindAddress}:${this.#port}`;
+    const endpoint = `https://${DEFAULT_BIND_ADDRESS}:${DEFAULT_PORT}`;
     const cliPath = this.getCliPath();
     try {
-      await this.exec.exec(cliPath, ['gateway', 'add', endpoint, '--local', '--name', 'kaiden-local']);
-      console.log(`[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
+      await this.exec.exec(cliPath, ['gateway', 'add', endpoint, '--local', '--name', GATEWAY_NAME]);
+      console.log(`[openshell-gateway] registered with CLI as ${GATEWAY_NAME} at ${endpoint}`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[openshell-gateway] failed to register with CLI: ${message}`);


### PR DESCRIPTION
## Summary
- Switch OpenShell gateway to use the VM compute driver (libkrun micro-VMs) with proper mTLS instead of running with TLS disabled
- Bootstrap mTLS certificates via `generate-certs` before first gateway start, spawn gateway with `--config gateway.toml` (VM driver, TLS enabled), and register as "kaiden" over `https://127.0.0.1:17670`
- Remove `openshell-sandbox` from Linux download maps since it is now auto-pulled as an OCI image

## Test plan
- [ ] Verify gateway starts with VM driver on Linux
- [ ] Verify gateway starts with VM driver on macOS
- [ ] Verify mTLS certificates are generated on first run
- [ ] Verify gateway registers as "kaiden" over https
- [ ] Verify sandbox binary is no longer downloaded (pulled as OCI image instead)
- [ ] Run `pnpm test:unit packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts`
- [ ] Run `pnpm test:unit extensions/openshell/src/openshell-download.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)