### PR TITLE
fix(agent-workspace): warn when workspace name is already taken

### DIFF
--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -29,6 +29,7 @@ import * as agentWorkspaceRuntimeStore from '/@/stores/agentworkspace-runtime';
 import * as mcpStore from '/@/stores/mcp-remote-servers';
 import * as modelCatalogStore from '/@/stores/model-catalog';
 import * as modelsStore from '/@/stores/models';
+import * as openshellSandboxesStore from '/@/stores/openshell-sandboxes';
 import * as providerStore from '/@/stores/providers';
 import * as ragStore from '/@/stores/rag-environments';
 import * as secretVaultStore from '/@/stores/secret-vault';
@@ -37,6 +38,7 @@ import * as workspaceProjectsStore from '/@/stores/workspace-projects';
 import type { AgentInfo } from '/@api/agent-info';
 import type { MCPRemoteServerInfo } from '/@api/mcp/mcp-server-info';
 import type { CatalogModelInfo } from '/@api/model-registry-info';
+import type { SandboxInfo } from '/@api/openshell-gateway-info';
 import type { ProviderInfo } from '/@api/provider-info';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { SecretVaultInfo } from '/@api/secret-vault/secret-vault-info';
@@ -55,6 +57,7 @@ vi.mock(import('/@/stores/providers'));
 vi.mock(import('/@/stores/rag-environments'));
 vi.mock(import('/@/stores/model-catalog'));
 vi.mock(import('/@/stores/models'));
