### PR TITLE
fix: deselect secrets by default when creating a new workspace

### DIFF
--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.spec.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.spec.ts
@@ -142,11 +142,11 @@ describe('resetDraft selects all available items', () => {
     expect(wizard.draft.selectedMcpIds).toEqual(['srv-1']);
   });
 
-  test('should select all secrets', () => {
+  test('should not select any secrets', () => {
     secretVaultInfos.set([{ id: 'sec-1', name: 'Secret 1', type: 'api', description: '' } as SecretVaultInfo]);
     resetDraft();
 
-    expect(wizard.draft.selectedSecretIds).toEqual(['sec-1']);
+    expect(wizard.draft.selectedSecretIds).toEqual([]);
   });
 
   test('should select knowledge bases with mcpServer only', () => {
@@ -173,7 +173,7 @@ describe('first emission seeding', () => {
     expect(wizard.draft.selectedSkillIds).toContain('k8s');
     expect(wizard.draft.selectedSkillIds).toContain('docker');
     expect(wizard.draft.selectedMcpIds).toContain('srv-1');
-    expect(wizard.draft.selectedSecretIds).toContain('sec-1');
+    expect(wizard.draft.selectedSecretIds).toEqual([]);
     expect(wizard.draft.selectedKnowledgeIds).toContain('kb-1');
   });
 });

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
@@ -88,7 +88,6 @@ export function resetDraft(): void {
     .filter(s => s.enabled)
     .map(s => s.name);
   wizard.draft.selectedMcpIds = get(mcpRemoteServerInfos).map(m => m.id);
-  wizard.draft.selectedSecretIds = get(secretVaultInfos).map(s => s.id);
   wizard.draft.selectedKnowledgeIds = get(ragEnvironments)
     .filter(r => r.mcpServer)
     .map(r => r.name);
@@ -110,12 +109,9 @@ mcpRemoteServerInfos.subscribe(servers => {
   prevMcp = available;
 });
 
-let prevSecrets: Set<string> | undefined;
 secretVaultInfos.subscribe(secrets => {
   const available = new Set(secrets.map(s => s.id));
-  const added = prevSecrets ? [...available].filter(id => !prevSecrets!.has(id)) : [...available];
-  wizard.draft.selectedSecretIds = [...wizard.draft.selectedSecretIds.filter(id => available.has(id)), ...added];
-  prevSecrets = available;
+  wizard.draft.selectedSecretIds = wizard.draft.selectedSecretIds.filter(id => available.has(id));
 });
 
 let prevKnowledge: Set<string> | undefined;


### PR DESCRIPTION
Secrets from the vault were all pre-selected during workspace creation,
causing unrelated provider connections to be attached. Now secrets start
unselected and the subscription only prunes removed secrets without
auto-selecting new ones.

Fixes #1883
