### PR TITLE
fix(ui): use CSS grid for CardSelector to enable responsive wrapping

### DIFF
--- a/packages/renderer/src/lib/ui/CardSelector.svelte
+++ b/packages/renderer/src/lib/ui/CardSelector.svelte
@@ -28,10 +28,10 @@ function handleClick(value: string): void {
   {#if label}
     <span class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">{label}</span>
   {/if}
-  <div class="flex flex-row gap-2 w-full">
+  <div class="grid gap-2 w-full grid-cols-[repeat(auto-fill,minmax(12rem,1fr))]">
     {#each options as option (option.value)}
       <button
-        class="rounded-md bg-[var(--pd-content-card-inset-bg)] p-3 flex-1 min-w-0 min-h-24 cursor-pointer
+        class="rounded-md bg-[var(--pd-content-card-inset-bg)] p-3 min-w-0 min-h-24 cursor-pointer
           hover:bg-[var(--pd-content-card-hover-inset-bg)]
           {selected === option.value ? 'border-[var(--pd-content-card-border-selected)]' : 'border-[var(--pd-content-card-border)]'}
           border-2 flex flex-col overflow-hidden"


### PR DESCRIPTION
## Summary
- Switch `CardSelector` layout from `flex-row` to CSS `grid` with `auto-fill`/`minmax` so cards wrap to multiple rows instead of stretching infinitely in a single row
- Remove `flex-1` from individual card buttons since grid handles sizing

## Test plan
- [ ] Open a view using `CardSelector` (e.g. workspace creation)
- [ ] Verify cards wrap to multiple rows when the container is narrow
- [ ] Verify cards fill available space evenly on wider screens
- [ ] Confirm selected/hover styles still work correctly

Fixes #2399

Before:

<img width="1040" height="633" alt="image" src="https://github.com/user-attachments/assets/afbc22d0-52ac-494d-8e37-813bbb730159" />

After:

<img width="1023" height="637" alt="image" src="https://github.com/user-attachments/assets/996ec10b-076d-4051-8bec-a540e4aebeb9" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)