### PR TITLE
chore(extensions): disable agent extensions except opencode and claude

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -410,7 +410,15 @@ export class ExtensionLoader implements IAsyncDisposable {
   getDisabledExtensionIds(): string[] {
     return this.configurationRegistry
       .getConfiguration(ExtensionLoaderSettings.SectionName)
-      .get<string[]>(ExtensionLoaderSettings.Disabled, ['kaiden.openai']);
+      .get<string[]>(ExtensionLoaderSettings.Disabled, [
+        'kaiden.openai',
+        'kaiden.codex',
+        'kaiden.copilot',
+        'kaiden.openclaw',
+        'kaiden.goose',
+        'kaiden.gemini',
+        'kaiden.cursor',
+      ]);
   }
 
   setDisabledExtensionIds(disabledExtensionIds: string[]): void {


### PR DESCRIPTION
For 0.3 the other agent integrations are not in a release-ready state. Add codex, copilot, openclaw, goose, gemini, and cursor to the default disabled list so only opencode and claude activate out of the box.

Closes #2320