### PR TITLE
feat(openshell): add openshell-gateway binary discovery and CLI tool registration

### DIFF
--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -44,6 +44,14 @@
           "scope": "DEFAULT",
           "default": "",
           "description": "Custom path to openshell-image-builder binary (Default is blank)"
+        },
+        "openshell.gateway.binary.path": {
+          "type": "string",
+          "format": "file",
+          "scope": "DEFAULT",
+          "when": "!isWindows",
+          "default": "",
+          "description": "Custom path to openshell-gateway binary (Default is blank)"
         }
       }
     }

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -95,6 +95,23 @@ export class OpenshellCliManager implements Disposable {
     );
 
     this.extensionContext.subscriptions.push(ibCliTool.registerInstaller(ibInstaller));
+
+    const gwResult = await this.discoverBinary('openshell-gateway', 'gateway.binary.path', 'openshell');
+    const gwRegistration: BinaryDiscoveryResult = gwResult ?? {
+      installationSource: 'extension',
+    };
+
+    if (!gwResult) {
+      console.warn('[openshell-gateway] CLI not found, registering installer-only entry');
+      return;
+    }
+
+    this.registerCliTool(
+      'openshell-gateway',
+      'OpenShell Gateway',
+      'OpenShell Gateway server for managing sandbox connections',
+      gwRegistration,
+    );
   }
 
   dispose(): void {}


### PR DESCRIPTION
## Summary
- Add discovery and registration of the `openshell-gateway` binary using the existing binary resolution pipeline (custom config → bundled → storage → system PATH)
- Introduce `openshell.gateway.binary.path` configuration property for custom binary paths (non-Windows only)
- If the gateway binary is not found, log a warning and skip registration (no installer for now)

Closes #2332
fixes https://github.com/openkaiden/kaiden/issues/2147

## Test plan
- [ ] Verify `openshell-gateway` appears in CLI tools list when the binary is available on the system
- [ ] Verify custom path via `openshell.gateway.binary.path` configuration takes priority
- [ ] Verify warning is logged and registration is skipped when the binary is not found
- [ ] Verify the setting is hidden on Windows (`when: "!isWindows"`)
- [ ] Verify existing `openshell` and `openshell-image-builder` registration is unaffected
