### PR TITLE
fix(workspaces): resolve tilde and symlinks in workspace paths

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Stats } from 'node:fs';
 import { access, lstat, readFile, realpath, rm, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import type {
@@ -55,6 +56,7 @@ import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 import { AgentWorkspaceManager, encodeWorkspaceLabels } from './agent-workspace-manager.js';
 
 vi.mock(import('node:fs/promises'));
+vi.mock(import('node:os'));
 vi.mock(import('js-yaml'));
 vi.mock(import('yaml'));
 vi.mock(import('node-pty'));
@@ -169,6 +171,7 @@ beforeEach(() => {
   vi.mocked(writeFile).mockResolvedValue(undefined);
   vi.mocked(rm).mockResolvedValue(undefined);
   vi.mocked(readFile).mockResolvedValue('{}');
+  vi.mocked(realpath).mockImplementation(async (p: unknown) => p as string);
   vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
     get: vi.fn().mockReturnValue(undefined),
   } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
@@ -187,8 +190,10 @@ beforeEach(() => {
       isDirectory: () => isDirectory,
       isFile: () => !isDirectory,
       isSymbolicLink: () => false,
-    } as Awaited<ReturnType<typeof lstat>>;
+    } as Stats;
   });
+  vi.mocked(homedir).mockReturnValue('/home/testuser');
+  vi.mocked(tmpdir).mockReturnValue('/tmp');
   gatewayStartCallback = undefined;
   gatewayInitFailedCallback = undefined;
   sandboxListChangeCallback = undefined;
@@ -311,7 +316,6 @@ describe('create – OpenShell mode', () => {
     vi.mocked(openshellCli.createSandbox).mockResolvedValue(undefined);
     vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue(mockAgent);
     vi.mocked(readFile).mockRejectedValue(mockEnoent());
-    vi.mocked(realpath).mockImplementation(async (p: unknown) => p as string);
   });
 
   test('calls openshellCli.createSandbox with gateway, name, providers, workspace label, and agent label', async () => {
@@ -397,6 +401,71 @@ describe('create – OpenShell mode', () => {
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
         from: 'registry.example.com/agent-base:v1',
+      }),
+    );
+  });
+
+  test('resolves tilde in sourcePath to home directory', async () => {
+    vi.mocked(lstat).mockResolvedValue({
+      isDirectory: () => true,
+      isFile: () => false,
+      isSymbolicLink: () => false,
+    } as Stats);
+    const options: AgentWorkspaceCreateOptions = {
+      ...defaultOptions,
+      sourcePath: '~/my-project',
+    };
+    await manager.create(options);
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: expect.arrayContaining([{ local: join(homedir(), 'my-project'), remote: '.' }]),
+        labels: expect.objectContaining(encodeWorkspaceLabels(join(homedir(), 'my-project'))),
+      }),
+    );
+  });
+
+  test('resolves symlinks in sourcePath via realpath', async () => {
+    vi.mocked(realpath).mockImplementation(async (p: unknown) => {
+      if (String(p) === '/tmp/symlinked-project') return '/real/path/project' as never;
+      return p as string;
+    });
+    vi.mocked(lstat).mockResolvedValue({
+      isDirectory: () => true,
+      isFile: () => false,
+      isSymbolicLink: () => false,
+    } as Stats);
+    const options: AgentWorkspaceCreateOptions = {
+      ...defaultOptions,
+      sourcePath: '/tmp/symlinked-project',
+    };
+    await manager.create(options);
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: expect.arrayContaining([{ local: '/real/path/project', remote: '.' }]),
+      }),
+    );
+  });
+
+  test('resolves symlinks in mount host paths via realpath', async () => {
+    vi.mocked(realpath).mockImplementation(async (p: unknown) => {
+      if (String(p) === resolve(homedir(), 'linked-dir')) return '/real/linked-dir' as never;
+      return p as string;
+    });
+    vi.mocked(lstat).mockResolvedValue({
+      isDirectory: () => true,
+      isFile: () => false,
+      isSymbolicLink: () => false,
+    } as Stats);
+    await manager.create({
+      ...defaultOptions,
+      mounts: [{ host: '$HOME/linked-dir', target: '$HOME/linked-dir', ro: false }],
+    });
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploads: expect.arrayContaining([{ local: '/real/linked-dir', remote: '~' }]),
       }),
     );
   });
