### PR TITLE
fix: approve unused Claude API key response

### DIFF
--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -220,6 +220,36 @@ describe('ClaudeExtension', () => {
       const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
       expect(written.hasCompletedOnboarding).toBe(true);
       expect(written.projects['/sandbox'].hasTrustDialogAccepted).toBe(true);
+      expect(written.customApiKeyResponses).toEqual({
+        approved: ['unused'],
+        rejected: [],
+      });
+    });
+
+    test('approves unused Claude API key response in .claude.json', async () => {
+      await claudeExtension.activate();
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const updateMock = vi.fn();
+      const existing = JSON.stringify({
+        customApiKeyResponses: {
+          approved: ['existing'],
+          rejected: ['unused', 'other'],
+        },
+      });
+      const configFile: AgentConfigurationFile = {
+        path: CLAUDE_JSON_PATH,
+        read: vi.fn().mockResolvedValue(existing),
+        update: updateMock,
+      };
+
+      await agent.preWorkspaceStart(createContext([configFile]));
+
+      const written = JSON.parse(updateMock.mock.calls[0]![0] as string);
+      expect(written.customApiKeyResponses).toEqual({
+        approved: ['existing', 'unused'],
+        rejected: ['other'],
+      });
     });
 
     test('writes command MCP servers as stdio in .claude.json', async () => {

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -59,11 +59,17 @@ const ClaudeProjectSchema = z.looseObject({
   hasTrustDialogAccepted: z.boolean().optional(),
 });
 
+const ClaudeCustomApiKeyResponsesSchema = z.looseObject({
+  approved: z.array(z.string()).optional(),
+  rejected: z.array(z.string()).optional(),
+});
+
 const ClaudeJsonCodec = jsonCodec(
   z.looseObject({
     hasCompletedOnboarding: z.boolean().optional(),
     projects: z.record(z.string(), ClaudeProjectSchema).optional(),
     mcpServers: z.record(z.string(), z.unknown()).optional(),
+    customApiKeyResponses: ClaudeCustomApiKeyResponsesSchema.optional(),
   }),
 );
 
@@ -160,6 +166,11 @@ export class ClaudeExtension {
           project.hasTrustDialogAccepted = true;
           projects[WORKSPACE_SOURCES_PATH] = project;
           config.projects = projects;
+
+          config.customApiKeyResponses = {
+            approved: Array.from(new Set([...(config.customApiKeyResponses?.approved ?? []), 'unused'])),
+            rejected: config.customApiKeyResponses?.rejected?.filter(response => response !== 'unused') ?? [],
+          };
 
           const mcpServers = context.workspace.mcp?.servers;
           const mcpCommands = context.workspace.mcp?.commands;


### PR DESCRIPTION
## Summary
- write customApiKeyResponses into the generated Claude Code .claude.json for agent workspaces
- pre-approve the unused Vertex AI placeholder API key so Claude does not show the selection warning

Fixes #2468

https://github.com/user-attachments/assets/2abcd6ee-1d4d-45f0-b731-9b14b359fc30



## Testing
- Create a workspace in Kaiden with Vertex AI and Claude, then go to the terminal and assert that the API key selection warning no longer appears.