### PR TITLE
fix(agent-workspace): preserve terminal agent session across page refresh

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -1549,6 +1549,39 @@ describe('terminal reconnection on page refresh', () => {
 
     expect(spawn).toHaveBeenCalledTimes(2);
   });
+
+  test('stale PTY exit does not remove newer active terminal entry', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(SANDBOXES_WITH_AGENT);
+    vi.mocked(agentRegistry.getAgent).mockResolvedValue({
+      id: 'test-agent',
+      name: 'Test Agent',
+      description: '',
+      command: '/usr/bin/agent start',
+      destinationSkillsFolder: '~/.agent',
+    });
+    const { pty: pty1, triggerData: triggerData1, triggerExit: triggerExit1 } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty1);
+
+    type TerminalHandler = (_listener: unknown, id: string, onDataId: number) => Promise<number>;
+    type CloseHandler = (_listener: unknown, onDataId: number) => Promise<void>;
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 10);
+    triggerData1('$ ');
+
+    await getIpcHandler<CloseHandler>('agent-workspace:terminalClose')({}, 10);
+
+    const { pty: pty2, triggerData: triggerData2 } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty2);
+
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 20);
+    triggerData2('$ ');
+
+    triggerExit1();
+
+    vi.mocked(spawn).mockClear();
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 30);
+
+    expect(spawn).not.toHaveBeenCalled();
+  });
 });
 
 describe('encodeWorkspaceLabels', () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -1373,6 +1373,184 @@ describe('terminal agent command execution', () => {
   });
 });
 
