### PR TITLE
fix(gemini): route Gemini through OpenAI-compatible endpoint for OpenShell

### DIFF
--- a/extensions/gemini/package.json
+++ b/extensions/gemini/package.json
@@ -28,14 +28,20 @@
         "gemini.connection._type": {
           "type": "string",
           "scope": "InferenceProviderConnection",
-          "description": "Gemini provider type",
+          "description": "OpenShell provider type",
           "hidden": true
         },
-        "gemini.connection.GEMINI_API_KEY": {
+        "gemini.connection.OPENAI_API_KEY": {
           "type": "string",
           "scope": "InferenceProviderConnection",
           "description": "API key secret reference",
           "format": "password",
+          "hidden": true
+        },
+        "gemini.connection.OPENAI_BASE_URL": {
+          "type": "string",
+          "scope": "InferenceProviderConnection",
+          "description": "Gemini OpenAI-compatible base URL",
           "hidden": true
         }
       }

--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -313,7 +313,8 @@ describe('factory', () => {
 
     expect(SAFE_STORAGE_MOCK.delete).toHaveBeenCalledWith('gemini:fake-uuid-1:token');
     expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection._type', undefined);
-    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.GEMINI_API_KEY', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.OPENAI_API_KEY', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.OPENAI_BASE_URL', undefined);
   });
 });
 
@@ -353,7 +354,8 @@ describe('connection delete lifecycle', () => {
 
     // Verify configuration clearing
     expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection._type', undefined);
-    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.GEMINI_API_KEY', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.OPENAI_API_KEY', undefined);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.OPENAI_BASE_URL', undefined);
 
     // Verify storage update - the tokens list is updated after per-connection secret
     expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledWith(TOKENS_KEY, JSON.stringify([]));
@@ -415,10 +417,14 @@ describe('workspace configuration', () => {
     expect(configuration.getConfiguration).toHaveBeenCalledWith(undefined, connection);
 
     // Verify configuration updates
-    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection._type', PROVIDER_ID);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection._type', 'openai');
     expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith(
-      'gemini.connection.GEMINI_API_KEY',
+      'gemini.connection.OPENAI_API_KEY',
       `${PROVIDER_ID}:fake-uuid-1:token`,
+    );
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith(
+      'gemini.connection.OPENAI_BASE_URL',
+      'https://generativelanguage.googleapis.com/v1beta/openai/',
     );
   });
 
@@ -437,8 +443,8 @@ describe('workspace configuration', () => {
     expect(SAFE_STORAGE_MOCK.store).toHaveBeenCalledWith(`${PROVIDER_ID}:id-2:token`, 'key2');
 
     // Verify configuration updates for both connections
-    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection._type', PROVIDER_ID);
-    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.GEMINI_API_KEY', `${PROVIDER_ID}:id-1:token`);
-    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.GEMINI_API_KEY', `${PROVIDER_ID}:id-2:token`);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection._type', 'openai');
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.OPENAI_API_KEY', `${PROVIDER_ID}:id-1:token`);
+    expect(CONFIG_UPDATE_MOCK).toHaveBeenCalledWith('gemini.connection.OPENAI_API_KEY', `${PROVIDER_ID}:id-2:token`);
   });
 });

