### PR TITLE
fix(workspaces): skip per-sandbox providers_v2_enabled when set globally

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -300,10 +300,18 @@ describe('create – OpenShell mode', () => {
     expect(result).toEqual({ id: 'my-sandbox' });
   });
 
-  test('calls openshellCli.enableV2Provider after createSandbox', async () => {
+  test('calls openshellCli.enableV2Provider when not globally enabled', async () => {
+    vi.mocked(openshellCli.isV2ProviderEnabled).mockResolvedValue(false);
     await manager.create(defaultOptions);
 
     expect(openshellCli.enableV2Provider).toHaveBeenCalledWith('my-sandbox');
+  });
+
+  test('skips openshellCli.enableV2Provider when globally enabled', async () => {
+    vi.mocked(openshellCli.isV2ProviderEnabled).mockResolvedValue(true);
+    await manager.create(defaultOptions);
+
+    expect(openshellCli.enableV2Provider).not.toHaveBeenCalled();
   });
 
   test('derives sandbox name from sourcePath basename when name is omitted', async () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -205,7 +205,10 @@ export class AgentWorkspaceManager implements Disposable {
       command: ['true'],
     });
 
-    await this.openshellCli.enableV2Provider(sandboxName);
+    const v2Globally = await this.openshellCli.isV2ProviderEnabled();
+    if (!v2Globally) {
+      await this.openshellCli.enableV2Provider(sandboxName);
+    }
 
     const finalNetwork = workspace.network;
     if (finalNetwork) {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -1153,6 +1153,60 @@ describe('setInference', () => {
   });
 });
 
+describe('isV2ProviderEnabled', () => {
+  const GLOBAL_SETTINGS = {
+    scope: 'global',
+    settings: {
+      agent_policy_proposals_enabled: '<unset>',
+      ocsf_json_enabled: '<unset>',
+      proposal_approval_mode: '<unset>',
+      providers_v2_enabled: '<unset>',
+    },
+    settings_revision: 0,
+  };
+
+  test('returns true when setting is globally enabled', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(
+      mockExecResult(
+        JSON.stringify({ ...GLOBAL_SETTINGS, settings: { ...GLOBAL_SETTINGS.settings, providers_v2_enabled: true } }),
+      ),
+    );
+
+    const result = await openshellCli.isV2ProviderEnabled();
+
+    expect(result).toBe(true);
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['settings', 'get', '--global', '--json']);
+  });
+
+  test('returns true when value is string "true"', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(
+      mockExecResult(
+        JSON.stringify({ ...GLOBAL_SETTINGS, settings: { ...GLOBAL_SETTINGS.settings, providers_v2_enabled: 'true' } }),
+      ),
+    );
+
+    const result = await openshellCli.isV2ProviderEnabled();
+
+    expect(result).toBe(true);
+  });
+
+  test('returns false when setting is unset', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(GLOBAL_SETTINGS)));
+
+    const result = await openshellCli.isV2ProviderEnabled();
+
+    expect(result).toBe(false);
+  });
+
+  test('returns false when command fails', async () => {
+    vi.mocked(exec.exec).mockRejectedValue(new Error('setting not found'));
+
+    const result = await openshellCli.isV2ProviderEnabled();
+
+    expect(result).toBe(false);
+  });
+});
+
 describe('enableV2Provider', () => {
   test('executes settings set with sandbox name', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -38,6 +38,19 @@ import type {
 } from '/@api/openshell-gateway-info.js';
 import { GatewayInfoSchema, OpenshellProviderInfoSchema, SandboxInfoSchema } from '/@api/openshell-gateway-info.js';
 
+const SettingValue = z.union([z.string(), z.boolean(), z.number()]);
+
+const OpenshellSettingsSchema = z.looseObject({
+  scope: z.string(),
+  settings: z.looseObject({
+    agent_policy_proposals_enabled: SettingValue,
+    ocsf_json_enabled: SettingValue,
+    proposal_approval_mode: SettingValue,
+    providers_v2_enabled: SettingValue,
+  }),
+  settings_revision: z.number(),
+});
+
 /**
  * Low-level wrapper around the `openshell` CLI binary.
  *
@@ -370,6 +383,18 @@ export class OpenshellCli {
 
   async setInference(options: SetInferenceOptions): Promise<void> {
     return this.runCli(['inference', 'set', '--provider', options.provider, '--model', options.model, '--no-verify']);
+  }
+
+  async isV2ProviderEnabled(): Promise<boolean> {
+    const cliPath = this.getCliPath();
+    try {
+      const result = await this.exec.exec(cliPath, ['settings', 'get', '--global', '--json']);
+      const parsed = OpenshellSettingsSchema.parse(JSON.parse(result.stdout));
+      const value = parsed.settings.providers_v2_enabled;
+      return value === true || value === 'true';
+    } catch {
+      return false;
+    }
   }
 
   async enableV2Provider(sandboxName: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `isV2ProviderEnabled()` method to `OpenshellCli` that queries global openshell settings via `openshell settings get --global --json`
- `enableV2Provider()` is now skipped during sandbox creation when the setting is already managed globally, preventing the CLI rejection error
- Added `OpenshellSettingsSchema` zod schema for validating the settings response

Fixes #2343

## Test plan
- [x] Unit tests for `isV2ProviderEnabled` (true/false/error cases)
- [x] Unit tests for conditional `enableV2Provider` call in workspace manager
- [x] Typecheck passes
- [ ] Manual test: set `providers_v2_enabled` globally, then create a workspace with Vertex AI — should succeed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)