### PR TITLE
Add OpenShell gateways store

### DIFF
--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -24,6 +24,10 @@ export const GatewayInfoSchema = z.object({
   active: z.boolean().optional(),
   auth: z.string().optional(),
   type: z.string().optional(),
+  source: z.string().optional(),
+  is_remote: z.boolean().optional(),
+  remote_host: z.string().nullable().optional(),
+  resolved_host: z.string().nullable().optional(),
 });
 
 export type GatewayInfo = z.output<typeof GatewayInfoSchema>;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -28,7 +28,7 @@ import type {
   FileSystemWatcher,
   ProviderConnectionStatus,
 } from '@openkaiden/api';
-import type { WebContents } from 'electron';
+import type { IpcMainInvokeEvent, WebContents } from 'electron';
 import type { IPty } from 'node-pty';
 import { spawn } from 'node-pty';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -49,7 +49,7 @@ import type { Exec } from '/@/plugin/util/exec.js';
 import type { AgentWorkspaceCreateOptions } from '/@api/agent-workspace-info.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationPropertyRecordedSchema, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
+import type { GatewayInfo, GatewaySandboxes } from '/@api/openshell-gateway-info.js';
 import { AGENT_LABEL, decodeWorkspaceLabels } from '/@api/openshell-gateway-info.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
@@ -228,6 +228,10 @@ describe('init', () => {
     expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:updateConfiguration', expect.any(Function));
   });
 
