### PR TITLE
fix(vertex-ai): expand tilde in credentials path before storing secret

### DIFF
--- a/extensions/vertex-ai/src/vertex-ai.spec.ts
+++ b/extensions/vertex-ai/src/vertex-ai.spec.ts
@@ -666,6 +666,25 @@ describe('workspace configuration', () => {
     expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('vertex-ai.connection.VERTEX_AI_REGION', 'us-east5');
   });
 
+  test('should expand tilde in credentials path when storing secret', async () => {
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    const mock = vi.mocked(PROVIDER_MOCK.setInferenceProviderConnectionFactory);
+    const create = mock.mock.calls[0][0].create;
+
+    await create({
+      'vertex-ai.factory.projectId': 'my-project',
+      'vertex-ai.factory.region': 'us-east5',
+      'vertex-ai.factory.credentialsFile': '~/.config/gcloud/application_default_credentials.json',
+    });
+
+    expect(SECRET_STORAGE_MOCK.store).toHaveBeenCalledWith(
+      `${PROVIDER_ID}:fake-uuid-1:token`,
+      join('/home/testuser', '.config/gcloud/application_default_credentials.json'),
+    );
+  });
+
   test('should set workspace configuration for each restored connection', async () => {
     const stored: StoredConnection[] = [
       { id: 'id-1', projectId: 'proj-a', region: 'us-east5', credentialsFile: '/path/a' },

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -282,7 +282,7 @@ export class VertexAi implements Disposable {
     config: VertexAiConnectionConfig,
   ): Promise<void> {
     const secretName = this.getSecretName(connection.id);
-    await this.secrets.store(secretName, config.credentialsFile);
+    await this.secrets.store(secretName, this.resolveCredentialsPath(config.credentialsFile));
 
     const cfg = this.configurationAPI.getConfiguration(undefined, connection);
     await cfg.update('vertex-ai.connection._type', PROVIDER_ID);


### PR DESCRIPTION
The credentials file path (e.g. ~/.config/gcloud/application_default_credentials.json)
was stored as-is in the secret. The openshell CLI does not expand ~, causing
workspace creation to fail with 'No such file or directory'.

Resolve the path via resolveCredentialsPath() before storing so the secret
always contains an absolute path.

fixes #2341 