### PR TITLE
refactor(agent-workspace): consolidate terminal sessions

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -1245,6 +1245,88 @@ describe('dispose', () => {
   });
 });
 
+describe('terminal IPC session lifecycle', () => {
+  function createTerminalMockPty(): { pty: IPty; triggerData: (data: string) => void } {
+    let onDataCb: ((data: string) => void) | undefined;
+    const pty = {
+      onData: vi.fn((cb: (data: string) => void) => {
+        onDataCb = cb;
+        return { dispose: vi.fn() };
+      }),
+      onExit: vi.fn(() => ({ dispose: vi.fn() })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      pid: 789,
+    } as unknown as IPty;
+    return {
+      pty,
+      triggerData: (data: string): void => {
+        onDataCb?.(data);
+      },
+    };
+  }
+
+  function getIpcHandler<T>(channel: string): T {
+    return vi.mocked(ipcHandle).mock.calls.find(call => call[0] === channel)![1] as unknown as T;
+  }
+
+  test('closes an active workspace terminal before opening a fresh one', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
+    const { pty: firstPty, triggerData: triggerFirstData } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(firstPty);
+
+    const terminalHandler =
+      getIpcHandler<(_listener: unknown, id: string, onDataId: number) => Promise<number>>('agent-workspace:terminal');
+
+    await terminalHandler({}, 'ws-1', 10);
+
+    const { pty: secondPty, triggerData: triggerSecondData } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(secondPty);
+    await terminalHandler({}, 'ws-1', 11);
+    triggerFirstData('stale output');
+    triggerSecondData('output');
+
+    expect(firstPty.kill).toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(webContents.send).not.toHaveBeenCalledWith('agent-workspace:terminal-onData', 11, 'stale output');
+    expect(webContents.send).toHaveBeenCalledWith('agent-workspace:terminal-onData', 11, 'output');
+  });
+
+  test('routes send and resize through the workspace terminal session and removes it on close', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
+    const { pty } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty);
+
+    const terminalHandler =
+      getIpcHandler<(_listener: unknown, id: string, onDataId: number) => Promise<number>>('agent-workspace:terminal');
+    const sendHandler =
+      getIpcHandler<(_listener: unknown, onDataId: number, content: string) => Promise<void>>(
+        'agent-workspace:terminalSend',
+      );
+    const resizeHandler = getIpcHandler<
+      (_listener: unknown, onDataId: number, width: number, height: number) => Promise<void>
+    >('agent-workspace:terminalResize');
+    const closeHandler = getIpcHandler<(_listener: unknown, onDataId: number) => Promise<void>>(
+      'agent-workspace:terminalClose',
+    );
+
+    await terminalHandler({}, 'ws-1', 10);
+    await sendHandler({}, 10, 'hello');
+    await resizeHandler({}, 10, 120, 40);
+    await closeHandler({}, 10);
+
+    const nextPty = createTerminalMockPty().pty;
+    vi.mocked(spawn).mockReturnValue(nextPty);
+    await terminalHandler({}, 'ws-1', 11);
+
+    expect(pty.write).toHaveBeenCalledWith('hello');
+    expect(pty.resize).toHaveBeenCalledWith(120, 40);
+    expect(pty.kill).toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('terminal agent command execution', () => {
   const SANDBOXES_WITH_AGENT: GatewaySandboxes[] = [
     {
@@ -1334,6 +1416,31 @@ describe('terminal agent command execution', () => {
     triggerData2('$ ');
 
     expect(pty2.write).not.toHaveBeenCalled();
+  });
+
+  test('retries agent command when replaced before first terminal data', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(SANDBOXES_WITH_AGENT);
+    vi.mocked(agentRegistry.getAgent).mockResolvedValue({
+      id: 'test-agent',
+      name: 'Test Agent',
+      description: '',
+      command: '/usr/bin/agent start',
+      destinationSkillsFolder: '~/.agent',
+    });
+    const { pty: pty1, triggerData: triggerData1 } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty1);
+
+    await getTerminalHandler()({}, 'ws-agent', 10);
+
+    const { pty: pty2, triggerData: triggerData2 } = createTerminalMockPty();
+    vi.mocked(spawn).mockReturnValue(pty2);
+    await getTerminalHandler()({}, 'ws-agent', 11);
+
+    triggerData1('$ ');
+    triggerData2('$ ');
+
+    expect(pty1.write).not.toHaveBeenCalledWith('/usr/bin/agent start\n');
+    expect(pty2.write).toHaveBeenCalledWith('/usr/bin/agent start\n');
   });
 
   test('does not execute command when workspace has no agent label', async () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -58,6 +58,14 @@ const MOUNT_HOME_PREFIX = '$HOME';
 
 type OpenshellUpload = { local: string; remote: string };
 
+interface WorkspaceTerminalSession {
+  callbackId: number;
+  pty: IPty;
+  write: (param: string) => void;
+  resize: (w: number, h: number) => void;
+  commandExecuted: boolean;
+}
+
 export function encodeWorkspaceLabels(sourcePath: string): Record<string, string> {
   const encoded = Buffer.from(sourcePath).toString('base64url');
   if (encoded.length <= LABEL_MAX_LENGTH) {
@@ -76,12 +84,7 @@ export function encodeWorkspaceLabels(sourcePath: string): Record<string, string
 @injectable()
 export class AgentWorkspaceManager implements Disposable {
   private instancesWatcher: FileSystemWatcher | undefined;
-  private readonly terminalCallbacks = new Map<
-    number,
-    { write: (param: string) => void; resize: (w: number, h: number) => void }
-  >();
-  private readonly terminalProcesses = new Map<number, IPty>();
-  private readonly commandExecutedWorkspaces = new Set<string>();
+  private readonly workspaceTerminals = new Map<string, WorkspaceTerminalSession>();
 
   constructor(
     @inject(ApiSenderType)
@@ -404,7 +407,7 @@ export class AgentWorkspaceManager implements Disposable {
     task.status = 'in-progress';
     try {
       await this.openshellCli.deleteSandbox(workspaceName);
-      this.commandExecutedWorkspaces.delete(id);
+      this.closeWorkspaceTerminal(id);
       this.apiSender.send('agent-workspace-update');
       task.status = 'success';
       return { id };
@@ -532,6 +535,33 @@ export class AgentWorkspaceManager implements Disposable {
     };
   }
 
+  private getWorkspaceTerminalByCallbackId(callbackId: number): WorkspaceTerminalSession | undefined {
+    return Array.from(this.workspaceTerminals.values()).find(session => session.callbackId === callbackId);
+  }
+
+  private closeWorkspaceTerminal(workspaceId: string): void {
+    const session = this.workspaceTerminals.get(workspaceId);
+    if (!session) {
+      return;
+    }
+    try {
+      session.pty.kill();
+    } catch {
+      /* already exited */
+    }
+    this.workspaceTerminals.delete(workspaceId);
+  }
+
+  private closeWorkspaceTerminalByCallbackId(callbackId: number): void {
+    const entry = Array.from(this.workspaceTerminals.entries()).find(
+      ([, session]) => session.callbackId === callbackId,
+    );
+    if (!entry) {
+      return;
+    }
+    this.closeWorkspaceTerminal(entry[0]);
+  }
+
   init(): void {
     const runtimeConfiguration: IConfigurationNode = {
       id: `preferences.${AgentWorkspaceSettings.SectionName}`,
@@ -611,7 +641,13 @@ export class AgentWorkspaceManager implements Disposable {
           throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
         }
 
-        const shouldExecuteCommand = !this.commandExecutedWorkspaces.has(id);
+        const existingSession = this.workspaceTerminals.get(id);
+        const commandExecuted = existingSession?.commandExecuted ?? false;
+        if (existingSession) {
+          this.closeWorkspaceTerminal(id);
+        }
+
+        const shouldExecuteCommand = !commandExecuted;
         let agentCommand: string | undefined;
         if (shouldExecuteCommand && workspace.labels) {
           const agentId = workspace.labels[AGENT_LABEL];
@@ -625,37 +661,55 @@ export class AgentWorkspaceManager implements Disposable {
           }
         }
 
-        if (agentCommand) {
-          this.commandExecutedWorkspaces.add(id);
-        }
-
         let commandSent = false;
         const invocation = this.shellInAgentWorkspace(
           workspace.name,
           (content: string) => {
+            const session = this.workspaceTerminals.get(id);
+            if (session && session.pty !== invocation.ptyProcess) {
+              return;
+            }
             if (!this.webContents.isDestroyed()) {
-              this.webContents.send('agent-workspace:terminal-onData', onDataId, content);
+              this.webContents.send('agent-workspace:terminal-onData', session?.callbackId ?? onDataId, content);
             }
             if (!commandSent && agentCommand) {
               commandSent = true;
               invocation.write(`${agentCommand}\n`);
+              const activeSession = this.workspaceTerminals.get(id);
+              if (activeSession?.pty === invocation.ptyProcess) {
+                activeSession.commandExecuted = true;
+              }
             }
           },
           (error: string) => {
+            const session = this.workspaceTerminals.get(id);
+            if (session && session.pty !== invocation.ptyProcess) {
+              return;
+            }
             if (!this.webContents.isDestroyed()) {
-              this.webContents.send('agent-workspace:terminal-onError', onDataId, error);
+              this.webContents.send('agent-workspace:terminal-onError', session?.callbackId ?? onDataId, error);
             }
           },
           () => {
-            if (!this.webContents.isDestroyed()) {
-              this.webContents.send('agent-workspace:terminal-onEnd', onDataId);
+            const session = this.workspaceTerminals.get(id);
+            if (session && session.pty !== invocation.ptyProcess) {
+              return;
             }
-            this.terminalCallbacks.delete(onDataId);
-            this.terminalProcesses.delete(onDataId);
+            if (!this.webContents.isDestroyed()) {
+              this.webContents.send('agent-workspace:terminal-onEnd', session?.callbackId ?? onDataId);
+            }
+            if (session?.pty === invocation.ptyProcess) {
+              this.workspaceTerminals.delete(id);
+            }
           },
         );
-        this.terminalCallbacks.set(onDataId, { write: invocation.write, resize: invocation.resize });
-        this.terminalProcesses.set(onDataId, invocation.ptyProcess);
+        this.workspaceTerminals.set(id, {
+          callbackId: onDataId,
+          pty: invocation.ptyProcess,
+          write: invocation.write,
+          resize: invocation.resize,
+          commandExecuted,
+        });
         return onDataId;
       },
     );
@@ -663,9 +717,9 @@ export class AgentWorkspaceManager implements Disposable {
     this.ipcHandle(
       'agent-workspace:terminalSend',
       async (_listener: unknown, onDataId: number, content: string): Promise<void> => {
-        const callback = this.terminalCallbacks.get(onDataId);
-        if (callback) {
-          callback.write(content);
+        const session = this.getWorkspaceTerminalByCallbackId(onDataId);
+        if (session) {
+          session.write(content);
         }
       },
     );
@@ -673,24 +727,15 @@ export class AgentWorkspaceManager implements Disposable {
     this.ipcHandle(
       'agent-workspace:terminalResize',
       async (_listener: unknown, onDataId: number, width: number, height: number): Promise<void> => {
-        const callback = this.terminalCallbacks.get(onDataId);
-        if (callback) {
-          callback.resize(width, height);
+        const session = this.getWorkspaceTerminalByCallbackId(onDataId);
+        if (session) {
+          session.resize(width, height);
         }
       },
     );
 
     this.ipcHandle('agent-workspace:terminalClose', async (_listener: unknown, onDataId: number): Promise<void> => {
-      const proc = this.terminalProcesses.get(onDataId);
-      if (proc) {
-        try {
-          proc.kill();
-        } catch {
-          /* already exited */
-        }
-      }
-      this.terminalProcesses.delete(onDataId);
-      this.terminalCallbacks.delete(onDataId);
+      this.closeWorkspaceTerminalByCallbackId(onDataId);
     });
 
     this.openshellGateway.onDidGatewayStart(() => {
@@ -715,15 +760,13 @@ export class AgentWorkspaceManager implements Disposable {
   @preDestroy()
   dispose(): void {
     this.instancesWatcher?.dispose();
-    for (const proc of this.terminalProcesses.values()) {
+    for (const session of this.workspaceTerminals.values()) {
       try {
-        proc.kill();
+        session.pty.kill();
       } catch {
         /* already exited */
       }
     }
-    this.terminalProcesses.clear();
-    this.terminalCallbacks.clear();
-    this.commandExecutedWorkspaces.clear();
+    this.workspaceTerminals.clear();
   }
 }


### PR DESCRIPTION
## Summary

- Consolidates native OpenShell terminal state into a single workspace-keyed `WorkspaceTerminalSession` map
- Routes send, resize, close, remove, and dispose cleanup through that consolidated session object
- Preserves current refresh behavior by closing any stale workspace PTY before opening a fresh terminal instead of rebinding a new renderer callback to an existing agent TUI
- Adds unit coverage for fresh terminal creation, stale output isolation, and session cleanup

## Context

Closes #2430.

This follows the cleanup concern raised by Marcel on #2426: terminal session state had become split across multiple collections, which made lifecycle cleanup fragile.

It intentionally does not carry forward the session-preservation behavior from #2426. As discussed in #2454, native TUI agents such as OpenCode can react differently to SIGWINCH, resize, and terminal state restoration than Claude, so reattaching arbitrary TUIs after a renderer refresh is fragile. The expected native OpenShell behavior remains: after a confirmed refresh, the old agent terminal is lost and the user gets a fresh sandbox shell.

Longer-term agent session resume should live in ACP/native agent sessions, as explored in #2110, where the app has protocol-level session state instead of trying to reconstruct a raw PTY/TUI screen.

## Test plan

- `pnpm exec vitest --run --project=main packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts`