### PR TITLE
chore: ensure unbinding inversify container on closing the Application

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -799,6 +799,30 @@ describe.each<{
   });
 });
 
+describe('before-quit container disposal', () => {
+  test('should call unbindAll on the container when before-quit is emitted', () => {
+    const beforeQuitCallbacks: (() => void)[] = [];
+    vi.mocked(app.on).mockImplementation(((event: string, cb: () => void) => {
+      if (event === 'before-quit') {
+        beforeQuitCallbacks.push(cb);
+      }
+      return app;
+    }) as typeof app.on);
+
+    const trayMenu = {} as TrayMenu;
+    const deferred = Promise.withResolvers<BrowserWindow>();
+    const ps = new PluginSystem(trayMenu, deferred);
+
+    const unbindAllMock = vi.fn().mockResolvedValue(undefined);
+    (ps as any).container = { unbindAll: unbindAllMock };
+
+    expect(beforeQuitCallbacks).toHaveLength(1);
+    beforeQuitCallbacks[0]!();
+
+    expect(unbindAllMock).toHaveBeenCalled();
+  });
+});
+
 describe('Log race condition fix', () => {
   let pluginSystem: PluginSystem;
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -289,12 +289,17 @@ export class PluginSystem {
   private extensionLoader!: ExtensionLoader;
   private validExtList!: ExtensionInfo[];
 
+  private container: Container | undefined;
+
   constructor(
     private trayMenu: TrayMenu,
     private mainWindowDeferred: PromiseWithResolvers<BrowserWindow>,
   ) {
     app.on('before-quit', () => {
       this.isQuitting = true;
+      this.container
+        ?.unbindAll()
+        .catch((err: unknown) => console.error('[PluginSystem] failed to dispose container:', err));
     });
   }
 
@@ -513,7 +518,8 @@ export class PluginSystem {
     // init api sender
     const apiSender = this.getApiSender(this.getWebContentsSender());
     const webContentsSender = this.getWebContentsSender();
-    const container = new Container();
+    this.container = new Container();
+    const container = this.container;
     container.bind<ApiSenderType>(ApiSenderType).toConstantValue(apiSender);
     container.bind<IPCHandle>(IPCHandle).toConstantValue(this.ipcHandle);
     container.bind<IPCMainOn>(IPCMainOn).toConstantValue(this.ipcMainOn);


### PR DESCRIPTION
with e2e tests it was failing, maybe because the gateway is not stopped.

there is a `@preDestroy` hook but it was never called


note: I'm backporting the fix on Podman Desktop as well