### PR TITLE
fix(agent-workspace): normalize openshell UTC timestamps

### DIFF
--- a/packages/api/src/openshell-gateway-info.spec.ts
+++ b/packages/api/src/openshell-gateway-info.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import { SandboxInfoSchema } from './openshell-gateway-info.js';
+
+describe('SandboxInfoSchema created_at transform', () => {
+  const baseSandbox = { id: 's1', name: 'test', phase: 'Ready' as const };
+
+  test('should append Z to ISO timestamp without timezone', () => {
+    const result = SandboxInfoSchema.parse({ ...baseSandbox, created_at: '2026-07-17T10:00:00' });
+    expect(result.created_at).toBe('2026-07-17T10:00:00Z');
+  });
+
+  test('should preserve ISO timestamp that already has Z', () => {
+    const result = SandboxInfoSchema.parse({ ...baseSandbox, created_at: '2026-07-17T10:00:00Z' });
+    expect(result.created_at).toBe('2026-07-17T10:00:00Z');
+  });
+
+  test('should preserve ISO timestamp with positive offset', () => {
+    const result = SandboxInfoSchema.parse({ ...baseSandbox, created_at: '2026-07-17T10:00:00+02:00' });
+    expect(result.created_at).toBe('2026-07-17T10:00:00+02:00');
+  });
+
+  test('should preserve ISO timestamp with negative offset', () => {
+    const result = SandboxInfoSchema.parse({ ...baseSandbox, created_at: '2026-07-17T10:00:00-05:00' });
+    expect(result.created_at).toBe('2026-07-17T10:00:00-05:00');
+  });
+
+  test('should handle missing created_at', () => {
+    const result = SandboxInfoSchema.parse(baseSandbox);
+    expect(result.created_at).toBeUndefined();
+  });
+
+  test('should append Z to ISO timestamp with seconds fraction', () => {
+    const result = SandboxInfoSchema.parse({ ...baseSandbox, created_at: '2026-07-17T10:00:00.123' });
+    expect(result.created_at).toBe('2026-07-17T10:00:00.123Z');
+  });
+
+  test('should append Z to space-separated timestamp from openshell', () => {
+    const result = SandboxInfoSchema.parse({ ...baseSandbox, created_at: '2026-07-17 14:07:58' });
+    expect(result.created_at).toBe('2026-07-17T14:07:58Z');
+  });
+});

--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -36,7 +36,15 @@ export const SandboxInfoSchema = z.object({
   id: z.string(),
   name: z.string(),
   phase: z.enum(['Provisioning', 'Ready', 'Error', 'Deleting', 'Unknown', 'Unspecified']),
-  created_at: z.string().optional(),
+  created_at: z
+    .string()
+    .transform(ts => {
+      if (/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(ts) && !/Z$/i.test(ts) && !/[+-]\d{2}:?\d{2}$/.test(ts)) {
+        return `${ts.replace(' ', 'T')}Z`;
+      }
+      return ts;
+    })
+    .optional(),
   current_policy_version: z.number().optional(),
   labels: z.record(z.string(), z.string()).optional(),
   resource_version: z.number().optional(),


### PR DESCRIPTION
Openshell returns created_at as a UTC timestamp without a timezone
indicator (e.g. '2026-07-17 14:07:58'). new Date() treats such strings
as local time, making workspace ages appear offset by the local UTC
difference (e.g. 2h in CEST).

Add a zod transform on SandboxInfoSchema.created_at that appends 'Z'
when the timestamp lacks a timezone suffix, ensuring correct UTC parsing
by all downstream consumers.

<img width="1484" height="1007" alt="Screenshot 2026-07-17 at 16 19 05" src="https://github.com/user-attachments/assets/67558fd7-f74c-40b6-8d62-89f9f1c8b295" />


Fixes #2482 
