### PR TITLE
fix(agent-workspace): prevent workspace rename

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -25,7 +25,6 @@ import type {
   AgentWorkspaceConfiguration,
   AISDKInferenceProvider,
   Configuration,
-  FileSystemWatcher,
   ProviderConnectionStatus,
 } from '@openkaiden/api';
 import type { IpcMainInvokeEvent, WebContents } from 'electron';
@@ -37,7 +36,6 @@ import type { AgentRegistry } from '/@/plugin/agent-registry.js';
 import * as configWriter from '/@/plugin/agent-workspace/workspace-config-writer.js';
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
-import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import type { ProviderImpl } from '/@/plugin/provider-impl.js';
@@ -108,16 +106,6 @@ const taskManager = {
   createTask: vi.fn().mockReturnValue(mockTask),
 } as unknown as TaskManager;
 
-const mockWatcher = {
-  onDidChange: vi.fn(),
-  onDidCreate: vi.fn(),
-  onDidDelete: vi.fn(),
-  dispose: vi.fn(),
-} as unknown as FileSystemWatcher;
-const filesystemMonitoring = {
-  createFileSystemWatcher: vi.fn().mockReturnValue(mockWatcher),
-} as unknown as FilesystemMonitoring;
-
 const webContents = {
   send: vi.fn(),
   receive: vi.fn(),
@@ -167,7 +155,6 @@ beforeEach(() => {
   mockTask.state = '' as TaskState;
   mockTask.status = '' as TaskStatus;
   mockTask.error = '';
-  vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
   vi.mocked(writeFile).mockResolvedValue(undefined);
   vi.mocked(rm).mockResolvedValue(undefined);
   vi.mocked(readFile).mockResolvedValue('{}');
@@ -195,7 +182,6 @@ beforeEach(() => {
     apiSender,
     ipcHandle,
     taskManager,
-    filesystemMonitoring,
     webContents,
     configurationRegistry,
     providerRegistry,
@@ -253,37 +239,6 @@ describe('init', () => {
     gatewayStartCallback!();
     expect(apiSender.send).toHaveBeenCalledWith('agent-gateway-update');
     expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
-  });
-});
-
-describe('watchInstancesFile', () => {
-  test('watches ~/.kdn/instances.json on init', () => {
-    expect(filesystemMonitoring.createFileSystemWatcher).toHaveBeenCalledWith(
-      expect.stringMatching(/\.kdn[\\/]instances\.json$/),
-    );
-  });
-
-  test('sends agent-workspace-update on file change', () => {
-    const changeCallback = vi.mocked(mockWatcher.onDidChange).mock.calls[0]![0] as () => void;
-    changeCallback();
-    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
-  });
-
-  test('sends agent-workspace-update on file create', () => {
-    const createCallback = vi.mocked(mockWatcher.onDidCreate).mock.calls[0]![0] as () => void;
-    createCallback();
-    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
-  });
-
-  test('sends agent-workspace-update on file delete', () => {
-    const deleteCallback = vi.mocked(mockWatcher.onDidDelete).mock.calls[0]![0] as () => void;
-    deleteCallback();
-    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
-  });
-
-  test('disposes watcher on dispose', () => {
-    manager.dispose();
-    expect(mockWatcher.dispose).toHaveBeenCalled();
   });
 });
 
@@ -1086,47 +1041,6 @@ describe('updateConfiguration', () => {
     vi.mocked(configWriter.updateWorkspaceConfig).mockRejectedValue(new Error('permission denied'));
 
     await expect(manager.updateConfiguration('ws-1', {})).rejects.toThrow('permission denied');
-  });
-});
-
-describe('updateSummary', () => {
-  const INSTANCES_JSON = [
-    { id: 'ws-1', name: 'old-name', paths: { source: '/tmp/ws1' } },
-    { id: 'ws-2', name: 'other-workspace', paths: { source: '/tmp/ws2' } },
-  ];
-
-  test('updates the name of the matching workspace in instances.json', async () => {
-    vi.mocked(readFile).mockResolvedValue(JSON.stringify(INSTANCES_JSON));
-
-    await manager.updateSummary('ws-1', { name: 'new-name' });
-
-    expect(writeFile).toHaveBeenCalledWith(
-      expect.stringMatching(/\.kdn[\\/]instances\.json$/),
-      expect.any(String),
-      'utf-8',
-    );
-    const written = JSON.parse(vi.mocked(writeFile).mock.calls[0]![1] as string) as { id: string; name: string }[];
-    expect(written.find(w => w.id === 'ws-1')?.name).toBe('new-name');
-    expect(written.find(w => w.id === 'ws-2')?.name).toBe('other-workspace');
-  });
-
-  test('throws when workspace id is not found', async () => {
-    vi.mocked(readFile).mockResolvedValue(JSON.stringify(INSTANCES_JSON));
-
-    await expect(manager.updateSummary('unknown-id', { name: 'x' })).rejects.toThrow(
-      'workspace "unknown-id" not found in instances.json',
-    );
-    expect(writeFile).not.toHaveBeenCalled();
-  });
-
-  test('propagates file read errors', async () => {
-    vi.mocked(readFile).mockRejectedValue(new Error('EACCES: permission denied'));
-
-    await expect(manager.updateSummary('ws-1', { name: 'x' })).rejects.toThrow('EACCES: permission denied');
-  });
-
-  test('registers IPC handler for updateSummary', () => {
-    expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:updateSummary', expect.any(Function));
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -20,7 +20,7 @@ import { access, lstat, readFile, realpath, rm, writeFile } from 'node:fs/promis
 import { homedir, tmpdir } from 'node:os';
 import { basename, isAbsolute, join, posix, resolve } from 'node:path';
 
-import type { Disposable, FileSystemWatcher } from '@openkaiden/api';
+import type { Disposable } from '@openkaiden/api';
 import type { WebContents } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
 import type { IPty } from 'node-pty';
@@ -30,7 +30,6 @@ import { AgentRegistry } from '/@/plugin/agent-registry.js';
 import { updateWorkspaceConfig, writeWorkspaceConfig } from '/@/plugin/agent-workspace/workspace-config-writer.js';
 import { WritableConfigurationFile } from '/@/plugin/agent-workspace/writable-configuration-file.js';
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
-import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import {
@@ -87,7 +86,6 @@ export function encodeWorkspaceLabels(sourcePath: string): Record<string, string
  */
 @injectable()
 export class AgentWorkspaceManager implements Disposable {
-  private instancesWatcher: FileSystemWatcher | undefined;
   private readonly workspaceTerminals = new Map<string, WorkspaceTerminalSession>();
 
   constructor(
@@ -97,8 +95,6 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly ipcHandle: IPCHandle,
     @inject(TaskManager)
     private readonly taskManager: TaskManager,
-    @inject(FilesystemMonitoring)
-    private readonly filesystemMonitoring: FilesystemMonitoring,
     @inject(WebContentsType)
     private readonly webContents: WebContents,
     @inject(IConfigurationRegistry)
@@ -750,25 +746,10 @@ export class AgentWorkspaceManager implements Disposable {
       this.apiSender.send('agent-gateway-update');
       this.apiSender.send('agent-workspace-update');
     });
-
-    this.watchInstancesFile();
-  }
-
-  private watchInstancesFile(): void {
-    this.instancesWatcher?.dispose();
-    const instancesPath = join(homedir(), '.kdn', 'instances.json');
-    this.instancesWatcher = this.filesystemMonitoring.createFileSystemWatcher(instancesPath);
-    const notify = (): void => {
-      this.apiSender.send('agent-workspace-update');
-    };
-    this.instancesWatcher.onDidChange(notify);
-    this.instancesWatcher.onDidCreate(notify);
-    this.instancesWatcher.onDidDelete(notify);
   }
 
   @preDestroy()
   dispose(): void {
-    this.instancesWatcher?.dispose();
     for (const session of this.workspaceTerminals.values()) {
       try {
         session.pty.kill();

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -68,7 +68,6 @@ beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
   vi.mocked(router).subscribe.mockImplementation(routerStore.subscribe);
-  vi.mocked(window.updateAgentWorkspaceSummary).mockResolvedValue(undefined);
   vi.mocked(window.updateAgentWorkspaceConfiguration).mockResolvedValue(undefined);
   vi.mocked(skillsStore).skillInfos = writable<readonly SkillInfo[]>([]);
   vi.mocked(ragStore).ragEnvironments = writable<RagEnvironment[]>([]);
@@ -103,64 +102,11 @@ test('Expect all settings nav sections are rendered', () => {
   }
 });
 
-test('Expect workspace name input is editable', async () => {
+test('Expect workspace name input is readonly', () => {
   render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
 
   const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
-  expect(nameInput).not.toHaveAttribute('readonly');
-  await fireEvent.input(nameInput, { target: { value: 'new-name' } });
-  expect(nameInput).toHaveValue('new-name');
-});
-
-test('Expect save/discard bar shown when workspace name is modified', async () => {
-  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
-
-  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
-  await fireEvent.input(nameInput, { target: { value: 'renamed' } });
-
-  expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Discard changes' })).toBeInTheDocument();
-});
-
-test('Expect save/discard bar not shown when workspace name matches original', async () => {
-  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
-
-  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
-  await fireEvent.input(nameInput, { target: { value: 'api-refactor' } });
-
-  expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
-});
-
-test('Expect clicking Save changes calls updateAgentWorkspaceSummary', async () => {
-  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
-
-  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
-  await fireEvent.input(nameInput, { target: { value: 'renamed' } });
-  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
-
-  expect(window.updateAgentWorkspaceSummary).toHaveBeenCalledWith('ws-1', { name: 'renamed' });
-});
-
-test('Expect clicking Discard changes resets workspace name to original', async () => {
-  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
-
-  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
-  await fireEvent.input(nameInput, { target: { value: 'renamed' } });
-  await fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
-
-  expect(nameInput).toHaveValue('api-refactor');
-  expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
-  expect(window.updateAgentWorkspaceSummary).not.toHaveBeenCalled();
-});
-
-test('Expect no save when workspace name has not changed', async () => {
-  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
-
-  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
-  await fireEvent.input(nameInput, { target: { value: 'api-refactor' } });
-
-  expect(window.updateAgentWorkspaceSummary).not.toHaveBeenCalled();
+  expect(nameInput).toHaveAttribute('readonly');
 });
 
 test('Expect working directory input is readonly', () => {
@@ -317,19 +263,6 @@ test('Expect Manage Skills button navigates to skills page', async () => {
   await fireEvent.click(screen.getByRole('button', { name: 'Manage Skills' }));
 
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'skills' });
-});
-
-test('Expect name save failure rolls back workspace name', async () => {
-  vi.mocked(window.updateAgentWorkspaceSummary).mockRejectedValueOnce(new Error('network error'));
-
-  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
-
-  const nameInput = screen.getByRole('textbox', { name: 'Workspace Name' });
-  await fireEvent.input(nameInput, { target: { value: 'renamed' } });
-  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
-
-  expect(nameInput).toHaveValue('api-refactor');
-  expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
 });
 
 test('Expect skills save failure rolls back skill selection', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -51,8 +51,7 @@ const sections: SectionConfig[] = [
 let activeSection: SettingsSection = $state('general');
 const activeLabel = $derived(sections.find(s => s.id === activeSection)?.label ?? '');
 
-const originalName = $derived(workspaceSummary?.name ?? '');
-let workspaceName = $state(originalName);
+const workspaceName = $derived(workspaceSummary?.name ?? '');
 
 let skillItems: ChecklistItem[] = $derived(
   $skillInfos.map(s => ({
@@ -75,7 +74,6 @@ function onSkillsChange(updated: string[]): void {
   pendingSkillIds = updated;
 }
 
-const hasNameChanges = $derived(workspaceName.trim() !== originalName && workspaceName.trim().length > 0);
 const hasSkillChanges = $derived(
   pendingSkillIds.length !== originalSkillIds.length || pendingSkillIds.some(id => !originalSkillIds.includes(id)),
 );
@@ -273,15 +271,12 @@ function updateCustomHost(index: number, value: string): void {
 }
 
 const hasChanges = $derived(
-  hasNameChanges || hasMountChanges || hasSkillChanges || hasKnowledgeChanges || hasMcpChanges || hasNetworkChanges,
+  hasMountChanges || hasSkillChanges || hasKnowledgeChanges || hasMcpChanges || hasNetworkChanges,
 );
 
 // --- Save / Discard ---
 async function saveChanges(): Promise<void> {
   try {
-    if (hasNameChanges) {
-      await window.updateAgentWorkspaceSummary(workspaceId, { name: workspaceName.trim() });
-    }
     if (hasMountChanges) {
       const newMounts = buildMountsFromSelection(pendingFileAccess, pendingCustomMounts);
       await window.updateAgentWorkspaceConfiguration(workspaceId, { mounts: newMounts });
@@ -394,7 +389,6 @@ function buildUnmanagedMcpConfig(): AgentWorkspaceMcpConfig {
 }
 
 function discardChanges(): void {
-  workspaceName = originalName;
   pendingFileAccess = originalFileAccess;
   pendingCustomMounts = originalCustomMounts.map(m => ({ ...m }));
   pendingSkillIds = [...originalSkillIds];
@@ -513,7 +507,8 @@ function handleDeleteWorkspace(): void {
                   <Input
                     id="input-workspace-name"
                     aria-label="Workspace Name"
-                    bind:value={workspaceName} />
+                    value={workspaceName}
+                    readonly />
                 </div>
                 <div class="flex flex-col gap-2">
                   <label for="input-working-directory" class="text-[13px] font-semibold text-[var(--pd-content-card-header-text)]">Working Directory</label>


### PR DESCRIPTION
Make the workspace name input readonly in settings since OpenShell
has no mechanism to rename a sandbox. Remove the instances.json
file watcher that referenced the legacy kdn-managed file.

updateSummary() / preload bridge are kept as they should be reused for workspace descriptions (#2383)

fixes #2448