### PR TITLE
fix(opencode): use anthropic provider prefix for vertexai models

### DIFF
--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -506,6 +506,36 @@ describe('activate', () => {
       expect(written.mcp['minimal']).not.toHaveProperty('environment');
     });
 
+    test('maps vertexai to anthropic provider with correct config and env vars', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      const workspace = {
+        environment: [] as { name: string; value: string }[],
+      };
+      const context: AgentWorkspaceContext = {
+        model: {
+          llmMetadata: { name: 'vertexai' },
+          model: { label: 'claude-sonnet-4-20250514' },
+          endpoint: 'https://custom.vertex.example.com',
+        },
+        configurationFiles: [configFile],
+        workspace,
+      };
+
+      await agent.preWorkspaceStart(context);
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.model).toBe('anthropic/claude-sonnet-4-20250514');
+      expect(written.provider.anthropic.npm).toBe('@ai-sdk/anthropic');
+      expect(written.provider.anthropic.options.baseURL).toBe('https://custom.vertex.example.com');
+      expect(written.provider).not.toHaveProperty('vertexai');
+
+      expect(workspace.environment).toContainEqual({ name: 'ANTHROPIC_BASE_URL', value: 'https://inference.local/v1' });
+      expect(workspace.environment).toContainEqual({ name: 'ANTHROPIC_API_KEY', value: 'unused' });
+    });
+
     test('adds Vertex AI environment variables when using vertexai model', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -63,6 +63,10 @@ const NATIVE_PROVIDER_SDKS: Record<string, string> = {
   anthropic: '@ai-sdk/anthropic',
 };
 
+const PROVIDER_ALIASES: Record<string, string> = {
+  vertexai: 'anthropic',
+};
+
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
     id: 'opencode',
@@ -113,7 +117,8 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       const config = OpenCodeConfigSchema.parse(JSON.parse(await configFile.read()));
 
       const modelName = context.model.model.label;
-      const provider = context.model.llmMetadata?.name;
+      const providerName = context.model.llmMetadata?.name;
+      const provider = providerName ? (PROVIDER_ALIASES[providerName] ?? providerName) : undefined;
       const endpoint = context.model.endpoint;
 
       if (provider) {


### PR DESCRIPTION
Opencode needs `anthropic/<modelname>` in its config, not `vertexai/<modelname>`,
because Vertex AI inference is handled transparently at the Openshell level.
Opencode uses the Anthropic SDK with ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY
env vars (already injected) to reach the inference endpoint.

Add a PROVIDER_ALIASES map to remap vertexai → anthropic for the opencode
config model string and provider block.

fixes #2473 