### PR TITLE
fix(agent-workspace): make model mandatory in create workspace

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -64,7 +64,7 @@ export type AgentWorkspaceMount = configComponents['schemas']['Mount'];
 export interface AgentWorkspaceCreateOptions {
   sourcePath: string;
   agent: string;
-  model?: string;
+  model: string;
   runtime?: string;
   name?: string;
   project?: string;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -258,6 +258,11 @@ describe('watchInstancesFile', () => {
   });
 });
 
+test('rejects with a descriptive error when model is missing at runtime', async () => {
+  const options = { sourcePath: '/tmp/p', agent: 'claude' } as AgentWorkspaceCreateOptions;
+  await expect(manager.create(options)).rejects.toThrow(/model is required to create a workspace/);
+});
+
 describe('create – OpenShell mode', () => {
   const defaultOptions: AgentWorkspaceCreateOptions = {
     sourcePath: '/tmp/my-project',

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -721,6 +721,7 @@ describe('ensureModelSecret', () => {
   const baseOptions: AgentWorkspaceCreateOptions = {
     sourcePath: '/tmp/my-project',
     agent: 'claude',
+    model: 'anthropic::claude-sonnet-4::',
     name: 'my-workspace',
   };
 
@@ -730,13 +731,6 @@ describe('ensureModelSecret', () => {
       model: 'anthropic::claude-sonnet-4-20250514::',
       workspaceConfiguration: { secrets: ['anthropic'] },
     } as AgentWorkspaceCreateOptions;
-    await manager.ensureModelSecret(options);
-
-    expect(secretManager.getSecretForModel).not.toHaveBeenCalled();
-  });
-
-  test('skips when no model is provided', async () => {
-    const options = { ...baseOptions };
     await manager.ensureModelSecret(options);
 
     expect(secretManager.getSecretForModel).not.toHaveBeenCalled();

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -106,6 +106,10 @@ export class AgentWorkspaceManager implements Disposable {
     task.state = 'running';
     task.status = 'in-progress';
     try {
+      if (!options.model) {
+        throw new Error('model is required to create a workspace');
+      }
+
       if (options.replaceConfig) {
         const configPath = join(options.sourcePath, '.kaiden', 'workspace.json');
         await rm(configPath, { force: true });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -127,13 +127,10 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   private async createOpenshell(options: AgentWorkspaceCreateOptions, secretName?: string): Promise<AgentWorkspaceId> {
-    if (options.model === undefined) {
-      throw new Error(`Can't start workspace without model`);
-    }
     const connectionInfo = this.providerRegistry.getInferenceConnectionCredentials(options.model);
 
-    const modelName = options.model?.split('::')[1] ?? '';
-    const rawEndpoint = connectionInfo?.endpoint ?? options.model?.split('::')[2] ?? undefined;
+    const modelName = options.model.split('::')[1] ?? '';
+    const rawEndpoint = connectionInfo?.endpoint ?? options.model.split('::')[2] ?? undefined;
     const endpoint = rawEndpoint ? rewriteLocalhostUrl(rawEndpoint) : undefined;
 
     const workspace = await writeWorkspaceConfig(options);
@@ -280,10 +277,6 @@ export class AgentWorkspaceManager implements Disposable {
    * model. Return undefined if there is no secret associated with this connection
 ·   */
   async ensureModelSecret(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
-    if (!options.model) {
-      return undefined;
-    }
-
     if (options.workspaceConfiguration?.secrets?.length) {
       return undefined;
     }
@@ -292,7 +285,7 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   private async ensureModelSecretFromConfig(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
-    const secret = await this.secretManager.getSecretForModel(options.model!);
+    const secret = await this.secretManager.getSecretForModel(options.model);
     if (!secret) return undefined;
 
     options.secrets = [...new Set([...(options.secrets ?? []), secret.name])];

--- a/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
@@ -36,6 +36,7 @@ function mockEnoent(): NodeJS.ErrnoException {
 const defaultOptions: AgentWorkspaceCreateOptions = {
   sourcePath: '/tmp/my-project',
   agent: 'claude',
+  model: 'anthropic::claude-sonnet-4::',
   runtime: 'podman',
 };
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -931,9 +931,20 @@ test('Expect use-all-defaults button disabled when no model available', async ()
   expect(screen.getByRole('button', { name: 'Use all defaults and create workspace' })).toBeDisabled();
 });
 
-test('Expect Start Workspace button disabled when no model available', async () => {
+test('Expect Continue button disabled on agent & model step when no model available', async () => {
   setProviders([]);
 
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+  expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+});
+
+test('Expect Start Workspace button disabled when no model available', async () => {
   render(AgentWorkspaceCreate);
 
   await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
@@ -944,7 +955,12 @@ test('Expect Start Workspace button disabled when no model available', async () 
     await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
   }
 
-  expect(screen.getByRole('button', { name: 'Start Workspace' })).toBeDisabled();
+  setProviders([]);
+  wizard.draft.selectedModel = undefined;
+
+  await vi.waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Start Workspace' })).toBeDisabled();
+  });
 });
 
 test('Expect first compatible model used when defaultWorkspaceSettings is undefined and providers exist', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -84,6 +84,42 @@ function setProviders(providers: ProviderInfo[]): void {
   vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(buildCatalogModels(providers));
 }
 
+const mockAnthropicProvider: ProviderInfo = {
+  id: 'claude',
+  name: 'Anthropic',
+  internalId: 'claude-internal',
+  status: 'started',
+  inferenceConnections: [
+    {
+      id: 'conn-0',
+      name: 'Anthropic Cloud',
+      type: 'cloud',
+      status: 'started',
+      llmMetadata: { name: 'anthropic' },
+      models: [{ label: 'claude-sonnet-4' }, { label: 'claude-opus-4' }],
+    },
+  ],
+  inferenceProviderConnectionCreation: false,
+} as unknown as ProviderInfo;
+
+const mockOllamaProvider: ProviderInfo = {
+  id: 'ollama',
+  name: 'Ollama',
+  internalId: 'ollama-internal',
+  status: 'started',
+  inferenceConnections: [
+    {
+      id: 'conn-1',
+      name: 'Ollama Local',
+      type: 'local',
+      status: 'started',
+      llmMetadata: { name: 'ollama' },
+      models: [{ label: 'llama3.2:3b' }],
+    },
+  ],
+  inferenceProviderConnectionCreation: false,
+} as unknown as ProviderInfo;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -125,7 +161,7 @@ beforeEach(() => {
   vi.mocked(skillsStore).skillInfos = writable<SkillInfo[]>([]);
   vi.mocked(mcpStore).mcpRemoteServerInfos = writable<MCPRemoteServerInfo[]>([]);
   vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([]);
-  setProviders([]);
+  setProviders([mockAnthropicProvider]);
   vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
   vi.mocked(modelCatalogStore).disabledModels = writable<Set<string>>(new Set());
   vi.mocked(modelCatalogStore.isModelEnabled).mockImplementation(
@@ -839,42 +875,6 @@ test('Expect createAgentWorkspace called without network when agent_mode selecte
   );
 });
 
-const mockAnthropicProvider: ProviderInfo = {
-  id: 'claude',
-  name: 'Anthropic',
-  internalId: 'claude-internal',
-  status: 'started',
-  inferenceConnections: [
-    {
-      id: 'conn-0',
-      name: 'Anthropic Cloud',
-      type: 'cloud',
-      status: 'started',
-      llmMetadata: { name: 'anthropic' },
-      models: [{ label: 'claude-sonnet-4' }, { label: 'claude-opus-4' }],
-    },
-  ],
-  inferenceProviderConnectionCreation: false,
-} as unknown as ProviderInfo;
-
-const mockOllamaProvider: ProviderInfo = {
-  id: 'ollama',
-  name: 'Ollama',
-  internalId: 'ollama-internal',
-  status: 'started',
-  inferenceConnections: [
-    {
-      id: 'conn-1',
-      name: 'Ollama Local',
-      type: 'local',
-      status: 'started',
-      llmMetadata: { name: 'ollama' },
-      models: [{ label: 'llama3.2:3b' }],
-    },
-  ],
-  inferenceProviderConnectionCreation: false,
-} as unknown as ProviderInfo;
-
 test('Expect default model from onboarding.defaultWorkspaceSettings when valid', async () => {
   vi.mocked(window.getConfigurationValue).mockResolvedValue({
     defaultAgent: 'opencode',
@@ -919,24 +919,32 @@ test('Expect first compatible model used when defaultWorkspaceSettings has no mo
   );
 });
 
-test('Expect model empty when no setting and no providers', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue({ defaultAgent: 'opencode' });
+test('Expect use-all-defaults button disabled when no model available', async () => {
+  setProviders([]);
 
   render(AgentWorkspaceCreate);
 
   await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
     target: { value: '/home/user/my-repo' },
   });
-  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
 
-  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
-    expect.objectContaining({
-      model: undefined,
-      agent: 'opencode',
-      name: 'my-repo',
-      skills: undefined,
-    }),
-  );
+  expect(screen.getByRole('button', { name: 'Use all defaults and create workspace' })).toBeDisabled();
+});
+
+test('Expect Start Workspace button disabled when no model available', async () => {
+  setProviders([]);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+
+  for (let i = 0; i < wizardStepCount - 1; i++) {
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  }
+
+  expect(screen.getByRole('button', { name: 'Start Workspace' })).toBeDisabled();
 });
 
 test('Expect first compatible model used when defaultWorkspaceSettings is undefined and providers exist', async () => {
@@ -1487,7 +1495,7 @@ test('Expect config-exists notification not shown when no existing config', asyn
   expect(screen.queryByText(/existing workspace configuration was found/)).not.toBeInTheDocument();
 });
 
-test('Expect Start workspace as-is calls createAgentWorkspace with minimal options', async () => {
+test('Expect Start workspace as-is calls createAgentWorkspace with model', async () => {
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(true);
 
   render(AgentWorkspaceCreate);
@@ -1507,6 +1515,7 @@ test('Expect Start workspace as-is calls createAgentWorkspace with minimal optio
       sourcePath: '/home/user/existing-project',
       runtime: 'podman',
       agent: 'opencode',
+      model: 'anthropic::claude-sonnet-4::',
       name: 'existing-project',
     }),
   );
@@ -1515,6 +1524,23 @@ test('Expect Start workspace as-is calls createAgentWorkspace with minimal optio
       replaceConfig: expect.anything(),
     }),
   );
+});
+
+test('Expect Start workspace as-is button disabled when no model available', async () => {
+  setProviders([]);
+  vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(true);
+
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/existing-project' },
+  });
+
+  await vi.waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Start workspace as-is' })).toBeInTheDocument();
+  });
+
+  expect(screen.getByRole('button', { name: 'Start workspace as-is' })).toBeDisabled();
 });
 
 test('Expect startWorkspace passes replaceConfig when configAction is replace and config exists', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -247,6 +247,7 @@ let error = $state('');
 
 let currentStepId = $derived(wizardSteps[wizard.draft.currentStepIndex]?.id ?? '');
 let isLastStep = $derived(wizard.draft.currentStepIndex === wizardSteps.length - 1);
+let hasModel = $derived(wizard.draft.selectedModel !== undefined);
 let isCurrentStepComplete = $derived(
   currentStepId === 'workspace'
     ? wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== ''
@@ -392,7 +393,7 @@ function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorksp
 }
 
 async function startAsIs(): Promise<void> {
-  if (!wizard.draft.sourcePath.trim()) return;
+  if (!wizard.draft.sourcePath.trim() || !wizard.draft.selectedModel) return;
 
   const draftSnapshot = $state.snapshot(wizard.draft);
 
@@ -401,6 +402,7 @@ async function startAsIs(): Promise<void> {
       sourcePath: draftSnapshot.sourcePath,
       runtime: $agentWorkspaceRuntime,
       agent: draftSnapshot.selectedAgent,
+      model: getModelId(draftSnapshot.selectedModel!),
       name: draftSnapshot.sessionName || getDefaultSessionName(draftSnapshot.sourcePath),
       project: draftSnapshot.selectedProjectId,
     });
@@ -421,7 +423,7 @@ async function startAsIs(): Promise<void> {
 }
 
 async function startWorkspace(): Promise<void> {
-  if (!wizard.draft.sessionName.trim() || !wizard.draft.sourcePath.trim()) return;
+  if (!wizard.draft.sessionName.trim() || !wizard.draft.sourcePath.trim() || !wizard.draft.selectedModel) return;
 
   const draftSnapshot = $state.snapshot(wizard.draft);
 
@@ -453,7 +455,7 @@ async function startWorkspace(): Promise<void> {
       sourcePath: draftSnapshot.sourcePath,
       runtime: $agentWorkspaceRuntime,
       agent: draftSnapshot.selectedAgent,
-      model: draftSnapshot.selectedModel ? getModelId(draftSnapshot.selectedModel) : undefined,
+      model: getModelId(draftSnapshot.selectedModel!),
       name: draftSnapshot.sessionName,
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
       network,
@@ -520,6 +522,7 @@ async function startWorkspace(): Promise<void> {
                 configExists={wizard.draft.configExists}
                 bind:configAction={wizard.draft.configAction}
                 onStartAsIs={startAsIs}
+                startAsIsDisabled={!hasModel}
                 projects={[...$workspaceProjectInfos]}
                 selectedProjectId={wizard.draft.selectedProjectId}
                 onProjectSelect={handleProjectSelect} />
@@ -568,12 +571,12 @@ async function startWorkspace(): Promise<void> {
               {/if}
               <Button onclick={cancel}>Cancel</Button>
               {#if currentStepId === 'workspace'}
-                <Button type="secondary" disabled={!isCurrentStepComplete} onclick={startWorkspace}>
+                <Button type="secondary" disabled={!isCurrentStepComplete || !hasModel} onclick={startWorkspace}>
                   Use all defaults and create workspace
                 </Button>
               {/if}
               {#if isLastStep}
-                <Button onclick={startWorkspace}>
+                <Button disabled={!hasModel} onclick={startWorkspace}>
                   Start Workspace
                 </Button>
               {:else}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -248,11 +248,15 @@ let error = $state('');
 let currentStepId = $derived(wizardSteps[wizard.draft.currentStepIndex]?.id ?? '');
 let isLastStep = $derived(wizard.draft.currentStepIndex === wizardSteps.length - 1);
 let hasModel = $derived(wizard.draft.selectedModel !== undefined);
-let isCurrentStepComplete = $derived(
-  currentStepId === 'workspace'
-    ? wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== ''
-    : true,
-);
+let isCurrentStepComplete = $derived.by(() => {
+  if (currentStepId === 'workspace') {
+    return wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== '';
+  }
+  if (currentStepId === 'agent-model') {
+    return hasModel;
+  }
+  return true;
+});
 
 function goNext(): void {
   if (wizard.draft.currentStepIndex < wizardSteps.length - 1) wizard.draft.currentStepIndex++;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
@@ -17,6 +17,7 @@ interface Props {
   configExists?: boolean;
   configAction?: 'merge' | 'replace';
   onStartAsIs?: () => Promise<void>;
+  startAsIsDisabled?: boolean;
   projects?: WorkspaceProjectInfo[];
   selectedProjectId?: string;
   onProjectSelect?: (project: WorkspaceProjectInfo | undefined) => void;
@@ -33,6 +34,7 @@ let {
   configExists = false,
   configAction = $bindable('merge'),
   onStartAsIs,
+  startAsIsDisabled = false,
   projects = [],
   selectedProjectId,
   onProjectSelect,
@@ -85,7 +87,7 @@ function toggleProject(): void {
       </div>
 
       <div class="flex flex-col gap-3 pl-6">
-        <Button type="secondary" onclick={onStartAsIs} aria-label="Start workspace as-is">
+        <Button type="secondary" disabled={startAsIsDisabled} onclick={onStartAsIs} aria-label="Start workspace as-is">
           Start workspace as-is
         </Button>
 


### PR DESCRIPTION
The backend rejects workspace creation without a model, but the type declared it optional. Make `model` required in `AgentWorkspaceCreateOptions`, remove the redundant runtime guard, and disable all creation buttons in the UI when no model is selected.

Closes #2326