### PR TITLE
fix(workspaces): upload custom mount paths to openshell sandbox

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -490,6 +490,24 @@ describe('create – OpenShell mode', () => {
     );
   });
 
+  test('uploads custom path mounts with relative sandbox target', async () => {
+    vi.mocked(lstat).mockResolvedValue({
+      isDirectory: () => true,
+      isFile: () => false,
+      isSymbolicLink: () => false,
+    } as Awaited<ReturnType<typeof lstat>>);
+    await manager.create({
+      ...defaultOptions,
+      mounts: [{ host: '/Users/fbricon/Dev/projects/gh-dashboard', target: 'gh-dashboard', ro: false }],
+    });
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: expect.arrayContaining([{ local: '/Users/fbricon/Dev/projects/gh-dashboard', remote: '.' }]),
+      }),
+    );
+  });
+
   test('uploads safe resolved mounts to the openshell sandbox', async () => {
     await manager.create({
       ...defaultOptions,

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -342,7 +342,7 @@ export class AgentWorkspaceManager implements Disposable {
     if (path.startsWith(`${MOUNT_HOME_PREFIX}/`)) {
       return posix.join('~', path.slice(MOUNT_HOME_PREFIX.length + 1));
     }
-    if (path.startsWith('/')) {
+    if (path.length > 0) {
       return path;
     }
     return undefined;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -1446,7 +1446,7 @@ test('Expect createAgentWorkspace called with ro:true when read-only toggled for
 
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
-      mounts: [{ host: '/home/user/data', target: '/home/user/data', ro: true }],
+      mounts: [{ host: '/home/user/data', target: 'data', ro: true }],
     }),
   );
 });
@@ -1466,7 +1466,27 @@ test('Expect custom mount defaults target to host path when target is empty', as
 
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(
     expect.objectContaining({
-      mounts: [{ host: '/home/user/configs', target: '/home/user/configs', ro: false }],
+      mounts: [{ host: '/home/user/configs', target: 'configs', ro: false }],
+    }),
+  );
+});
+
+test('Expect custom mount strips trailing separators when deriving target from host', async () => {
+  render(AgentWorkspaceCreate);
+
+  await navigateToFileSystemStep();
+  await fireEvent.click(screen.getByRole('radio', { name: 'Use Custom Paths' }));
+
+  await fireEvent.input(screen.getByLabelText('Host path 1'), {
+    target: { value: '/home/user/data/' },
+  });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Start Workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mounts: [{ host: '/home/user/data/', target: 'data', ro: false }],
     }),
   );
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -395,7 +395,8 @@ function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorksp
         .map(m => {
           const host = m.host.trim();
           const trimmedTarget = m.target.trim();
-          const target = trimmedTarget !== '' ? trimmedTarget : host;
+          const basename = host.split('/').filter(Boolean).pop();
+          const target = trimmedTarget !== '' ? trimmedTarget : (basename ?? host);
           return { host, target, ro: m.ro };
         });
       return filtered.length > 0 ? filtered : undefined;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -449,6 +449,40 @@ test('Expect saving custom mounts calls updateAgentWorkspaceConfiguration', asyn
   });
 });
 
+test('Expect saving custom mount with empty target defaults to basename of host', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Custom Paths' }));
+  const hostInput = screen.getByRole('textbox', { name: 'Host path 1' });
+  await fireEvent.input(hostInput, { target: { value: '/home/user/data' } });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.updateAgentWorkspaceConfiguration).toHaveBeenCalledWith('ws-1', {
+    mounts: [{ host: '/home/user/data', target: 'data', ro: false }],
+  });
+});
+
+test('Expect saving custom mount with trailing separator derives correct basename', async () => {
+  render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration: {} });
+
+  const fileAccessNav = screen.getByRole('link', { name: 'File Access' });
+  await fireEvent.click(fileAccessNav);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Custom Paths' }));
+  const hostInput = screen.getByRole('textbox', { name: 'Host path 1' });
+  await fireEvent.input(hostInput, { target: { value: '/home/user/data/' } });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+  expect(window.updateAgentWorkspaceConfiguration).toHaveBeenCalledWith('ws-1', {
+    mounts: [{ host: '/home/user/data/', target: 'data', ro: false }],
+  });
+});
+
 test('Expect discarding file access changes resets to original mode', async () => {
   render(AgentWorkspaceDetailsSettings, { workspaceId: 'ws-1', workspaceSummary, configuration });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -109,7 +109,13 @@ function buildMountsFromSelection(fileAccess: string, mounts: CustomMount[]): Ag
     case 'custom': {
       const filtered = mounts
         .filter(m => m.host.trim() !== '')
-        .map(m => ({ host: m.host.trim(), target: m.target.trim() ?? m.host.trim(), ro: m.ro }));
+        .map(m => {
+          const host = m.host.trim();
+          const trimmedTarget = m.target.trim();
+          const basename = host.split('/').filter(Boolean).pop();
+          const target = trimmedTarget !== '' ? trimmedTarget : (basename ?? host);
+          return { host, target, ro: m.ro };
+        });
       return filtered.length > 0 ? filtered : undefined;
     }
   }


### PR DESCRIPTION
Custom path mounts from the workspace wizard were silently skipped
because resolveOpenshellSandboxPath rejected relative target paths.
Also, when the user leaves the target empty, buildMountsFrom used
the full host path as the sandbox target, which fails because
openshell sandboxes only allow writes under /sandbox and /tmp.

- Accept any non-empty string in resolveOpenshellSandboxPath (not
  just absolute paths)
- Default empty target to basename(host) instead of the full host
  path, in both AgentWorkspaceCreate and AgentWorkspaceDetailsSettings
- Fix dead nullish coalescing fallback in AgentWorkspaceDetailsSettings
  (trim() always returns a string, never null)

fixes #2450 
