### PR TITLE
fix: ensure provider network rules are applied to sandbox

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -353,7 +353,7 @@ describe('create – OpenShell mode', () => {
     vi.mocked(openshellCli.isV2ProviderEnabled).mockResolvedValue(false);
     await manager.create(defaultOptions);
 
-    expect(openshellCli.enableV2Provider).toHaveBeenCalledWith('my-sandbox');
+    expect(openshellCli.enableV2Provider).toHaveBeenCalledWith();
   });
 
   test('skips openshellCli.enableV2Provider when globally enabled', async () => {
@@ -555,7 +555,7 @@ describe('create – OpenShell mode', () => {
     expect(openshellCli.createSandbox).not.toHaveBeenCalled();
   });
 
-  test('passes policy file to createSandbox for deny mode with hosts', async () => {
+  test('updates policy with endpoint flags after sandbox creation for deny mode with hosts', async () => {
     const options = {
       ...defaultOptions,
       network: { mode: 'deny' as const, hosts: ['registry.npmjs.org', 'pypi.python.org'] },
@@ -563,28 +563,38 @@ describe('create – OpenShell mode', () => {
 
     await manager.create(options);
 
-    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
-      expect.objectContaining({ policy: expect.stringContaining('kaiden-policy-my-sandbox') }),
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(expect.not.objectContaining({ policy: expect.anything() }));
+    expect(openshellCli.updatePolicy).toHaveBeenCalledWith(
+      'my-sandbox',
+      expect.arrayContaining([
+        'registry.npmjs.org:443:full:rest',
+        'registry.npmjs.org:80:full:rest',
+        'pypi.python.org:443:full:rest',
+        'pypi.python.org:80:full:rest',
+      ]),
+      ['/**'],
     );
   });
 
-  test('does not pass policy for deny mode with no hosts and no model endpoint', async () => {
+  test('does not set policy for deny mode with no hosts and no model endpoint', async () => {
     const options = { ...defaultOptions, network: { mode: 'deny' as const } };
 
     await manager.create(options);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(expect.not.objectContaining({ policy: expect.anything() }));
+    expect(openshellCli.updatePolicy).not.toHaveBeenCalled();
   });
 
-  test('does not pass policy for deny mode with empty hosts and no model endpoint', async () => {
+  test('does not set policy for deny mode with empty hosts and no model endpoint', async () => {
     const options = { ...defaultOptions, network: { mode: 'deny' as const, hosts: [] } };
 
     await manager.create(options);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(expect.not.objectContaining({ policy: expect.anything() }));
+    expect(openshellCli.updatePolicy).not.toHaveBeenCalled();
   });
 
-  test('does not pass policy for allow mode with no model endpoint', async () => {
+  test('does not set policy for allow mode with no model endpoint', async () => {
     const options = {
       ...defaultOptions,
       network: { mode: 'allow' as const, hosts: ['registry.npmjs.org'] },
@@ -593,35 +603,27 @@ describe('create – OpenShell mode', () => {
     await manager.create(options);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(expect.not.objectContaining({ policy: expect.anything() }));
+    expect(openshellCli.updatePolicy).not.toHaveBeenCalled();
   });
 
-  test('does not pass policy when network is undefined and no model endpoint', async () => {
+  test('does not set policy when network is undefined and no model endpoint', async () => {
     await manager.create(defaultOptions);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(expect.not.objectContaining({ policy: expect.anything() }));
+    expect(openshellCli.updatePolicy).not.toHaveBeenCalled();
   });
 
-  test('cleans up policy temp file after successful createSandbox', async () => {
+  test('deletes sandbox and rethrows when updatePolicy fails', async () => {
     const options = {
       ...defaultOptions,
       network: { mode: 'deny' as const, hosts: ['registry.npmjs.org'] },
     };
+    vi.mocked(openshellCli.updatePolicy).mockRejectedValue(new Error('policy update failed'));
+    vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
 
-    await manager.create(options);
+    await expect(manager.create(options)).rejects.toThrow('policy update failed');
 
-    expect(rm).toHaveBeenCalledWith(expect.stringContaining('kaiden-policy-my-sandbox'), { force: true });
-  });
-
-  test('cleans up policy temp file after failed createSandbox', async () => {
-    vi.mocked(openshellCli.createSandbox).mockRejectedValue(new Error('sandbox create failed'));
-
-    const options = {
-      ...defaultOptions,
-      network: { mode: 'deny' as const, hosts: ['registry.npmjs.org'] },
-    };
-
-    await expect(manager.create(options)).rejects.toThrow('sandbox create failed');
-    expect(rm).toHaveBeenCalledWith(expect.stringContaining('kaiden-policy-my-sandbox'), { force: true });
+    expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('my-sandbox');
   });
 
   test('attaches secret to sandbox when ensureSecretForModel returns a secret', async () => {
@@ -719,7 +721,7 @@ describe('create – OpenShell mode', () => {
     expect(call!.env).toBeUndefined();
   });
 
-  test('passes policy file for model with endpoint', async () => {
+  test('updates policy with model endpoint', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { api_key: 'sk-test' },
       llmMetadataName: 'openai',
@@ -730,8 +732,10 @@ describe('create – OpenShell mode', () => {
     const options = { ...defaultOptions, model: 'openai::gpt-4o::https://api.example.com/v1' };
     await manager.create(options);
 
-    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
-      expect.objectContaining({ policy: expect.stringContaining('kaiden-policy-my-sandbox') }),
+    expect(openshellCli.updatePolicy).toHaveBeenCalledWith(
+      'my-sandbox',
+      expect.arrayContaining(['api.example.com:443']),
+      ['/**'],
     );
   });
 
@@ -754,12 +758,14 @@ describe('create – OpenShell mode', () => {
         }),
       }),
     );
-    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
-      expect.objectContaining({ policy: expect.stringContaining('kaiden-policy-my-sandbox') }),
+    expect(openshellCli.updatePolicy).toHaveBeenCalledWith(
+      'my-sandbox',
+      expect.arrayContaining(['host.openshell.internal:11434']),
+      ['/**'],
     );
   });
 
-  test('does not pass policy when model has no endpoint', async () => {
+  test('does not update policy when model has no endpoint', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { api_key: 'sk-test' },
       llmMetadataName: 'anthropic',
@@ -769,21 +775,23 @@ describe('create – OpenShell mode', () => {
     const options = { ...defaultOptions, model: 'anthropic::claude-sonnet-4-20250514' };
     await manager.create(options);
 
-    expect(openshellCli.createSandbox).toHaveBeenCalledWith(expect.not.objectContaining({ policy: expect.anything() }));
+    expect(openshellCli.updatePolicy).not.toHaveBeenCalled();
   });
 
-  test('passes policy for endpoint extracted from model ID when connectionInfo is unavailable', async () => {
+  test('updates policy for endpoint extracted from model ID when connectionInfo is unavailable', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue(undefined);
 
     const options = { ...defaultOptions, model: 'ollama::qwen3:0.6b::http://localhost:11434/v1' };
     await manager.create(options);
 
-    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
-      expect.objectContaining({ policy: expect.stringContaining('kaiden-policy-my-sandbox') }),
+    expect(openshellCli.updatePolicy).toHaveBeenCalledWith(
+      'my-sandbox',
+      expect.arrayContaining(['host.openshell.internal:11434']),
+      ['/**'],
     );
   });
 
-  test('passes policy with both network and model rules together', async () => {
+  test('updates policy with both network and model endpoints together', async () => {
     vi.mocked(providerRegistry.getInferenceConnectionCredentials).mockReturnValue({
       credentials: { api_key: 'sk-test' },
       llmMetadataName: 'openai',
@@ -799,8 +807,10 @@ describe('create – OpenShell mode', () => {
 
     await manager.create(options);
 
-    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
-      expect.objectContaining({ policy: expect.stringContaining('kaiden-policy-my-sandbox') }),
+    expect(openshellCli.updatePolicy).toHaveBeenCalledWith(
+      'my-sandbox',
+      expect.arrayContaining(['registry.npmjs.org:443:full:rest', 'api.openai.com:443']),
+      ['/**'],
     );
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -23,7 +23,6 @@ import { basename, isAbsolute, join, posix, resolve } from 'node:path';
 import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
-import { dump } from 'js-yaml';
 import type { IPty } from 'node-pty';
 import { spawn } from 'node-pty';
 
@@ -34,7 +33,12 @@ import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
-import { buildPolicyObject, rewriteLocalhostUrl } from '/@/plugin/openshell-cli/openshell-network-policy.js';
+import {
+  buildPolicyObject,
+  collectBinaryFlags,
+  collectEndpointFlags,
+  rewriteLocalhostUrl,
+} from '/@/plugin/openshell-cli/openshell-network-policy.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
@@ -206,42 +210,44 @@ export class AgentWorkspaceManager implements Disposable {
 
     const t0 = performance.now();
 
-    const policy = buildPolicyObject(workspace.network, endpoint);
-    let policyFile: string | undefined;
-    if (policy) {
-      policyFile = join(tmpdir(), `kaiden-policy-${sandboxName}-${Date.now()}.yaml`);
-      await writeFile(policyFile, dump(policy), 'utf-8');
-    }
-
-    try {
-      await this.openshellCli.createSandbox({
-        name: sandboxName,
-        from: agent.baseImage,
-        providers: options.secrets,
-        env: env && Object.keys(env).length > 0 ? env : undefined,
-        labels: { ...encodeWorkspaceLabels(options.sourcePath), [AGENT_LABEL]: options.agent },
-        uploads: dedupedUploads.length > 0 ? dedupedUploads : undefined,
-        noTty: true,
-        command: ['true'],
-        policy: policyFile,
-      });
-    } finally {
-      if (policyFile) {
-        await rm(policyFile, { force: true }).catch(() => {});
-      }
-    }
-
-    const tSandbox = performance.now();
-    console.log(`[workspace-timing] createSandbox: ${(tSandbox - t0).toFixed(0)}ms`);
-
     const v2Globally = await this.openshellCli.isV2ProviderEnabled();
     if (!v2Globally) {
-      await this.openshellCli.enableV2Provider(sandboxName);
+      await this.openshellCli.enableV2Provider();
     }
 
     const tV2 = performance.now();
-    console.log(`[workspace-timing] enableV2Provider: ${(tV2 - tSandbox).toFixed(0)}ms`);
-    console.log(`[workspace-timing] total createOpenshell: ${(tV2 - t0).toFixed(0)}ms`);
+    console.log(`[workspace-timing] enableV2Provider: ${(tV2 - t0).toFixed(0)}ms`);
+
+    await this.openshellCli.createSandbox({
+      name: sandboxName,
+      from: agent.baseImage,
+      providers: options.secrets,
+      env: env && Object.keys(env).length > 0 ? env : undefined,
+      labels: { ...encodeWorkspaceLabels(options.sourcePath), [AGENT_LABEL]: options.agent },
+      uploads: dedupedUploads.length > 0 ? dedupedUploads : undefined,
+      noTty: true,
+      command: ['true'],
+    });
+
+    const tSandbox = performance.now();
+    console.log(`[workspace-timing] createSandbox: ${(tSandbox - tV2).toFixed(0)}ms`);
+
+    const networkPolicy = buildPolicyObject(workspace.network, endpoint);
+    if (networkPolicy) {
+      const endpointFlags = collectEndpointFlags(networkPolicy);
+      if (endpointFlags.length > 0) {
+        try {
+          await this.openshellCli.updatePolicy(sandboxName, endpointFlags, collectBinaryFlags(networkPolicy));
+        } catch (err) {
+          await this.openshellCli.deleteSandbox(sandboxName).catch(() => {});
+          throw err;
+        }
+      }
+    }
+
+    const tPolicy = performance.now();
+    console.log(`[workspace-timing] updatePolicy: ${(tPolicy - tSandbox).toFixed(0)}ms`);
+    console.log(`[workspace-timing] total createOpenshell: ${(tPolicy - t0).toFixed(0)}ms`);
 
     return { id: sandboxName };
   }

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -404,6 +404,42 @@ describe('createSandbox', () => {
   });
 });
 
+describe('updatePolicy', () => {
+  test('executes policy update with --add-endpoint flags', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.updatePolicy('my-sandbox', ['api.example.com:443:full:rest', 'host.local:11434']);
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      [
+        'policy',
+        'update',
+        'my-sandbox',
+        '--add-endpoint',
+        'api.example.com:443:full:rest',
+        '--add-endpoint',
+        'host.local:11434',
+      ],
+      undefined,
+    );
+  });
+
+  test('includes --binary flags when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.updatePolicy('my-sandbox', ['api.example.com:443'], ['/**']);
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['policy', 'update', 'my-sandbox', '--add-endpoint', 'api.example.com:443', '--binary', '/**'],
+      undefined,
+    );
+  });
+});
+
 describe('listSandboxes', () => {
   test('executes openshell sandbox list with json output', async () => {
     const payload = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
@@ -1173,15 +1209,15 @@ describe('isV2ProviderEnabled', () => {
 });
 
 describe('enableV2Provider', () => {
-  test('executes settings set with sandbox name', async () => {
+  test('executes settings set with --global flag', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
 
-    await openshellCli.enableV2Provider('my-sandbox');
+    await openshellCli.enableV2Provider();
 
     expect(exec.exec).toHaveBeenCalledWith(
       OPENSHELL_CLI_PATH,
-      ['settings', 'set', '--key', 'providers_v2_enabled', '--value', 'true', '--yes', 'my-sandbox'],
+      ['settings', 'set', '--global', '--key', 'providers_v2_enabled', '--value', 'true', '--yes'],
       undefined,
     );
   });
@@ -1189,8 +1225,8 @@ describe('enableV2Provider', () => {
   test('rejects when CLI fails', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    vi.mocked(exec.exec).mockRejectedValue(new Error('sandbox not found'));
+    vi.mocked(exec.exec).mockRejectedValue(new Error('settings update failed'));
 
-    await expect(openshellCli.enableV2Provider('unknown')).rejects.toThrow('sandbox not found');
+    await expect(openshellCli.enableV2Provider()).rejects.toThrow('settings update failed');
   });
 });

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -397,9 +397,23 @@ export class OpenshellCli {
     }
   }
 
-  async enableV2Provider(sandboxName: string): Promise<void> {
-    return this.runCli(['settings', 'set', '--key', 'providers_v2_enabled', '--value', 'true', '--yes', sandboxName]);
+  async enableV2Provider(): Promise<void> {
+    return this.runCli(['settings', 'set', '--global', '--key', 'providers_v2_enabled', '--value', 'true', '--yes']);
   }
+
+  // ── policy commands ──────────────────────────────────────────────
+
+  async updatePolicy(sandboxName: string, endpoints: string[], binaries?: string[]): Promise<void> {
+    const args = ['policy', 'update', sandboxName];
+    for (const ep of endpoints) {
+      args.push('--add-endpoint', ep);
+    }
+    for (const bin of binaries ?? []) {
+      args.push('--binary', bin);
+    }
+    await this.runCli(args);
+  }
+
   // ── helpers ───────────────────────────────────────────────────────
 
   private async runCli(

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.spec.ts
@@ -20,6 +20,9 @@ import { describe, expect, test } from 'vitest';
 
 import {
   buildPolicyObject,
+  collectBinaryFlags,
+  collectEndpointFlags,
+  formatEndpointFlag,
   OPENSHELL_CONTAINER_HOST,
   parseModelEndpoint,
   rewriteLocalhostUrl,
@@ -186,5 +189,150 @@ describe('buildPolicyObject', () => {
 
   test('returns undefined for invalid model endpoint with no network', () => {
     expect(buildPolicyObject(undefined, 'not-a-url')).toBeUndefined();
+  });
+});
+
+describe('formatEndpointFlag', () => {
+  test('formats host and port only', () => {
+    expect(formatEndpointFlag({ host: 'api.example.com', port: 443 })).toBe('api.example.com:443');
+  });
+
+  test('formats with access and protocol', () => {
+    expect(formatEndpointFlag({ host: 'api.example.com', port: 443, access: 'full', protocol: 'rest' })).toBe(
+      'api.example.com:443:full:rest',
+    );
+  });
+
+  test('formats with enforcement', () => {
+    expect(
+      formatEndpointFlag({
+        host: 'api.example.com',
+        port: 443,
+        access: 'read-only',
+        protocol: 'rest',
+        enforcement: 'enforce',
+      }),
+    ).toBe('api.example.com:443:read-only:rest:enforce');
+  });
+
+  test('ignores allow_encoded_slash (not supported by --add-endpoint)', () => {
+    expect(
+      formatEndpointFlag({
+        host: 'registry.npmjs.org',
+        port: 443,
+        access: 'full',
+        protocol: 'rest',
+        allow_encoded_slash: true,
+      }),
+    ).toBe('registry.npmjs.org:443:full:rest');
+  });
+
+  test('appends websocket-credential-rewrite option', () => {
+    expect(
+      formatEndpointFlag({
+        host: 'ws.example.com',
+        port: 443,
+        access: 'read-write',
+        protocol: 'websocket',
+        enforcement: 'enforce',
+        websocket_credential_rewrite: true,
+      }),
+    ).toBe('ws.example.com:443:read-write:websocket:enforce:websocket-credential-rewrite');
+  });
+
+  test('combines multiple options', () => {
+    expect(
+      formatEndpointFlag({
+        host: 'api.example.com',
+        port: 443,
+        access: 'full',
+        protocol: 'rest',
+        enforcement: 'enforce',
+        websocket_credential_rewrite: true,
+        request_body_credential_rewrite: true,
+      }),
+    ).toBe('api.example.com:443:full:rest:enforce:websocket-credential-rewrite,request-body-credential-rewrite');
+  });
+});
+
+describe('collectEndpointFlags', () => {
+  test('returns empty array when no network_policies', () => {
+    expect(collectEndpointFlags({ version: 1 })).toEqual([]);
+  });
+
+  test('collects endpoints from all rules', () => {
+    const flags = collectEndpointFlags({
+      version: 1,
+      network_policies: {
+        'kdn-network': {
+          endpoints: [
+            { host: 'registry.npmjs.org', port: 443, access: 'full', protocol: 'rest', allow_encoded_slash: true },
+          ],
+          binaries: [{ path: '/**' }],
+        },
+        'kdn-model': {
+          endpoints: [{ host: 'api.example.com', port: 443 }],
+          binaries: [{ path: '/**' }],
+        },
+      },
+    });
+
+    expect(flags).toEqual(['registry.npmjs.org:443:full:rest', 'api.example.com:443']);
+  });
+});
+
+describe('collectBinaryFlags', () => {
+  test('returns empty array when no network_policies', () => {
+    expect(collectBinaryFlags({ version: 1 })).toEqual([]);
+  });
+
+  test('collects binary paths from all rules', () => {
+    const flags = collectBinaryFlags({
+      version: 1,
+      network_policies: {
+        'kdn-network': {
+          endpoints: [{ host: 'registry.npmjs.org', port: 443 }],
+          binaries: [{ path: '/**' }],
+        },
+        'kdn-model': {
+          endpoints: [{ host: 'api.example.com', port: 443 }],
+          binaries: [{ path: '/**' }],
+        },
+      },
+    });
+
+    expect(flags).toEqual(['/**']);
+  });
+
+  test('deduplicates binary paths', () => {
+    const flags = collectBinaryFlags({
+      version: 1,
+      network_policies: {
+        rule1: {
+          endpoints: [{ host: 'a.com', port: 443 }],
+          binaries: [{ path: '/**' }, { path: '/usr/bin/curl' }],
+        },
+        rule2: {
+          endpoints: [{ host: 'b.com', port: 443 }],
+          binaries: [{ path: '/**' }],
+        },
+      },
+    });
+
+    expect(flags).toEqual(['/**', '/usr/bin/curl']);
+  });
+
+  test('handles rules with empty binaries', () => {
+    const flags = collectBinaryFlags({
+      version: 1,
+      network_policies: {
+        rule1: {
+          endpoints: [{ host: 'a.com', port: 443 }],
+          binaries: [],
+        },
+      },
+    });
+
+    expect(flags).toEqual([]);
   });
 });

--- a/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-network-policy.ts
@@ -191,6 +191,41 @@ export function parseModelEndpoint(endpoint: string): ModelEndpoint | undefined 
   return { host: parsed.hostname, port };
 }
 
+/**
+ * Formats an {@link OpenshellEndpoint} as a CLI `--add-endpoint` string:
+ * `host:port[:access[:protocol[:enforcement[:options]]]]`
+ */
+export function formatEndpointFlag(ep: OpenshellEndpoint): string {
+  const parts: string[] = [ep.host, String(ep.port)];
+  if (ep.access) parts.push(ep.access);
+  if (ep.protocol) parts.push(ep.protocol);
+  if (ep.enforcement) parts.push(ep.enforcement);
+
+  const options: string[] = [];
+  if (ep.websocket_credential_rewrite) options.push('websocket-credential-rewrite');
+  if (ep.request_body_credential_rewrite) options.push('request-body-credential-rewrite');
+  if (options.length) {
+    if (!ep.enforcement) parts.push('enforce');
+    parts.push(options.join(','));
+  }
+
+  return parts.join(':');
+}
+
+/**
+ * Collects all endpoints from a policy's network_policies into CLI
+ * `--add-endpoint` formatted strings.
+ */
+export function collectEndpointFlags(policy: OpenshellPolicy): string[] {
+  if (!policy.network_policies) return [];
+  return Object.values(policy.network_policies).flatMap(rule => rule.endpoints.map(formatEndpointFlag));
+}
+
+export function collectBinaryFlags(policy: OpenshellPolicy): string[] {
+  if (!policy.network_policies) return [];
+  return [...new Set(Object.values(policy.network_policies).flatMap(rule => (rule.binaries ?? []).map(b => b.path)))];
+}
+
 export function buildPolicyObject(network?: NetworkConfiguration, modelEndpoint?: string): OpenshellPolicy | undefined {
   const networkPolicies: Record<string, OpenshellNetworkPolicyEntry> = {};
 


### PR DESCRIPTION
Enable v2 providers globally (--global) before creating the sandbox so
provider network rules are active at creation time. After creation, add
workspace-specific network endpoints incrementally via
`openshell policy update --add-endpoint` instead of `policy set`,
which did a full replace and broke filesystem policy on live sandboxes.

- Move v2 check+enable before createSandbox, use --global flag
- Add `updatePolicy` method to OpenshellCli using --add-endpoint and
  --binary flags
- Add `formatEndpointFlag` and `collectEndpointFlags` helpers to
  convert OpenshellEndpoint objects to CLI flag strings
- Remove `js-yaml` dump import (no longer writing temp policy files)


https://github.com/user-attachments/assets/4388b8e9-be28-4ee3-8813-10b332d893e5



Fixes #2417 
