### PR TITLE
feat(secret-manager): report provider profiles from OpenShell adapter

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -125,6 +125,24 @@ export const OpenshellProviderInfoSchema = z.object({
 
 export type OpenshellProviderInfo = z.output<typeof OpenshellProviderInfoSchema>;
 
+export const OpenshellProfileCredentialSchema = z.looseObject({
+  name: z.string(),
+  required: z.boolean(),
+  description: z.string().optional(),
+  env_vars: z.array(z.string()).optional(),
+});
+
+export type OpenshellProfileCredential = z.output<typeof OpenshellProfileCredentialSchema>;
+
+export const OpenshellProfileSchema = z.looseObject({
+  id: z.string(),
+  display_name: z.string(),
+  description: z.string().optional(),
+  credentials: z.array(OpenshellProfileCredentialSchema).optional(),
+});
+
+export type OpenshellProfile = z.output<typeof OpenshellProfileSchema>;
+
 export interface CreateProviderOptions {
   name: string;
   type: string;

--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -30,8 +30,6 @@ export type SecretName = components['schemas']['SecretName'];
  */
 export type SecretInfo = components['schemas']['SecretInfo'];
 
-export type SecretService = components['schemas']['SecretService'];
-
 /**
  * Options for creating a new secret via `kdn secret create`.
  */

--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -18,6 +18,8 @@
 
 import type { components } from '@openkaiden/kdn-api';
 
+import type { OpenshellProfile } from './openshell-gateway-info.js';
+
 /**
  * Returned by secret create/remove commands to confirm which secret was affected.
  */
@@ -54,5 +56,5 @@ export interface SecretCliBackend {
   createSecret(options: SecretCreateOptions): Promise<SecretName>;
   listSecrets(): Promise<SecretInfo[]>;
   removeSecret(name: string): Promise<SecretName>;
-  listServices(): Promise<SecretService[]>;
+  listServices(): Promise<OpenshellProfile[]>;
 }

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -816,6 +816,45 @@ describe('listProviders', () => {
   });
 });
 
+describe('listProfiles', () => {
+  test('executes provider list-profiles with json output and returns parsed result', async () => {
+    const payload = [
+      {
+        id: 'openai',
+        display_name: 'OpenAI',
+        description: 'OpenAI API provider',
+        credentials: [{ name: 'api_key', required: true, description: 'API key', env_vars: ['OPENAI_API_KEY'] }],
+      },
+      {
+        id: 'anthropic',
+        display_name: 'Anthropic',
+        credentials: [{ name: 'api_key', required: true, env_vars: ['ANTHROPIC_API_KEY'] }],
+      },
+    ];
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(payload)));
+
+    const result = await openshellCli.listProfiles();
+
+    expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['provider', 'list-profiles', '-o', 'json'], undefined);
+    expect(result).toEqual(payload);
+  });
+
+  test('returns empty array when no profiles exist', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify([])));
+
+    const result = await openshellCli.listProfiles();
+
+    expect(result).toEqual([]);
+  });
+
+  test('rejects when CLI fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockRejectedValue(new Error('no gateway configured'));
+
+    await expect(openshellCli.listProfiles()).rejects.toThrow('no gateway configured');
+  });
+});
+
 describe('deleteProvider', () => {
   test('executes provider delete with name', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -25,17 +25,21 @@ import z from 'zod';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { Exec } from '/@/plugin/util/exec.js';
-import type {
-  CreateProviderOptions,
-  CreateSandboxOptions,
-  GatewayAddOptions,
-  GatewayInfo,
-  GatewaySandboxes,
-  OpenshellProviderInfo,
-  SandboxInfo,
-  SetInferenceOptions,
+import {
+  type CreateProviderOptions,
+  type CreateSandboxOptions,
+  type GatewayAddOptions,
+  type GatewayInfo,
+  GatewayInfoSchema,
+  type GatewaySandboxes,
+  type OpenshellProfile,
+  OpenshellProfileSchema,
+  type OpenshellProviderInfo,
+  OpenshellProviderInfoSchema,
+  type SandboxInfo,
+  SandboxInfoSchema,
+  type SetInferenceOptions,
 } from '/@api/openshell-gateway-info.js';
-import { GatewayInfoSchema, OpenshellProviderInfoSchema, SandboxInfoSchema } from '/@api/openshell-gateway-info.js';
 
 const SettingValue = z.union([z.string(), z.boolean(), z.number()]);
 
@@ -343,6 +347,11 @@ export class OpenshellCli {
   async listProviders(): Promise<OpenshellProviderInfo[]> {
     const data = await this.execCLI<unknown>(['provider', 'list']);
     return z.array(OpenshellProviderInfoSchema).parse(data);
+  }
+
+  async listProfiles(): Promise<OpenshellProfile[]> {
+    const data = await this.execCLI<unknown>(['provider', 'list-profiles']);
+    return z.array(OpenshellProfileSchema).parse(data);
   }
 
   async deleteProvider(name: string): Promise<void> {

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
@@ -142,9 +142,39 @@ describe('removeSecret', () => {
 });
 
 describe('listServices', () => {
-  test('returns empty array (not supported by OpenShell)', async () => {
+  test('delegates to openshellCli.listProfiles', async () => {
+    const profiles = [
+      {
+        id: 'openai',
+        display_name: 'OpenAI',
+        description: 'OpenAI API provider',
+        credentials: [{ name: 'api_key', required: true, env_vars: ['OPENAI_API_KEY'] }],
+      },
+      {
+        id: 'anthropic',
+        display_name: 'Anthropic',
+        credentials: [{ name: 'api_key', required: true, env_vars: ['ANTHROPIC_API_KEY'] }],
+      },
+    ];
+    vi.mocked(openshellCli.listProfiles).mockResolvedValue(profiles);
+
+    const result = await adapter.listServices();
+
+    expect(openshellCli.listProfiles).toHaveBeenCalled();
+    expect(result).toEqual(profiles);
+  });
+
+  test('returns empty array when no profiles exist', async () => {
+    vi.mocked(openshellCli.listProfiles).mockResolvedValue([]);
+
     const result = await adapter.listServices();
 
     expect(result).toEqual([]);
+  });
+
+  test('rejects when openshellCli.listProfiles fails', async () => {
+    vi.mocked(openshellCli.listProfiles).mockRejectedValue(new Error('no gateway configured'));
+
+    await expect(adapter.listServices()).rejects.toThrow('no gateway configured');
   });
 });

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -19,13 +19,8 @@
 import { inject, injectable } from 'inversify';
 
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
-import type {
-  SecretCliBackend,
-  SecretCreateOptions,
-  SecretInfo,
-  SecretName,
-  SecretService,
-} from '/@api/secret-info.js';
+import type { OpenshellProfile } from '/@api/openshell-gateway-info.js';
+import type { SecretCliBackend, SecretCreateOptions, SecretInfo, SecretName } from '/@api/secret-info.js';
 
 /**
  * Adapts {@link OpenshellCli} provider commands to the
@@ -36,7 +31,7 @@ import type {
  *   - `createSecret`  → `openshell provider create`
  *   - `listSecrets`   → `openshell provider list`
  *   - `removeSecret`  → `openshell provider delete`
- *   - `listServices`  → returns `[]` (not supported by OpenShell)
+ *   - `listServices`  → `openshell provider list-profiles`
  */
 @injectable()
 export class OpenshellSecretAdapter implements SecretCliBackend {
@@ -69,7 +64,7 @@ export class OpenshellSecretAdapter implements SecretCliBackend {
     return { name };
   }
 
-  async listServices(): Promise<SecretService[]> {
-    return [];
+  async listServices(): Promise<OpenshellProfile[]> {
+    return this.openshellCli.listProfiles();
   }
 }

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -208,10 +208,13 @@ describe('openshellAdapter', () => {
     expect(result).toEqual({ name: 'my-openai' });
   });
 
-  test('listServices returns empty array', async () => {
+  test('listServices delegates to openshellAdapter', async () => {
+    const profiles = [{ id: 'openai', display_name: 'OpenAI', description: 'OpenAI API provider' }];
+    vi.mocked(openshellCli.listProfiles).mockResolvedValue(profiles);
+
     const result = await manager.listServices();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(profiles);
   });
 
   test('skips file watching', () => {

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -31,14 +31,8 @@ import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SafeStorageRegistry } from '/@/plugin/safe-storage/safe-storage-registry.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import { IConfigurationPropertyRecordedSchema, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type {
-  SecretCliBackend,
-  SecretCreateOptions,
-  SecretInfo,
-  SecretName,
-  SecretService,
-  SecretValue,
-} from '/@api/secret-info.js';
+import type { OpenshellProfile } from '/@api/openshell-gateway-info.js';
+import type { SecretCliBackend, SecretCreateOptions, SecretInfo, SecretName, SecretValue } from '/@api/secret-info.js';
 
 import { OpenshellSecretAdapter } from './openshell-secret-adapter.js';
 
@@ -85,7 +79,7 @@ export class SecretManager {
     return result;
   }
 
-  async listServices(): Promise<SecretService[]> {
+  async listServices(): Promise<OpenshellProfile[]> {
     return this.cli.listServices();
   }
 
@@ -245,7 +239,7 @@ export class SecretManager {
       return this.remove(name);
     });
 
-    this.ipcHandle('secret-manager:list-services', async (): Promise<SecretService[]> => {
+    this.ipcHandle('secret-manager:list-services', async (): Promise<OpenshellProfile[]> => {
       return this.listServices();
     });
   }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -128,7 +128,7 @@ import type { NavigationRequest } from '/@api/navigation-request';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
 import type { OnboardingInfo, OnboardingStatus } from '/@api/onboarding';
-import type { GatewaySandboxes } from '/@api/openshell-gateway-info';
+import type { GatewaySandboxes, OpenshellProfile } from '/@api/openshell-gateway-info';
 import type { V1Route } from '/@api/openshift-types';
 import type { PodCreateOptions, PodInfo, PodInspectInfo } from '/@api/pod-info';
 import type {
@@ -144,7 +144,7 @@ import type { PullEvent } from '/@api/pull-event';
 import type { RagEnvironment } from '/@api/rag/rag-environment';
 import type { ExtensionBanner, RecommendedRegistry } from '/@api/recommendations/recommendations';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info';
-import type { SecretCreateOptions, SecretInfo, SecretName, SecretService } from '/@api/secret-info';
+import type { SecretCreateOptions, SecretInfo, SecretName } from '/@api/secret-info';
 import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info';
 import type { SkillFileContent, SkillFolderInfo, SkillInfo, SkillResourceEntry } from '/@api/skill/skill-info';
 import type { StatusBarEntryDescriptor } from '/@api/status-bar';
@@ -461,7 +461,7 @@ export function initExposure(): void {
     return ipcInvoke('secret-manager:remove', name);
   });
 
-  contextBridge.exposeInMainWorld('listSecretServices', async (): Promise<SecretService[]> => {
+  contextBridge.exposeInMainWorld('listSecretServices', async (): Promise<OpenshellProfile[]> => {
     return ipcInvoke('secret-manager:list-services');
   });
 

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -21,26 +21,28 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { SecretService } from '/@api/secret-info';
+import type { OpenshellProfile } from '/@api/openshell-gateway-info';
 
 import SecretVaultCreate from './SecretVaultCreate.svelte';
 
 vi.mock(import('/@/navigation'));
 
-const MOCK_SERVICES: SecretService[] = [
+const MOCK_SERVICES: OpenshellProfile[] = [
   {
-    name: 'github',
-    hostPattern: 'api.github.com',
-    headerName: 'Authorization',
-    headerTemplate: 'Bearer ${value}',
-    envVars: ['GH_TOKEN', 'GITHUB_TOKEN'],
+    id: 'github',
+    display_name: 'GitHub',
+    description: 'GitHub API provider',
+    credentials: [
+      { name: 'token', required: true, description: 'Personal access token', env_vars: ['GH_TOKEN', 'GITHUB_TOKEN'] },
+    ],
   },
   {
-    name: 'gemini',
-    hostPattern: 'generativelanguage.googleapis.com',
-    headerName: 'x-goog-api-key',
-    headerTemplate: '${value}',
-    envVars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+    id: 'gemini',
+    display_name: 'Gemini',
+    description: 'Google Gemini API provider',
+    credentials: [
+      { name: 'api_key', required: true, description: 'API key', env_vars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'] },
+    ],
   },
 ];
 

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -10,11 +10,12 @@ import FormPage from '/@/lib/ui/FormPage.svelte';
 import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
-import type { SecretCreateOptions, SecretService } from '/@api/secret-info';
+import type { OpenshellProfile } from '/@api/openshell-gateway-info';
+import type { SecretCreateOptions } from '/@api/secret-info';
 
-import { getServiceIcon, getServiceLabel, OTHER_TYPE } from './secret-vault-utils';
+import { getServiceIcon, OTHER_TYPE } from './secret-vault-utils';
 
-let services = $state<SecretService[]>([]);
+let services = $state<OpenshellProfile[]>([]);
 let loading = $state(true);
 
 let type = $state(OTHER_TYPE);
@@ -29,14 +30,14 @@ let injectionOpen = $state(true);
 let saving = $state(false);
 let error = $state('');
 
-let serviceMap = $derived(new Map(services.map(s => [s.name, s])));
+let serviceMap = $derived(new Map(services.map(s => [s.id, s])));
 
 let typeOptions = $derived<CardSelectorOption[]>([
   ...services.map(s => ({
-    title: getServiceLabel(s.name),
-    badge: getServiceLabel(s.name),
-    value: s.name,
-    icon: getServiceIcon(s.name),
+    title: s.display_name,
+    badge: s.display_name,
+    value: s.id,
+    icon: getServiceIcon(s.id),
   })),
   {
     title: 'Other',
@@ -54,7 +55,7 @@ let title = $derived.by(() => {
   if (isOther) return 'Other Secret';
   const svc = serviceMap.get(effectiveType);
   if (!svc) return 'Other Secret';
-  return `${getServiceLabel(svc.name)} Secret`;
+  return `${svc.display_name} Secret`;
 });
 
 let subtitle = $derived.by(() => {


### PR DESCRIPTION
## Summary
- Implement `listServices()` in `OpenshellSecretAdapter` by calling `openshell provider list-profiles -o json` instead of returning an empty array
- Replace `SecretService` with `OpenshellProfile` throughout the interface chain (SecretCliBackend, SecretManager, preload, renderer) so the UI receives full profile data (id, display_name, description, credentials)
- Add `listProfiles()` method to `OpenshellCli` with Zod validation using `z.looseObject`

Fixes #2390

## Test plan
- [x] Unit tests for `OpenshellCli.listProfiles()` (happy path, empty, CLI failure)
- [x] Unit tests for `OpenshellSecretAdapter.listServices()` (delegates to listProfiles, empty, failure)
- [x] Unit tests for `SecretManager.listServices()` delegation
- [x] Renderer tests for `SecretVaultCreate` with `OpenshellProfile` mock data
- [x] All 137 affected tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)