### PR TITLE
feat(api): define OpenShell extension API for gateways and CLIs

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5609,4 +5609,89 @@ declare module '@openkaiden/api' {
   export namespace agents {
     export function registerAgent(agent: Agent): Disposable;
   }
+
+  export interface OpenShellGatewayFeatures {
+    readonly supportMount: boolean;
+  }
+
+  export interface OpenShellGateway {
+    readonly id: string;
+    readonly name: string;
+    readonly endpoint: string;
+    status(): ProviderConnectionStatus;
+    readonly features: OpenShellGatewayFeatures;
+  }
+
+  export interface OpenShellSandboxInfo {
+    readonly id: string;
+    readonly name: string;
+    readonly phase: 'Provisioning' | 'Ready' | 'Error';
+  }
+
+  export interface OpenShellSandboxAttach {
+    readonly columns: number;
+    readonly rows: number;
+    readonly onData: Event<string>;
+    readonly onExit: Event<number>;
+    resize(columns: number, rows: number): void;
+    write(data: string | Buffer): void;
+    kill(): void;
+    clear(): void;
+  }
+
+  export interface OpenShellProviderInfo {
+    readonly name: string;
+    readonly type: string;
+  }
+
+  export interface OpenShellBaseParams {
+    readonly gatewayId: string;
+  }
+
+  export interface OpenShellSandboxParams extends OpenShellBaseParams {
+    readonly sandboxName: string;
+  }
+
+  export interface OpenShellProviderParams extends OpenShellBaseParams {
+    readonly providerName: string;
+  }
+
+  export interface OpenShellCreateProviderParams extends OpenShellProviderParams {
+    readonly providerType: string;
+    readonly credentials: Record<string, string>;
+    readonly config?: Record<string, string>;
+    readonly flags?: ReadonlyArray<string>;
+    readonly env?: Record<string, string>;
+  }
+
+  export interface OpenShellSetInferenceParams extends OpenShellProviderParams {
+    readonly model: string;
+  }
+
+  export interface OpenShellCLI {
+    readonly sandbox: {
+      list(params: OpenShellBaseParams): Promise<OpenShellSandboxInfo[]>;
+      delete(params: OpenShellSandboxParams): Promise<void>;
+      connect(params: OpenShellSandboxParams): OpenShellSandboxAttach;
+      enableV2Provider(params: OpenShellSandboxParams): Promise<void>;
+    };
+    readonly provider: {
+      list(params: OpenShellBaseParams): Promise<ReadonlyArray<OpenShellProviderInfo>>;
+      delete(params: OpenShellProviderParams): Promise<void>;
+      create(params: OpenShellCreateProviderParams): Promise<void>;
+    };
+    readonly inference: {
+      set(params: OpenShellSetInferenceParams): Promise<void>;
+    };
+  }
+
+  export namespace openshell {
+    export function registerGateway(gateway: OpenShellGateway): Disposable;
+    export const onDidRegisterGateway: Event<OpenShellGateway>;
+    export const onDidUnregisterGateway: Event<OpenShellGateway>;
+    export const onDidUpdateGateway: Event<OpenShellGateway>;
+    export function registerCLI(cli: OpenShellCLI): Disposable;
+    export const onDidRegisterCLI: Event<OpenShellCLI>;
+    export const onDidUnregisterCLI: Event<OpenShellCLI>;
+  }
 }

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -66,6 +66,7 @@ import type { KubernetesClient } from '../kubernetes/kubernetes-client.js';
 import type { MenuRegistry } from '../menu-registry.js';
 import type { MessageBox } from '../message-box.js';
 import type { OnboardingRegistry } from '../onboarding-registry.js';
+import type { OpenShellRegistry } from '../openshell-registry.js';
 import type { ProviderRegistry } from '../provider-registry.js';
 import type { Proxy } from '../proxy.js';
 import type { SafeStorageRegistry, SecretStorageWrapper } from '../safe-storage/safe-storage-registry.js';
