### PR TITLE
fix(openshell-cli): auto-refresh sandbox list while deleting sandboxes

### DIFF
--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -127,6 +127,7 @@ const providerRegistry = {
 } as unknown as ProviderRegistry;
 
 let gatewayStartCallback: (() => void) | undefined;
+let sandboxListChangeCallback: (() => void) | undefined;
 
 const openshellGateway = {
   onDidGatewayStart: vi.fn((cb: () => void) => {
@@ -178,6 +179,15 @@ beforeEach(() => {
     } as Awaited<ReturnType<typeof lstat>>;
   });
   gatewayStartCallback = undefined;
+  sandboxListChangeCallback = undefined;
+  Object.defineProperty(openshellCli, 'onDidSandboxListChange', {
+    value: vi.fn((cb: () => void) => {
+      sandboxListChangeCallback = cb;
+      return { dispose: vi.fn() };
+    }),
+    writable: true,
+    configurable: true,
+  });
   manager = new AgentWorkspaceManager(
     apiSender,
     ipcHandle,
@@ -238,6 +248,15 @@ describe('init', () => {
   test('sends gateway and workspace update events when gateway starts', () => {
     gatewayStartCallback!();
     expect(apiSender.send).toHaveBeenCalledWith('agent-gateway-update');
+    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
+  });
+
+  test('subscribes to sandbox list change event', () => {
+    expect(openshellCli.onDidSandboxListChange).toHaveBeenCalled();
+  });
+
+  test('sends agent-workspace-update when sandbox list changes from polling', () => {
+    sandboxListChangeCallback!();
     expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
   });
 });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -746,7 +746,12 @@ export class AgentWorkspaceManager implements Disposable {
       this.apiSender.send('agent-gateway-update');
       this.apiSender.send('agent-workspace-update');
     });
-  }
+
+    this.openshellCli.onDidSandboxListChange(() => {
+      this.apiSender.send('agent-workspace-update');
+    });
+
+s  }
 
   @preDestroy()
   dispose(): void {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -745,7 +745,7 @@ export class AgentWorkspaceManager implements Disposable {
 
     this.disposables.push(
       this.openshellGateway.onDidGatewayStart(() => {
-      this.apiSender.send('agent-gateway-update');
+        this.apiSender.send('agent-gateway-update');
         this.apiSender.send('agent-workspace-update');
       }),
     );
@@ -755,8 +755,7 @@ export class AgentWorkspaceManager implements Disposable {
         this.apiSender.send('agent-workspace-update');
       }),
     );
-
-   }
+  }
 
   @preDestroy()
   dispose(): void {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -87,6 +87,7 @@ export function encodeWorkspaceLabels(sourcePath: string): Record<string, string
 @injectable()
 export class AgentWorkspaceManager implements Disposable {
   private readonly workspaceTerminals = new Map<string, WorkspaceTerminalSession>();
+  private readonly disposables: Disposable[] = [];
 
   constructor(
     @inject(ApiSenderType)
@@ -742,16 +743,20 @@ export class AgentWorkspaceManager implements Disposable {
       this.closeWorkspaceTerminalByCallbackId(onDataId);
     });
 
-    this.openshellGateway.onDidGatewayStart(() => {
+    this.disposables.push(
+      this.openshellGateway.onDidGatewayStart(() => {
       this.apiSender.send('agent-gateway-update');
-      this.apiSender.send('agent-workspace-update');
-    });
+        this.apiSender.send('agent-workspace-update');
+      }),
+    );
 
-    this.openshellCli.onDidSandboxListChange(() => {
-      this.apiSender.send('agent-workspace-update');
-    });
+    this.disposables.push(
+      this.openshellCli.onDidSandboxListChange(() => {
+        this.apiSender.send('agent-workspace-update');
+      }),
+    );
 
-s  }
+   }
 
   @preDestroy()
   dispose(): void {
@@ -763,5 +768,6 @@ s  }
       }
     }
     this.workspaceTerminals.clear();
