### PR TITLE
fix(openshell): gateway not initialized when extensions are started

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -39,6 +39,8 @@ import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import type { OpenshellGatewayCli } from '/@/plugin/openshell-cli/openshell-gateway-cli.js';
 import type { ProviderImpl } from '/@/plugin/provider-impl.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
@@ -85,7 +87,12 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 const ipcHandle: IPCHandle = vi.fn();
-const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
+const openshellCli = new OpenshellCli(
+  {} as Exec,
+  {} as CliToolRegistry,
+  {} as OpenshellGatewayCli,
+  {} as OpenshellGateway,
+);
 
 const agentRegistry = {
   getAgentRegistration: vi.fn(),

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -71,6 +71,7 @@ import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import { OpenshellGatewayCli } from '/@/plugin/openshell-cli/openshell-gateway-cli.js';
 import { OpenshellImageBuilder } from '/@/plugin/openshell-cli/openshell-image-builder.js';
 import { OpenShellRegistry } from '/@/plugin/openshell-registry.js';
 import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
@@ -599,6 +600,7 @@ export class PluginSystem {
     container.bind<CliToolRegistry>(CliToolRegistry).toSelf().inSingletonScope();
     container.bind<AgentRegistry>(AgentRegistry).toSelf().inSingletonScope();
     container.bind<OpenShellRegistry>(OpenShellRegistry).toSelf().inSingletonScope();
+    container.bind<OpenshellGatewayCli>(OpenshellGatewayCli).toSelf().inSingletonScope();
     container.bind<OpenshellCli>(OpenshellCli).toSelf().inSingletonScope();
     container.bind<OpenshellGateway>(OpenshellGateway).toSelf().inSingletonScope();
     container.bind<OpenshellImageBuilder>(OpenshellImageBuilder).toSelf().inSingletonScope();
@@ -925,7 +927,7 @@ export class PluginSystem {
     await ragEnvironmentRegistry.init();
 
     const workspaceProjectManager = container.get<WorkspaceProjectManager>(WorkspaceProjectManager);
-    await workspaceProjectManager.init();
+    workspaceProjectManager.init().catch(console.error);
 
     const semanticRouterManager = container.get<SemanticRouterManager>(SemanticRouterManager);
     await semanticRouterManager.init();

--- a/packages/main/src/plugin/openshell-cli/openshell-cli-base.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli-base.ts
@@ -1,0 +1,133 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { RunError, RunOptions } from '@openkaiden/api';
+import { inject, injectable } from 'inversify';
+
+import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { Exec } from '/@/plugin/util/exec.js';
+
+@injectable()
+export abstract class OpenshellCliBase {
+  constructor(
+    @inject(Exec)
+    protected readonly exec: Exec,
+    @inject(CliToolRegistry)
+    protected readonly cliToolRegistry: CliToolRegistry,
+  ) {}
+
+  getCliPath(): string {
+    const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
+    if (tool?.path) {
+      return tool.path;
+    }
+
+    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+    if (resourcesPath) {
+      const bundledPath = join(resourcesPath, 'openshell', 'openshell');
+      if (existsSync(bundledPath)) {
+        return bundledPath;
+      }
+    }
+
+    return 'openshell';
+  }
+
+  protected extractCliError(err: unknown): string {
+    if (err instanceof Error && 'stdout' in err) {
+      const runErr = err as RunError;
+
+      const jsonError = this.tryExtractJsonError(runErr.stdout) ?? this.tryExtractJsonError(runErr.stderr);
+      if (jsonError) {
+        return jsonError;
+      }
+
+      if (runErr.stderr?.trim()) {
+        return `${err.message} (stderr: ${runErr.stderr.trim()})`;
+      }
+      if (runErr.stdout?.trim()) {
+        return `${err.message} (stdout: ${runErr.stdout.trim()})`;
+      }
+    }
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  protected tryExtractJsonError(output: string | undefined): string | undefined {
+    if (typeof output !== 'string' || !output) {
+      return undefined;
+    }
+    try {
+      const parsed: unknown = JSON.parse(output);
+      if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
+        const errorField = (parsed as { error: unknown }).error;
+        if (typeof errorField === 'string' && errorField) {
+          return errorField;
+        }
+      }
+    } catch {
+      // not JSON
+    }
+    return undefined;
+  }
+
+  protected async runCli(
+    args: string[],
+    options?: { redact?: boolean; env?: { [p: string]: string }; quiet?: boolean },
+  ): Promise<void> {
+    const cliPath = this.getCliPath();
+    const displayArgs = options?.redact ? this.redactSensitiveArgs(args) : args;
+    if (!options?.quiet) {
+      console.log(`Executing: ${cliPath} ${displayArgs.join(' ')}`);
+    }
+    try {
+      await this.exec.exec(cliPath, args, options?.env ? { env: options.env } : undefined);
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      if (!options?.quiet) {
+        console.error(`openshell failed: ${cliPath} ${displayArgs.join(' ')} — ${detail}`);
+      }
+      throw new Error(detail);
+    }
+  }
+
+  protected redactSensitiveArgs(args: string[]): string[] {
+    const sensitiveFlags = new Set(['--credential', '--config', '--env']);
+    return args.map((arg, i) => {
+      if (i > 0 && sensitiveFlags.has(args[i - 1]!)) {
+        return '***';
+      }
+      return arg;
+    });
+  }
+
+  protected async execCLI<T>(args: string[], options?: RunOptions): Promise<T> {
+    const cliPath = this.getCliPath();
+    const fullArgs = [...args, '-o', 'json'];
+    try {
+      const result = await this.exec.exec(cliPath, fullArgs, options);
+      return JSON.parse(result.stdout) as T;
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      console.error(`openshell failed: ${cliPath} ${fullArgs.join(' ')} — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+}

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -28,6 +28,8 @@ import { Exec } from '/@/plugin/util/exec.js';
 import type { CliToolInfo } from '/@api/cli-tool-info.js';
 
 import { OpenshellCli } from './openshell-cli.js';
+import type { OpenshellGateway } from './openshell-gateway.js';
+import type { OpenshellGatewayCli } from './openshell-gateway-cli.js';
 
 vi.mock(import('node:fs'));
 vi.mock(import('/@/plugin/util/exec.js'));
@@ -40,6 +42,14 @@ const exec = new Exec({} as Proxy);
 const cliToolRegistry = {
   getCliToolInfos: vi.fn().mockReturnValue([{ name: 'openshell', path: OPENSHELL_CLI_PATH }]),
 } as unknown as CliToolRegistry;
+
+const openshellGatewayCli = {
+  listGateways: vi.fn(),
+} as unknown as OpenshellGatewayCli;
+
+const openshellGateway = {
+  checkAvailable: vi.fn().mockResolvedValue(undefined),
+} as unknown as OpenshellGateway;
 
 function mockExecResult(stdout: string): RunResult {
   return { command: OPENSHELL_CLI_PATH, stdout, stderr: '' };
@@ -61,7 +71,8 @@ beforeEach(() => {
   vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
     { name: 'openshell', path: OPENSHELL_CLI_PATH },
   ] as unknown as CliToolInfo[]);
-  openshellCli = new OpenshellCli(exec, cliToolRegistry);
+  vi.mocked(openshellGateway.checkAvailable).mockResolvedValue(undefined);
+  openshellCli = new OpenshellCli(exec, cliToolRegistry, openshellGatewayCli, openshellGateway);
 });
 
 describe('getCliPath', () => {
@@ -523,122 +534,6 @@ describe('connectSandbox', () => {
   });
 });
 
-describe('addGateway', () => {
-  test('executes gateway add with endpoint', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.addGateway({ endpoint: 'https://gw.example.com' });
-
-    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'add', 'https://gw.example.com'], undefined);
-  });
-
-  test('includes --name flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.addGateway({ endpoint: 'https://gw.example.com', name: 'my-gw' });
-
-    expect(exec.exec).toHaveBeenCalledWith(
-      OPENSHELL_CLI_PATH,
-      ['gateway', 'add', 'https://gw.example.com', '--name', 'my-gw'],
-      undefined,
-    );
-  });
-
-  test('includes --remote flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.addGateway({ endpoint: 'https://gw.example.com', remote: 'user@host' });
-
-    expect(exec.exec).toHaveBeenCalledWith(
-      OPENSHELL_CLI_PATH,
-      ['gateway', 'add', 'https://gw.example.com', '--remote', 'user@host'],
-      undefined,
-    );
-  });
-
-  test('includes --local flag when provided', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.addGateway({ endpoint: 'https://127.0.0.1', local: true });
-
-    expect(exec.exec).toHaveBeenCalledWith(
-      OPENSHELL_CLI_PATH,
-      ['gateway', 'add', 'https://127.0.0.1', '--local'],
-      undefined,
-    );
-  });
-
-  test('extracts JSON error from stdout on failure', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    const runError = mockRunError({
-      stdout: JSON.stringify({ error: 'invalid endpoint' }),
-    });
-    vi.mocked(exec.exec).mockRejectedValue(runError);
-
-    await expect(openshellCli.addGateway({ endpoint: 'bad' })).rejects.toThrow('invalid endpoint');
-  });
-});
-
-describe('removeGateway', () => {
-  test('executes gateway remove with name', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.removeGateway('my-gw');
-
-    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'remove', 'my-gw'], undefined);
-  });
-
-  test('executes gateway remove without name for active gateway', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.removeGateway();
-
-    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'remove'], undefined);
-  });
-});
-
-describe('selectGateway', () => {
-  test('executes gateway select with name', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.selectGateway('my-gw');
-
-    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'select', 'my-gw'], undefined);
-  });
-
-  test('executes gateway select without name', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-
-    await openshellCli.selectGateway();
-
-    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'select'], undefined);
-  });
-});
-
-describe('listGateways', () => {
-  test('executes gateway list with json output and returns parsed result', async () => {
-    const payload = [
-      { name: 'gw-1', endpoint: 'https://gw1.example.com' },
-      { name: 'gw-2', endpoint: 'https://gw2.example.com' },
-    ];
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(payload)));
-
-    const result = await openshellCli.listGateways();
-
-    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'list', '-o', 'json'], undefined);
-    expect(result).toEqual(payload);
-  });
-});
-
 describe('listSandboxesForGateway', () => {
   test('lists sandboxes for a specific gateway using -g flag', async () => {
     const gateways = [
@@ -647,25 +542,24 @@ describe('listSandboxesForGateway', () => {
     ];
     const sandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
 
-    vi.mocked(exec.exec)
-      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
-      .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes)));
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes)));
 
     const result = await openshellCli.listSandboxesForGateway('gw-2');
 
     expect(result.gateway.name).toBe('gw-2');
     expect(result.sandboxes).toEqual(sandboxes);
+    expect(openshellGatewayCli.listGateways).toHaveBeenCalled();
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
       ['sandbox', 'list', '-g', 'gw-2', '-o', 'json'],
       undefined,
     );
-    expect(exec.exec).not.toHaveBeenCalledWith(OPENSHELL_CLI_PATH, expect.arrayContaining(['gateway', 'select']));
   });
 
   test('throws when gateway is not found', async () => {
     const gateways = [{ name: 'gw-1', endpoint: 'https://gw1.example.com', active: true }];
-    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)));
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
 
     await expect(openshellCli.listSandboxesForGateway('unknown')).rejects.toThrow('Gateway not found: unknown');
   });
@@ -680,8 +574,8 @@ describe('listSandboxesPerGateway', () => {
     const sandboxes1 = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
     const sandboxes2 = [{ id: 'sb-2', name: 'sb-2', phase: 'Unknown' }];
 
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
     vi.mocked(exec.exec)
-      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes1)))
       .mockResolvedValueOnce(mockExecResult(JSON.stringify(sandboxes2)));
 
@@ -693,6 +587,7 @@ describe('listSandboxesPerGateway', () => {
     expect(first?.sandboxes).toEqual(sandboxes1);
     expect(second?.gateway.name).toBe('gw-2');
     expect(second?.sandboxes).toEqual(sandboxes2);
+    expect(openshellGatewayCli.listGateways).toHaveBeenCalled();
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
       ['sandbox', 'list', '-g', 'gw-1', '-o', 'json'],
@@ -703,11 +598,10 @@ describe('listSandboxesPerGateway', () => {
       ['sandbox', 'list', '-g', 'gw-2', '-o', 'json'],
       undefined,
     );
-    expect(exec.exec).not.toHaveBeenCalledWith(OPENSHELL_CLI_PATH, expect.arrayContaining(['gateway', 'select']));
   });
 
   test('returns empty array when no gateways exist', async () => {
-    vi.mocked(exec.exec).mockResolvedValueOnce(mockExecResult(JSON.stringify([])));
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue([]);
 
     const results = await openshellCli.listSandboxesPerGateway();
 
@@ -719,70 +613,13 @@ describe('listSandboxesPerGateway', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const gateways = [{ name: 'gw-1', endpoint: 'https://gw1.example.com', active: true }];
 
-    vi.mocked(exec.exec)
-      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
-      .mockRejectedValueOnce(new Error('connection refused'));
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(exec.exec).mockRejectedValueOnce(new Error('connection refused'));
 
     const results = await openshellCli.listSandboxesPerGateway();
 
     expect(results).toHaveLength(1);
     expect(results.at(0)?.sandboxes).toEqual([]);
-  });
-});
-
-describe('checkEndpointStatus', () => {
-  test('returns true when endpoint is healthy', async () => {
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-    expect(await openshellCli.checkEndpointStatus('https://127.0.0.1:8443')).toBe(true);
-    expect(exec.exec).toHaveBeenCalledWith(
-      OPENSHELL_CLI_PATH,
-      ['status', '--gateway-endpoint', 'https://127.0.0.1:8443'],
-      undefined,
-    );
-  });
-
-  test('returns false when endpoint is unreachable', async () => {
-    vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
-    expect(await openshellCli.checkEndpointStatus('http://127.0.0.1:17670')).toBe(false);
-  });
-
-  test('appends --gateway-insecure for http endpoints', async () => {
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-    await openshellCli.checkEndpointStatus('http://127.0.0.1:17670');
-    expect(exec.exec).toHaveBeenCalledWith(
-      OPENSHELL_CLI_PATH,
-      ['status', '--gateway-endpoint', 'http://127.0.0.1:17670', '--gateway-insecure'],
-      undefined,
-    );
-  });
-
-  test('does not append --gateway-insecure for https endpoints', async () => {
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
-    await openshellCli.checkEndpointStatus('https://127.0.0.1:8443');
-    expect(exec.exec).toHaveBeenCalledWith(
-      OPENSHELL_CLI_PATH,
-      expect.not.arrayContaining(['--gateway-insecure']),
-      undefined,
-    );
-  });
-});
-
-describe('getGatewayStatus', () => {
-  test('executes status and returns trimmed output', async () => {
-    const statusText = 'Server Status\n\n  Gateway: openshell\n  Status: Connected\n';
-    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(statusText));
-
-    const result = await openshellCli.getGatewayStatus();
-
-    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['status']);
-    expect(result).toBe(statusText.trim());
-  });
-
-  test('rejects when no gateway is configured', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockRejectedValue(new Error('no gateway configured'));
-
-    await expect(openshellCli.getGatewayStatus()).rejects.toThrow('no gateway configured');
   });
 });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -16,26 +16,26 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
-
-import type { RunError, RunOptions } from '@openkaiden/api';
+import { RunOptions } from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 import z from 'zod';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import { Exec } from '/@/plugin/util/exec.js';
-import type {
+import {
   CreateProviderOptions,
   CreateSandboxOptions,
-  GatewayAddOptions,
-  GatewayInfo,
   GatewaySandboxes,
   OpenshellProviderInfo,
+  OpenshellProviderInfoSchema,
   SandboxInfo,
+  SandboxInfoSchema,
   SetInferenceOptions,
 } from '/@api/openshell-gateway-info.js';
-import { GatewayInfoSchema, OpenshellProviderInfoSchema, SandboxInfoSchema } from '/@api/openshell-gateway-info.js';
+
+import { OpenshellCliBase } from './openshell-cli-base.js';
+import { OpenshellGatewayCli } from './openshell-gateway-cli.js';
 
 const SettingValue = z.union([z.string(), z.boolean(), z.number()]);
 
@@ -65,79 +65,41 @@ const OpenshellSettingsSchema = z.looseObject({
  * Policy commands:
  *   - `openshell policy update`
  *
- * Gateway registration commands:
- *   - `openshell gateway add <endpoint>`
- *   - `openshell gateway remove [name]`
- *   - `openshell gateway select [name]`
- *   - `openshell gateway list`
- *   - `openshell status`
- *
  * Provider commands:
  *   - `openshell provider list`
  *   - `openshell provider delete <name>`
  *   - `openshell provider create`
  */
 @injectable()
-export class OpenshellCli {
+export class OpenshellCli extends OpenshellCliBase {
   constructor(
     @inject(Exec)
-    private readonly exec: Exec,
+    exec: Exec,
     @inject(CliToolRegistry)
-    private readonly cliToolRegistry: CliToolRegistry,
-  ) {}
-
-  getCliPath(): string {
-    const tool = this.cliToolRegistry.getCliToolInfos().find(t => t.name === 'openshell');
-    if (tool?.path) {
-      return tool.path;
-    }
-
-    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
-    if (resourcesPath) {
-      const bundledPath = join(resourcesPath, 'openshell', 'openshell');
-      if (existsSync(bundledPath)) {
-        return bundledPath;
-      }
-    }
-
-    return 'openshell';
+    cliToolRegistry: CliToolRegistry,
+    @inject(OpenshellGatewayCli)
+    private readonly openshellGatewayCli: OpenshellGatewayCli,
+    @inject(OpenshellGateway)
+    private readonly openshellGateway: OpenshellGateway,
+  ) {
+    super(exec, cliToolRegistry);
   }
 
-  private extractCliError(err: unknown): string {
-    if (err instanceof Error && 'stdout' in err) {
-      const runErr = err as RunError;
-
-      const jsonError = this.tryExtractJsonError(runErr.stdout) ?? this.tryExtractJsonError(runErr.stderr);
-      if (jsonError) {
-        return jsonError;
-      }
-
-      if (runErr.stderr?.trim()) {
-        return `${err.message} (stderr: ${runErr.stderr.trim()})`;
-      }
-      if (runErr.stdout?.trim()) {
-        return `${err.message} (stdout: ${runErr.stdout.trim()})`;
-      }
-    }
-    return err instanceof Error ? err.message : String(err);
+  protected override async runCli(
+    args: string[],
+    options?: {
+      redact?: boolean;
+      env?: { [p: string]: string };
+      quiet?: boolean;
+    },
+  ): Promise<void> {
+    await this.openshellGateway.checkAvailable();
+    return super.runCli(args, options);
   }
 
-  private tryExtractJsonError(output: string | undefined): string | undefined {
-    if (typeof output !== 'string' || !output) {
-      return undefined;
-    }
-    try {
-      const parsed: unknown = JSON.parse(output);
-      if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
-        const errorField = (parsed as { error: unknown }).error;
-        if (typeof errorField === 'string' && errorField) {
-          return errorField;
-        }
-      }
-    } catch {
-      // not JSON
-    }
-    return undefined;
+  protected override async execCLI<T>(args: string[], options?: RunOptions): Promise<T> {
+    await this.openshellGateway.checkAvailable();
+    return super.execCLI(args, options);
   }
 
   async getVersion(): Promise<string> {
@@ -244,7 +206,7 @@ export class OpenshellCli {
   }
 
   async listSandboxesForGateway(gatewayName: string): Promise<GatewaySandboxes> {
-    const gateways = await this.listGateways();
+    const gateways = await this.openshellGatewayCli.listGateways();
     const targetGateway = gateways.find(g => g.name === gatewayName);
     if (!targetGateway) {
       throw new Error(`Gateway not found: ${gatewayName}`);
@@ -255,7 +217,7 @@ export class OpenshellCli {
   }
 
   async listSandboxesPerGateway(): Promise<GatewaySandboxes[]> {
-    const gateways = await this.listGateways();
+    const gateways = await this.openshellGatewayCli.listGateways();
     if (gateways.length === 0) {
       return [];
     }
@@ -274,68 +236,6 @@ export class OpenshellCli {
     }
 
     return results;
-  }
-
-  // ── gateway registration commands ─────────────────────────────────
-
-  async addGateway(options: GatewayAddOptions): Promise<void> {
-    const args = ['gateway', 'add', options.endpoint];
-    if (options.name) {
-      args.push('--name', options.name);
-    }
-    if (options.remote) {
-      args.push('--remote', options.remote);
-    }
-    if (options.local) {
-      args.push('--local');
-    }
-    await this.runCli(args);
-  }
-
-  async removeGateway(name?: string): Promise<void> {
-    const args = ['gateway', 'remove'];
-    if (name) {
-      args.push(name);
-    }
-    await this.runCli(args);
-  }
-
-  async selectGateway(name?: string): Promise<void> {
-    const args = ['gateway', 'select'];
-    if (name) {
-      args.push(name);
-    }
-    await this.runCli(args);
-  }
-
-  async listGateways(): Promise<GatewayInfo[]> {
-    const data = await this.execCLI<unknown>(['gateway', 'list']);
-    return z.array(GatewayInfoSchema).parse(data);
-  }
-
-  async checkEndpointStatus(endpoint: string): Promise<boolean> {
-    const args = ['status', '--gateway-endpoint', endpoint];
-    if (endpoint.startsWith('http://')) {
-      args.push('--gateway-insecure');
-    }
-    try {
-      await this.runCli(args, { quiet: true });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  async getGatewayStatus(): Promise<string> {
-    const cliPath = this.getCliPath();
-    try {
-      const result = await this.exec.exec(cliPath, ['status']);
-      return result.stdout.trim();
-    } catch (err: unknown) {
-      const detail = this.extractCliError(err);
-      console.error(`openshell failed: ${cliPath} status — ${detail}`);
-      throw new Error(detail);
-    }
   }
 
   // ── provider commands ──────────────────────────────────────────────
@@ -390,49 +290,5 @@ export class OpenshellCli {
 
   async enableV2Provider(sandboxName: string): Promise<void> {
     return this.runCli(['settings', 'set', '--key', 'providers_v2_enabled', '--value', 'true', '--yes', sandboxName]);
-  }
-  // ── helpers ───────────────────────────────────────────────────────
-
-  private async runCli(
-    args: string[],
-    options?: { redact?: boolean; env?: { [p: string]: string }; quiet?: boolean },
-  ): Promise<void> {
-    const cliPath = this.getCliPath();
-    const displayArgs = options?.redact ? this.redactSensitiveArgs(args) : args;
-    if (!options?.quiet) {
-      console.log(`Executing: ${cliPath} ${displayArgs.join(' ')}`);
-    }
-    try {
-      await this.exec.exec(cliPath, args, options?.env ? { env: options.env } : undefined);
-    } catch (err: unknown) {
-      const detail = this.extractCliError(err);
-      if (!options?.quiet) {
-        console.error(`openshell failed: ${cliPath} ${displayArgs.join(' ')} — ${detail}`);
-      }
-      throw new Error(detail);
-    }
-  }
-
-  private redactSensitiveArgs(args: string[]): string[] {
-    const sensitiveFlags = new Set(['--credential', '--config', '--env']);
-    return args.map((arg, i) => {
-      if (i > 0 && sensitiveFlags.has(args[i - 1]!)) {
-        return '***';
-      }
-      return arg;
-    });
-  }
-
-  private async execCLI<T>(args: string[], options?: RunOptions): Promise<T> {
-    const cliPath = this.getCliPath();
-    const fullArgs = [...args, '-o', 'json'];
-    try {
-      const result = await this.exec.exec(cliPath, fullArgs, options);
-      return JSON.parse(result.stdout) as T;
-    } catch (err: unknown) {
-      const detail = this.extractCliError(err);
-      console.error(`openshell failed: ${cliPath} ${fullArgs.join(' ')} — ${detail}`);
-      throw new Error(detail);
-    }
   }
 }

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-cli.spec.ts
@@ -1,0 +1,233 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RunError, RunResult } from '@openkaiden/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { Proxy } from '/@/plugin/proxy.js';
+import { Exec } from '/@/plugin/util/exec.js';
+import type { CliToolInfo } from '/@api/cli-tool-info.js';
+
+import { OpenshellGatewayCli } from './openshell-gateway-cli.js';
+
+vi.mock(import('/@/plugin/util/exec.js'));
+
+const OPENSHELL_CLI_PATH = '/usr/local/bin/openshell';
+
+let openshellGatewayCli: OpenshellGatewayCli;
+
+const exec = new Exec({} as Proxy);
+const cliToolRegistry = {
+  getCliToolInfos: vi.fn().mockReturnValue([{ name: 'openshell', path: OPENSHELL_CLI_PATH }]),
+} as unknown as CliToolRegistry;
+
+function mockExecResult(stdout: string): RunResult {
+  return { command: OPENSHELL_CLI_PATH, stdout, stderr: '' };
+}
+
+function mockRunError(overrides: Partial<RunError> = {}): RunError {
+  const err = new Error(overrides.message ?? 'Command execution failed with exit code 1') as RunError;
+  err.exitCode = overrides.exitCode ?? 1;
+  err.command = overrides.command ?? OPENSHELL_CLI_PATH;
+  err.stdout = overrides.stdout ?? '';
+  err.stderr = overrides.stderr ?? '';
+  err.cancelled = overrides.cancelled ?? false;
+  err.killed = overrides.killed ?? false;
+  return err;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
+    { name: 'openshell', path: OPENSHELL_CLI_PATH },
+  ] as unknown as CliToolInfo[]);
+  openshellGatewayCli = new OpenshellGatewayCli(exec, cliToolRegistry);
+});
+
+describe('addGateway', () => {
+  test('executes gateway add with endpoint', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.addGateway({ endpoint: 'https://gw.example.com' });
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'add', 'https://gw.example.com'], undefined);
+  });
+
+  test('includes --name flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.addGateway({ endpoint: 'https://gw.example.com', name: 'my-gw' });
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['gateway', 'add', 'https://gw.example.com', '--name', 'my-gw'],
+      undefined,
+    );
+  });
+
+  test('includes --remote flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.addGateway({ endpoint: 'https://gw.example.com', remote: 'user@host' });
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['gateway', 'add', 'https://gw.example.com', '--remote', 'user@host'],
+      undefined,
+    );
+  });
+
+  test('includes --local flag when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.addGateway({ endpoint: 'https://127.0.0.1', local: true });
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['gateway', 'add', 'https://127.0.0.1', '--local'],
+      undefined,
+    );
+  });
+
+  test('extracts JSON error from stdout on failure', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runError = mockRunError({
+      stdout: JSON.stringify({ error: 'invalid endpoint' }),
+    });
+    vi.mocked(exec.exec).mockRejectedValue(runError);
+
+    await expect(openshellGatewayCli.addGateway({ endpoint: 'bad' })).rejects.toThrow('invalid endpoint');
+  });
+});
+
+describe('removeGateway', () => {
+  test('executes gateway remove with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.removeGateway('my-gw');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'remove', 'my-gw'], undefined);
+  });
+
+  test('executes gateway remove without name for active gateway', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.removeGateway();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'remove'], undefined);
+  });
+});
+
+describe('selectGateway', () => {
+  test('executes gateway select with name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.selectGateway('my-gw');
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'select', 'my-gw'], undefined);
+  });
+
+  test('executes gateway select without name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellGatewayCli.selectGateway();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'select'], undefined);
+  });
+});
+
+describe('listGateways', () => {
+  test('executes gateway list with json output and returns parsed result', async () => {
+    const payload = [
+      { name: 'gw-1', endpoint: 'https://gw1.example.com' },
+      { name: 'gw-2', endpoint: 'https://gw2.example.com' },
+    ];
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(payload)));
+
+    const result = await openshellGatewayCli.listGateways();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'list', '-o', 'json'], undefined);
+    expect(result).toEqual(payload);
+  });
+});
+
+describe('checkEndpointStatus', () => {
+  test('returns true when endpoint is healthy', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    expect(await openshellGatewayCli.checkEndpointStatus('https://127.0.0.1:8443')).toBe(true);
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['status', '--gateway-endpoint', 'https://127.0.0.1:8443'],
+      undefined,
+    );
+  });
+
+  test('returns false when endpoint is unreachable', async () => {
+    vi.mocked(exec.exec).mockRejectedValue(new Error('connection refused'));
+    expect(await openshellGatewayCli.checkEndpointStatus('http://127.0.0.1:17670')).toBe(false);
+  });
+
+  test('appends --gateway-insecure for http endpoints', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    await openshellGatewayCli.checkEndpointStatus('http://127.0.0.1:17670');
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['status', '--gateway-endpoint', 'http://127.0.0.1:17670', '--gateway-insecure'],
+      undefined,
+    );
+  });
+
+  test('does not append --gateway-insecure for https endpoints', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+    await openshellGatewayCli.checkEndpointStatus('https://127.0.0.1:8443');
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      expect.not.arrayContaining(['--gateway-insecure']),
+      undefined,
+    );
+  });
+});
+
+describe('getGatewayStatus', () => {
+  test('executes status and returns trimmed output', async () => {
+    const statusText = 'Server Status\n\n  Gateway: openshell\n  Status: Connected\n';
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(statusText));
+
+    const result = await openshellGatewayCli.getGatewayStatus();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['status']);
+    expect(result).toBe(statusText.trim());
+  });
+
+  test('rejects when no gateway is configured', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('no gateway configured'));
+
+    await expect(openshellGatewayCli.getGatewayStatus()).rejects.toThrow('no gateway configured');
+  });
+});

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-cli.ts
@@ -1,0 +1,107 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+import z from 'zod';
+
+import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { Exec } from '/@/plugin/util/exec.js';
+import type { GatewayAddOptions, GatewayInfo } from '/@api/openshell-gateway-info.js';
+import { GatewayInfoSchema } from '/@api/openshell-gateway-info.js';
+
+import { OpenshellCliBase } from './openshell-cli-base.js';
+
+/**
+ * CLI wrapper for `openshell` gateway registration commands:
+ *   - `openshell gateway add <endpoint>`
+ *   - `openshell gateway remove [name]`
+ *   - `openshell gateway select [name]`
+ *   - `openshell gateway list`
+ *   - `openshell status`
+ */
+@injectable()
+export class OpenshellGatewayCli extends OpenshellCliBase {
+  constructor(
+    @inject(Exec)
+    exec: Exec,
+    @inject(CliToolRegistry)
+    cliToolRegistry: CliToolRegistry,
+  ) {
+    super(exec, cliToolRegistry);
+  }
+
+  async addGateway(options: GatewayAddOptions): Promise<void> {
+    const args = ['gateway', 'add', options.endpoint];
+    if (options.name) {
+      args.push('--name', options.name);
+    }
+    if (options.remote) {
+      args.push('--remote', options.remote);
+    }
+    if (options.local) {
+      args.push('--local');
+    }
+    await this.runCli(args);
+  }
+
+  async removeGateway(name?: string): Promise<void> {
+    const args = ['gateway', 'remove'];
+    if (name) {
+      args.push(name);
+    }
+    await this.runCli(args);
+  }
+
+  async selectGateway(name?: string): Promise<void> {
+    const args = ['gateway', 'select'];
+    if (name) {
+      args.push(name);
+    }
+    await this.runCli(args);
+  }
+
+  async listGateways(): Promise<GatewayInfo[]> {
+    const data = await this.execCLI<unknown>(['gateway', 'list']);
+    return z.array(GatewayInfoSchema).parse(data);
+  }
+
+  async checkEndpointStatus(endpoint: string): Promise<boolean> {
+    const args = ['status', '--gateway-endpoint', endpoint];
+    if (endpoint.startsWith('http://')) {
+      args.push('--gateway-insecure');
+    }
+    try {
+      await this.runCli(args, { quiet: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getGatewayStatus(): Promise<string> {
+    const cliPath = this.getCliPath();
+    try {
+      const result = await this.exec.exec(cliPath, ['status']);
+      return result.stdout.trim();
+    } catch (err: unknown) {
+      const detail = this.extractCliError(err);
+      console.error(`openshell failed: ${cliPath} status — ${detail}`);
+      throw new Error(detail);
+    }
+  }
+}

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -26,7 +26,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { Directories } from '/@/plugin/directories.js';
-import type { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { OpenshellGatewayCli } from '/@/plugin/openshell-cli/openshell-gateway-cli.js';
 import type { Exec } from '/@/plugin/util/exec.js';
 import type { CliToolInfo } from '/@api/cli-tool-info.js';
 import type { GatewayInfo } from '/@api/openshell-gateway-info.js';
@@ -62,14 +62,15 @@ let gateway: OpenshellGateway;
 
 const cliToolRegistry = {
   getCliToolInfos: vi.fn(),
+  onDidCliToolsChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
 } as unknown as CliToolRegistry;
 
-const openshellCli = {
+const openshellGatewayCli = {
   listGateways: vi.fn(),
   selectGateway: vi.fn(),
   checkEndpointStatus: vi.fn(),
   addGateway: vi.fn(),
-} as unknown as OpenshellCli;
+} as unknown as OpenshellGatewayCli;
 
 const directories = {
   getDataDirectory: vi.fn().mockReturnValue(KAIDEN_DATA_DIRECTORY),
@@ -85,8 +86,9 @@ beforeEach(() => {
   vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
     { name: 'openshell-gateway', path: GATEWAY_BINARY },
   ] as unknown as CliToolInfo[]);
+  vi.mocked(cliToolRegistry.onDidCliToolsChange).mockReturnValue({ dispose: vi.fn() });
   vi.mocked(exec.exec).mockResolvedValue({ command: '', stdout: '', stderr: '' });
-  gateway = new OpenshellGateway(cliToolRegistry, openshellCli, directories, exec);
+  gateway = new OpenshellGateway(cliToolRegistry, openshellGatewayCli, directories, exec);
 });
 
 describe('init', () => {
@@ -95,36 +97,36 @@ describe('init', () => {
     const existingGateways: GatewayInfo[] = [
       { name: 'local-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
     ];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(existingGateways);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
-    expect(openshellCli.listGateways).toHaveBeenCalled();
-    expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
+    expect(openshellGatewayCli.listGateways).toHaveBeenCalled();
+    expect(openshellGatewayCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
     expect(spawn).not.toHaveBeenCalled();
-    expect(openshellCli.selectGateway).not.toHaveBeenCalled();
+    expect(openshellGatewayCli.selectGateway).not.toHaveBeenCalled();
   });
 
   test('selects healthy gateway when it is not active', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const existingGateways: GatewayInfo[] = [{ name: 'kaiden-alt', endpoint: 'http://127.0.0.1:18080', active: false }];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(existingGateways);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(existingGateways);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
-    expect(openshellCli.selectGateway).toHaveBeenCalledWith('kaiden-alt');
+    expect(openshellGatewayCli.selectGateway).toHaveBeenCalledWith('kaiden-alt');
     expect(spawn).not.toHaveBeenCalled();
   });
 
   test('auto-starts local gateway when no gateways exist and port is free', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue([]);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
 
     await gateway.init();
@@ -139,13 +141,13 @@ describe('init', () => {
   test('reuses orphan gateway when port is already healthy', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue([]);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
     expect(spawn).not.toHaveBeenCalled();
-    expect(openshellCli.addGateway).toHaveBeenCalledWith({
+    expect(openshellGatewayCli.addGateway).toHaveBeenCalledWith({
       endpoint: 'http://127.0.0.1:17670',
       local: true,
       name: 'kaiden-local',
@@ -154,7 +156,7 @@ describe('init', () => {
 
   test('skips auto-start when discovery fails and binary is not registered', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('CLI not found'));
+    vi.mocked(openshellGatewayCli.listGateways).mockRejectedValue(new Error('CLI not found'));
     vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([] as unknown as CliToolInfo[]);
 
     await gateway.init();
@@ -165,10 +167,10 @@ describe('init', () => {
   test('auto-starts when discovery fails but binary is available and port is free', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('no gateway configured'));
+    vi.mocked(openshellGatewayCli.listGateways).mockRejectedValue(new Error('no gateway configured'));
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
 
     await gateway.init();
@@ -186,8 +188,8 @@ describe('init', () => {
       { name: 'gw-stopped', endpoint: 'http://127.0.0.1:8080', active: false },
       { name: 'gw-healthy', endpoint: 'http://127.0.0.1:9090', active: true },
     ];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     await gateway.init();
 
@@ -198,10 +200,10 @@ describe('init', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const gateways: GatewayInfo[] = [{ name: 'broken-gw', endpoint: 'http://127.0.0.1:19999', active: true }];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus)
+    vi.mocked(openshellGatewayCli.checkEndpointStatus)
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(false)
       .mockResolvedValue(true);
@@ -221,27 +223,27 @@ describe('init', () => {
     const gateways: GatewayInfo[] = [
       { name: 'tls-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
     ];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.init();
 
-    expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
+    expect(openshellGatewayCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
   });
 
   test('skips remote gateways during init and auto-starts local', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const gateways: GatewayInfo[] = [{ name: 'remote-gw', endpoint: 'https://gw.example.com', active: true }];
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(gateways);
+    vi.mocked(openshellGatewayCli.listGateways).mockResolvedValue(gateways);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValueOnce(false).mockResolvedValue(true);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
 
     await gateway.init();
 
-    expect(openshellCli.checkEndpointStatus).not.toHaveBeenCalledWith('https://gw.example.com');
+    expect(openshellGatewayCli.checkEndpointStatus).not.toHaveBeenCalledWith('https://gw.example.com');
     expect(spawn).toHaveBeenCalled();
   });
 });
@@ -263,7 +265,7 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -279,7 +281,7 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start({ port: 9999, bindAddress: '0.0.0.0' });
 
@@ -295,7 +297,7 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start({ disableTls: false });
 
@@ -311,7 +313,7 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
     await gateway.start();
@@ -330,11 +332,11 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
-    expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('http://127.0.0.1:17670');
+    expect(openshellGatewayCli.checkEndpointStatus).toHaveBeenCalledWith('http://127.0.0.1:17670');
   });
 
   test('registers gateway via openshellCli after health check passes', async () => {
@@ -342,11 +344,11 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
-    expect(openshellCli.addGateway).toHaveBeenCalledWith({
+    expect(openshellGatewayCli.addGateway).toHaveBeenCalledWith({
       endpoint: 'http://127.0.0.1:17670',
       local: true,
       name: 'kaiden-local',
@@ -358,19 +360,19 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start({ skipRegistration: true });
 
     expect(spawn).toHaveBeenCalled();
-    expect(openshellCli.addGateway).not.toHaveBeenCalled();
+    expect(openshellGatewayCli.addGateway).not.toHaveBeenCalled();
   });
 
   test('generates certs by calling the gateway binary with generate-certs', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -392,7 +394,7 @@ describe('start', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -411,7 +413,7 @@ describe('start', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
     vi.mocked(exec.exec).mockRejectedValue(new Error('generate-certs failed'));
 
     await gateway.start();
@@ -430,7 +432,9 @@ describe('start', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockRejectedValue(new Error('command not found'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(false);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(false);
+
+    const availablePromise = gateway.checkAvailable().catch(() => {});
 
     let caughtError: unknown;
     const startPromise = gateway.start().catch((err: unknown) => {
@@ -444,6 +448,7 @@ describe('start', () => {
     proc.emit('exit', 1, undefined);
     await vi.advanceTimersByTimeAsync(5000);
     await startPromise;
+    await availablePromise;
 
     expect(caughtError).toBeInstanceOf(Error);
     expect((caughtError as Error).message).toContain('Gateway did not become ready');
@@ -458,7 +463,7 @@ describe('stop', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -484,7 +489,7 @@ describe('isRunning', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -498,7 +503,7 @@ describe('dispose', () => {
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
 
@@ -515,7 +520,7 @@ describe('gateway config generation', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
-    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    vi.mocked(openshellGatewayCli.checkEndpointStatus).mockResolvedValue(true);
   });
 
   test('writes gateway config under the kaiden data directory', async () => {

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -27,7 +27,7 @@ import Mustache from 'mustache';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { Directories } from '/@/plugin/directories.js';
-import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import { OpenshellGatewayCli } from '/@/plugin/openshell-cli/openshell-gateway-cli.js';
 import { Exec } from '/@/plugin/util/exec.js';
 import type { OpenshellGatewayStartOptions } from '/@api/openshell-gateway-info.js';
 
@@ -53,29 +53,35 @@ export class OpenshellGateway implements Disposable {
   #gatewayProcess: ChildProcess | undefined;
   #port: number = DEFAULT_PORT;
   #bindAddress: string = DEFAULT_BIND_ADDRESS;
+  #availablePromise: PromiseWithResolvers<void>;
+  #disposables: Disposable[] = [];
 
   constructor(
     @inject(CliToolRegistry)
     private readonly cliToolRegistry: CliToolRegistry,
-    @inject(OpenshellCli)
-    private readonly openshellCli: OpenshellCli,
+    @inject(OpenshellGatewayCli)
+    private readonly openshellGatewayCli: OpenshellGatewayCli,
     @inject(Directories)
     private readonly directories: Directories,
     @inject(Exec)
     private readonly exec: Exec,
-  ) {}
+  ) {
+    this.#availablePromise = Promise.withResolvers<void>();
+    this.#disposables.push(cliToolRegistry.onDidCliToolsChange(() => this.start().catch(console.error)));
+  }
 
   async init(): Promise<void> {
     try {
-      const gateways = await this.openshellCli.listGateways();
+      const gateways = await this.openshellGatewayCli.listGateways();
       const localGateways = gateways.filter(gw => gw.type === 'local' || this.isLocalEndpoint(gw.endpoint));
       if (localGateways.length > 0) {
         for (const gw of localGateways) {
           if (await this.isEndpointHealthy(gw.endpoint)) {
             if (!gw.active) {
-              await this.openshellCli.selectGateway(gw.name);
+              await this.openshellGatewayCli.selectGateway(gw.name);
             }
             console.log(`[openshell-gateway] gateway detected (${gw.endpoint}) and is healthy`);
+            this.#availablePromise.resolve(undefined);
             return;
           }
         }
@@ -95,6 +101,7 @@ export class OpenshellGateway implements Disposable {
     if (await this.isEndpointHealthy()) {
       console.log('[openshell-gateway] found healthy gateway on default port, registering');
       await this.registerWithCli();
+      this.#availablePromise.resolve(undefined);
       return;
     }
 
@@ -104,7 +111,7 @@ export class OpenshellGateway implements Disposable {
 
   private async isEndpointHealthy(endpoint?: string): Promise<boolean> {
     const target = endpoint ?? `http://${this.#bindAddress}:${this.#port}`;
-    return this.openshellCli.checkEndpointStatus(target);
+    return this.openshellGatewayCli.checkEndpointStatus(target);
   }
 
   private isLocalEndpoint(endpoint: string): boolean {
@@ -177,11 +184,13 @@ export class OpenshellGateway implements Disposable {
       });
       this.#port = previousPort;
       this.#bindAddress = previousBindAddress;
+      this.#availablePromise.reject(err);
       throw err;
     }
     if (!options?.skipRegistration) {
       await this.registerWithCli();
     }
+    this.#availablePromise.resolve(undefined);
   }
 
   async stop(): Promise<void> {
@@ -211,6 +220,10 @@ export class OpenshellGateway implements Disposable {
     this.#gatewayProcess = undefined;
   }
 
+  async checkAvailable(): Promise<void> {
+    return this.#availablePromise.promise;
+  }
+
   isRunning(): boolean {
     return this.#gatewayProcess !== undefined && typeof this.#gatewayProcess.exitCode !== 'number';
   }
@@ -218,6 +231,7 @@ export class OpenshellGateway implements Disposable {
   @preDestroy()
   dispose(): void {
     this.stop().catch((err: unknown) => console.error('[openshell-gateway] failed to stop: ', err));
+    this.#disposables.forEach(disposable => disposable.dispose());
   }
 
   private async generateCerts(binaryPath: string, gatewayDir: string): Promise<void> {
@@ -303,7 +317,7 @@ export class OpenshellGateway implements Disposable {
         throw new Error('Gateway process exited before becoming ready');
       }
 
-      if (await this.openshellCli.checkEndpointStatus(endpoint)) {
+      if (await this.openshellGatewayCli.checkEndpointStatus(endpoint)) {
         console.log('[openshell-gateway] server is ready');
         return;
       }
@@ -317,7 +331,7 @@ export class OpenshellGateway implements Disposable {
   private async registerWithCli(): Promise<void> {
     const endpoint = `http://${this.#bindAddress}:${this.#port}`;
     try {
-      await this.openshellCli.addGateway({ endpoint, local: true, name: 'kaiden-local' });
+      await this.openshellGatewayCli.addGateway({ endpoint, local: true, name: 'kaiden-local' });
       console.log(`[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
@@ -20,6 +20,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import type { OpenshellGatewayCli } from '/@/plugin/openshell-cli/openshell-gateway-cli.js';
 import type { Exec } from '/@/plugin/util/exec.js';
 import type { SecretCreateOptions } from '/@api/secret-info.js';
 
@@ -28,7 +30,12 @@ import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
 vi.mock(import('/@/plugin/openshell-cli/openshell-cli.js'));
 
 let adapter: OpenshellSecretAdapter;
-const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
+const openshellCli = new OpenshellCli(
+  {} as Exec,
+  {} as CliToolRegistry,
+  {} as OpenshellGatewayCli,
+  {} as OpenshellGateway,
+);
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -23,6 +23,8 @@ import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import type { OpenshellGatewayCli } from '/@/plugin/openshell-cli/openshell-gateway-cli.js';
 import type { ProviderImpl } from '/@/plugin/provider-impl.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
@@ -43,7 +45,12 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 const ipcHandle: IPCHandle = vi.fn();
-const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
+const openshellCli = new OpenshellCli(
+  {} as Exec,
+  {} as CliToolRegistry,
+  {} as OpenshellGatewayCli,
+  {} as OpenshellGateway,
+);
 const openshellAdapter = new OpenshellSecretAdapter(openshellCli);
 
 let registerInferenceCallback: ((event: RegisterInferenceConnectionEvent) => void) | undefined;


### PR DESCRIPTION
## Summary

- Extract `OpenshellCliBase` abstract class with shared CLI plumbing (`getCliPath`, `runCli`, `execCLI`, error handling)
- Move gateway commands (`addGateway`, `removeGateway`, `selectGateway`, `listGateways`, `checkEndpointStatus`, `getGatewayStatus`) into new `OpenshellGatewayCli` class
- `OpenshellCli` now extends the base and gates CLI access behind `OpenshellGateway.checkAvailable()`, ensuring the gateway is initialized before extensions invoke CLI operations
- `OpenshellGateway` depends on `OpenshellGatewayCli` instead of the full `OpenshellCli`, breaking the circular initialization dependency

Fixes #2371

## Test plan

- [x] All 284 existing unit tests pass
- [x] Typecheck clean (`pnpm run typecheck:main`)
- [x] Lint clean (`pnpm run lint:check`)
- [x] Gateway CLI tests extracted to `openshell-gateway-cli.spec.ts` (16 tests)
- [x] Unhandled rejection in `openshell-gateway.spec.ts` fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)