+  test('registers IPC handler for listOpenshellGateways', () => {
+    expect(ipcHandle).toHaveBeenCalledWith('agent-workspace:listOpenshellGateways', expect.any(Function));
+  });
+
   test('registers defaultBaseImage configuration', () => {
     expect(configurationRegistry.registerConfigurations).toHaveBeenCalledWith([
       expect.objectContaining({
@@ -245,8 +249,9 @@ describe('init', () => {
     expect(openshellGateway.onDidGatewayStart).toHaveBeenCalled();
   });
 
-  test('sends agent-workspace-update when gateway starts', () => {
+  test('sends gateway and workspace update events when gateway starts', () => {
     gatewayStartCallback!();
+    expect(apiSender.send).toHaveBeenCalledWith('agent-gateway-update');
     expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
   });
 });
@@ -898,6 +903,55 @@ describe('list', () => {
     vi.mocked(openshellCli.listSandboxesPerGateway).mockRejectedValue(new Error('command not found'));
 
     await expect(manager.listOpenshellSandboxes()).rejects.toThrow('command not found');
+  });
+});
+
+describe('listOpenshellGateways', () => {
+  const TEST_GATEWAYS: GatewayInfo[] = [
+    {
+      name: 'kaiden-local',
+      endpoint: 'http://127.0.0.1:17670',
+      active: true,
+      auth: 'plaintext',
+      type: 'local',
+      source: 'user',
+    },
+    {
+      name: 'remote-vm',
+      endpoint: 'https://127.0.0.1:17670',
+      active: false,
+      auth: 'mtls',
+      type: 'remote',
+      source: 'user',
+      is_remote: true,
+      remote_host: 'user@gateway-alias',
+      resolved_host: '10.0.0.5',
+    },
+  ];
+
+  test('delegates to openshellCli.listGateways and returns registered gateways', async () => {
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(TEST_GATEWAYS);
+
+    const result = await manager.listOpenshellGateways();
+
+    expect(openshellCli.listGateways).toHaveBeenCalled();
+    expect(result).toEqual(TEST_GATEWAYS);
+  });
+
+  test('rejects when openshellCli.listGateways fails', async () => {
+    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('command not found'));
+
+    await expect(manager.listOpenshellGateways()).rejects.toThrow('command not found');
+  });
+
+  test('IPC handler returns OpenShell gateways', async () => {
+    vi.mocked(openshellCli.listGateways).mockResolvedValue(TEST_GATEWAYS);
+    const handler = vi
+      .mocked(ipcHandle)
+      .mock.calls.find(([channel]) => channel === 'agent-workspace:listOpenshellGateways')?.[1];
+
+    expect(handler).toBeDefined();
+    await expect(handler?.({} as IpcMainInvokeEvent)).resolves.toEqual(TEST_GATEWAYS);
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -52,7 +52,7 @@ import type {
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { IConfigurationNode } from '/@api/configuration/models.js';
 import { IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { GatewaySandboxes } from '/@api/openshell-gateway-info.js';
+import type { GatewayInfo, GatewaySandboxes } from '/@api/openshell-gateway-info.js';
 import { AGENT_LABEL, decodeWorkspaceLabels, WORKSPACE_LABEL } from '/@api/openshell-gateway-info.js';
 
 const HOME_VARIABLE = '${HOME}';
@@ -489,6 +489,10 @@ export class AgentWorkspaceManager implements Disposable {
     return results;
   }
 
+  async listOpenshellGateways(): Promise<GatewayInfo[]> {
+    return this.openshellCli.listGateways();
+  }
+
   async deleteOpenshellSandbox(name: string): Promise<void> {
     const task = this.taskManager.createTask({ title: `Deleting workspace ${name}` });
     task.state = 'running';
@@ -625,6 +629,10 @@ export class AgentWorkspaceManager implements Disposable {
       return this.listOpenshellSandboxes();
     });
 
+    this.ipcHandle('agent-workspace:listOpenshellGateways', async (): Promise<GatewayInfo[]> => {
+      return this.listOpenshellGateways();
+    });
+
     this.ipcHandle(
       'agent-workspace:deleteOpenshellSandbox',
       async (_listener: unknown, name: string): Promise<void> => {
@@ -739,6 +747,7 @@ export class AgentWorkspaceManager implements Disposable {
     });
 
     this.openshellGateway.onDidGatewayStart(() => {
+      this.apiSender.send('agent-gateway-update');
       this.apiSender.send('agent-workspace-update');
     });
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -128,7 +128,7 @@ import type { NavigationRequest } from '/@api/navigation-request';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
 import type { OnboardingInfo, OnboardingStatus } from '/@api/onboarding';
-import type { GatewaySandboxes, OpenshellProfile } from '/@api/openshell-gateway-info';
+import type { GatewayInfo, GatewaySandboxes, OpenshellProfile } from '/@api/openshell-gateway-info';
 import type { V1Route } from '/@api/openshift-types';
 import type { PodCreateOptions, PodInfo, PodInspectInfo } from '/@api/pod-info';
 import type {
@@ -375,6 +375,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('listOpenshellSandboxes', async (): Promise<GatewaySandboxes[]> => {
     return ipcInvoke('agent-workspace:listOpenshellSandboxes');
+  });
+
+  contextBridge.exposeInMainWorld('listOpenshellGateways', async (): Promise<GatewayInfo[]> => {
+    return ipcInvoke('agent-workspace:listOpenshellGateways');
   });
 
   contextBridge.exposeInMainWorld('deleteOpenshellSandbox', async (name: string): Promise<void> => {

--- a/packages/renderer/src/stores/openshell-gateways.spec.ts
+++ b/packages/renderer/src/stores/openshell-gateways.spec.ts
@@ -1,0 +1,124 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { GatewayInfo } from '/@api/openshell-gateway-info';
+
+const callbacks = new Map<string, () => Promise<void> | void>();
+const eventEmitter = {
+  receive: (message: string, callback: () => Promise<void> | void): void => {
+    callbacks.set(message, callback);
+  },
+};
+
+beforeEach(() => {
+  callbacks.clear();
+  vi.resetAllMocks();
+  vi.resetModules();
+  Object.defineProperty(window, 'events', {
+    value: {
+      receive: vi.fn(eventEmitter.receive),
+    },
+    configurable: true,
+  });
+  vi.spyOn(window, 'addEventListener').mockImplementation(eventEmitter.receive as typeof window.addEventListener);
+});
+
+test('does not fetch gateways before extensions are started', async () => {
+  const { openshellGateways } = await import('./openshell-gateways');
+
+  vi.mocked(window.listOpenshellGateways).mockResolvedValue([{ name: 'local', endpoint: 'http://127.0.0.1:17670' }]);
+
+  await callbacks.get('openshell-registry:gateway-update')?.();
+
+  expect(window.listOpenshellGateways).not.toHaveBeenCalled();
+  expect(get(openshellGateways)).toEqual([]);
+});
+
+test('populates gateways when extensions are started', async () => {
+  const { openshellGateways } = await import('./openshell-gateways');
+  const gateways: GatewayInfo[] = [
+    {
+      name: 'local',
+      endpoint: 'http://127.0.0.1:17670',
+      active: true,
+      auth: 'plaintext',
+      type: 'local',
+      source: 'user',
+    },
+  ];
+  vi.mocked(window.listOpenshellGateways).mockResolvedValue(gateways);
+
+  await callbacks.get('extensions-already-started')?.();
+
+  await vi.waitFor(() => {
+    expect(window.listOpenshellGateways).toHaveBeenCalled();
+    expect(get(openshellGateways)).toEqual(gateways);
+  });
+});
+
+test('refreshes gateways on OpenShell registry gateway updates after startup', async () => {
+  const { openshellGateways } = await import('./openshell-gateways');
+  const initialGateways: GatewayInfo[] = [{ name: 'local', endpoint: 'http://127.0.0.1:17670', active: true }];
+  const updatedGateways: GatewayInfo[] = [
+    ...initialGateways,
+    {
+      name: 'production',
+      endpoint: 'https://gateway.example.com',
+      active: false,
+      auth: 'mtls',
+      type: 'remote',
+      source: 'user',
+      is_remote: true,
+      remote_host: 'user@gateway.example.com',
+      resolved_host: '10.0.0.5',
+    },
+  ];
+  vi.mocked(window.listOpenshellGateways).mockResolvedValueOnce(initialGateways).mockResolvedValueOnce(updatedGateways);
+
+  await callbacks.get('extensions-already-started')?.();
+  await vi.waitFor(() => expect(get(openshellGateways)).toEqual(initialGateways));
+
+  await callbacks.get('openshell-registry:gateway-update')?.();
+
+  await vi.waitFor(() => {
+    expect(window.listOpenshellGateways).toHaveBeenCalledTimes(2);
+    expect(get(openshellGateways)).toEqual(updatedGateways);
+  });
+});
+
+test('refreshes gateways on agent gateway updates after startup', async () => {
+  const { openshellGateways } = await import('./openshell-gateways');
+  const initialGateways: GatewayInfo[] = [{ name: 'local', endpoint: 'http://127.0.0.1:17670', active: true }];
+  const updatedGateways: GatewayInfo[] = [
+    { name: 'local', endpoint: 'http://127.0.0.1:17670', active: true, auth: 'plaintext', type: 'local' },
+  ];
+  vi.mocked(window.listOpenshellGateways).mockResolvedValueOnce(initialGateways).mockResolvedValueOnce(updatedGateways);
+
+  await callbacks.get('extensions-already-started')?.();
+  await vi.waitFor(() => expect(get(openshellGateways)).toEqual(initialGateways));
+
+  await callbacks.get('agent-gateway-update')?.();
+
+  await vi.waitFor(() => {
+    expect(window.listOpenshellGateways).toHaveBeenCalledTimes(2);
+    expect(get(openshellGateways)).toEqual(updatedGateways);
+  });
+});

--- a/packages/renderer/src/stores/openshell-gateways.ts
+++ b/packages/renderer/src/stores/openshell-gateways.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import type { GatewayInfo } from '/@api/openshell-gateway-info';
+
+import { EventStore } from './event-store';
+
+const windowEvents = ['agent-gateway-update', 'openshell-registry:gateway-update'];
+const windowListeners = ['extensions-already-started'];
+
+let readyToUpdate = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  if (eventName === 'extensions-already-started') {
+    readyToUpdate = true;
+  }
+
+  return readyToUpdate;
+}
+
+export const openshellGateways: Writable<GatewayInfo[]> = writable([]);
+
+const listOpenshellGateways = (): Promise<GatewayInfo[]> => {
+  return window.listOpenshellGateways();
+};
+
+export const openshellGatewaysEventStore = new EventStore<GatewayInfo[]>(
+  'openshell-gateways',
+  openshellGateways,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  listOpenshellGateways,
+);
+openshellGatewaysEventStore.setup();


### PR DESCRIPTION
## Summary
- expose OpenShell gateways through AgentWorkspaceManager IPC and preload
- add a renderer EventStore-backed OpenShell gateways store
- preserve gateway metadata from OpenShell CLI JSON output, including source and remote details

Fixes #2461

Test to see wiring is done correctly

First create a new gateway (seps for podman)

In a terminal window do this command `openshell-gateway --port 17671 --bind-address 0.0.0.0`

Then in another terminal window `openshell gateway add https://127.0.0.1:17671 --name kaiden-store-test --local`

That will create u a new gateway thats active and binded correctly 


  1. Make sure OpenShell itself has gateway data:

  openshell gateway list -o json
  
  2. Start Kaiden dev mode:

  pnpm watch

  3. In the running Electron app, open DevTools and run:

  const gateways = await window.listOpenshellGateways();
  console.table(gateways);

  That validates the backend path:

  renderer -> preload -> IPC -> AgentWorkspaceManager -> OpenshellCli.listGateways()