+    this.disposables.forEach(disposable => disposable.dispose());
   }
 }

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -20,7 +20,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { RunError, RunResult } from '@openkaiden/api';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { Proxy } from '/@/plugin/proxy.js';
@@ -763,6 +763,163 @@ describe('listSandboxesPerGateway', () => {
 
     expect(results).toHaveLength(1);
     expect(results.at(0)?.sandboxes).toEqual([]);
+  });
+});
+
+describe('listSandboxesPerGateway auto-refresh', () => {
+  const gateways = [{ name: 'gw-1', endpoint: 'https://gw1.example.com', active: true }];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    openshellCli.dispose();
+    vi.useRealTimers();
+  });
+
+  test('schedules re-list 5s after detecting a Deleting sandbox and fires emitter', async () => {
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+    const readySandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+
+    expect(listener).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith([{ gateway: gateways[0], sandboxes: readySandboxes }]);
+  });
+
+  test('does not schedule poll when no sandbox is in Deleting state', async () => {
+    const readySandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('does not schedule a second timer if one is already pending', async () => {
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+    const readySandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+    await openshellCli.listSandboxesPerGateway();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  test('does not fire emitter when sandbox counts are unchanged', async () => {
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('continues polling while Deleting sandboxes remain and fires only on change', async () => {
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+    const readySandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Ready' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(readySandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(listener).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(listener).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  test('handles errors in the polling re-list gracefully', async () => {
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)))
+      .mockRejectedValueOnce(new Error('connection lost'));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deleting-poll refresh failed'));
+  });
+
+  test('dispose clears pending poll timer', async () => {
+    const deletingSandboxes = [{ id: 'sb-1', name: 'sb-1', phase: 'Deleting' }];
+
+    vi.mocked(exec.exec)
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(gateways)))
+      .mockResolvedValueOnce(mockExecResult(JSON.stringify(deletingSandboxes)));
+
+    const listener = vi.fn();
+    openshellCli.onDidSandboxListChange(listener);
+
+    await openshellCli.listSandboxesPerGateway();
+    openshellCli.dispose();
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(listener).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -20,11 +20,13 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { RunError, RunOptions } from '@openkaiden/api';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, preDestroy } from 'inversify';
 import z from 'zod';
 
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import { Emitter } from '/@/plugin/events/emitter.js';
 import { Exec } from '/@/plugin/util/exec.js';
+import type { Event } from '/@api/event.js';
 import {
   type CreateProviderOptions,
   type CreateSandboxOptions,
@@ -83,6 +85,10 @@ const OpenshellSettingsSchema = z.looseObject({
  */
 @injectable()
 export class OpenshellCli {
+  private readonly _onDidSandboxListChange = new Emitter<GatewaySandboxes[]>();
+  readonly onDidSandboxListChange: Event<GatewaySandboxes[]> = this._onDidSandboxListChange.event;
+  private _deletingPollTimer: ReturnType<typeof setTimeout> | undefined;
+
   constructor(
     @inject(Exec)
     private readonly exec: Exec,
@@ -277,7 +283,32 @@ export class OpenshellCli {
       }
     }
 
+    this.scheduleDeletingPollIfNeeded(results);
     return results;
+  }
+
+  private scheduleDeletingPollIfNeeded(results: GatewaySandboxes[]): void {
+    const allSandboxes = results.flatMap(entry => entry.sandboxes);
+    const deletingCount = allSandboxes.filter(s => s.phase === 'Deleting').length;
+    if (deletingCount === 0 || this._deletingPollTimer !== undefined) {
+      return;
+    }
+    const sandboxCount = allSandboxes.length;
+    this._deletingPollTimer = setTimeout(() => {
+      this._deletingPollTimer = undefined;
+      this.listSandboxesPerGateway()
+        .then(updated => {
+          const updatedSandboxes = updated.flatMap(entry => entry.sandboxes);
+          const newSandboxCount = updatedSandboxes.length;
+          const newDeletingCount = updatedSandboxes.filter(s => s.phase === 'Deleting').length;
+          if (newSandboxCount !== sandboxCount || newDeletingCount !== deletingCount) {
+            this._onDidSandboxListChange.fire(updated);
+          }
+        })
+        .catch((err: unknown) => {
+          console.warn(`[openshell] deleting-poll refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+    }, 5000);
   }
 
   // ── gateway registration commands ─────────────────────────────────
@@ -457,5 +488,14 @@ export class OpenshellCli {
       console.error(`openshell failed: ${cliPath} ${fullArgs.join(' ')} — ${detail}`);
       throw new Error(detail);
     }
+  }
+
+  @preDestroy()
+  dispose(): void {
+    if (this._deletingPollTimer !== undefined) {
+      clearTimeout(this._deletingPollTimer);
+      this._deletingPollTimer = undefined;
+    }
+    this._onDidSandboxListChange.dispose();
   }
 }

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -307,6 +307,7 @@ export class OpenshellCli {
         })
         .catch((err: unknown) => {
           console.warn(`[openshell] deleting-poll refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+          this.scheduleDeletingPollIfNeeded(results);
         });
     }, 5000);
   }


### PR DESCRIPTION
## Summary

- When listing sandboxes via `openshell sandbox list`, if any sandbox is in "Deleting" phase, automatically re-poll after 5 seconds to detect when the deletion completes
- The emitter only fires when the total sandbox count or deleting count actually changes, avoiding unnecessary UI refreshes
- `AgentWorkspaceManager` subscribes to the new `onDidSandboxListChange` event and forwards `agent-workspace-update` to the renderer

## Test plan

- [x] Unit tests for auto-refresh polling logic (schedule, dedup, change detection, error handling, dispose)
- [x] Unit test for `AgentWorkspaceManager` subscription wiring
- [x] Typecheck passes (`pnpm run typecheck:main`)
- [x] Lint passes (`pnpm run lint:check`)

Fixes #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)