+describe('terminal reconnection on page refresh', () => {
+  const SANDBOXES_WITH_AGENT: GatewaySandboxes[] = [
+    {
+      gateway: { name: 'kaiden', endpoint: 'http://localhost:10080' },
+      sandboxes: [
+        {
+          id: 'ws-agent',
+          name: 'agent-workspace',
+          phase: 'Ready',
+          labels: { [AGENT_LABEL]: 'test-agent' },
+        },
+      ],
+    },
+  ];
+
+  function createTerminalMockPty(): { pty: IPty; triggerData: (data: string) => void; triggerExit: () => void } {
+    let onDataCb: ((data: string) => void) | undefined;
+    let onExitCb: (() => void) | undefined;
+    const pty = {
+      onData: vi.fn((cb: (data: string) => void) => {
+        onDataCb = cb;
+        return { dispose: vi.fn() };
+      }),
+      onExit: vi.fn((cb: () => void) => {
+        onExitCb = cb;
+        return { dispose: vi.fn() };
+      }),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      pid: 789,
+    } as unknown as IPty;
+    return {
+      pty,
+      triggerData: (data: string): void => {
+        onDataCb?.(data);
+      },
+      triggerExit: (): void => {
+        onExitCb?.();
+      },
+    };
+  }
+
+  function getIpcHandler<T>(channel: string): T {
+    return vi.mocked(ipcHandle).mock.calls.find(call => call[0] === channel)![1] as T;
+  }
+
+  test('reuses existing PTY on reconnect instead of spawning a new one', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(SANDBOXES_WITH_AGENT);
+    vi.mocked(agentRegistry.getAgent).mockResolvedValue({
+      id: 'test-agent',
+      name: 'Test Agent',
+      description: '',
+      command: '/usr/bin/agent start',
+      destinationSkillsFolder: '~/.agent',
+    });
+    const { pty, triggerData } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty);
+
+    type TerminalHandler = (_listener: unknown, id: string, onDataId: number) => Promise<number>;
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 10);
+    triggerData('$ ');
+
+    vi.mocked(spawn).mockClear();
+
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 20);
+
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('forwards data using the new callbackId after reconnect', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(SANDBOXES_WITH_AGENT);
+    vi.mocked(agentRegistry.getAgent).mockResolvedValue({
+      id: 'test-agent',
+      name: 'Test Agent',
+      description: '',
+      command: '/usr/bin/agent start',
+      destinationSkillsFolder: '~/.agent',
+    });
+    const { pty, triggerData } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty);
+
+    type TerminalHandler = (_listener: unknown, id: string, onDataId: number) => Promise<number>;
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 10);
+    triggerData('$ ');
+    vi.mocked(webContents.send).mockClear();
+
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 20);
+
+    triggerData('agent output');
+
+    expect(webContents.send).toHaveBeenCalledWith('agent-workspace:terminal-onData', 20, 'agent output');
+    expect(webContents.send).not.toHaveBeenCalledWith('agent-workspace:terminal-onData', 10, expect.anything());
+  });
+
+  test('cleans up old callbackId entries from maps on reconnect', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(SANDBOXES_WITH_AGENT);
+    vi.mocked(agentRegistry.getAgent).mockResolvedValue({
+      id: 'test-agent',
+      name: 'Test Agent',
+      description: '',
+      command: '/usr/bin/agent start',
+      destinationSkillsFolder: '~/.agent',
+    });
+    const { pty, triggerData } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty);
+
+    type TerminalHandler = (_listener: unknown, id: string, onDataId: number) => Promise<number>;
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 10);
+    triggerData('$ ');
+
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 20);
+
+    type SendHandler = (_listener: unknown, onDataId: number, content: string) => Promise<void>;
+    const sendHandler = getIpcHandler<SendHandler>('agent-workspace:terminalSend');
+
+    await sendHandler({}, 10, 'should not reach pty');
+    expect(pty.write).not.toHaveBeenCalledWith('should not reach pty');
+
+    await sendHandler({}, 20, 'should reach pty');
+    expect(pty.write).toHaveBeenCalledWith('should reach pty');
+  });
+
+  test('terminalClose cleans up activeWorkspaceTerminals so next request spawns a new PTY', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(SANDBOXES_WITH_AGENT);
+    vi.mocked(agentRegistry.getAgent).mockResolvedValue({
+      id: 'test-agent',
+      name: 'Test Agent',
+      description: '',
+      command: '/usr/bin/agent start',
+      destinationSkillsFolder: '~/.agent',
+    });
+    const { pty, triggerData } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty);
+
+    type TerminalHandler = (_listener: unknown, id: string, onDataId: number) => Promise<number>;
+    type CloseHandler = (_listener: unknown, onDataId: number) => Promise<void>;
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 10);
+    triggerData('$ ');
+
+    await getIpcHandler<CloseHandler>('agent-workspace:terminalClose')({}, 10);
+
+    const { pty: pty2 } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty2);
+
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 20);
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  test('PTY exit cleans up activeWorkspaceTerminals entry', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(SANDBOXES_WITH_AGENT);
+    vi.mocked(agentRegistry.getAgent).mockResolvedValue({
+      id: 'test-agent',
+      name: 'Test Agent',
+      description: '',
+      command: '/usr/bin/agent start',
+      destinationSkillsFolder: '~/.agent',
+    });
+    const { pty, triggerData, triggerExit } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty);
+
+    type TerminalHandler = (_listener: unknown, id: string, onDataId: number) => Promise<number>;
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 10);
+    triggerData('$ ');
+
+    triggerExit();
+
+    const { pty: pty2, triggerData: triggerData2 } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty2);
+
+    await getIpcHandler<TerminalHandler>('agent-workspace:terminal')({}, 'ws-agent', 20);
+    triggerData2('$ ');
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('encodeWorkspaceLabels', () => {
   test('returns single label for short paths', () => {
     const labels = encodeWorkspaceLabels('/tmp/my-project');

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -82,6 +82,7 @@ export class AgentWorkspaceManager implements Disposable {
   >();
   private readonly terminalProcesses = new Map<number, IPty>();
   private readonly commandExecutedWorkspaces = new Set<string>();
+  private readonly activeWorkspaceTerminals = new Map<string, { callbackRef: { id: number } }>();
 
   constructor(
     @inject(ApiSenderType)
@@ -610,6 +611,24 @@ export class AgentWorkspaceManager implements Disposable {
           throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
         }
 
+        const existing = this.activeWorkspaceTerminals.get(id);
+        if (existing && this.terminalProcesses.has(existing.callbackRef.id)) {
+          const oldId = existing.callbackRef.id;
+          const proc = this.terminalProcesses.get(oldId)!;
+          const cb = this.terminalCallbacks.get(oldId);
+
+          this.terminalProcesses.delete(oldId);
+          this.terminalCallbacks.delete(oldId);
+
+          this.terminalProcesses.set(onDataId, proc);
+          if (cb) {
+            this.terminalCallbacks.set(onDataId, cb);
+          }
+
+          existing.callbackRef.id = onDataId;
+          return onDataId;
+        }
+
         const shouldExecuteCommand = !this.commandExecutedWorkspaces.has(id);
         let agentCommand: string | undefined;
         if (shouldExecuteCommand && workspace.labels) {
@@ -628,12 +647,15 @@ export class AgentWorkspaceManager implements Disposable {
           this.commandExecutedWorkspaces.add(id);
         }
 
+        const callbackRef = { id: onDataId };
+        this.activeWorkspaceTerminals.set(id, { callbackRef });
+
         let commandSent = false;
         const invocation = this.shellInAgentWorkspace(
           workspace.name,
           (content: string) => {
             if (!this.webContents.isDestroyed()) {
-              this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
+              this.webContents.send('agent-workspace:terminal-onData', callbackRef.id, content);
             }
             if (!commandSent && agentCommand) {
               commandSent = true;
@@ -642,15 +664,16 @@ export class AgentWorkspaceManager implements Disposable {
           },
           (error: string) => {
             if (!this.webContents.isDestroyed()) {
-              this.webContents.send('agent-workspace:terminal-onError', onDataId, error);
+              this.webContents.send('agent-workspace:terminal-onError', callbackRef.id, error);
             }
           },
           () => {
             if (!this.webContents.isDestroyed()) {
-              this.webContents.send('agent-workspace:terminal-onEnd', onDataId);
+              this.webContents.send('agent-workspace:terminal-onEnd', callbackRef.id);
             }
-            this.terminalCallbacks.delete(onDataId);
-            this.terminalProcesses.delete(onDataId);
+            this.terminalCallbacks.delete(callbackRef.id);
+            this.terminalProcesses.delete(callbackRef.id);
+            this.activeWorkspaceTerminals.delete(id);
           },
         );
         this.terminalCallbacks.set(onDataId, { write: invocation.write, resize: invocation.resize });
@@ -690,6 +713,12 @@ export class AgentWorkspaceManager implements Disposable {
       }
       this.terminalProcesses.delete(onDataId);
       this.terminalCallbacks.delete(onDataId);
+      for (const [wsId, entry] of this.activeWorkspaceTerminals) {
+        if (entry.callbackRef.id === onDataId) {
+          this.activeWorkspaceTerminals.delete(wsId);
+          break;
+        }
+      }
     });
 
     this.openshellGateway.onDidGatewayStart(() => {
@@ -724,5 +753,6 @@ export class AgentWorkspaceManager implements Disposable {
     this.terminalProcesses.clear();
     this.terminalCallbacks.clear();
     this.commandExecutedWorkspaces.clear();
+    this.activeWorkspaceTerminals.clear();
   }
 }

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -673,7 +673,9 @@ export class AgentWorkspaceManager implements Disposable {
             }
             this.terminalCallbacks.delete(callbackRef.id);
             this.terminalProcesses.delete(callbackRef.id);
-            this.activeWorkspaceTerminals.delete(id);
+            if (this.activeWorkspaceTerminals.get(id)?.callbackRef === callbackRef) {
+              this.activeWorkspaceTerminals.delete(id);
+            }
           },
         );
         this.terminalCallbacks.set(onDataId, { write: invocation.write, resize: invocation.resize });


### PR DESCRIPTION
On renderer reload (Cmd+R), the main-process PTY with the running agent was orphaned and a new bare shell was spawned without re-executing the agent command. Track active PTYs per workspace and reattach to the existing process on reconnect using a mutable callbackRef pattern.

## Test Plan
### Setup
1. Start Kaiden and create an agent workspace with a model configured
### Scenario 1: Page refresh preserves agent session
1. Navigate to the workspace's Terminal tab
2. Wait for the agent command to execute and the agent session to appear
3. Press **Cmd+R** (macOS) / **Ctrl+R** (Linux) to refresh the page
4. **Expected**: The terminal reconnects to the same agent session (agent output preserved, agent still responsive to input)


https://github.com/user-attachments/assets/dc3f4786-be60-448b-9410-4376cfc68027


Closes #2425