### PR TITLE
Prevent refreshing agent terminal without warning

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -92,6 +92,10 @@ async function createWindow(): Promise<BrowserWindow> {
   };
   browserWindow.setBounds(initialBounds);
 
+  browserWindow.webContents.on('will-prevent-unload', () => {
+    browserWindow.webContents.send('api-sender', 'agent-terminal:confirm-reload', {});
+  });
+
   /**
    * If you install `show: true` then it can cause issues when trying to close the window.
    * Use `show: false` and listener events `ready-to-show` to fix these issues.

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -13,6 +13,7 @@ import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 import { getExistingTerminal, registerTerminal } from '/@/stores/agent-workspace-terminal-store';
 import { allOpenshellSandboxes } from '/@/stores/openshell-sandboxes';
+import { AGENT_LABEL } from '/@api/openshell-gateway-info';
 import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 const MAX_RECONNECT_ATTEMPTS = 30;
@@ -44,6 +45,7 @@ let reconnectCount = 0;
 const workspaceSummary = $derived($allOpenshellSandboxes.find(ws => ws.id === workspaceId));
 const status = $derived(workspaceSummary?.phase ?? 'Provisioning');
 const isRunning = $derived(status === 'Ready');
+const hasAgent = $derived(Boolean(workspaceSummary?.labels?.[AGENT_LABEL]));
 let lastStatus = $state('');
 
 function registerInputHandler(callbackId: number): void {
@@ -133,7 +135,7 @@ function handleResize(): void {
 let skipBeforeUnload = false;
 
 function handleBeforeUnload(event: BeforeUnloadEvent): void {
-  if (sendCallbackId && !skipBeforeUnload) {
+  if (sendCallbackId && hasAgent && !skipBeforeUnload) {
     event.preventDefault();
   }
 }
@@ -142,7 +144,8 @@ function handleConfirmReload(): void {
   window
     .showMessageBox({
       title: 'Reload Application',
-      message: 'An agent terminal session is active. Reloading will disconnect it and you will need to reconnect.',
+      message:
+        'If an agent session is active, reloading will disconnect it and the agent terminal will be lost. Do you want to continue?',
       type: 'warning',
       buttons: ['Reload', 'Cancel'],
     })

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -135,7 +135,7 @@ function handleResize(): void {
 let skipBeforeUnload = false;
 
 function handleBeforeUnload(event: BeforeUnloadEvent): void {
-  if (sendCallbackId && hasAgent && !skipBeforeUnload) {
+  if (sendCallbackId !== undefined && hasAgent && !skipBeforeUnload) {
     event.preventDefault();
   }
 }

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceTerminal.svelte
@@ -130,6 +130,31 @@ function handleResize(): void {
   }
 }
 
+let skipBeforeUnload = false;
+
+function handleBeforeUnload(event: BeforeUnloadEvent): void {
+  if (sendCallbackId && !skipBeforeUnload) {
+    event.preventDefault();
+  }
+}
+
+function handleConfirmReload(): void {
+  window
+    .showMessageBox({
+      title: 'Reload Application',
+      message: 'An agent terminal session is active. Reloading will disconnect it and you will need to reconnect.',
+      type: 'warning',
+      buttons: ['Reload', 'Cancel'],
+    })
+    .then(result => {
+      if (result?.response === 0) {
+        skipBeforeUnload = true;
+        location.reload();
+      }
+    })
+    .catch((err: unknown) => console.error('Error showing reload confirmation', err));
+}
+
 function createDataCallback(): (data: string) => void {
   return (data: string) => {
     shellTerminal.write(data);
@@ -230,18 +255,24 @@ async function refreshTerminal(): Promise<void> {
   window.dispatchEvent(new Event('resize'));
 }
 
+let confirmReloadDisposable: { dispose: () => void } | undefined;
+
 onMount(async () => {
   reconnect = manualReconnect;
   reconnectExhausted = false;
   reconnectCount = 0;
   await refreshTerminal();
   window.addEventListener('resize', handleResize);
+  window.addEventListener('beforeunload', handleBeforeUnload);
+  confirmReloadDisposable = window.events?.receive('agent-terminal:confirm-reload', handleConfirmReload);
   await executeShellInWorkspace();
 });
 
 onDestroy(() => {
   clearReconnectTimer();
   window.removeEventListener('resize', handleResize);
+  window.removeEventListener('beforeunload', handleBeforeUnload);
+  confirmReloadDisposable?.dispose();
   onDataDisposable?.dispose();
   const terminalContent = serializeAddon?.serialize() ?? '';
   registerTerminal({ workspaceId, callbackId: sendCallbackId, terminal: terminalContent });


### PR DESCRIPTION
## Summary

- Adds a reload confirmation dialog when an agent terminal session (opencode, claude) may be active, warning the user that reloading will disconnect it
- Uses the app's styled `MessageBox` dialog (via `beforeunload` + `will-prevent-unload` IPC bridge) for UI consistency
- Only triggers for workspaces with an agent label — plain sandbox terminals reload freely

## Context

This replaces the approach in PR #2426 , which attempted to seamlessly reconnect to the PTY after a page refresh. That approach works for Claude but fails for OpenCode and potentially other agents, because each TUI framework handles SIGWINCH signals and terminal state transitions differently — and we have no control over their behavior. Attempting to hand-roll PTY reconnection for arbitrary TUI apps is inherently fragile.

Instead, this PR takes a simpler and more robust approach: warn the user before reload and accept that the agent terminal will be lost. In the future, ACP/native agent sessions would solve this properly by making the terminal a stateless rendering client that can cleanly reattach — eliminating the need for PTY-level reconnection entirely.


https://github.com/user-attachments/assets/c67640ef-5c82-4a79-be9e-a10e7145127c


Closes #2425 

## Test plan

- [ ] Open an agent workspace terminal (opencode or claude running)
- [ ] Press Cmd+R / Ctrl+R — verify the styled warning dialog appears
- [ ] Click "Cancel" — verify reload is blocked and terminal continues working
- [ ] Click "Reload" — verify the page reloads normally