@@ -234,6 +235,16 @@ const agentRegistry: AgentRegistry = {
   registerAgent: vi.fn(),
 } as unknown as AgentRegistry;
 
+const openShellRegistry: OpenShellRegistry = {
+  registerGateway: vi.fn(),
+  registerCLI: vi.fn(),
+  onDidRegisterGateway: vi.fn(),
+  onDidUnregisterGateway: vi.fn(),
+  onDidUpdateGateway: vi.fn(),
+  onDidRegisterCLI: vi.fn(),
+  onDidUnregisterCLI: vi.fn(),
+} as unknown as OpenShellRegistry;
+
 const safeStorageRegistry: SafeStorageRegistry = {
   getExtensionStorage: vi.fn(),
 } as unknown as SafeStorageRegistry;
@@ -385,6 +396,7 @@ beforeEach(() => {
     kubernetesGeneratorRegistry,
     cliToolRegistry,
     agentRegistry,
+    openShellRegistry,
     notificationRegistry,
     imageCheckerImpl,
     imageFilesImpl,
@@ -2127,6 +2139,63 @@ test('registerAgent', async () => {
   expect(disposables.length).toBe(1);
 
   expect(agentRegistry.registerAgent).toHaveBeenCalledWith(agent);
+});
+
+test('registerGateway', async () => {
+  const disposables: IDisposable[] = [];
+
+  const api = createApi(disposables);
+
+  expect(api).toBeDefined();
+  expect(disposables.length).toBe(0);
+
+  const gateway: containerDesktopAPI.OpenShellGateway = {
+    id: 'gw-1',
+    name: 'Test Gateway',
+    endpoint: 'https://localhost:17670',
+    status: () => 'started',
+    features: { supportMount: false },
+  };
+
+  vi.mocked(openShellRegistry.registerGateway).mockReturnValue(Disposable.create(() => {}));
+
+  api.openshell.registerGateway(gateway);
+  expect(disposables.length).toBe(1);
+
+  expect(openShellRegistry.registerGateway).toHaveBeenCalledWith(gateway);
+});
+
+test('registerCLI', async () => {
+  const disposables: IDisposable[] = [];
+
+  const api = createApi(disposables);
+
+  expect(api).toBeDefined();
+  expect(disposables.length).toBe(0);
+
+  const cli: containerDesktopAPI.OpenShellCLI = {
+    sandbox: {
+      list: vi.fn(),
+      delete: vi.fn(),
+      connect: vi.fn(),
+      enableV2Provider: vi.fn(),
+    },
+    provider: {
+      list: vi.fn(),
+      delete: vi.fn(),
+      create: vi.fn(),
+    },
+    inference: {
+      set: vi.fn(),
+    },
+  };
+
+  vi.mocked(openShellRegistry.registerCLI).mockReturnValue(Disposable.create(() => {}));
+
+  api.openshell.registerCLI(cli);
+  expect(disposables.length).toBe(1);
+
+  expect(openShellRegistry.registerCLI).toHaveBeenCalledWith(cli);
 });
 
 test('registerImageCheckerProvider ', async () => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -77,6 +77,7 @@ import { MCPRegistry } from '../mcp/mcp-registry.js';
 import { MessageBox } from '../message-box.js';
 import { ModuleLoader } from '../module-loader.js';
 import { OnboardingRegistry } from '../onboarding-registry.js';
+import { OpenShellRegistry } from '../openshell-registry.js';
 import { ProviderRegistry } from '../provider-registry.js';
 import { Proxy } from '../proxy.js';
 import { createHttpPatchedModules } from '../proxy-resolver.js';
@@ -202,6 +203,8 @@ export class ExtensionLoader implements IAsyncDisposable {
     private cliToolRegistry: CliToolRegistry,
     @inject(AgentRegistry)
     private agentRegistry: AgentRegistry,
+    @inject(OpenShellRegistry)
+    private openShellRegistry: OpenShellRegistry,
     @inject(NotificationRegistry)
     private notificationRegistry: NotificationRegistry,
     @inject(ImageCheckerImpl)
@@ -1707,6 +1710,34 @@ export class ExtensionLoader implements IAsyncDisposable {
       },
     };
 
+    const openshell: typeof containerDesktopAPI.openshell = {
+      registerGateway(gateway: containerDesktopAPI.OpenShellGateway): containerDesktopAPI.Disposable {
+        const disposable = instance.openShellRegistry.registerGateway(gateway);
+        disposables.push(disposable);
+        return disposable;
+      },
+      onDidRegisterGateway: (listener, thisArg, disposableArr) => {
+        return instance.openShellRegistry.onDidRegisterGateway(listener, thisArg, disposableArr);
+      },
+      onDidUnregisterGateway: (listener, thisArg, disposableArr) => {
+        return instance.openShellRegistry.onDidUnregisterGateway(listener, thisArg, disposableArr);
+      },
+      onDidUpdateGateway: (listener, thisArg, disposableArr) => {
+        return instance.openShellRegistry.onDidUpdateGateway(listener, thisArg, disposableArr);
+      },
+      registerCLI(cli: containerDesktopAPI.OpenShellCLI): containerDesktopAPI.Disposable {
+        const disposable = instance.openShellRegistry.registerCLI(cli);
+        disposables.push(disposable);
+        return disposable;
+      },
+      onDidRegisterCLI: (listener, thisArg, disposableArr) => {
+        return instance.openShellRegistry.onDidRegisterCLI(listener, thisArg, disposableArr);
+      },
+      onDidUnregisterCLI: (listener, thisArg, disposableArr) => {
+        return instance.openShellRegistry.onDidUnregisterCLI(listener, thisArg, disposableArr);
+      },
+    };
+
     return <typeof containerDesktopAPI>{
       // Types
       Disposable: Disposable,
@@ -1744,6 +1775,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       net,
       mcpRegistry,
       agents,
+      openshell,
     };
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -72,6 +72,7 @@ import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import { OpenshellImageBuilder } from '/@/plugin/openshell-cli/openshell-image-builder.js';
+import { OpenShellRegistry } from '/@/plugin/openshell-registry.js';
 import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
 import { SchedulerRegistry } from '/@/plugin/scheduler/scheduler-registry.js';
 import { OpenshellSecretAdapter } from '/@/plugin/secret-manager/openshell-secret-adapter.js';
@@ -591,6 +592,7 @@ export class PluginSystem {
     container.bind<MCPManager>(MCPManager).toSelf().inSingletonScope();
     container.bind<CliToolRegistry>(CliToolRegistry).toSelf().inSingletonScope();
     container.bind<AgentRegistry>(AgentRegistry).toSelf().inSingletonScope();
+    container.bind<OpenShellRegistry>(OpenShellRegistry).toSelf().inSingletonScope();
     container.bind<OpenshellCli>(OpenshellCli).toSelf().inSingletonScope();
     container.bind<OpenshellGateway>(OpenshellGateway).toSelf().inSingletonScope();
     container.bind<OpenshellImageBuilder>(OpenshellImageBuilder).toSelf().inSingletonScope();

--- a/packages/main/src/plugin/openshell-registry.spec.ts
+++ b/packages/main/src/plugin/openshell-registry.spec.ts
@@ -1,0 +1,211 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { OpenShellCLI, OpenShellGateway } from '@openkaiden/api';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+
+import { OpenShellRegistry } from './openshell-registry.js';
+
+const apiSender: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
+};
+
+let registry: OpenShellRegistry;
+
+function createGateway(overrides?: Partial<OpenShellGateway>): OpenShellGateway {
+  return {
+    id: 'gw-1',
+    name: 'Test Gateway',
+    endpoint: 'https://localhost:17670',
+    status: () => 'started',
+    features: { supportMount: false },
+    ...overrides,
+  };
+}
+
+function createCLI(overrides?: Partial<OpenShellCLI>): OpenShellCLI {
+  return {
+    sandbox: {
+      list: vi.fn(),
+      delete: vi.fn(),
+      connect: vi.fn(),
+      enableV2Provider: vi.fn(),
+    },
+    provider: {
+      list: vi.fn(),
+      delete: vi.fn(),
+      create: vi.fn(),
+    },
+    inference: {
+      set: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+describe('OpenShellRegistry', () => {
+  beforeEach(() => {
+    registry = new OpenShellRegistry(apiSender);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('registerGateway', () => {
+    test('sends openshell-registry:gateway-update event via apiSender', () => {
+      registry.registerGateway(createGateway());
+
+      expect(apiSender.send).toHaveBeenCalledWith('openshell-registry:gateway-update');
+    });
+
+    test('fires onDidRegisterGateway event with the gateway', () => {
+      const listener = vi.fn();
+      registry.onDidRegisterGateway(listener);
+
+      const gateway = createGateway();
+      registry.registerGateway(gateway);
+
+      expect(listener).toHaveBeenCalledWith(gateway);
+    });
+
+    test('throws when registering duplicate gateway id', () => {
+      registry.registerGateway(createGateway());
+
+      expect(() => registry.registerGateway(createGateway())).toThrow(
+        `OpenShell gateway with id 'gw-1' is already registered`,
+      );
+    });
+
+    test('returns a Disposable that removes the gateway', () => {
+      const disposable = registry.registerGateway(createGateway());
+
+      expect(registry.getGateways()).toHaveLength(1);
+
+      disposable.dispose();
+
+      expect(registry.getGateways()).toHaveLength(0);
+    });
+
+    test('dispose sends openshell-registry:gateway-update event', () => {
+      const disposable = registry.registerGateway(createGateway());
+
+      disposable.dispose();
+
+      expect(apiSender.send).toHaveBeenCalledTimes(2);
+      expect(apiSender.send).toHaveBeenNthCalledWith(2, 'openshell-registry:gateway-update');
+    });
+
+    test('dispose fires onDidUnregisterGateway event', () => {
+      const listener = vi.fn();
+      registry.onDidUnregisterGateway(listener);
+
+      const gateway = createGateway();
+      const disposable = registry.registerGateway(gateway);
+      disposable.dispose();
+
+      expect(listener).toHaveBeenCalledWith(gateway);
+    });
+  });
+
+  describe('getGateways', () => {
+    test('returns empty array when no gateways registered', () => {
+      expect(registry.getGateways()).toEqual([]);
+    });
+
+    test('returns registered gateways', () => {
+      const gateway = createGateway();
+      registry.registerGateway(gateway);
+
+      const gateways = registry.getGateways();
+      expect(gateways).toHaveLength(1);
+      expect(gateways[0]!.id).toBe('gw-1');
+    });
+
+    test('returns multiple gateways', () => {
+      registry.registerGateway(createGateway({ id: 'gw-1', name: 'Gateway 1' }));
+      registry.registerGateway(createGateway({ id: 'gw-2', name: 'Gateway 2' }));
+
+      expect(registry.getGateways()).toHaveLength(2);
+    });
+  });
+
+  describe('registerCLI', () => {
+    test('sends openshell-registry:cli-update event via apiSender', () => {
+      registry.registerCLI(createCLI());
+
+      expect(apiSender.send).toHaveBeenCalledWith('openshell-registry:cli-update');
+    });
+
+    test('fires onDidRegisterCLI event with the CLI', () => {
+      const listener = vi.fn();
+      registry.onDidRegisterCLI(listener);
+
+      const cli = createCLI();
+      registry.registerCLI(cli);
+
+      expect(listener).toHaveBeenCalledWith(cli);
+    });
+
+    test('returns a Disposable that removes the CLI', () => {
+      const disposable = registry.registerCLI(createCLI());
+
+      expect(registry.getCLIs()).toHaveLength(1);
+
+      disposable.dispose();
+
+      expect(registry.getCLIs()).toHaveLength(0);
+    });
+
+    test('dispose sends openshell-registry:cli-update event', () => {
+      const disposable = registry.registerCLI(createCLI());
+
+      disposable.dispose();
+
+      expect(apiSender.send).toHaveBeenCalledTimes(2);
+      expect(apiSender.send).toHaveBeenNthCalledWith(2, 'openshell-registry:cli-update');
+    });
+
+    test('dispose fires onDidUnregisterCLI event', () => {
+      const listener = vi.fn();
+      registry.onDidUnregisterCLI(listener);
+
+      const cli = createCLI();
+      const disposable = registry.registerCLI(cli);
+      disposable.dispose();
+
+      expect(listener).toHaveBeenCalledWith(cli);
+    });
+
+    test('allows registering multiple CLIs', () => {
+      registry.registerCLI(createCLI());
+      registry.registerCLI(createCLI());
+
+      expect(registry.getCLIs()).toHaveLength(2);
+    });
+  });
+
+  describe('getCLIs', () => {
+    test('returns empty array when no CLIs registered', () => {
+      expect(registry.getCLIs()).toEqual([]);
+    });
+  });
+});

--- a/packages/main/src/plugin/openshell-registry.spec.ts
+++ b/packages/main/src/plugin/openshell-registry.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { OpenShellCLI, OpenShellGateway } from '@openkaiden/api';
+import type { OpenShellCLI, OpenShellGateway, ProviderConnectionStatus } from '@openkaiden/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
@@ -206,6 +206,83 @@ describe('OpenShellRegistry', () => {
   describe('getCLIs', () => {
     test('returns empty array when no CLIs registered', () => {
       expect(registry.getCLIs()).toEqual([]);
+    });
+  });
+
+  describe('gateway status polling', () => {
+    let pollingRegistry: OpenShellRegistry;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      pollingRegistry = new OpenShellRegistry(apiSender);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test('fires onDidUpdateGateway when gateway status changes', () => {
+      const listener = vi.fn();
+      pollingRegistry.onDidUpdateGateway(listener);
+
+      let currentStatus: ProviderConnectionStatus = 'started';
+      const gateway = createGateway({ status: () => currentStatus });
+      pollingRegistry.registerGateway(gateway);
+      vi.mocked(apiSender.send).mockClear();
+
+      currentStatus = 'stopped';
+      vi.advanceTimersByTime(5000);
+
+      expect(listener).toHaveBeenCalledWith(gateway);
+      expect(apiSender.send).toHaveBeenCalledWith('openshell-registry:gateway-update');
+    });
+
+    test('does not fire event when status stays the same', () => {
+      const listener = vi.fn();
+      pollingRegistry.onDidUpdateGateway(listener);
+
+      const gateway = createGateway({ status: () => 'started' });
+      pollingRegistry.registerGateway(gateway);
+
+      vi.advanceTimersByTime(5000);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('dispose stops polling', () => {
+      const listener = vi.fn();
+      pollingRegistry.onDidUpdateGateway(listener);
+
+      let currentStatus: ProviderConnectionStatus = 'started';
+      const gateway = createGateway({ status: () => currentStatus });
+      pollingRegistry.registerGateway(gateway);
+      vi.mocked(apiSender.send).mockClear();
+
+      pollingRegistry.dispose();
+
+      currentStatus = 'stopped';
+      vi.advanceTimersByTime(5000);
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(apiSender.send).not.toHaveBeenCalled();
+    });
+
+    test('does not poll disposed gateways', () => {
+      const listener = vi.fn();
+      pollingRegistry.onDidUpdateGateway(listener);
+
+      let currentStatus: ProviderConnectionStatus = 'started';
+      const gateway = createGateway({ status: () => currentStatus });
+      const disposable = pollingRegistry.registerGateway(gateway);
+
+      disposable.dispose();
+      vi.mocked(apiSender.send).mockClear();
+
+      currentStatus = 'stopped';
+      vi.advanceTimersByTime(5000);
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(apiSender.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/main/src/plugin/openshell-registry.spec.ts
+++ b/packages/main/src/plugin/openshell-registry.spec.ts
@@ -63,11 +63,12 @@ function createCLI(overrides?: Partial<OpenShellCLI>): OpenShellCLI {
 
 describe('OpenShellRegistry', () => {
   beforeEach(() => {
+    vi.resetAllMocks();
     registry = new OpenShellRegistry(apiSender);
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
+    registry.dispose();
   });
 
   describe('registerGateway', () => {

--- a/packages/main/src/plugin/openshell-registry.ts
+++ b/packages/main/src/plugin/openshell-registry.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { OpenShellCLI, OpenShellGateway } from '@openkaiden/api';
+import { inject, injectable } from 'inversify';
+
+import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { Event } from '/@api/event.js';
+
+import { Emitter } from './events/emitter.js';
+import { Disposable } from './types/disposable.js';
+
+@injectable()
+export class OpenShellRegistry {
+  constructor(@inject(ApiSenderType) private apiSender: ApiSenderType) {}
+
+  private gateways = new Map<string, OpenShellGateway>();
+  private clis: OpenShellCLI[] = [];
+
+  private readonly _onDidRegisterGateway = new Emitter<OpenShellGateway>();
+  readonly onDidRegisterGateway: Event<OpenShellGateway> = this._onDidRegisterGateway.event;
+
+  private readonly _onDidUnregisterGateway = new Emitter<OpenShellGateway>();
+  readonly onDidUnregisterGateway: Event<OpenShellGateway> = this._onDidUnregisterGateway.event;
+
+  private readonly _onDidUpdateGateway = new Emitter<OpenShellGateway>();
+  readonly onDidUpdateGateway: Event<OpenShellGateway> = this._onDidUpdateGateway.event;
+
+  private readonly _onDidRegisterCLI = new Emitter<OpenShellCLI>();
+  readonly onDidRegisterCLI: Event<OpenShellCLI> = this._onDidRegisterCLI.event;
+
+  private readonly _onDidUnregisterCLI = new Emitter<OpenShellCLI>();
+  readonly onDidUnregisterCLI: Event<OpenShellCLI> = this._onDidUnregisterCLI.event;
+
+  registerGateway(gateway: OpenShellGateway): Disposable {
+    if (this.gateways.has(gateway.id)) {
+      throw new Error(`OpenShell gateway with id '${gateway.id}' is already registered`);
+    }
+
+    this.gateways.set(gateway.id, gateway);
+    this.apiSender.send('openshell-registry:gateway-update');
+    this._onDidRegisterGateway.fire(gateway);
+
+    return Disposable.create(() => {
+      this.gateways.delete(gateway.id);
+      this.apiSender.send('openshell-registry:gateway-update');
+      this._onDidUnregisterGateway.fire(gateway);
+    });
+  }
+
+  registerCLI(cli: OpenShellCLI): Disposable {
+    this.clis.push(cli);
+    this.apiSender.send('openshell-registry:cli-update');
+    this._onDidRegisterCLI.fire(cli);
+
+    return Disposable.create(() => {
+      const index = this.clis.indexOf(cli);
+      if (index >= 0) {
+        this.clis.splice(index, 1);
+      }
+      this.apiSender.send('openshell-registry:cli-update');
+      this._onDidUnregisterCLI.fire(cli);
+    });
+  }
+
+  getGateways(): readonly OpenShellGateway[] {
+    return Array.from(this.gateways.values());
+  }
+
+  getCLIs(): readonly OpenShellCLI[] {
+    return Array.from(this.clis);
+  }
+}

--- a/packages/main/src/plugin/openshell-registry.ts
+++ b/packages/main/src/plugin/openshell-registry.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { OpenShellCLI, OpenShellGateway } from '@openkaiden/api';
+import type { OpenShellCLI, OpenShellGateway, ProviderConnectionStatus } from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
@@ -27,9 +27,14 @@ import { Disposable } from './types/disposable.js';
 
 @injectable()
 export class OpenShellRegistry {
-  constructor(@inject(ApiSenderType) private apiSender: ApiSenderType) {}
+  private intervalId: NodeJS.Timeout | undefined;
+
+  constructor(@inject(ApiSenderType) private apiSender: ApiSenderType) {
+    this.startGatewayStatusPolling();
+  }
 
   private gateways = new Map<string, OpenShellGateway>();
+  private gatewayStatuses = new Map<string, ProviderConnectionStatus>();
   private clis: OpenShellCLI[] = [];
 
   private readonly _onDidRegisterGateway = new Emitter<OpenShellGateway>();
@@ -53,11 +58,13 @@ export class OpenShellRegistry {
     }
 
     this.gateways.set(gateway.id, gateway);
+    this.gatewayStatuses.set(gateway.id, gateway.status());
     this.apiSender.send('openshell-registry:gateway-update');
     this._onDidRegisterGateway.fire(gateway);
 
     return Disposable.create(() => {
       this.gateways.delete(gateway.id);
+      this.gatewayStatuses.delete(gateway.id);
       this.apiSender.send('openshell-registry:gateway-update');
       this._onDidUnregisterGateway.fire(gateway);
     });
@@ -84,5 +91,25 @@ export class OpenShellRegistry {
 
   getCLIs(): readonly OpenShellCLI[] {
     return Array.from(this.clis);
+  }
+
+  startGatewayStatusPolling(): void {
+    this.intervalId = setInterval(() => {
+      for (const gateway of this.gateways.values()) {
+        const status = gateway.status();
+        if (status !== this.gatewayStatuses.get(gateway.id)) {
+          this.gatewayStatuses.set(gateway.id, status);
+          this.apiSender.send('openshell-registry:gateway-update');
+          this._onDidUpdateGateway.fire(gateway);
+        }
+      }
+    }, 5000);
+  }
+
+  dispose(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+    }
   }
 }

--- a/packages/main/src/plugin/openshell-registry.ts
+++ b/packages/main/src/plugin/openshell-registry.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 
 import type { OpenShellCLI, OpenShellGateway, ProviderConnectionStatus } from '@openkaiden/api';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, preDestroy } from 'inversify';
+import { IDisposable } from 'node-pty';
 
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { Event } from '/@api/event.js';
@@ -26,7 +27,7 @@ import { Emitter } from './events/emitter.js';
 import { Disposable } from './types/disposable.js';
 
 @injectable()
-export class OpenShellRegistry {
+export class OpenShellRegistry implements IDisposable {
   private intervalId: NodeJS.Timeout | undefined;
 
   constructor(@inject(ApiSenderType) private apiSender: ApiSenderType) {
@@ -106,6 +107,7 @@ export class OpenShellRegistry {
     }, 5000);
   }
 
+  @preDestroy()
   dispose(): void {
     if (this.intervalId) {
       clearInterval(this.intervalId);


### PR DESCRIPTION
## Summary
- Add new `openshell` namespace to the extension API with types and registration points for OpenShell gateways and CLI clients
- Define `OpenShellGateway`, `OpenShellCLI`, `OpenShellSandboxInfo`, `OpenShellSandboxAttach`, and associated params interfaces
- Implement `OpenShellRegistry` class with gateway/CLI registration, lifecycle events, and Disposable management
- Wire the namespace through extension-loader and DI container

## Test plan
- [x] `pnpm run typecheck` passes across all packages
- [x] `pnpm run lint:check` passes
- [x] 16 new unit tests in `openshell-registry.spec.ts` pass
- [x] 2 new integration tests in `extension-loader.spec.ts` pass (registerGateway, registerCLI)
- [x] All existing 114 extension-loader tests still pass

Fixes #2328

🤖 Generated with [Claude Code](https://claude.com/claude-code)