+vi.mock(import('/@/stores/openshell-sandboxes'));
 vi.mock(import('/@/stores/workspace-projects'));
 
 function buildCatalogModels(providers: ProviderInfo[]): CatalogModelInfo[] {
@@ -174,6 +177,7 @@ beforeEach(() => {
     (providerId: string, connectionId: string, label: string): string => `${providerId}::${connectionId}::${label}`,
   );
   vi.mocked(workspaceProjectsStore).workspaceProjectInfos = writable<readonly WorkspaceProjectInfo[]>([]);
+  vi.mocked(openshellSandboxesStore).allOpenshellSandboxes = writable<(SandboxInfo & { gatewayName: string })[]>([]);
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   resetDraft();

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -249,14 +249,17 @@ let error = $state('');
 let currentStepId = $derived(wizardSteps[wizard.draft.currentStepIndex]?.id ?? '');
 let isLastStep = $derived(wizard.draft.currentStepIndex === wizardSteps.length - 1);
 let hasModel = $derived(wizard.draft.selectedModel !== undefined);
-let isNameDuplicate = $derived.by(() => {
+let validationErrors = $derived.by(() => {
+  const errors: { name?: string } = {};
   const name = wizard.draft.sessionName.trim().toLowerCase();
-  if (!name) return false;
-  return $allOpenshellSandboxes.some(s => s.name.toLowerCase() === name);
+  if (name && $allOpenshellSandboxes.some(s => s.name.toLowerCase() === name)) {
+    errors.name = 'A workspace with this name already exists. Please choose a different name.';
+  }
+  return errors;
 });
 let isCurrentStepComplete = $derived.by(() => {
   if (currentStepId === 'workspace') {
-    return wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== '' && !isNameDuplicate;
+    return wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== '' && !validationErrors.name;
   }
   if (currentStepId === 'agent-model') {
     return hasModel;
@@ -536,7 +539,7 @@ async function startWorkspace(): Promise<void> {
                 projects={[...$workspaceProjectInfos]}
                 selectedProjectId={wizard.draft.selectedProjectId}
                 onProjectSelect={handleProjectSelect}
-                nameDuplicate={isNameDuplicate} />
+                errors={validationErrors} />
             {:else if currentStepId === 'agent-model'}
               <AgentWorkspaceCreateStepAgentModel bind:selectedAgent={wizard.draft.selectedAgent} bind:selectedModel={wizard.draft.selectedModel} />
             {:else if currentStepId === 'tools-secrets'}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -17,6 +17,7 @@ import { agentWorkspaceRuntime } from '/@/stores/agentworkspace-runtime';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
 import { catalogModels } from '/@/stores/models';
+import { allOpenshellSandboxes } from '/@/stores/openshell-sandboxes';
 import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
 import { secretVaultInfos } from '/@/stores/secret-vault';
@@ -248,9 +249,14 @@ let error = $state('');
 let currentStepId = $derived(wizardSteps[wizard.draft.currentStepIndex]?.id ?? '');
 let isLastStep = $derived(wizard.draft.currentStepIndex === wizardSteps.length - 1);
 let hasModel = $derived(wizard.draft.selectedModel !== undefined);
+let isNameDuplicate = $derived.by(() => {
+  const name = wizard.draft.sessionName.trim().toLowerCase();
+  if (!name) return false;
+  return $allOpenshellSandboxes.some(s => s.name.toLowerCase() === name);
+});
 let isCurrentStepComplete = $derived.by(() => {
   if (currentStepId === 'workspace') {
-    return wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== '';
+    return wizard.draft.sessionName.trim() !== '' && wizard.draft.sourcePath.trim() !== '' && !isNameDuplicate;
   }
   if (currentStepId === 'agent-model') {
     return hasModel;
@@ -529,7 +535,8 @@ async function startWorkspace(): Promise<void> {
                 startAsIsDisabled={!hasModel}
                 projects={[...$workspaceProjectInfos]}
                 selectedProjectId={wizard.draft.selectedProjectId}
-                onProjectSelect={handleProjectSelect} />
+                onProjectSelect={handleProjectSelect}
+                nameDuplicate={isNameDuplicate} />
             {:else if currentStepId === 'agent-model'}
               <AgentWorkspaceCreateStepAgentModel bind:selectedAgent={wizard.draft.selectedAgent} bind:selectedModel={wizard.draft.selectedModel} />
             {:else if currentStepId === 'tools-secrets'}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
@@ -156,14 +156,17 @@ test('selects replace radio when clicked', async () => {
   expect(screen.getByLabelText('Replace existing')).toBeChecked();
 });
 
-test('shows duplicate name error when nameDuplicate is true', () => {
-  render(AgentWorkspaceCreateStepWorkspace, { ...defaultProps, nameDuplicate: true });
+test('shows name error when errors.name is set', () => {
+  render(AgentWorkspaceCreateStepWorkspace, {
+    ...defaultProps,
+    errors: { name: 'A workspace with this name already exists. Please choose a different name.' },
+  });
 
   expect(screen.getByText(/workspace with this name already exists/)).toBeInTheDocument();
 });
 
-test('hides duplicate name error when nameDuplicate is false', () => {
-  render(AgentWorkspaceCreateStepWorkspace, { ...defaultProps, nameDuplicate: false });
+test('hides name error when errors is empty', () => {
+  render(AgentWorkspaceCreateStepWorkspace, { ...defaultProps, errors: {} });
 
   expect(screen.queryByText(/workspace with this name already exists/)).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
@@ -155,3 +155,15 @@ test('selects replace radio when clicked', async () => {
 
   expect(screen.getByLabelText('Replace existing')).toBeChecked();
 });
+
+test('shows duplicate name error when nameDuplicate is true', () => {
+  render(AgentWorkspaceCreateStepWorkspace, { ...defaultProps, nameDuplicate: true });
+
+  expect(screen.getByText(/workspace with this name already exists/)).toBeInTheDocument();
+});
+
+test('hides duplicate name error when nameDuplicate is false', () => {
+  render(AgentWorkspaceCreateStepWorkspace, { ...defaultProps, nameDuplicate: false });
+
+  expect(screen.queryByText(/workspace with this name already exists/)).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
@@ -21,7 +21,7 @@ interface Props {
   projects?: WorkspaceProjectInfo[];
   selectedProjectId?: string;
   onProjectSelect?: (project: WorkspaceProjectInfo | undefined) => void;
-  nameDuplicate?: boolean;
+  errors?: { name?: string };
 }
 
 let {
@@ -39,7 +39,7 @@ let {
   projects = [],
   selectedProjectId,
   onProjectSelect,
-  nameDuplicate = false,
+  errors = {},
 }: Props = $props();
 
 function markNameEdited(): void {
@@ -133,8 +133,8 @@ function toggleProject(): void {
       placeholder="e.g., Frontend Refactoring"
       class="w-full"
       oninput={markNameEdited}
-      error={nameDuplicate ? 'A workspace with this name already exists. Please choose a different name.' : ''}
-      aria-invalid={nameDuplicate}
+      error={errors?.name ?? ''}
+      aria-invalid={!!errors?.name}
     />
   </div>
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
@@ -21,6 +21,7 @@ interface Props {
   projects?: WorkspaceProjectInfo[];
   selectedProjectId?: string;
   onProjectSelect?: (project: WorkspaceProjectInfo | undefined) => void;
+  nameDuplicate?: boolean;
 }
 
 let {
@@ -38,6 +39,7 @@ let {
   projects = [],
   selectedProjectId,
   onProjectSelect,
+  nameDuplicate = false,
 }: Props = $props();
 
 function markNameEdited(): void {
@@ -131,6 +133,8 @@ function toggleProject(): void {
       placeholder="e.g., Frontend Refactoring"
       class="w-full"
       oninput={markNameEdited}
+      error={nameDuplicate ? 'A workspace with this name already exists. Please choose a different name.' : ''}
+      aria-invalid={nameDuplicate}
     />
   </div>
 


### PR DESCRIPTION
## Summary
- Validates workspace name against existing sandboxes (case-insensitive) during creation
- Shows inline error using the `Input` component's built-in error styling when a duplicate name is detected
- Disables Continue and quick-create buttons until the user picks a unique name
- Error clears reactively as the user types a new name

Fixes https://github.com/openkaiden/kaiden/issues/2312

Create a workspace, then try creating another with the same name — error should appear and buttons should be disabled

<img width="1308" height="871" alt="Screenshot From 2026-07-06 04-25-27" src="https://github.com/user-attachments/assets/7e4c3095-6cb0-4037-a644-d3390be479d6" />


