### PR TITLE
fix(claude): preserve skills for Vertex workspaces

### DIFF
--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -398,7 +398,9 @@ describe('ClaudeExtension', () => {
       await agent.preWorkspaceStart(context);
 
       expect(workspace.environment).toContainEqual({ name: 'CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS', value: '1' });
-      expect(workspace.environment).toContainEqual({ name: 'CLAUDE_CODE_SIMPLE', value: '1' });
+      expect(workspace.environment).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'CLAUDE_CODE_SIMPLE' })]),
+      );
       expect(workspace.environment).toContainEqual({ name: 'ANTHROPIC_BASE_URL', value: 'https://inference.local' });
       expect(workspace.environment).toContainEqual({ name: 'ANTHROPIC_API_KEY', value: 'unused' });
     });
@@ -462,8 +464,7 @@ describe('ClaudeExtension', () => {
         name: 'CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS',
         value: '1',
       });
-      expect(claudeCodeUseSimple).toHaveLength(1);
-      expect(claudeCodeUseSimple[0]).toEqual({ name: 'CLAUDE_CODE_SIMPLE', value: '1' });
+      expect(claudeCodeUseSimple).toHaveLength(0);
       expect(anthropicBaseURL).toHaveLength(1);
       expect(anthropicBaseURL[0]).toEqual({ name: 'ANTHROPIC_BASE_URL', value: 'https://inference.local' });
       expect(anthropicKey).toHaveLength(1);

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -124,7 +124,6 @@ export class ClaudeExtension {
         if (context.model.llmMetadata?.name === 'vertexai') {
           // Add Claude Code-specific environment variables for Vertex AI
           const claudeEnvVars = [
-            { name: 'CLAUDE_CODE_SIMPLE', value: '1' },
             { name: 'CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS', value: '1' },
             { name: 'ANTHROPIC_BASE_URL', value: 'https://inference.local' },
             { name: 'ANTHROPIC_API_KEY', value: 'unused' },
@@ -139,6 +138,9 @@ export class ClaudeExtension {
             }
             context.workspace.environment.push(envVar);
           }
+
+          // CLAUDE_CODE_SIMPLE prevents Claude Code from indexing user-installed skills.
+          context.workspace.environment = context.workspace.environment.filter(e => e.name !== 'CLAUDE_CODE_SIMPLE');
         }
 
         const settingsFile = context.configurationFiles.find(f => f.path === CLAUDE_SETTINGS_PATH);


### PR DESCRIPTION
## Summary
- stop setting CLAUDE_CODE_SIMPLE for Claude Vertex workspaces because it prevents Claude Code from indexing user-installed skills
- filter any stale CLAUDE_CODE_SIMPLE entry while preserving the Vertex inference env vars
- update Claude extension tests for the new env behavior

Fixes: https://github.com/openkaiden/kaiden/issues/2441

## Validation
- pnpm exec vitest run extensions/claude/src/claude-extension.spec.ts