### PR TITLE
feat(secret-manager): adapt SecretVaultCreate form to OpenShellProfile credentials

### DIFF
--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -244,6 +244,7 @@ test('submits predefined service type with credential fields as SecretValue', as
     value: {
       credentials: {
         GH_TOKEN: 'ghp_abc123',
+        GITHUB_TOKEN: 'ghp_abc123',
       },
     },
   });

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -93,7 +93,6 @@ test('hides injection fields and shows credential fields when a predefined servi
   expect(screen.getByText('GitHub Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
   expect(screen.getByLabelText('Token')).toBeInTheDocument();
-  screen.debug(undefined, 16384);
   expect(screen.getByText('Token (Personal access token)')).toBeInTheDocument();
   expect(screen.queryByLabelText('Secret value')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('Description')).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -81,7 +81,7 @@ test('defaults to Other type with full form fields', async () => {
   expect(screen.getByLabelText('Value format')).toBeInTheDocument();
 });
 
-test('hides injection fields when a predefined service type is selected', async () => {
+test('hides injection fields and shows credential fields when a predefined service type is selected', async () => {
   render(SecretVaultCreate);
 
   await waitFor(() => {
@@ -92,12 +92,15 @@ test('hides injection fields when a predefined service type is selected', async 
 
   expect(screen.getByText('GitHub Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
-  expect(screen.getByLabelText('Secret value')).toBeInTheDocument();
+  expect(screen.getByLabelText('Token')).toBeInTheDocument();
+  expect(screen.getByText('Personal access token')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Secret value')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Description')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('Host pattern')).not.toBeInTheDocument();
   expect(screen.queryByText('Injection settings')).not.toBeInTheDocument();
 });
 
-test('shows no subtitle for predefined service type', async () => {
+test('shows profile description as subtitle for predefined service type', async () => {
   render(SecretVaultCreate);
 
   await waitFor(() => {
@@ -107,7 +110,7 @@ test('shows no subtitle for predefined service type', async () => {
   await fireEvent.click(screen.getByLabelText('GitHub'));
 
   expect(screen.queryByText(/Configure a custom secret/)).not.toBeInTheDocument();
-  expect(screen.queryByText(/Automatically injected/)).not.toBeInTheDocument();
+  expect(screen.getByText('GitHub API provider')).toBeInTheDocument();
 });
 
 test('Add Secret button is disabled when required fields are empty', async () => {
@@ -219,7 +222,7 @@ test('submits Other secret using default Authorization header when header name i
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
 });
 
-test('submits predefined service type without injection fields', async () => {
+test('submits predefined service type with credential fields as SecretValue', async () => {
   const { handleNavigation } = await import('/@/navigation');
 
   render(SecretVaultCreate);
@@ -230,14 +233,18 @@ test('submits predefined service type without injection fields', async () => {
 
   await fireEvent.click(screen.getByLabelText('GitHub'));
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'gh-token' } });
-  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'ghp_abc123' } });
+  await fireEvent.input(screen.getByLabelText('Token'), { target: { value: 'ghp_abc123' } });
 
   await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
 
   expect(window.createSecret).toHaveBeenCalledWith({
     name: 'gh-token',
     type: 'github',
-    value: 'ghp_abc123',
+    value: {
+      credentials: {
+        GH_TOKEN: 'ghp_abc123',
+      },
+    },
   });
 
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
@@ -254,7 +261,7 @@ test('displays error when createSecret fails', async () => {
 
   await fireEvent.click(screen.getByLabelText('GitHub'));
   await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'test' } });
-  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'val' } });
+  await fireEvent.input(screen.getByLabelText('Token'), { target: { value: 'val' } });
 
   await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
 
@@ -292,4 +299,65 @@ test('still renders form when listSecretServices fails', async () => {
 
   expect(screen.getByText('Other Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
+});
+
+test('Add Secret button is disabled when required credentials are empty for predefined type', async () => {
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByLabelText('GitHub'));
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'gh-token' } });
+
+  expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
+});
+
+test('credentials reset when switching between service types', async () => {
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByLabelText('GitHub'));
+  await fireEvent.input(screen.getByLabelText('Token'), { target: { value: 'ghp_abc123' } });
+
+  await fireEvent.click(screen.getByLabelText('Gemini'));
+
+  expect(screen.getByLabelText('Api Key')).toHaveValue('');
+});
+
+test('uses credential name as fallback key when env_vars is empty', async () => {
+  const services: OpenshellProfile[] = [
+    {
+      id: 'custom-provider',
+      display_name: 'Custom',
+      credentials: [{ name: 'secret_key', required: true }],
+    },
+  ];
+  vi.mocked(window.listSecretServices).mockResolvedValue(services);
+
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Custom')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByLabelText('Custom'));
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-custom' } });
+  await fireEvent.input(screen.getByLabelText('Secret Key'), { target: { value: 'sk-123' } });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
+
+  expect(window.createSecret).toHaveBeenCalledWith({
+    name: 'my-custom',
+    type: 'custom-provider',
+    value: {
+      credentials: {
+        secret_key: 'sk-123',
+      },
+    },
+  });
 });

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -93,7 +93,8 @@ test('hides injection fields and shows credential fields when a predefined servi
   expect(screen.getByText('GitHub Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
   expect(screen.getByLabelText('Token')).toBeInTheDocument();
-  expect(screen.getByText('Personal access token')).toBeInTheDocument();
+  screen.debug(undefined, 16384);
+  expect(screen.getByText('Token (Personal access token)')).toBeInTheDocument();
   expect(screen.queryByLabelText('Secret value')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('Description')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('Host pattern')).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -330,6 +330,36 @@ test('credentials reset when switching between service types', async () => {
   expect(screen.getByLabelText('Api Key')).toHaveValue('');
 });
 
+test('filters out profiles without credentials from type options', async () => {
+  const services: OpenshellProfile[] = [
+    {
+      id: 'has-creds',
+      display_name: 'With Creds',
+      credentials: [{ name: 'key', required: true }],
+    },
+    {
+      id: 'no-creds',
+      display_name: 'No Creds',
+    },
+    {
+      id: 'empty-creds',
+      display_name: 'Empty Creds',
+      credentials: [],
+    },
+  ];
+  vi.mocked(window.listSecretServices).mockResolvedValue(services);
+
+  render(SecretVaultCreate);
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('With Creds')).toBeInTheDocument();
+  });
+
+  expect(screen.queryByLabelText('No Creds')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Empty Creds')).not.toBeInTheDocument();
+  expect(screen.getByLabelText('Other')).toBeInTheDocument();
+});
+
 test('uses credential name as fallback key when env_vars is empty', async () => {
   const services: OpenshellProfile[] = [
     {

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -62,6 +62,10 @@ function formatCredentialLabel(credName: string): string {
   return credName.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
+function formatCredentialPlaceholder(credName: string): string {
+  return `Enter ${credName.replace(/_/g, ' ')}`;
+}
+
 let title = $derived.by(() => {
   if (isOther) return 'Other Secret';
   if (!selectedProfile) return 'Other Secret';
@@ -215,9 +219,6 @@ async function addSecret(): Promise<void> {
                 </span>
                 <PasswordInput
                   bind:password={credentialValues[credential.name]}
-  function formatCredentialPlaceholder(credName: string): string {
-  return `Enter ${credName.replace(/_/g, ' ')}`;
-}
                   placeholder={formatCredentialPlaceholder(credential.name)}
                   aria-label={formatCredentialLabel(credential.name)}
                 />

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -11,7 +11,7 @@ import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
 import type { OpenshellProfile } from '/@api/openshell-gateway-info';
-import type { SecretCreateOptions } from '/@api/secret-info';
+import type { SecretCreateOptions, SecretValue } from '/@api/secret-info';
 
 import { getServiceIcon, OTHER_TYPE } from './secret-vault-utils';
 
@@ -29,6 +29,7 @@ let valueFormat = $state('');
 let injectionOpen = $state(true);
 let saving = $state(false);
 let error = $state('');
+let credentialValues = $state<Record<string, string>>({});
 
 let serviceMap = $derived(new Map(services.map(s => [s.id, s])));
 
@@ -50,23 +51,38 @@ let typeOptions = $derived<CardSelectorOption[]>([
 
 let effectiveType = $derived(type || OTHER_TYPE);
 let isOther = $derived(!serviceMap.has(effectiveType));
+let selectedProfile = $derived(serviceMap.get(effectiveType));
+
+$effect(() => {
+  effectiveType;
+  credentialValues = {};
+});
+
+function formatCredentialLabel(credName: string): string {
+  return credName.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
 
 let title = $derived.by(() => {
   if (isOther) return 'Other Secret';
-  const svc = serviceMap.get(effectiveType);
-  if (!svc) return 'Other Secret';
-  return `${svc.display_name} Secret`;
+  if (!selectedProfile) return 'Other Secret';
+  return `${selectedProfile.display_name} Secret`;
 });
 
 let subtitle = $derived.by(() => {
   if (isOther) return 'Configure a custom secret to inject as a header into matching requests.';
-  return '';
+  return selectedProfile?.description ?? '';
 });
 
 let canSave = $derived.by(() => {
   if (loading) return false;
-  if (!name.trim() || !secret.trim()) return false;
-  if (isOther && (!hostPattern.trim() || !headerName.trim())) return false;
+  if (!name.trim()) return false;
+  if (isOther) {
+    if (!secret.trim() || !hostPattern.trim() || !headerName.trim()) return false;
+  } else {
+    const creds = selectedProfile?.credentials ?? [];
+    const requiredFilled = creds.filter(c => c.required).every(c => credentialValues[c.name]?.trim());
+    if (!requiredFilled) return false;
+  }
   return true;
 });
 
@@ -93,17 +109,31 @@ async function addSecret(): Promise<void> {
   saving = true;
   error = '';
   try {
+    let value: string | SecretValue;
+
+    if (isOther) {
+      value = secret;
+    } else {
+      const creds = selectedProfile?.credentials ?? [];
+      value = {
+        credentials: Object.fromEntries(
+          creds
+            .filter(c => credentialValues[c.name]?.trim())
+            .map(c => [c.env_vars?.[0] ?? c.name, credentialValues[c.name]!.trim()]),
+        ),
+      };
+    }
+
     const options: SecretCreateOptions = {
       name: name.trim(),
       type: effectiveType,
-      value: secret,
+      value,
     };
 
-    if (description.trim()) {
-      options.description = description.trim();
-    }
-
     if (isOther) {
+      if (description.trim()) {
+        options.description = description.trim();
+      }
       options.hosts = [hostPattern.trim()];
       options.header = headerName.trim();
       if (pathPattern.trim()) {
@@ -150,25 +180,48 @@ async function addSecret(): Promise<void> {
             <Input bind:value={name} placeholder="e.g. GitHub Token" aria-label="Name" />
           </div>
 
-          <div>
-            <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Secret value</span>
-            <PasswordInput
-              bind:password={secret}
-              placeholder="Enter secret value"
-              aria-label="Secret value"
-            />
-            <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
-              Encrypted at rest. You won't be able to view this value again.
-            </p>
-          </div>
+          {#if isOther}
+            <div>
+              <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Secret value</span>
+              <PasswordInput
+                bind:password={secret}
+                placeholder="Enter secret value"
+                aria-label="Secret value"
+              />
+              <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
+                Encrypted at rest. You won't be able to view this value again.
+              </p>
+            </div>
 
-          <div>
-            <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
-              Description
-              <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
-            </span>
-            <Input bind:value={description} placeholder="What this secret is used for" aria-label="Description" />
-          </div>
+            <div>
+              <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                Description
+                <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
+              </span>
+              <Input bind:value={description} placeholder="What this secret is used for" aria-label="Description" />
+            </div>
+          {:else if selectedProfile?.credentials}
+            {#each selectedProfile.credentials as credential (credential.name)}
+              <div>
+                <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
+                  {formatCredentialLabel(credential.name)}
+                  {#if !credential.required}
+                    <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
+                  {/if}
+                </span>
+                <PasswordInput
+                  bind:password={credentialValues[credential.name]}
+                  placeholder="Enter {credential.name.replace(/_/g, ' ')}"
+                  aria-label={formatCredentialLabel(credential.name)}
+                />
+                {#if credential.description}
+                  <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
+                    {credential.description}
+                  </p>
+                {/if}
+              </div>
+            {/each}
+          {/if}
 
           {#if isOther}
             <div>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -88,7 +88,7 @@ let canSave = $derived.by(() => {
 
 onMount(async () => {
   try {
-    services = await window.listSecretServices();
+    services = (await window.listSecretServices()).filter(s => s.credentials?.length);
   } catch (err: unknown) {
     console.error('Failed to load secret services', err);
   } finally {

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -218,7 +218,7 @@ async function addSecret(): Promise<void> {
   function formatCredentialPlaceholder(credName: string): string {
   return `Enter ${credName.replace(/_/g, ' ')}`;
 }
-                  placeholder="formatCredentialPlaceholder(credential.name)"
+                  placeholder={formatCredentialPlaceholder(credential.name)}
                   aria-label={formatCredentialLabel(credential.name)}
                 />
               </div>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -215,7 +215,10 @@ async function addSecret(): Promise<void> {
                 </span>
                 <PasswordInput
                   bind:password={credentialValues[credential.name]}
-                  placeholder="Enter {credential.name.replace(/_/g, ' ')}"
+  function formatCredentialPlaceholder(credName: string): string {
+  return `Enter ${credName.replace(/_/g, ' ')}`;
+}
+                  placeholder="formatCredentialPlaceholder(credential.name)"
                   aria-label={formatCredentialLabel(credential.name)}
                 />
               </div>

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -204,7 +204,7 @@ async function addSecret(): Promise<void> {
             {#each selectedProfile.credentials as credential (credential.name)}
               <div>
                 <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
-                  {formatCredentialLabel(credential.name)}
+                  {formatCredentialLabel(credential.name)} {#if credential.description}({credential.description}){/if}
                   {#if !credential.required}
                     <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
                   {/if}
@@ -214,11 +214,6 @@ async function addSecret(): Promise<void> {
                   placeholder="Enter {credential.name.replace(/_/g, ' ')}"
                   aria-label={formatCredentialLabel(credential.name)}
                 />
-                {#if credential.description}
-                  <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
-                    {credential.description}
-                  </p>
-                {/if}
               </div>
             {/each}
           {/if}

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -119,7 +119,11 @@ async function addSecret(): Promise<void> {
         credentials: Object.fromEntries(
           creds
             .filter(c => credentialValues[c.name]?.trim())
-            .map(c => [c.env_vars?.[0] ?? c.name, credentialValues[c.name]!.trim()]),
+            .flatMap(c => {
+              const val = credentialValues[c.name]!.trim();
+              const keys = c.env_vars?.length ? c.env_vars : [c.name];
+              return keys.map(k => [k, val]);
+            }),
         ),
       };
     }


### PR DESCRIPTION
## Test

- create a GitHub secret with your token
- create a sandbox with the github secret injected
- once in the sandbox run gh api repos/openkaiden/kaiden/releases -> should be ok but see #2417 

## Summary
- When a predefined service type (GitHub, Gemini, etc.) is selected, the form now dynamically renders credential input fields from the profile's `credentials` array instead of showing a single "Secret value" + "Description" field
- On submit, credentials are packed into a `SecretValue` object using the first `env_vars` entry as the key (falling back to credential `name`)
- Credential values reset when switching between service types

Fixes #2397

## Test plan
- [x] All 17 unit tests pass (`SecretVaultCreate.spec.ts`)
- [x] Typecheck passes (0 errors)
- [x] Lint and format checks pass
- [ ] Manual verification: select a predefined service type and confirm dynamic credential fields appear
- [ ] Manual verification: fill credentials and submit — verify `SecretValue` object is sent correctly
- [ ] Manual verification: switch between service types and confirm credentials reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)