### PR TITLE
feat: add semantic router factory to extension API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -787,6 +787,16 @@ declare module '@openkaiden/api' {
     create(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
+  export interface SemanticRouterCreateParams {
+    name: string;
+    config: string;
+  }
+
+  export interface SemanticRouterFactory extends ProviderConnectionFactory {
+    readonly type: string;
+    create(params: SemanticRouterCreateParams, logger?: Logger, token?: CancellationToken): Promise<void>;
+  }
+
   // create a kubernetes provider
   export interface KubernetesProviderConnectionFactory extends ProviderConnectionFactory {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -996,6 +1006,11 @@ declare module '@openkaiden/api' {
 
     setChunkProviderConnectionFactory(
       chunkProviderConnectionFactory: ChunkProviderConnectionFactory,
+      connectionAuditor?: Auditor,
+    ): Disposable;
+
+    setSemanticRouterConnectionFactory(
+      semanticRouterConnectionFactory: SemanticRouterFactory,
       connectionAuditor?: Auditor,
     ): Disposable;
 

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -45,6 +45,7 @@ import type {
   ProviderUpdate,
   RagProviderConnection,
   RagProviderConnectionFactory,
+  SemanticRouterFactory,
   VmProviderConnection,
   VmProviderConnectionFactory,
 } from '@openkaiden/api';
@@ -75,6 +76,7 @@ export class ProviderImpl implements Provider, IDisposable {
   private _inferenceProviderConnectionFactory: InferenceProviderConnectionFactory | undefined = undefined;
   private _ragProviderConnectionFactory: RagProviderConnectionFactory | undefined = undefined;
   private _chunkProviderConnectionFactory: ChunkProviderConnectionFactory | undefined = undefined;
+  private _semanticRouterConnectionFactory: SemanticRouterFactory | undefined = undefined;
 
   private _connectionAuditor: Auditor | undefined = undefined;
 
@@ -160,6 +162,10 @@ export class ProviderImpl implements Provider, IDisposable {
 
   get chunkProviderConnectionFactory(): ChunkProviderConnectionFactory | undefined {
     return this._chunkProviderConnectionFactory;
+  }
+
+  get semanticRouterConnectionFactory(): SemanticRouterFactory | undefined {
+    return this._semanticRouterConnectionFactory;
   }
 
   get connectionAuditor(): Auditor | undefined {
@@ -356,6 +362,18 @@ export class ProviderImpl implements Provider, IDisposable {
     this._connectionAuditor = connectionAuditor;
     return Disposable.create(() => {
       this._chunkProviderConnectionFactory = undefined;
+      this._connectionAuditor = undefined;
+    });
+  }
+
+  setSemanticRouterConnectionFactory(
+    semanticRouterConnectionFactory: SemanticRouterFactory,
+    connectionAuditor?: Auditor,
+  ): Disposable {
+    this._semanticRouterConnectionFactory = semanticRouterConnectionFactory;
+    this._connectionAuditor = connectionAuditor;
+    return Disposable.create(() => {
+      this._semanticRouterConnectionFactory = undefined;
       this._connectionAuditor = undefined;
     });
   }

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -2935,3 +2935,84 @@ test('rejects duplicate inference connection id for the same provider', () => {
     /an inference connection with id 'conn-0' is already registered for provider 'provider-a'/,
   );
 });
+
+test('getSemanticRouterFactory returns undefined when no provider has a factory', () => {
+  providerRegistry.createProvider('id', 'name', {
+    id: 'provider-a',
+    name: 'Provider A',
+    status: 'installed',
+  });
+
+  expect(providerRegistry.getSemanticRouterFactory()).toBeUndefined();
+});
+
+test('getSemanticRouterFactory returns factory when a provider has one set', () => {
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'provider-a',
+    name: 'Provider A',
+    status: 'installed',
+  });
+
+  const factory = {
+    type: 'semantic-router',
+    create: vi.fn(),
+  };
+  provider.setSemanticRouterConnectionFactory(factory);
+
+  const result = providerRegistry.getSemanticRouterFactory();
+  expect(result).toBeDefined();
+  expect(result!.factory).toBe(factory);
+});
+
+test('getSemanticRouterFactory returns undefined after factory disposable is disposed', () => {
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'provider-a',
+    name: 'Provider A',
+    status: 'installed',
+  });
+
+  const factory = {
+    type: 'semantic-router',
+    create: vi.fn(),
+  };
+  const disposable = provider.setSemanticRouterConnectionFactory(factory);
+
+  disposable.dispose();
+
+  expect(providerRegistry.getSemanticRouterFactory()).toBeUndefined();
+});
+
+test('deleteInferenceConnectionBySemanticRouter calls lifecycle.delete on matching connection', async () => {
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'provider-a',
+    name: 'Provider A',
+    status: 'installed',
+  });
+
+  const deleteMock = vi.fn().mockResolvedValue(undefined);
+  provider.registerInferenceProviderConnection({
+    id: 'conn-1',
+    name: 'my-router',
+    type: 'cloud',
+    llmMetadata: { name: 'test', semanticRouter: 'my-router' },
+    sdk: {} as never,
+    credentials: (): Record<string, string> => ({}),
+    lifecycle: { delete: deleteMock },
+    status: (): ProviderConnectionStatus => 'started',
+    models: [],
+  });
+
+  await providerRegistry.deleteInferenceConnectionBySemanticRouter('my-router');
+
+  expect(deleteMock).toHaveBeenCalled();
+});
+
+test('deleteInferenceConnectionBySemanticRouter does nothing when no matching connection exists', async () => {
+  providerRegistry.createProvider('id', 'name', {
+    id: 'provider-a',
+    name: 'Provider A',
+    status: 'installed',
+  });
+
+  await expect(providerRegistry.deleteInferenceConnectionBySemanticRouter('nonexistent')).resolves.toBeUndefined();
+});

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -59,6 +59,7 @@ import type {
   RegisterKubernetesConnectionEvent,
   RegisterRagConnectionEvent,
   RegisterVmConnectionEvent,
+  SemanticRouterFactory,
   UnregisterChunkProviderConnectionEvent,
   UnregisterContainerConnectionEvent,
   UnregisterFlowConnectionEvent,
@@ -1772,6 +1773,27 @@ export class ProviderRegistry {
       }
     });
     return factories;
