### PR TITLE
feat(semantic-router): add default model support

### DIFF
--- a/packages/api/src/semantic-router-info.ts
+++ b/packages/api/src/semantic-router-info.ts
@@ -59,6 +59,7 @@ export const DecisionConfigSchema = z.object({
 export const RoutingConfigSchema = z.object({
   keywords: z.array(KeywordGroupSchema),
   decisions: z.array(DecisionConfigSchema),
+  defaultModelRef: ModelRefSchema.optional(),
 });
 
 export const SemanticRouterConfigSchema = z.object({

--- a/packages/main/src/plugin/semantic-router/semantic-router-manager.spec.ts
+++ b/packages/main/src/plugin/semantic-router/semantic-router-manager.spec.ts
@@ -386,3 +386,60 @@ test('create succeeds when no provider has a semantic router factory', async () 
   expect(result.name).toBe('my-router');
   expect(writeFile).toHaveBeenCalled();
 });
+
+test('create persists defaultModelRef when provided', async () => {
+  mockEmptyDir();
+  const configWithDefault: SemanticRouterConfigInfo = {
+    ...sampleConfig,
+    routing: {
+      ...sampleConfig.routing,
+      defaultModelRef: { providerId: 'openai', connectionId: 'conn-1', label: 'GPT-4', useReasoning: false },
+    },
+  };
+
+  const manager = createManager();
+  await manager.init();
+
+  const result = await manager.create(configWithDefault);
+
+  expect(result.routing.defaultModelRef).toEqual({
+    providerId: 'openai',
+    connectionId: 'conn-1',
+    label: 'GPT-4',
+    useReasoning: false,
+  });
+  const written = vi.mocked(writeFile).mock.calls[0]![1] as string;
+  expect(JSON.parse(written).routing.defaultModelRef).toBeDefined();
+});
+
+test('create works without defaultModelRef for backward compatibility', async () => {
+  mockEmptyDir();
+  const manager = createManager();
+  await manager.init();
+
+  const result = await manager.create(sampleConfig);
+
+  expect(result.routing.defaultModelRef).toBeUndefined();
+});
+
+test('loadFromDisk loads configs with defaultModelRef', async () => {
+  const configWithDefault: SemanticRouterConfigInfo = {
+    ...sampleConfig,
+    routing: {
+      ...sampleConfig.routing,
+      defaultModelRef: { providerId: 'openai', connectionId: 'conn-1', label: 'GPT-4', useReasoning: false },
+    },
+  };
+  mockDirWithConfigs(configWithDefault);
+
+  const manager = createManager();
+  await manager.init();
+
+  const result = manager.findByName('my-router');
+  expect(result?.routing.defaultModelRef).toEqual({
+    providerId: 'openai',
+    connectionId: 'conn-1',
+    label: 'GPT-4',
+    useReasoning: false,
+  });
+});

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -32,8 +32,10 @@ interface Props {
   selectedKeys?: Set<string>;
   multiSelect?: boolean;
   showCatalogLink?: boolean;
+  defaultModel?: CatalogModelInfo;
   onselect?: (model: CatalogModelInfo) => void;
   ontoggle?: (model: CatalogModelInfo) => void;
+  ondefaultchange?: (model: CatalogModelInfo) => void;
 }
 
 let {
@@ -42,9 +44,14 @@ let {
   selectedKeys,
   multiSelect = false,
   showCatalogLink = true,
+  defaultModel,
   onselect,
   ontoggle,
+  ondefaultchange,
 }: Props = $props();
+
+let defaultModelKey: string = $derived(defaultModel ? getKey(defaultModel) : '');
+let showDefaultColumn: boolean = $derived(multiSelect && defaultModel !== undefined);
 
 let searchTerm = $state('');
 
@@ -137,6 +144,7 @@ function navigateToModels(): void {
                 <col class="w-16" />
                 <col class="w-24" />
                 <col class="w-14" />
+                {#if showDefaultColumn}<col class="w-16" />{/if}
               </colgroup>
               <thead>
                 <tr class="border-b border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg)">
@@ -145,6 +153,9 @@ function navigateToModels(): void {
                   <th class="px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Size</th>
                   <th class="px-3 py-2 text-left text-xs font-medium text-(--pd-content-card-text) opacity-60">Runtime</th>
                   <th class="px-3 py-2 text-center text-xs font-medium text-(--pd-content-card-text) opacity-60">Use</th>
+                  {#if showDefaultColumn}
+                    <th class="px-3 py-2 text-center text-xs font-medium text-(--pd-content-card-text) opacity-60">Default</th>
+                  {/if}
                 </tr>
               </thead>
               <tbody>
@@ -193,6 +204,17 @@ function navigateToModels(): void {
                           onchange={onselect?.bind(undefined, model)} />
                       {/if}
                     </td>
+                    {#if showDefaultColumn}
+                      <td class="px-3 py-2 text-center">
+                        <input
+                          type="checkbox"
+                          checked={defaultModelKey === key}
+                          disabled={!selected}
+                          aria-label="Set {model.label} as default"
+                          onclick={(e: MouseEvent): void => e.stopPropagation()}
+                          onchange={ondefaultchange?.bind(undefined, model)} />
+                      </td>
+                    {/if}
                   </tr>
                 {/each}
               </tbody>

--- a/packages/renderer/src/lib/models/ModelSelectionTable.svelte
+++ b/packages/renderer/src/lib/models/ModelSelectionTable.svelte
@@ -96,6 +96,13 @@ function getModelStatus(model: CatalogModelInfo): string {
 function navigateToModels(): void {
   handleNavigation({ page: NavigationPage.MODELS });
 }
+
+function onDefaultClick(event: MouseEvent, key: string): void {
+  event.stopPropagation();
+  if (defaultModelKey === key) {
+    event.preventDefault();
+  }
+}
 </script>
 
 <!-- Toolbar -->
@@ -211,7 +218,7 @@ function navigateToModels(): void {
                           checked={defaultModelKey === key}
                           disabled={!selected}
                           aria-label="Set {model.label} as default"
-                          onclick={(e: MouseEvent): void => e.stopPropagation()}
+                          onclick={(event): void => onDefaultClick(event, key)}
                           onchange={ondefaultchange?.bind(undefined, model)} />
                       </td>
                     {/if}

--- a/packages/renderer/src/lib/models/SemanticRouterCards.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCards.spec.ts
@@ -188,6 +188,26 @@ test('should show in-house badge for self-hosted provider', () => {
   expect(screen.getByText('in-house')).toBeInTheDocument();
 });
 
+test('should show default badge for the default model', () => {
+  const routerWithDefault: SemanticRouterConfigInfo = {
+    ...mockRouter,
+    routing: {
+      ...mockRouter.routing,
+      defaultModelRef: { providerId: 'gemini', connectionId: 'conn-1', label: 'gemini-2.5-pro', useReasoning: false },
+    },
+  };
+
+  render(SemanticRouterCards, { routers: [routerWithDefault] });
+
+  expect(screen.getByText('default')).toBeInTheDocument();
+});
+
+test('should not show default badge when no defaultModelRef is set', () => {
+  render(SemanticRouterCards, { routers: [mockRouter] });
+
+  expect(screen.queryByText('default')).not.toBeInTheDocument();
+});
+
 test('should deduplicate model refs across rules', () => {
   const routerWithDuplicates: SemanticRouterConfigInfo = {
     name: 'dup-router',

--- a/packages/renderer/src/lib/models/SemanticRouterCards.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCards.svelte
@@ -22,6 +22,7 @@ interface ModelRef {
   label: string;
   providerId: string;
   type: InferenceProviderConnectionType;
+  isDefault: boolean;
 }
 
 async function removeRouter(name: string): Promise<void> {
@@ -43,6 +44,11 @@ function getBackendType(providerId: string): InferenceProviderConnectionType {
   return providerTypeMap.get(providerId) ?? 'cloud';
 }
 
+function isDefaultModel(router: SemanticRouterInfo, ref: { providerId: string; label: string }): boolean {
+  const d = router.routing.defaultModelRef;
+  return d?.providerId === ref.providerId && d.label === ref.label;
+}
+
 function getUniqueModelRefs(router: SemanticRouterInfo): ModelRef[] {
   const seen = new SvelteSet<string>();
   const refs: ModelRef[] = [];
@@ -52,7 +58,12 @@ function getUniqueModelRefs(router: SemanticRouterInfo): ModelRef[] {
         const key = `${ref.providerId}::${ref.label}`;
         if (!seen.has(key)) {
           seen.add(key);
-          refs.push({ label: ref.label, providerId: ref.providerId, type: getBackendType(ref.providerId) });
+          refs.push({
+            label: ref.label,
+            providerId: ref.providerId,
+            type: getBackendType(ref.providerId),
+            isDefault: isDefaultModel(router, ref),
+          });
         }
       }
     }
@@ -146,6 +157,9 @@ function getKeywordGroupNames(router: SemanticRouterInfo): string[] {
                 class:bg-[var(--pd-state-warning)]={ref.type === 'self-hosted'}>
               </span>
               <span class="text-xs font-mono text-[var(--pd-content-card-text)] truncate">{ref.label}</span>
+              {#if ref.isDefault}
+                <span class="text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded-full bg-[color-mix(in_srgb,var(--pd-button-primary-bg)_12%,transparent)] text-[var(--pd-button-primary-bg)] border border-[color-mix(in_srgb,var(--pd-button-primary-bg)_25%,transparent)]">default</span>
+              {/if}
               <span
                 class="ml-auto text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded-full flex-shrink-0 border"
                 class:bg-[color-mix(in_srgb,var(--pd-status-running)_10%,transparent)]={ref.type === 'local'}

--- a/packages/renderer/src/lib/models/SemanticRouterCards.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCards.svelte
@@ -21,6 +21,7 @@ let providerTypeMap: Map<string, InferenceProviderConnectionType> = $derived(
 interface ModelRef {
   label: string;
   providerId: string;
+  connectionId: string;
   type: InferenceProviderConnectionType;
   isDefault: boolean;
 }
@@ -44,9 +45,12 @@ function getBackendType(providerId: string): InferenceProviderConnectionType {
   return providerTypeMap.get(providerId) ?? 'cloud';
 }
 
-function isDefaultModel(router: SemanticRouterInfo, ref: { providerId: string; label: string }): boolean {
+function isDefaultModel(
+  router: SemanticRouterInfo,
+  ref: { providerId: string; connectionId: string; label: string },
+): boolean {
   const d = router.routing.defaultModelRef;
-  return d?.providerId === ref.providerId && d.label === ref.label;
+  return d?.providerId === ref.providerId && d?.connectionId === ref.connectionId && d?.label === ref.label;
 }
 
 function getUniqueModelRefs(router: SemanticRouterInfo): ModelRef[] {
@@ -55,12 +59,13 @@ function getUniqueModelRefs(router: SemanticRouterInfo): ModelRef[] {
   for (const decision of router.routing.decisions) {
     for (const rule of decision.rules) {
       for (const ref of rule.modelRefs) {
-        const key = `${ref.providerId}::${ref.label}`;
+        const key = `${ref.providerId}::${ref.connectionId}::${ref.label}`;
         if (!seen.has(key)) {
           seen.add(key);
           refs.push({
             label: ref.label,
             providerId: ref.providerId,
+            connectionId: ref.connectionId,
             type: getBackendType(ref.providerId),
             isDefault: isDefaultModel(router, ref),
           });

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.spec.ts
@@ -265,6 +265,12 @@ describe('create flow', () => {
               ],
             },
           ],
+          defaultModelRef: {
+            providerId: 'claude',
+            connectionId: 'conn-0',
+            label: 'claude-sonnet-4',
+            useReasoning: false,
+          },
         }),
       }),
     );

--- a/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreate.svelte
@@ -25,6 +25,7 @@ let currentStepId = $derived(WIZARD_STEPS[currentStepIndex]?.id ?? '');
 let isLastStep = $derived(currentStepIndex === WIZARD_STEPS.length - 1);
 
 let selectedModels: CatalogModelInfo[] = $state([]);
+let defaultModel: CatalogModelInfo | undefined = $state(undefined);
 
 let error = $state('');
 let creating = $state(false);
@@ -71,6 +72,14 @@ function handleStepClick(index: number): void {
   routerWizard.draft.currentStepIndex = index;
 }
 
+function resolveDefaultModelRef():
+  | { providerId: string; connectionId: string; label: string; useReasoning: boolean }
+  | undefined {
+  const target = defaultModel ?? selectedModels[0];
+  if (!target) return undefined;
+  return { providerId: target.providerId, connectionId: target.connectionId, label: target.label, useReasoning: false };
+}
+
 function buildConfig(): SemanticRouterConfigInfo {
   const d = $state.snapshot(routerWizard.draft);
   const modelRefs = buildModelRefs();
@@ -86,6 +95,7 @@ function buildConfig(): SemanticRouterConfigInfo {
           : modelRefs.length > 0
             ? [{ name: 'default', priority: 0, rules: [{ operator: 'OR', conditions: [], modelRefs }] }]
             : [],
+      defaultModelRef: resolveDefaultModelRef(),
     },
   };
 }
@@ -206,7 +216,7 @@ function cancel(): void {
               </div>
             </div>
             {:else if currentStepId === 'models'}
-              <SemanticRouterCreateStepModels bind:selectedModels={selectedModels} />
+              <SemanticRouterCreateStepModels bind:selectedModels={selectedModels} bind:defaultModel={defaultModel} />
             {:else if currentStepId === 'signals'}
               <SemanticRouterCreateStepSignals
                 bind:keywords={routerWizard.draft.keywords}

--- a/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.spec.ts
+++ b/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.spec.ts
@@ -222,3 +222,69 @@ test('no selected count shown when nothing selected', () => {
 
   expect(screen.queryByTestId('selected-count')).not.toBeInTheDocument();
 });
+
+test('shows Default column header once a model is selected', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  expect(screen.queryByText('Default')).not.toBeInTheDocument();
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+
+  expect(screen.getByText('Default')).toBeInTheDocument();
+});
+
+test('default checkbox is disabled for unselected models', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+
+  const defaultCheckbox = screen.getByRole('checkbox', { name: 'Set gemini-2.5-pro as default' });
+  expect(defaultCheckbox).toBeDisabled();
+});
+
+test('first selected model is automatically the default', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+
+  const defaultCheckbox = screen.getByRole('checkbox', { name: 'Set claude-sonnet-4 as default' });
+  expect(defaultCheckbox).toBeChecked();
+});
+
+test('user can change default model via default checkbox', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>(mockCloudModels);
+
+  render(SemanticRouterCreateStepModels);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use gemini-2.5-pro' }));
+
+  const geminiDefault = screen.getByRole('checkbox', { name: 'Set gemini-2.5-pro as default' });
+  await fireEvent.click(geminiDefault);
+
+  expect(geminiDefault).toBeChecked();
+  expect(screen.getByRole('checkbox', { name: 'Set claude-sonnet-4 as default' })).not.toBeChecked();
+});
+
+test('deselecting the default model promotes the next model', async () => {
+  vi.mocked(modelsStore).catalogModels = writable<CatalogModelInfo[]>([...mockCloudModels, mockLocalModel]);
+
+  render(SemanticRouterCreateStepModels);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use gemini-2.5-pro' }));
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use llama3.2:3b' }));
+
+  expect(screen.getByRole('checkbox', { name: 'Set claude-sonnet-4 as default' })).toBeChecked();
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Use claude-sonnet-4' }));
+
+  const geminiDefault = screen.getByRole('checkbox', { name: 'Set gemini-2.5-pro as default' });
+  expect(geminiDefault).toBeChecked();
+});

--- a/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.svelte
+++ b/packages/renderer/src/lib/models/SemanticRouterCreateStepModels.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { untrack } from 'svelte';
 import { SvelteSet } from 'svelte/reactivity';
 
 import { disabledModels, isModelEnabled, modelKey, modelSelectionKey } from '/@/stores/model-catalog';
@@ -9,9 +10,10 @@ import ModelSelectionTable from './ModelSelectionTable.svelte';
 
 interface Props {
   selectedModels?: CatalogModelInfo[];
+  defaultModel?: CatalogModelInfo;
 }
 
-let { selectedModels = $bindable([]) }: Props = $props();
+let { selectedModels = $bindable([]), defaultModel = $bindable() }: Props = $props();
 
 let selectedKeys = new SvelteSet<string>(
   selectedModels.map(m => modelSelectionKey(m.providerId, m.connectionId, m.label)),
@@ -35,6 +37,25 @@ $effect(() => {
   );
 });
 
+$effect(() => {
+  const models = selectedModels;
+  if (models.length > 0) {
+    const current = untrack(() => defaultModel);
+    const defaultStillSelected =
+      current !== undefined &&
+      models.some(
+        m =>
+          modelSelectionKey(m.providerId, m.connectionId, m.label) ===
+          modelSelectionKey(current.providerId, current.connectionId, current.label),
+      );
+    if (!defaultStillSelected) {
+      defaultModel = models[0]!;
+    }
+  } else {
+    defaultModel = undefined;
+  }
+});
+
 function toggleModel(model: CatalogModelInfo): void {
   const key = modelSelectionKey(model.providerId, model.connectionId, model.label);
   if (selectedKeys.has(key)) {
@@ -42,6 +63,10 @@ function toggleModel(model: CatalogModelInfo): void {
   } else {
     selectedKeys.add(key);
   }
+}
+
+function setDefaultModel(model: CatalogModelInfo): void {
+  defaultModel = model;
 }
 </script>
 
@@ -56,5 +81,7 @@ function toggleModel(model: CatalogModelInfo): void {
     models={eligibleModels}
     multiSelect={true}
     selectedKeys={selectedKeys}
-    ontoggle={toggleModel} />
+    defaultModel={defaultModel}
+    ontoggle={toggleModel}
+    ondefaultchange={setDefaultModel} />
 </div>


### PR DESCRIPTION
## Summary
- Add `defaultModelRef` optional field to `RoutingConfigSchema` so semantic routers can designate a fallback model for unmatched requests
- First selected model is automatically set as default; users can change it via an inline "Default" checkbox column in the model selection table
- Default model is persisted in the router JSON config and displayed with a badge in the router cards view

## Test plan
- [x] `pnpm run typecheck` passes (0 errors)
- [x] All 72 unit tests pass across 4 test files (manager, create wizard, step models, cards)
- [ ] Manual: create a semantic router with 2+ models, verify first is auto-defaulted
- [ ] Manual: change default via checkbox, confirm config includes correct `defaultModelRef`
- [ ] Manual: verify card shows "default" badge next to the default model
- [ ] Manual: verify old routers without `defaultModelRef` load and display correctly

Fixes #2436

🤖 Generated with [Claude Code](https://claude.com/claude-code)