### PR TITLE
fix(workspaces): resolve symlinked skill paths before uploading to sandbox

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { access, lstat, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, lstat, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -325,6 +325,7 @@ describe('create – OpenShell mode', () => {
     vi.mocked(openshellCli.createSandbox).mockResolvedValue(undefined);
     vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue(mockAgent);
     vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(realpath).mockImplementation(async (p: unknown) => p as string);
   });
 
   test('calls openshellCli.createSandbox with name, providers, workspace label, and agent label', async () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { access, lstat, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, lstat, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { basename, isAbsolute, join, posix, resolve } from 'node:path';
 
@@ -172,7 +172,7 @@ export class AgentWorkspaceManager implements Disposable {
         uploads.push({ local: file.localPath, remote: file.path });
       }
 
-      const skillUploads = this.buildOpenshellSkillUploads(options.skills, agent.destinationSkillsFolder);
+      const skillUploads = await this.buildOpenshellSkillUploads(options.skills, agent.destinationSkillsFolder);
       uploads.push(...skillUploads);
     } else {
       throw new Error(`Unable to create workspace: agent ${options.agent} not registered`);
@@ -254,16 +254,17 @@ export class AgentWorkspaceManager implements Disposable {
     }
   }
 
-  private buildOpenshellSkillUploads(skills: string[] | undefined, destinationSkillsFolder: string): OpenshellUpload[] {
+  private async buildOpenshellSkillUploads(
+    skills: string[] | undefined,
+    destinationSkillsFolder: string,
+  ): Promise<OpenshellUpload[]> {
     if (!skills?.length) {
       return [];
     }
 
     const remoteBase = this.resolveOpenshellSkillsDestination(destinationSkillsFolder);
-    return skills.map(skillPath => ({
-      local: skillPath,
-      remote: remoteBase,
-    }));
+    const resolved = await Promise.all(skills.map(skillPath => realpath(skillPath)));
+    return resolved.map(local => ({ local, remote: remoteBase }));
   }
 
   private async buildOpenshellFilesystemUploads(


### PR DESCRIPTION
Skill paths passed to openshell sandbox create are now resolved via
realpath() so symlinks are followed to their actual targets. This
prevents broken symlinks inside the sandbox when the directory
structure differs from the host. Mixing symlinks and real files in
the same directory would also cause errors like:

> mkdir: cannot create directory '.opencode/skills': File exists

fixes #2382 