@@ -506,7 +575,7 @@ describe('create – OpenShell mode', () => {
       isDirectory: () => true,
       isFile: () => false,
       isSymbolicLink: () => false,
-    } as Awaited<ReturnType<typeof lstat>>);
+    } as Stats);
     await manager.create({
       ...defaultOptions,
       mounts: [{ host: '/Users/fbricon/Dev/projects/gh-dashboard', target: 'gh-dashboard', ro: false }],
@@ -533,7 +602,7 @@ describe('create – OpenShell mode', () => {
         uploads: expect.arrayContaining([
           { local: '/tmp/my-project', remote: '.' },
           { local: resolve('/tmp/my-project', './subdir'), remote: 'subdir' },
-          { local: join(homedir(), '.gitconfig'), remote: '~/.gitconfig' },
+          { local: resolve(homedir(), '.gitconfig'), remote: '~/.gitconfig' },
         ]),
       }),
     );
@@ -994,6 +1063,15 @@ describe('checkWorkspaceConfigExists', () => {
 
     expect(result).toBe(false);
     expect(access).not.toHaveBeenCalled();
+  });
+
+  test('resolves tilde in sourcePath before checking', async () => {
+    vi.mocked(access).mockResolvedValue(undefined);
+
+    const result = await manager.checkWorkspaceConfigExists('~/my-project');
+
+    expect(result).toBe(true);
+    expect(access).toHaveBeenCalledWith(join('/home/testuser/my-project', '.kaiden', 'workspace.json'));
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -42,6 +42,7 @@ import {
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
+import { resolveHomePath } from '/@/plugin/util/resolve-home-path.js';
 import { AgentWorkspaceSettings } from '/@api/agent-workspace/agent-workspace-settings.js';
 import type {
   AgentWorkspaceConfiguration,
@@ -129,6 +130,9 @@ export class AgentWorkspaceManager implements Disposable {
     task.state = 'running';
     task.status = 'in-progress';
     try {
+      if (options.sourcePath) {
+        options.sourcePath = resolveHomePath(options.sourcePath);
+      }
       if (!options.model) {
         throw new Error('model is required to create a workspace');
       }
@@ -282,7 +286,7 @@ export class AgentWorkspaceManager implements Disposable {
   async checkWorkspaceConfigExists(sourcePath: string): Promise<boolean> {
     if (!sourcePath) return false;
     try {
-      await access(join(sourcePath, '.kaiden', 'workspace.json'));
+      await access(join(resolveHomePath(sourcePath), '.kaiden', 'workspace.json'));
       return true;
     } catch {
       return false;
@@ -318,17 +322,23 @@ export class AgentWorkspaceManager implements Disposable {
   ): Promise<OpenshellUpload[]> {
     const uploads: OpenshellUpload[] = [];
     if (sourcePath) {
-      uploads.push({ local: sourcePath, remote: '.' });
+      uploads.push({ local: await realpath(sourcePath), remote: '.' });
     }
 
     for (const mount of workspace.mounts ?? []) {
-      const local = this.resolveHostPath(mount.host, sourcePath);
+      const raw = this.resolveHostPath(mount.host, sourcePath);
       const remote = this.resolveOpenshellSandboxPath(mount.target, sourcePath);
-      if (!local || !remote) {
+      if (!raw || !remote) {
         console.warn(
           `[AgentWorkspaceManager] skipping mount "${mount.host}" → "${mount.target}": cannot resolve without a project folder`,
         );
         continue;
+      }
+      let local: string;
+      try {
+        local = await realpath(raw);
+      } catch {
+        throw new Error(`Mount host path does not exist: ${raw}`);
       }
       const resolvedRemote = await this.resolveUploadRemotePath(local, remote);
       uploads.push({ local, remote: resolvedRemote });
@@ -364,8 +374,8 @@ export class AgentWorkspaceManager implements Disposable {
     if (path.startsWith(`${MOUNT_HOME_PREFIX}/`)) {
       return resolve(homedir(), path.slice(MOUNT_HOME_PREFIX.length + 1));
     }
-    if (path.startsWith('~/')) {
-      return resolve(homedir(), path.slice(2));
+    if (path === '~' || path.startsWith('~/')) {
+      return resolveHomePath(path);
     }
     if (isAbsolute(path)) {
       return path;

--- a/packages/main/src/plugin/util/resolve-home-path.spec.ts
+++ b/packages/main/src/plugin/util/resolve-home-path.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { resolveHomePath } from './resolve-home-path.js';
+
+vi.mock(import('node:os'));
+
+describe('resolveHomePath', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(homedir).mockReturnValue('/home/testuser');
+  });
+
+  test('resolves bare ~ to home directory', () => {
+    expect(resolveHomePath('~')).toBe('/home/testuser');
+  });
+
+  test('resolves ~/path to home directory joined with path', () => {
+    expect(resolveHomePath('~/my-project')).toBe(join('/home/testuser', 'my-project'));
+  });
+
+  test('resolves ~/nested/path to home directory joined with nested path', () => {
+    expect(resolveHomePath('~/a/b/c')).toBe(join('/home/testuser', 'a/b/c'));
+  });
+
+  test('returns absolute paths unchanged', () => {
+    expect(resolveHomePath('/tmp/my-project')).toBe('/tmp/my-project');
+  });
+
+  test('returns relative paths unchanged', () => {
+    expect(resolveHomePath('relative/path')).toBe('relative/path');
+  });
+});

--- a/packages/main/src/plugin/util/resolve-home-path.ts
+++ b/packages/main/src/plugin/util/resolve-home-path.ts
@@ -20,6 +20,9 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 export function resolveHomePath(inputPath: string): string {
+  if (inputPath === '~') {
+    return homedir();
+  }
   if (inputPath.startsWith('~/')) {
     return join(homedir(), inputPath.slice(2));
   }

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.spec.ts
@@ -161,8 +161,8 @@ test('Expect filesystem shows workspace source path', () => {
 test('Expect mounts are displayed with access type', () => {
   render(AgentWorkspaceDetailsOverview, { workspaceSummary, configuration });
 
-  expect(screen.getByText('/workspace/shared-lib')).toBeInTheDocument();
-  expect(screen.getByText('/workspace/.gitconfig')).toBeInTheDocument();
+  expect(screen.getByText('$SOURCES/../shared-lib')).toBeInTheDocument();
+  expect(screen.getByText('$HOME/.gitconfig')).toBeInTheDocument();
 });
 
 test('Expect no skills message when configuration has no skills', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsOverview.svelte
@@ -283,7 +283,7 @@ function formatRelativeTime(ts: string | undefined): string {
                 <Icon icon={faFolder} size="sm" />
               </div>
               <span class="flex-1 min-w-0 text-[13px] font-medium text-[var(--pd-content-card-header-text)] truncate">
-                {mount.target}
+                {mount.host}
               </span>
               <span class="text-[11px] shrink-0 {mount.ro ? 'text-[var(--pd-content-text)] opacity-60' : 'text-[var(--pd-status-running)]'}">
                 {mount.ro ? 'read-only' : 'read-write'}


### PR DESCRIPTION
**fix(workspaces): resolve tilde and symlinks in workspace paths (#1483)**
Workspace paths starting with ~ were not expanded to the real home
directory, causing filesystem operations to fail or create files
relative to the working directory.

- Normalize sourcePath with resolveHomePath() in create() so tilde
  is expanded but symlinks are preserved for mount resolution
- Resolve symlinks with realpath() at the upload level in
  buildOpenshellFilesystemUploads so $SOURCES-relative mounts
  resolve against the user's original path, not the symlink target
- Apply resolveHomePath() in checkWorkspaceConfigExists()
- Handle bare ~ (not just ~/) in the resolveHomePath utility

related small fix:
**fix(workspaces): display host path instead of target for mounts**
The workspace details overview was showing mount.target (the sandbox-side
path) instead of mount.host (the source path on the host machine). This
caused mounts like ~/Dev/projects/gh-dashboard to display as just
'gh-dashboard' in the Filesystem section.

fixes #1483