--- a/extensions/gemini/src/gemini.spec.ts
+++ b/extensions/gemini/src/gemini.spec.ts
@@ -290,6 +290,7 @@ describe('factory', () => {
       name: 'dum*****',
       type: 'cloud',
       llmMetadata: { name: 'gemini' },
+      endpoint: 'https://generativelanguage.googleapis.com/v1beta/openai/',
       status: expect.any(Function),
       lifecycle: {
         delete: expect.any(Function),

--- a/extensions/gemini/src/gemini.ts
+++ b/extensions/gemini/src/gemini.ts
@@ -74,7 +74,7 @@ export class Gemini implements Disposable {
     // register MCP Provider connection factory
     this.provider?.setInferenceProviderConnectionFactory({
       connectionTypes: ['cloud'],
-      llmMetadata: { name: 'gemini' },
+      llmMetadata: { name: PROVIDER_ID },
       create: this.mcpFactory.bind(this),
     });
 
@@ -175,7 +175,8 @@ export class Gemini implements Disposable {
       id,
       name: this.maskKey(token),
       type: 'cloud',
-      llmMetadata: { name: 'gemini' },
+      llmMetadata: { name: PROVIDER_ID },
+      endpoint: OPENAI_COMPAT_BASE_URL,
       sdk: google,
       status(): ProviderConnectionStatus {
         return status;

--- a/extensions/gemini/src/gemini.ts
+++ b/extensions/gemini/src/gemini.ts
@@ -33,6 +33,14 @@ import { configuration } from '@openkaiden/api';
 export const PROVIDER_ID = 'gemini';
 export const TOKENS_KEY = 'gemini:tokens';
 
+// OpenShell has no dedicated "gemini" provider type — it only understands
+// protocol families (openai, anthropic, ...). Google publishes an
+// OpenAI-compatible endpoint that accepts a plain Bearer API key, so the
+// connection is registered with OpenShell as an "openai" provider pointed
+// at that endpoint.
+const OPENSHELL_PROVIDER_TYPE = 'openai';
+const OPENAI_COMPAT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/openai/';
+
 export interface StoredConnection {
   id: string;
   token: string;
@@ -126,8 +134,9 @@ export class Gemini implements Disposable {
     await this.secrets.store(secretName, token);
 
     const config = configuration.getConfiguration(undefined, connection);
-    await config.update('gemini.connection._type', PROVIDER_ID);
-    await config.update('gemini.connection.GEMINI_API_KEY', secretName);
+    await config.update('gemini.connection._type', OPENSHELL_PROVIDER_TYPE);
+    await config.update('gemini.connection.OPENAI_API_KEY', secretName);
+    await config.update('gemini.connection.OPENAI_BASE_URL', OPENAI_COMPAT_BASE_URL);
   }
 
   private async clearConnectionConfiguration(connection: InferenceProviderConnection): Promise<void> {
@@ -136,7 +145,8 @@ export class Gemini implements Disposable {
 
     const config = configuration.getConfiguration(undefined, connection);
     await config.update('gemini.connection._type', undefined);
-    await config.update('gemini.connection.GEMINI_API_KEY', undefined);
+    await config.update('gemini.connection.OPENAI_API_KEY', undefined);
+    await config.update('gemini.connection.OPENAI_BASE_URL', undefined);
   }
 
   private async registerInferenceProviderConnection({ id, token }: { id: string; token: string }): Promise<void> {

--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -169,7 +169,7 @@ describe('activate', () => {
           ollama: {
             name: 'ollama',
             npm: '@ai-sdk/openai-compatible',
-            options: { baseURL: 'http://localhost:11434/v1' },
+            options: { apiKey: '{env:OPENAI_API_KEY}', baseURL: 'http://localhost:11434/v1' },
             models: {
               llama3: { _launch: true, name: 'llama3' },
             },

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -128,7 +128,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
           providerEntry.name = provider;
           providerEntry.npm = NATIVE_PROVIDER_SDKS[provider] ?? '@ai-sdk/openai-compatible';
-          providerEntry.options = { ...providerEntry.options, baseURL: endpoint };
+          providerEntry.options = { apiKey: '{env:OPENAI_API_KEY}', ...providerEntry.options, baseURL: endpoint };
 
           providerEntry.models ??= {};
           providerEntry.models[modelName] ??= { _launch: true, name: modelName };


### PR DESCRIPTION
## Summary
- Register Gemini connections with OpenShell as `openai` provider type since OpenShell has no native `gemini` provider, using Google's OpenAI-compatible endpoint (`generativelanguage.googleapis.com/v1beta/openai/`)
- Add `endpoint` to the Gemini connection so the OpenCode agent generates a proper custom provider config block with `@ai-sdk/openai-compatible`
- Inject default `apiKey: '{env:OPENAI_API_KEY}'` in OpenCode's custom provider options so the SDK can authenticate via the env var OpenShell injects

https://github.com/user-attachments/assets/498e9d0a-eb94-423d-8e7d-f5436af96f85

Fixes: https://github.com/openkaiden/kaiden/issues/2429

Test: 

Add ur api key to the gemini extension so its saved in kaiden

select the opencode provider with gemini and create a sandbox see if u can interact with it