### PR TITLE
fix: delegate CLI path resolution in OpenshellGateway to OpenshellCli

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -734,11 +734,36 @@ describe('checkEndpointStatus', () => {
   test('returns true when endpoint is healthy', async () => {
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
     expect(await openshellCli.checkEndpointStatus('https://127.0.0.1:8443')).toBe(true);
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['status', '--gateway-endpoint', 'https://127.0.0.1:8443'],
+      undefined,
+    );
   });
 
   test('returns false when endpoint is unreachable', async () => {
     vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
     expect(await openshellCli.checkEndpointStatus('http://127.0.0.1:17670')).toBe(false);
+  });
+
+  test('appends --gateway-insecure for http endpoints', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    await openshellCli.checkEndpointStatus('http://127.0.0.1:17670');
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['status', '--gateway-endpoint', 'http://127.0.0.1:17670', '--gateway-insecure'],
+      undefined,
+    );
+  });
+
+  test('does not append --gateway-insecure for https endpoints', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    await openshellCli.checkEndpointStatus('https://127.0.0.1:8443');
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      expect.not.arrayContaining(['--gateway-insecure']),
+      undefined,
+    );
   });
 });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -730,6 +730,18 @@ describe('listSandboxesPerGateway', () => {
   });
 });
 
+describe('checkEndpointStatus', () => {
+  test('returns true when endpoint is healthy', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    expect(await openshellCli.checkEndpointStatus('https://127.0.0.1:8443')).toBe(true);
+  });
+
+  test('returns false when endpoint is unreachable', async () => {
+    vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
+    expect(await openshellCli.checkEndpointStatus('http://127.0.0.1:17670')).toBe(false);
+  });
+});
+
 describe('getGatewayStatus', () => {
   test('executes status and returns trimmed output', async () => {
     const statusText = 'Server Status\n\n  Gateway: openshell\n  Status: Connected\n';

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -313,6 +313,19 @@ export class OpenshellCli {
     return z.array(GatewayInfoSchema).parse(data);
   }
 
+  async checkEndpointStatus(endpoint: string): Promise<boolean> {
+    const args = ['status', '--gateway-endpoint', endpoint];
+    if (endpoint.startsWith('http://')) {
+      args.push('--gateway-insecure');
+    }
+    try {
+      await this.runCli(args);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async getGatewayStatus(): Promise<string> {
     const cliPath = this.getCliPath();
     try {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -319,7 +319,7 @@ export class OpenshellCli {
       args.push('--gateway-insecure');
     }
     try {
-      await this.runCli(args);
+      await this.runCli(args, { quiet: true });
       return true;
     } catch {
       return false;
@@ -393,15 +393,22 @@ export class OpenshellCli {
   }
   // ── helpers ───────────────────────────────────────────────────────
 
-  private async runCli(args: string[], options?: { redact?: boolean; env?: { [p: string]: string } }): Promise<void> {
+  private async runCli(
+    args: string[],
+    options?: { redact?: boolean; env?: { [p: string]: string }; quiet?: boolean },
+  ): Promise<void> {
     const cliPath = this.getCliPath();
     const displayArgs = options?.redact ? this.redactSensitiveArgs(args) : args;
-    console.log(`Executing: ${cliPath} ${displayArgs.join(' ')}`);
+    if (!options?.quiet) {
+      console.log(`Executing: ${cliPath} ${displayArgs.join(' ')}`);
+    }
     try {
       await this.exec.exec(cliPath, args, options?.env ? { env: options.env } : undefined);
     } catch (err: unknown) {
       const detail = this.extractCliError(err);
-      console.error(`openshell failed: ${cliPath} ${displayArgs.join(' ')} — ${detail}`);
+      if (!options?.quiet) {
+        console.error(`openshell failed: ${cliPath} ${displayArgs.join(' ')} — ${detail}`);
+      }
       throw new Error(detail);
     }
   }

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -19,25 +19,20 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 
-import type { RunResult } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
-import type { Proxy } from '/@/plugin/proxy.js';
-import { Exec } from '/@/plugin/util/exec.js';
 import type { CliToolInfo } from '/@api/cli-tool-info.js';
 import type { GatewayInfo } from '/@api/openshell-gateway-info.js';
 
 import { OpenshellGateway } from './openshell-gateway.js';
 
 vi.mock(import('node:child_process'));
-vi.mock(import('/@/plugin/util/exec.js'));
 
 const { spawn } = await import('node:child_process');
 
 const GATEWAY_BINARY = '/usr/local/bin/openshell-gateway';
-const CLI_BINARY = '/usr/local/bin/openshell';
 
 function createMockChildProcess(): ChildProcess & { _stdout: EventEmitter; _stderr: EventEmitter } {
   const proc = new EventEmitter() as ChildProcess & { _stdout: EventEmitter; _stderr: EventEmitter };
@@ -49,13 +44,8 @@ function createMockChildProcess(): ChildProcess & { _stdout: EventEmitter; _stde
   return proc;
 }
 
-function mockExecResult(stdout = ''): RunResult {
-  return { command: CLI_BINARY, stdout, stderr: '' };
-}
-
 let gateway: OpenshellGateway;
 
-const exec = new Exec({} as Proxy);
 const cliToolRegistry = {
   getCliToolInfos: vi.fn(),
 } as unknown as CliToolRegistry;
@@ -63,15 +53,16 @@ const cliToolRegistry = {
 const openshellCli = {
   listGateways: vi.fn(),
   selectGateway: vi.fn(),
+  checkEndpointStatus: vi.fn(),
+  addGateway: vi.fn(),
 } as unknown as OpenshellCli;
 
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
     { name: 'openshell-gateway', path: GATEWAY_BINARY },
-    { name: 'openshell', path: CLI_BINARY },
   ] as unknown as CliToolInfo[]);
-  gateway = new OpenshellGateway(exec, cliToolRegistry, openshellCli);
+  gateway = new OpenshellGateway(cliToolRegistry, openshellCli);
 });
 
 describe('init', () => {
@@ -81,12 +72,12 @@ describe('init', () => {
       { name: 'local-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
     ];
     vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
     expect(openshellCli.listGateways).toHaveBeenCalled();
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://127.0.0.1:8443']);
+    expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
     expect(spawn).not.toHaveBeenCalled();
     expect(openshellCli.selectGateway).not.toHaveBeenCalled();
   });
@@ -95,7 +86,7 @@ describe('init', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const existingGateways: GatewayInfo[] = [{ name: 'kaiden-alt', endpoint: 'http://127.0.0.1:18080', active: false }];
     vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
@@ -109,7 +100,7 @@ describe('init', () => {
     vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
 
     await gateway.init();
 
@@ -124,27 +115,22 @@ describe('init', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
     expect(spawn).not.toHaveBeenCalled();
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
-      'gateway',
-      'add',
-      'http://127.0.0.1:17670',
-      '--local',
-      '--name',
-      'kaiden-local',
-    ]);
+    expect(openshellCli.addGateway).toHaveBeenCalledWith({
+      endpoint: 'http://127.0.0.1:17670',
+      local: true,
+      name: 'kaiden-local',
+    });
   });
 
   test('skips auto-start when discovery fails and binary is not registered', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('CLI not found'));
-    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
-      { name: 'openshell', path: CLI_BINARY },
-    ] as unknown as CliToolInfo[]);
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([] as unknown as CliToolInfo[]);
 
     await gateway.init();
 
@@ -157,7 +143,7 @@ describe('init', () => {
     vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('no gateway configured'));
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
 
     await gateway.init();
 
@@ -175,9 +161,7 @@ describe('init', () => {
       { name: 'gw-healthy', endpoint: 'http://127.0.0.1:9090', active: true },
     ];
     vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    vi.mocked(exec.exec)
-      .mockRejectedValueOnce(new Error('connection refused'))
-      .mockResolvedValueOnce(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     await gateway.init();
 
@@ -191,10 +175,10 @@ describe('init', () => {
     vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec)
-      .mockRejectedValueOnce(new Error('connection refused'))
-      .mockRejectedValueOnce(new Error('connection refused'))
-      .mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
 
     await gateway.init();
 
@@ -205,17 +189,17 @@ describe('init', () => {
     );
   });
 
-  test('does not pass --gateway-insecure for https endpoints during health check', async () => {
+  test('delegates health check to openshellCli for https endpoints', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const gateways: GatewayInfo[] = [
       { name: 'tls-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
     ];
     vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, ['status', '--gateway-endpoint', 'https://127.0.0.1:8443']);
+    expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
   });
 
   test('skips remote gateways during init and auto-starts local', async () => {
@@ -225,14 +209,11 @@ describe('init', () => {
     vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused')).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
 
     await gateway.init();
 
-    expect(exec.exec).not.toHaveBeenCalledWith(
-      CLI_BINARY,
-      expect.arrayContaining(['--gateway-endpoint', 'https://gw.example.com']),
-    );
+    expect(openshellCli.checkEndpointStatus).not.toHaveBeenCalledWith('https://gw.example.com');
     expect(spawn).toHaveBeenCalled();
   });
 });
@@ -243,9 +224,7 @@ describe('getGatewayBinaryPath', () => {
   });
 
   test('returns undefined when openshell-gateway is not registered', () => {
-    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
-      { name: 'openshell', path: CLI_BINARY },
-    ] as unknown as CliToolInfo[]);
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([] as unknown as CliToolInfo[]);
     expect(gateway.getGatewayBinaryPath()).toBeUndefined();
   });
 });
@@ -255,7 +234,7 @@ describe('start', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -270,7 +249,7 @@ describe('start', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start({ port: 9999, bindAddress: '0.0.0.0' });
 
@@ -285,7 +264,7 @@ describe('start', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start({ disableTls: false });
 
@@ -300,7 +279,7 @@ describe('start', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('connected'));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
     await gateway.start();
@@ -309,57 +288,47 @@ describe('start', () => {
   });
 
   test('throws when gateway binary is not registered', async () => {
-    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
-      { name: 'openshell', path: CLI_BINARY },
-    ] as unknown as CliToolInfo[]);
+    vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([] as unknown as CliToolInfo[]);
 
     await expect(gateway.start()).rejects.toThrow('openshell-gateway binary not registered');
   });
 
-  test('performs health check with openshell status', async () => {
+  test('performs health check via openshellCli', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
-      'status',
-      '--gateway-endpoint',
-      'http://127.0.0.1:17670',
-      '--gateway-insecure',
-    ]);
+    expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('http://127.0.0.1:17670');
   });
 
-  test('registers gateway with CLI after health check passes', async () => {
+  test('registers gateway via openshellCli after health check passes', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
-    expect(exec.exec).toHaveBeenCalledWith(CLI_BINARY, [
-      'gateway',
-      'add',
-      'http://127.0.0.1:17670',
-      '--local',
-      '--name',
-      'kaiden-local',
-    ]);
+    expect(openshellCli.addGateway).toHaveBeenCalledWith({
+      endpoint: 'http://127.0.0.1:17670',
+      local: true,
+      name: 'kaiden-local',
+    });
   });
 
   test('skips registerWithCli when skipRegistration is true', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start({ skipRegistration: true });
 
     expect(spawn).toHaveBeenCalled();
-    expect(exec.exec).not.toHaveBeenCalledWith(CLI_BINARY, expect.arrayContaining(['gateway', 'add']));
+    expect(openshellCli.addGateway).not.toHaveBeenCalled();
   });
 
   test('stops the spawned process when waitForReady fails', async () => {
@@ -368,7 +337,7 @@ describe('start', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(false);
 
     let caughtError: unknown;
     const startPromise = gateway.start().catch((err: unknown) => {
@@ -395,7 +364,7 @@ describe('stop', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -420,7 +389,7 @@ describe('isRunning', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -433,7 +402,7 @@ describe('dispose', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -24,7 +24,6 @@ import { inject, injectable, preDestroy } from 'inversify';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
-import { Exec } from '/@/plugin/util/exec.js';
 import type { OpenshellGatewayStartOptions } from '/@api/openshell-gateway-info.js';
 
 const DEFAULT_PORT = 17670;
@@ -48,8 +47,6 @@ export class OpenshellGateway implements Disposable {
   #bindAddress: string = DEFAULT_BIND_ADDRESS;
 
   constructor(
-    @inject(Exec)
-    private readonly exec: Exec,
     @inject(CliToolRegistry)
     private readonly cliToolRegistry: CliToolRegistry,
     @inject(OpenshellCli)
@@ -66,7 +63,7 @@ export class OpenshellGateway implements Disposable {
             if (!gw.active) {
               await this.openshellCli.selectGateway(gw.name);
             }
-            console.log(`[openshell-gateway] gateway '${gw.name}' is healthy and selected`);
+            console.log(`[openshell-gateway] gateway detected (${gw.endpoint}) and is healthy`);
             return;
           }
         }
@@ -95,17 +92,7 @@ export class OpenshellGateway implements Disposable {
 
   private async isEndpointHealthy(endpoint?: string): Promise<boolean> {
     const target = endpoint ?? `http://${this.#bindAddress}:${this.#port}`;
-    const cliPath = this.getCliPath();
-    const args = ['status', '--gateway-endpoint', target];
-    if (target.startsWith('http://')) {
-      args.push('--gateway-insecure');
-    }
-    try {
-      await this.exec.exec(cliPath, args);
-      return true;
-    } catch {
-      return false;
-    }
+    return this.openshellCli.checkEndpointStatus(target);
   }
 
   private isLocalEndpoint(endpoint: string): boolean {
@@ -120,11 +107,6 @@ export class OpenshellGateway implements Disposable {
   getGatewayBinaryPath(): string | undefined {
     const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell-gateway');
     return tool?.path;
-  }
-
-  private getCliPath(): string {
-    const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
-    return tool?.path ?? 'openshell';
   }
 
   async start(options?: OpenshellGatewayStartOptions): Promise<void> {
@@ -239,18 +221,14 @@ export class OpenshellGateway implements Disposable {
     const endpoint = `http://${this.#bindAddress}:${this.#port}`;
     console.log(`[openshell-gateway] waiting for server at ${endpoint}`);
 
-    const cliPath = this.getCliPath();
     for (let attempt = 0; attempt < MAX_HEALTH_CHECK_ATTEMPTS; attempt++) {
       if (!this.isRunning()) {
         throw new Error('Gateway process exited before becoming ready');
       }
 
-      try {
-        await this.exec.exec(cliPath, ['status', '--gateway-endpoint', endpoint, '--gateway-insecure']);
+      if (await this.openshellCli.checkEndpointStatus(endpoint)) {
         console.log('[openshell-gateway] server is ready');
         return;
-      } catch {
-        // not ready yet
       }
 
       await new Promise<void>(resolve => setTimeout(resolve, HEALTH_CHECK_INTERVAL_MS));
@@ -261,9 +239,8 @@ export class OpenshellGateway implements Disposable {
 
   private async registerWithCli(): Promise<void> {
     const endpoint = `http://${this.#bindAddress}:${this.#port}`;
-    const cliPath = this.getCliPath();
     try {
-      await this.exec.exec(cliPath, ['gateway', 'add', endpoint, '--local', '--name', 'kaiden-local']);
+      await this.openshellCli.addGateway({ endpoint, local: true, name: 'kaiden-local' });
       console.log(`[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Removed the duplicate `getCliPath()` from `OpenshellGateway` and delegated to the already-injected `OpenshellCli` instance
- This ensures the gateway uses the same resolution logic (including the bundled binary fallback) as the rest of the openshell CLI operations

Fixes: https://github.com/openkaiden/kaiden/issues/2327