### PR TITLE
fix(openshell): register gateway CLI tool when binary is not found

### DIFF
--- a/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.spec.ts
@@ -68,6 +68,26 @@ beforeEach(() => {
 });
 
 describe('OpenshellCliManager', () => {
+  test('registers gateway CLI tool even when binary is not found', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const manager = createManager();
+    await manager.init();
+
+    const createCalls = vi.mocked(cli.createCliTool).mock.calls;
+    const registeredNames = createCalls.map(call => call[0].name);
+
+    expect(registeredNames).toContain('openshell');
+    expect(registeredNames).toContain('openshell-image-builder');
+    expect(registeredNames).toContain('openshell-gateway');
+
+    const gwCall = createCalls.find(call => call[0].name === 'openshell-gateway');
+    expect(gwCall).toBeDefined();
+    expect(gwCall![0].installationSource).toBe('extension');
+    expect(gwCall![0].path).toBeUndefined();
+    expect(gwCall![0].version).toBeUndefined();
+  });
+
   describe('binary discovery priority', () => {
     test('prefers bundled resource over system PATH', async () => {
       const bundledPath = join('/resources', 'openshell', 'openshell');

--- a/extensions/openshell/src/manager/openshell-cli-manager.ts
+++ b/extensions/openshell/src/manager/openshell-cli-manager.ts
@@ -103,7 +103,6 @@ export class OpenshellCliManager implements Disposable {
 
     if (!gwResult) {
       console.warn('[openshell-gateway] CLI not found, registering installer-only entry');
-      return;
     }
 
     this.registerCliTool(


### PR DESCRIPTION
## Summary
- Removed early `return` in `OpenshellCliManager.init()` that prevented `openshell-gateway` from being registered when the binary was absent
- The gateway CLI tool is now always registered with a fallback entry, matching the existing pattern for `openshell` and `openshell-image-builder`
- Added test verifying all three CLI tools are registered even when no binaries are found

Fixes https://github.com/openkaiden/kaiden/issues/2379

## Test plan
if gateway binary isn't there we should still register it!
