### PR TITLE
fix(agent-workspace): enable L7 encoded slash support for npm scoped packages

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
@@ -128,8 +128,8 @@ describe('buildPolicyObject', () => {
       network_policies: {
         'kdn-network': {
           endpoints: [
-            { host: 'registry.npmjs.org', port: 443, access: 'full' },
-            { host: 'registry.npmjs.org', port: 80, access: 'full' },
+            { host: 'registry.npmjs.org', port: 443, protocol: 'rest', access: 'full', allow_encoded_slash: true },
+            { host: 'registry.npmjs.org', port: 80, protocol: 'rest', access: 'full', allow_encoded_slash: true },
           ],
           binaries: [{ path: '/**' }],
         },
@@ -159,8 +159,8 @@ describe('buildPolicyObject', () => {
       network_policies: {
         'kdn-network': {
           endpoints: [
-            { host: 'registry.npmjs.org', port: 443, access: 'full' },
-            { host: 'registry.npmjs.org', port: 80, access: 'full' },
+            { host: 'registry.npmjs.org', port: 443, protocol: 'rest', access: 'full', allow_encoded_slash: true },
+            { host: 'registry.npmjs.org', port: 80, protocol: 'rest', access: 'full', allow_encoded_slash: true },
           ],
           binaries: [{ path: '/**' }],
         },

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
@@ -196,8 +196,8 @@ export function buildPolicyObject(network?: NetworkConfiguration, modelEndpoint?
 
   if (network && network.mode !== 'allow' && network.hosts?.length) {
     const endpoints: OpenshellEndpoint[] = network.hosts.flatMap(host => [
-      { host, port: 443, access: 'full' as const },
-      { host, port: 80, access: 'full' as const },
+      { host, port: 443, protocol: 'rest' as const, access: 'full' as const, allow_encoded_slash: true },
+      { host, port: 80, protocol: 'rest' as const, access: 'full' as const, allow_encoded_slash: true },
     ]);
     networkPolicies[NETWORK_RULE_NAME] = {
       endpoints,


### PR DESCRIPTION
## Summary

- Add `protocol: 'rest'` and `allow_encoded_slash: true` to `kdn-network` policy endpoints in `buildPolicyObject()` so the OpenShell L7 proxy preserves `%2F` in URL paths instead of rejecting them
- This fixes npm scoped package installs (e.g. `@playwright/mcp`, `@modelcontextprotocol/server`) which encode the scope separator as `%2F` in registry URLs

## Root Cause

npm requests scoped packages using URL-encoded paths like `/@playwright%2fmcp`. Without `protocol: rest` and `allow_encoded_slash: true` on the policy endpoint, the OpenShell proxy treats the connection as TCP passthrough and the L7 encoded slash setting is ignored — causing `ECONNRESET` for all scoped package installs while unscoped packages work fine.

Based on documentation from https://docs.nvidia.com/openshell/reference/policy-schema#endpoint-object

## Test plan
Create a workspace with opencode and the playwright mcp from the defualt mcp registery

first go to the mcp registry and click on the playwright mcp server and register it

then create a workspace selecting the playwright mcp

inside the terminal do `opencode mcp list` to spawn it and it should work now before it wasnt working

<img width="1311" height="873" alt="Screenshot From 2026-07-07 11-09-43" src="https://github.com/user-attachments/assets/6c09c0c8-7462-4372-9c79-5744f370e0df" />


Fixes #2394
