### PR TITLE
chore: update fullsend allowed resources

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -11,3 +11,6 @@ create_issues:
         repos:
             - openkaiden/kaiden
             - fullsend-ai/fullsend
+allowed_remote_resources:
+    - https://raw.githubusercontent.com/fullsend-ai/fullsend/
+    - https://raw.githubusercontent.com/fullsend-ai/agents/


### PR DESCRIPTION
Adds an allowed_remote_resources with both https://raw.githubusercontent.com/fullsend-ai/fullsend/ and https://raw.githubusercontent.com/fullsend-ai/agents/

This change is required for fullsend v0.29.0. The new version resolves agent harnesses from fullsend-ai/agents at runtime, and the URL must be in the config allowlist. No behaviour change on prior releases.

Same change as https://github.com/redhat-developer/rhdh-plugins/pull/3696.

Fixes #2401.