+  }
+
+  getSemanticRouterFactory(): { internalId: string; factory: SemanticRouterFactory } | undefined {
+    for (const [internalId, provider] of this.providers) {
+      if (provider.semanticRouterConnectionFactory) {
+        return { internalId, factory: provider.semanticRouterConnectionFactory };
+      }
+    }
+    return undefined;
+  }
+
+  async deleteInferenceConnectionBySemanticRouter(semanticRouterName: string): Promise<void> {
+    for (const [, provider] of this.providers) {
+      const connection = provider.inferenceConnections.find(
+        c => c.name === semanticRouterName && c.llmMetadata?.semanticRouter,
+      );
+      if (connection?.lifecycle?.delete) {
+        await connection.lifecycle.delete();
+        return;
+      }
+    }
   }
 
   onDidRegisterVmConnectionCallback(provider: ProviderImpl, vmProviderConnection: VmProviderConnection): void {

--- a/packages/main/src/plugin/semantic-router/semantic-router-manager.spec.ts
+++ b/packages/main/src/plugin/semantic-router/semantic-router-manager.spec.ts
@@ -20,10 +20,12 @@ import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
+import type { SemanticRouterFactory } from '@openkaiden/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { Directories } from '/@/plugin/directories.js';
+import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info.js';
 
@@ -45,8 +47,13 @@ const directories = {
   getSemanticRoutersDirectory: vi.fn().mockReturnValue(ROUTERS_DIR),
 } as unknown as Directories;
 
+const providerRegistry = {
+  getSemanticRouterFactory: vi.fn().mockReturnValue(undefined),
+  deleteInferenceConnectionBySemanticRouter: vi.fn().mockResolvedValue(undefined),
+} as unknown as ProviderRegistry;
+
 function createManager(): SemanticRouterManager {
-  return new SemanticRouterManager(apiSender, ipcHandle, directories);
+  return new SemanticRouterManager(apiSender, ipcHandle, directories, providerRegistry);
 }
 
 const sampleConfig: SemanticRouterConfigInfo = {
@@ -293,4 +300,48 @@ test('remove throws when name not found', async () => {
   await manager.init();
 
   await expect(manager.remove('nonexistent')).rejects.toThrow('Semantic router "nonexistent" not found');
+});
+
+test('remove calls deleteInferenceConnectionBySemanticRouter with the router name', async () => {
+  mockDirWithConfigs(sampleConfig);
+  const manager = createManager();
+  await manager.init();
+
+  await manager.remove('my-router');
+
+  expect(providerRegistry.deleteInferenceConnectionBySemanticRouter).toHaveBeenCalledWith('my-router');
+});
+
+test('create calls semantic router factory when a provider has one', async () => {
+  mockEmptyDir();
+  const factory: SemanticRouterFactory = {
+    type: 'semantic-router',
+    create: vi.fn().mockResolvedValue(undefined),
+  };
+  vi.mocked(providerRegistry.getSemanticRouterFactory).mockReturnValue({ internalId: 'provider-1', factory });
+
+  const manager = createManager();
+  await manager.init();
+
+  await manager.create(sampleConfig);
+
+  expect(factory.create).toHaveBeenCalledWith({
+    name: 'my-router',
+    config: expect.any(String),
+  });
+  const callArgs = vi.mocked(factory.create).mock.calls[0]!;
+  expect(JSON.parse(callArgs[0].config)).toMatchObject({ name: 'my-router' });
+});
+
+test('create succeeds when no provider has a semantic router factory', async () => {
+  mockEmptyDir();
+  vi.mocked(providerRegistry.getSemanticRouterFactory).mockReturnValue(undefined);
+
+  const manager = createManager();
+  await manager.init();
+
+  const result = await manager.create(sampleConfig);
+
+  expect(result.name).toBe('my-router');
+  expect(writeFile).toHaveBeenCalled();
 });

--- a/packages/main/src/plugin/semantic-router/semantic-router-manager.ts
+++ b/packages/main/src/plugin/semantic-router/semantic-router-manager.ts
@@ -24,6 +24,7 @@ import { inject, injectable } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
 import { Directories } from '/@/plugin/directories.js';
+import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { SemanticRouterConfigInfo } from '/@api/semantic-router-info.js';
 import { SemanticRouterConfigSchema } from '/@api/semantic-router-info.js';
@@ -36,6 +37,7 @@ export class SemanticRouterManager {
     @inject(ApiSenderType) private readonly apiSender: ApiSenderType,
     @inject(IPCHandle) private readonly ipcHandle: IPCHandle,
     @inject(Directories) private readonly directories: Directories,
+    @inject(ProviderRegistry) private readonly providerRegistry: ProviderRegistry,
   ) {}
 
   async init(): Promise<void> {
@@ -89,6 +91,12 @@ export class SemanticRouterManager {
     await this.saveToDisk(parsed);
     this.configs.set(parsed.name, parsed);
     this.apiSender.send('semantic-router-update');
+
+    const result = this.providerRegistry.getSemanticRouterFactory();
+    if (result) {
+      await result.factory.create({ name: parsed.name, config: JSON.stringify(parsed) });
+    }
+
     return parsed;
   }
 
@@ -99,6 +107,7 @@ export class SemanticRouterManager {
     await rm(this.getFilePath(name));
     this.configs.delete(name);
     this.apiSender.send('semantic-router-update');
+    await this.providerRegistry.deleteInferenceConnectionBySemanticRouter(name);
   }
 
   private async loadFromDisk(): Promise<void> {


### PR DESCRIPTION
## Summary

- Add `SemanticRouterFactory` and `SemanticRouterCreateParams` interfaces to the extension API, with `Provider.setSemanticRouterConnectionFactory()` for extensions to register a factory
- Wire `SemanticRouterManager.create()` to look up a registered factory and call `factory.create()` when a new semantic router config is added
- Wire `SemanticRouterManager.remove()` to delete the associated inference connection (matched by name and `semanticRouter` flag) when a config is removed

Fixes #2363

## Test plan

- [x] Typecheck passes (`pnpm run typecheck`)
- [x] All unit tests pass (`pnpm run test:main` — provider-registry and semantic-router-manager specs)
- [x] Linting passes (`pnpm run lint:check`)
- [ ] Verify factory is called by an extension registering a `SemanticRouterFactory` and creating a semantic router config

🤖 Generated with [Claude Code](https://claude.com/claude-code)