### PR TITLE
fix: use path.join in openshell tests for Windows compatibility

### DIFF
--- a/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
@@ -18,6 +18,7 @@
 
 import type { PathLike } from 'node:fs';
 import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { cli, configuration, process as extensionProcess } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -69,7 +70,7 @@ beforeEach(() => {
 describe('OpenshellCliManager', () => {
   describe('binary discovery priority', () => {
     test('prefers bundled resource over system PATH', async () => {
-      const bundledPath = '/resources/openshell/openshell';
+      const bundledPath = join('/resources', 'openshell', 'openshell');
 
       Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
 
@@ -127,8 +128,8 @@ describe('OpenshellCliManager', () => {
     });
 
     test('prefers extension storage over bundled resource when resolution is storage,bundled,system', async () => {
-      const storageBinPath = `${STORAGE_PATH}/bin/openshell`;
-      const bundledPath = '/resources/openshell/openshell';
+      const storageBinPath = join(STORAGE_PATH, 'bin', 'openshell');
+      const bundledPath = join('/resources', 'openshell', 'openshell');
 
       Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
 
@@ -167,7 +168,7 @@ describe('OpenshellCliManager', () => {
     });
 
     test('prefers system PATH over bundled resource when resolution is system,bundled,storage', async () => {
-      const bundledPath = '/resources/openshell/openshell';
+      const bundledPath = join('/resources', 'openshell', 'openshell');
 
       Object.defineProperty(process, 'resourcesPath', { value: '/resources', configurable: true });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 import type { RunError, RunResult } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -73,7 +74,7 @@ describe('getCliPath', () => {
     Object.defineProperty(process, 'resourcesPath', { value: '/app/resources', configurable: true });
     vi.mocked(existsSync).mockReturnValue(true);
 
-    expect(openshellCli.getCliPath()).toBe('/app/resources/openshell/openshell');
+    expect(openshellCli.getCliPath()).toBe(join('/app/resources', 'openshell', 'openshell'));
 
     Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
   });
@@ -83,7 +84,7 @@ describe('getCliPath', () => {
     Object.defineProperty(process, 'resourcesPath', { value: '/app/resources', configurable: true });
     vi.mocked(existsSync).mockReturnValue(true);
 
-    expect(openshellCli.getCliPath()).toBe('/app/resources/openshell/openshell');
+    expect(openshellCli.getCliPath()).toBe(join('/app/resources', 'openshell', 'openshell'));
 
     Object.defineProperty(process, 'resourcesPath', { value: undefined, configurable: true });
   });


### PR DESCRIPTION
## Summary
- Openshell CLI tests hardcoded Unix-style forward-slash paths in assertions, but the production code uses `path.join()` which produces backslashes on Windows
- Replace hardcoded path strings with `join()` calls so expected values use the correct separator on all platforms
- Fixes 4 unit test failures on the `windows-2022` CI runner

## Test plan
- [x] `pnpm vitest run packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts` — 82 tests pass
- [x] `pnpm vitest run extensions/openshell/src/manager/openshell-cli-manager.spec.ts` — 5 tests pass
- [x] Verify Windows CI passes on this PR