### PR TITLE
feat: support gateway selection for workspaces

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -75,6 +75,7 @@ export interface AgentWorkspaceCreateOptions {
   sourcePath: string;
   agent: string;
   model: string;
+  gateway: string;
   name?: string;
   project?: string;
   skills?: string[];

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -287,6 +287,7 @@ describe('create – OpenShell mode', () => {
     agent: 'claude',
     name: 'my-sandbox',
     model: 'ramalama::granite-4.6::',
+    gateway: 'kaiden',
   };
 
   const mockAgent: Agent = {
@@ -306,13 +307,14 @@ describe('create – OpenShell mode', () => {
     vi.mocked(realpath).mockImplementation(async (p: unknown) => p as string);
   });
 
-  test('calls openshellCli.createSandbox with name, providers, workspace label, and agent label', async () => {
+  test('calls openshellCli.createSandbox with gateway, name, providers, workspace label, and agent label', async () => {
     const options = { ...defaultOptions, secrets: ['my-secret'] };
     await manager.create(options);
 
     expect(openshellCli.createSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'my-sandbox',
+        gateway: 'kaiden',
         providers: ['my-secret'],
         labels: { ...encodeWorkspaceLabels('/tmp/my-project'), [AGENT_LABEL]: 'claude' },
         noTty: true,
@@ -346,6 +348,7 @@ describe('create – OpenShell mode', () => {
       sourcePath: '/tmp/my-project',
       agent: 'claude',
       model: 'ramalama::granite-4::',
+      gateway: 'kaiden',
     };
     const result = await manager.create(options);
 
@@ -369,6 +372,7 @@ describe('create – OpenShell mode', () => {
       sourcePath: `/tmp/${longBasename}`,
       agent: 'claude',
       model: 'ramalama::granite-4::',
+      gateway: 'kaiden',
     };
 
     await expect(manager.create(options)).rejects.toThrow(/must not exceed 56 characters/);
@@ -641,7 +645,7 @@ describe('create – OpenShell mode', () => {
 
     await expect(manager.create(options)).rejects.toThrow('policy update failed');
 
-    expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('my-sandbox');
+    expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('my-sandbox', 'kaiden');
   });
 
   test('attaches secret to sandbox when ensureSecretForModel returns a secret', async () => {
@@ -858,6 +862,7 @@ describe('ensureModelSecret', () => {
     agent: 'claude',
     model: 'anthropic::claude-sonnet-4::',
     name: 'my-workspace',
+    gateway: 'kaiden',
   };
 
   test('skips when workspaceConfiguration already has secrets (e.g. onboarding)', async () => {
@@ -971,9 +976,9 @@ describe('remove', () => {
     vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
 
-    const result = await manager.remove('ws-1');
+    const result = await manager.remove('ws-1', 'kaiden');
 
-    expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('test-workspace-1');
+    expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('test-workspace-1', 'kaiden');
     expect(result).toEqual({ id: 'ws-1' });
   });
 
@@ -981,7 +986,7 @@ describe('remove', () => {
     vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
 
-    await manager.remove('ws-1');
+    await manager.remove('ws-1', 'kaiden');
 
     expect(taskManager.createTask).toHaveBeenCalledWith({ title: 'Deleting workspace "test-workspace-1"' });
     expect(mockTask.status).toBe('success');
@@ -992,7 +997,7 @@ describe('remove', () => {
     vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue([]);
     vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
 
-    await manager.remove('unknown-id');
+    await manager.remove('unknown-id', 'kaiden');
 
     expect(taskManager.createTask).toHaveBeenCalledWith({ title: 'Deleting workspace "unknown-id"' });
   });
@@ -1001,7 +1006,7 @@ describe('remove', () => {
     vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(openshellCli.deleteSandbox).mockRejectedValue(new Error('workspace not found: unknown-id'));
 
-    await expect(manager.remove('unknown-id')).rejects.toThrow('workspace not found: unknown-id');
+    await expect(manager.remove('unknown-id', 'kaiden')).rejects.toThrow('workspace not found: unknown-id');
 
     expect(mockTask.status).toBe('failure');
     expect(mockTask.error).toContain('workspace not found: unknown-id');
@@ -1012,7 +1017,7 @@ describe('remove', () => {
     vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(openshellCli.deleteSandbox).mockRejectedValue(new Error('failed to remove workspace: permission denied'));
 
-    await expect(manager.remove('ws-1')).rejects.toThrow('failed to remove workspace: permission denied');
+    await expect(manager.remove('ws-1', 'kaiden')).rejects.toThrow('failed to remove workspace: permission denied');
 
     expect(mockTask.error).toBe('Failed to delete workspace: failed to remove workspace: permission denied');
   });
@@ -1021,9 +1026,19 @@ describe('remove', () => {
     vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
     vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
 
-    await manager.remove('ws-1');
+    await manager.remove('ws-1', 'kaiden');
 
     expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
+  });
+});
+
+describe('deleteOpenshellSandbox', () => {
+  test('deletes the sandbox from the requested gateway', async () => {
+    vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
+
+    await manager.deleteOpenshellSandbox('shared-name', 'remote-gateway');
+
+    expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('shared-name', 'remote-gateway');
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -225,6 +225,7 @@ export class AgentWorkspaceManager implements Disposable {
 
     await this.openshellCli.createSandbox({
       name: sandboxName,
+      gateway: options.gateway,
       from: agent.baseImage,
       providers: options.secrets,
       env: env && Object.keys(env).length > 0 ? env : undefined,
@@ -244,7 +245,7 @@ export class AgentWorkspaceManager implements Disposable {
         try {
           await this.openshellCli.updatePolicy(sandboxName, endpointFlags, collectBinaryFlags(networkPolicy));
         } catch (err) {
-          await this.openshellCli.deleteSandbox(sandboxName).catch(() => {});
+          await this.openshellCli.deleteSandbox(sandboxName, options.gateway).catch(() => {});
           throw err;
         }
       }
@@ -406,15 +407,18 @@ export class AgentWorkspaceManager implements Disposable {
     return secret.name;
   }
 
-  async remove(id: string): Promise<AgentWorkspaceId> {
+  async remove(id: string, gateway: string): Promise<AgentWorkspaceId> {
     const workspaces = await this.listOpenshellSandboxes();
-    const workspace = workspaces.flatMap(gw => gw.sandboxes).find(ws => ws.id === id);
+    const workspace = workspaces
+      .filter(entry => entry.gateway.name === gateway)
+      .flatMap(entry => entry.sandboxes)
+      .find(ws => ws.id === id);
     const workspaceName = workspace?.name ?? id;
     const task = this.taskManager.createTask({ title: `Deleting workspace "${workspaceName}"` });
     task.state = 'running';
     task.status = 'in-progress';
     try {
-      await this.openshellCli.deleteSandbox(workspaceName);
+      await this.openshellCli.deleteSandbox(workspaceName, gateway);
       this.closeWorkspaceTerminal(id);
       this.apiSender.send('agent-workspace-update');
       task.status = 'success';
@@ -495,12 +499,12 @@ export class AgentWorkspaceManager implements Disposable {
     return this.openshellCli.listGateways();
   }
 
-  async deleteOpenshellSandbox(name: string): Promise<void> {
+  async deleteOpenshellSandbox(name: string, gateway: string): Promise<void> {
     const task = this.taskManager.createTask({ title: `Deleting workspace ${name}` });
     task.state = 'running';
     task.status = 'in-progress';
     try {
-      await this.openshellCli.deleteSandbox(name);
+      await this.openshellCli.deleteSandbox(name, gateway);
       this.apiSender.send('agent-workspace-update');
       task.status = 'success';
     } catch (err: unknown) {
@@ -602,9 +606,12 @@ export class AgentWorkspaceManager implements Disposable {
       },
     );
 
-    this.ipcHandle('agent-workspace:remove', async (_listener: unknown, id: string): Promise<AgentWorkspaceId> => {
-      return this.remove(id);
-    });
+    this.ipcHandle(
+      'agent-workspace:remove',
+      async (_listener: unknown, id: string, gateway: string): Promise<AgentWorkspaceId> => {
+        return this.remove(id, gateway);
+      },
+    );
 
     this.ipcHandle(
       'agent-workspace:getConfiguration',
@@ -637,8 +644,8 @@ export class AgentWorkspaceManager implements Disposable {
 
     this.ipcHandle(
       'agent-workspace:deleteOpenshellSandbox',
-      async (_listener: unknown, name: string): Promise<void> => {
-        return this.deleteOpenshellSandbox(name);
+      async (_listener: unknown, name: string, gateway: string): Promise<void> => {
+        return this.deleteOpenshellSandbox(name, gateway);
       },
     );
 

--- a/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
@@ -37,6 +37,7 @@ const defaultOptions: AgentWorkspaceCreateOptions = {
   sourcePath: '/tmp/my-project',
   agent: 'claude',
   model: 'anthropic::claude-sonnet-4::',
+  gateway: 'kaiden',
 };
 
 beforeEach(() => {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -507,6 +507,19 @@ describe('deleteSandbox', () => {
     expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['sandbox', 'delete', 'my-sandbox'], undefined);
   });
 
+  test('includes -g flag when gateway is provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.deleteSandbox('my-sandbox', 'remote-gateway');
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['sandbox', 'delete', 'my-sandbox', '-g', 'remote-gateway'],
+      undefined,
+    );
+  });
+
   test('rejects when CLI fails', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -237,8 +237,12 @@ export class OpenshellCli {
     await this.runCli(['sandbox', 'stop', name]);
   }
 
-  async deleteSandbox(name: string): Promise<void> {
-    await this.runCli(['sandbox', 'delete', name]);
+  async deleteSandbox(name: string, gatewayName?: string): Promise<void> {
+    const args = ['sandbox', 'delete', name];
+    if (gatewayName) {
+      args.push('-g', gatewayName);
+    }
+    await this.runCli(args);
   }
 
   async deleteAllSandboxes(gatewayName?: string): Promise<void> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -340,9 +340,12 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('removeAgentWorkspace', async (id: string): Promise<AgentWorkspaceId> => {
-    return ipcInvoke('agent-workspace:remove', id);
-  });
+  contextBridge.exposeInMainWorld(
+    'removeAgentWorkspace',
+    async (id: string, gateway: string): Promise<AgentWorkspaceId> => {
+      return ipcInvoke('agent-workspace:remove', id, gateway);
+    },
+  );
 
   contextBridge.exposeInMainWorld(
     'getAgentWorkspaceConfiguration',
@@ -381,8 +384,8 @@ export function initExposure(): void {
     return ipcInvoke('agent-workspace:listOpenshellGateways');
   });
 
-  contextBridge.exposeInMainWorld('deleteOpenshellSandbox', async (name: string): Promise<void> => {
-    return ipcInvoke('agent-workspace:deleteOpenshellSandbox', name);
+  contextBridge.exposeInMainWorld('deleteOpenshellSandbox', async (name: string, gateway: string): Promise<void> => {
+    return ipcInvoke('agent-workspace:deleteOpenshellSandbox', name, gateway);
   });
 
   // Agent Workspace Terminal

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -28,6 +28,7 @@ import * as agentsStore from '/@/stores/agents';
 import * as mcpStore from '/@/stores/mcp-remote-servers';
 import * as modelCatalogStore from '/@/stores/model-catalog';
 import * as modelsStore from '/@/stores/models';
+import * as openshellGatewaysStore from '/@/stores/openshell-gateways';
 import * as openshellSandboxesStore from '/@/stores/openshell-sandboxes';
 import * as providerStore from '/@/stores/providers';
 import * as ragStore from '/@/stores/rag-environments';
@@ -55,6 +56,7 @@ vi.mock(import('/@/stores/providers'));
 vi.mock(import('/@/stores/rag-environments'));
 vi.mock(import('/@/stores/model-catalog'));
 vi.mock(import('/@/stores/models'));
+vi.mock(import('/@/stores/openshell-gateways'));
 vi.mock(import('/@/stores/openshell-sandboxes'));
 vi.mock(import('/@/stores/workspace-projects'));
 
@@ -173,6 +175,9 @@ beforeEach(() => {
     (providerId: string, connectionId: string, label: string): string => `${providerId}::${connectionId}::${label}`,
   );
   vi.mocked(workspaceProjectsStore).workspaceProjectInfos = writable<readonly WorkspaceProjectInfo[]>([]);
+  vi.mocked(openshellGatewaysStore).openshellGateways = writable([
+    { name: 'kaiden', endpoint: 'http://localhost:17670', active: true },
+  ]);
   vi.mocked(openshellSandboxesStore).allOpenshellSandboxes = writable<(SandboxInfo & { gatewayName: string })[]>([]);
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
@@ -237,6 +242,50 @@ test('Expect workspace name auto-suggested from source path', async () => {
   });
 
   expect((screen.getByPlaceholderText('e.g., Frontend Refactoring') as HTMLInputElement).value).toBe('my-project');
+});
+
+test('Expect gateway selector hidden when only one gateway is available', () => {
+  render(AgentWorkspaceCreate);
+
+  expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+});
+
+test('Expect gateway selector defaults to the active OpenShell gateway when multiple gateways are available', async () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    { name: 'local', endpoint: 'http://localhost:17670', active: false },
+    { name: 'remote', endpoint: 'https://remote.example.com', active: true },
+  ]);
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+
+  const gatewaySelector = screen.getByRole('combobox');
+  expect(gatewaySelector).toHaveValue('remote');
+  expect(screen.queryByRole('option', { name: 'Select a gateway' })).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
+
+  await fireEvent.change(gatewaySelector, { target: { value: 'local' } });
+
+  expect(gatewaySelector).toHaveValue('local');
+  expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
+});
+
+test('Expect selected gateway included when creating a workspace', async () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    { name: 'local', endpoint: 'http://localhost:17670', active: true },
+    { name: 'remote', endpoint: 'https://remote.example.com', active: false },
+  ]);
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.change(screen.getByRole('combobox'), { target: { value: 'remote' } });
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '/home/user/my-repo' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(expect.objectContaining({ gateway: 'remote' }));
 });
 
 test('Expect Continue button rendered on step 1', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -16,6 +16,7 @@ import { agentInfos } from '/@/stores/agents';
 import { mcpRemoteServerInfos } from '/@/stores/mcp-remote-servers';
 import { disabledModels, isModelEnabled, modelKey } from '/@/stores/model-catalog';
 import { catalogModels } from '/@/stores/models';
+import { openshellGateways } from '/@/stores/openshell-gateways';
 import { allOpenshellSandboxes } from '/@/stores/openshell-sandboxes';
 import { providerInfos } from '/@/stores/providers';
 import { ragEnvironments } from '/@/stores/rag-environments';
@@ -208,6 +209,15 @@ onMount(async () => {
 });
 let customHosts = $derived(wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? []);
 
+$effect.pre(() => {
+  const selectedGatewayExists = $openshellGateways.some(gateway => gateway.name === wizard.draft.selectedGateway);
+  if (!selectedGatewayExists) {
+    const activeGateway = $openshellGateways.find(gateway => gateway.active);
+    wizard.draft.selectedGateway =
+      activeGateway?.name ?? ($openshellGateways.length === 1 ? ($openshellGateways[0]?.name ?? '') : '');
+  }
+});
+
 function getDefaultSessionName(path: string): string {
   const normalized = path.trim().replace(/[\\/]+$/, '');
   return normalized.split(/[\\/]/).filter(Boolean).at(-1) ?? '';
@@ -264,7 +274,12 @@ let hasModel = $derived(wizard.draft.selectedModel !== undefined);
 let validationErrors = $derived.by(() => {
   const errors: { name?: string } = {};
   const name = wizard.draft.sessionName.trim().toLowerCase();
-  if (name && $allOpenshellSandboxes.some(s => s.name.toLowerCase() === name)) {
+  if (
+    name &&
+    $allOpenshellSandboxes.some(
+      sandbox => sandbox.gatewayName === wizard.draft.selectedGateway && sandbox.name.toLowerCase() === name,
+    )
+  ) {
     errors.name = 'A workspace with this name already exists. Please choose a different name.';
   }
   return errors;
@@ -272,6 +287,7 @@ let validationErrors = $derived.by(() => {
 let isCurrentStepComplete = $derived.by(() => {
   if (currentStepId === 'workspace') {
     return (
+      wizard.draft.selectedGateway !== '' &&
       getEffectiveWorkspaceName() !== '' &&
       wizard.draft.sourcePath.trim() !== '' &&
       isWorkspaceNameValid() &&
@@ -425,6 +441,7 @@ function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorksp
 
 async function startAsIs(): Promise<void> {
   if (
+    !wizard.draft.selectedGateway ||
     !wizard.draft.sourcePath.trim() ||
     !wizard.draft.selectedModel ||
     !isWorkspaceNameValid() ||
@@ -440,6 +457,7 @@ async function startAsIs(): Promise<void> {
       sourcePath: draftSnapshot.sourcePath,
       agent: draftSnapshot.selectedAgent,
       model: getModelId(draftSnapshot.selectedModel!),
+      gateway: draftSnapshot.selectedGateway,
       name: getEffectiveWorkspaceNameFromSnapshot(draftSnapshot),
       project: draftSnapshot.selectedProjectId,
     });
@@ -461,6 +479,7 @@ async function startAsIs(): Promise<void> {
 
 async function startWorkspace(): Promise<void> {
   if (
+    !wizard.draft.selectedGateway ||
     !getEffectiveWorkspaceName() ||
     !wizard.draft.sourcePath.trim() ||
     !wizard.draft.selectedModel ||
@@ -500,6 +519,7 @@ async function startWorkspace(): Promise<void> {
       sourcePath: draftSnapshot.sourcePath,
       agent: draftSnapshot.selectedAgent,
       model: getModelId(draftSnapshot.selectedModel!),
+      gateway: draftSnapshot.selectedGateway,
       name: getEffectiveWorkspaceNameFromSnapshot(draftSnapshot),
       skills: selectedSkillPaths.length > 0 ? selectedSkillPaths : undefined,
       network,
@@ -558,6 +578,8 @@ async function startWorkspace(): Promise<void> {
               <AgentWorkspaceCreateStepWorkspace
                 bind:sourcePath={wizard.draft.sourcePath}
                 bind:sessionName={wizard.draft.sessionName}
+                gateways={[...$openshellGateways]}
+                bind:selectedGateway={wizard.draft.selectedGateway}
                 bind:description={wizard.draft.description}
                 bind:nameManuallyEdited={wizard.draft.nameManuallyEdited}
                 bind:descriptionOpen={wizard.draft.descriptionOpen}
@@ -566,7 +588,7 @@ async function startWorkspace(): Promise<void> {
                 configExists={wizard.draft.configExists}
                 bind:configAction={wizard.draft.configAction}
                 onStartAsIs={startAsIs}
-                startAsIsDisabled={!hasModel}
+                startAsIsDisabled={!hasModel || wizard.draft.selectedGateway === ''}
                 projects={[...$workspaceProjectInfos]}
                 selectedProjectId={wizard.draft.selectedProjectId}
                 onProjectSelect={handleProjectSelect}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
 import { faChevronDown, faFolder, faFolderOpen, faInfoCircle, faRocket } from '@fortawesome/free-solid-svg-icons';
-import { Button, Input } from '@podman-desktop/ui-svelte';
+import { Button, Dropdown, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { Textarea } from '/@/lib/chat/components/ui/textarea';
 import { getSandboxNameValidationError } from '/@api/agent-workspace-info';
+import type { GatewayInfo } from '/@api/openshell-gateway-info';
 import type { WorkspaceProjectInfo } from '/@api/workspace-project-info';
 
 interface Props {
   sourcePath: string;
   sessionName: string;
+  gateways?: GatewayInfo[];
+  selectedGateway?: string;
   description: string;
   nameManuallyEdited: boolean;
   descriptionOpen: boolean;
@@ -28,6 +31,8 @@ interface Props {
 let {
   sourcePath = $bindable(),
   sessionName = $bindable(),
+  gateways = [],
+  selectedGateway = $bindable(''),
   description = $bindable(),
   nameManuallyEdited = $bindable(),
   descriptionOpen = $bindable(),
@@ -74,6 +79,22 @@ let nameInputError = $derived(sessionNameError ?? errors?.name ?? '');
 </p>
 
 <div class="space-y-4">
+  {#if gateways.length > 1}
+    <div>
+      <label for="workspace-gateway" class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">
+        Gateway
+      </label>
+      <Dropdown id="workspace-gateway" name="workspace-gateway" class="w-full" bind:value={selectedGateway}>
+        {#each gateways as gateway (gateway.name)}
+          <option value={gateway.name}>{gateway.name} — {gateway.endpoint}</option>
+        {/each}
+      </Dropdown>
+      <p class="text-xs text-[var(--pd-content-card-text)] opacity-50 mt-1.5">
+        The workspace will be created on this OpenShell gateway.
+      </p>
+    </div>
+  {/if}
+
   <div>
     <label for="workspace-source" class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">
       Project folder

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.spec.ts
@@ -157,7 +157,7 @@ test('Expect workspace removed and navigated to list when user confirms', async 
   await fireEvent.click(removeButton);
 
   await waitFor(() => {
-    expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1');
+    expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1', 'kaiden');
   });
 
   expect(router.goto).toHaveBeenCalledWith('/agent-workspaces');
@@ -227,7 +227,7 @@ test('Expect no navigation when removal fails', async () => {
   await fireEvent.click(removeButton);
 
   await waitFor(() => {
-    expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1');
+    expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1', 'kaiden');
   });
 
   expect(router.goto).not.toHaveBeenCalled();

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetails.svelte
@@ -71,7 +71,10 @@ function handleRemove(): void {
   withConfirmation(
     async () => {
       try {
-        await window.removeAgentWorkspace(workspaceId);
+        if (!workspaceSummary) {
+          throw new Error(`workspace "${workspaceId}" not found`);
+        }
+        await window.removeAgentWorkspace(workspaceId, workspaceSummary.gatewayName);
         router.goto('/agent-workspaces');
       } catch (error: unknown) {
         console.error('Failed to remove agent workspace', error);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.spec.ts
@@ -1018,7 +1018,7 @@ test('Expect delete confirmation calls removeAgentWorkspace and navigates', asyn
   await fireEvent.click(screen.getByRole('link', { name: 'Advanced' }));
   await fireEvent.click(screen.getByRole('button', { name: 'Delete workspace' }));
 
-  expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1');
+  expect(window.removeAgentWorkspace).toHaveBeenCalledWith('ws-1', 'kaiden');
   await vi.waitFor(() => {
     expect(router.goto).toHaveBeenCalledWith('/agent-workspaces');
   });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceDetailsSettings.svelte
@@ -445,7 +445,10 @@ function handleDeleteWorkspace(): void {
         return;
       }
       try {
-        await window.removeAgentWorkspace(workspaceId);
+        if (!workspaceSummary) {
+          throw new Error(`workspace "${workspaceId}" not found`);
+        }
+        await window.removeAgentWorkspace(workspaceId, workspaceSummary.gatewayName);
         router.goto('/agent-workspaces');
       } catch (error: unknown) {
         console.error('Failed to remove agent workspace', error);

--- a/packages/renderer/src/lib/agent-workspaces/columns/SandboxActions.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/columns/SandboxActions.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import type { SandboxInfoWithGateway } from '/@/stores/openshell-sandboxes';
+
+import SandboxActions from './SandboxActions.svelte';
+
+vi.mock(import('/@/lib/dialogs/messagebox-utils'));
+
+const sandbox: SandboxInfoWithGateway = {
+  id: 'sandbox-1',
+  name: 'shared-name',
+  phase: 'Ready',
+  gatewayName: 'remote-gateway',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.mocked(withConfirmation).mockImplementation(action => action());
+  vi.mocked(window.deleteOpenshellSandbox).mockResolvedValue(undefined);
+});
+
+test('deletes the sandbox from its gateway', async () => {
+  render(SandboxActions, { object: sandbox });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Remove workspace' }));
+
+  expect(window.deleteOpenshellSandbox).toHaveBeenCalledWith('shared-name', 'remote-gateway');
+});

--- a/packages/renderer/src/lib/agent-workspaces/columns/SandboxActions.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/columns/SandboxActions.svelte
@@ -13,7 +13,7 @@ let { object }: Props = $props();
 
 function handleRemove(): void {
   withConfirmation(
-    () => window.deleteOpenshellSandbox(object.name).catch(console.error),
+    () => window.deleteOpenshellSandbox(object.name, object.gatewayName).catch(console.error),
     `remove workspace ${object.name}`,
   );
 }

--- a/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
+++ b/packages/renderer/src/stores/agent-workspace-create-draft.svelte.ts
@@ -30,6 +30,7 @@ const REGISTRY_HOSTS = ['registry.npmjs.org', 'pypi.python.org'];
 interface WorkspaceCreateDraft {
   currentStepIndex: number;
   selectedProjectId: string | undefined;
+  selectedGateway: string;
   sourcePath: string;
   sessionName: string;
   description: string;
@@ -55,6 +56,7 @@ function createInitialDraft(): WorkspaceCreateDraft {
   return {
     currentStepIndex: 0,
     selectedProjectId: undefined,
+    selectedGateway: '',
     sourcePath: '',
     sessionName: '',
     description: '',


### PR DESCRIPTION
## Summary

- bind workspace creation and deletion to the selected OpenShell gateway
- add a gateway selector when multiple gateways are available and default it to OpenShell's active gateway
- scope duplicate-name validation and cleanup operations to the target gateway

Fixes #2487

## Tests

Ok to test this on podman is pretty involved because if we have multiple gateways connected to the same podman socket (i.e rootless socket) openshell sandbox list will show dups of each sandbox.

The reason is since the gateways have access to both. Its a openshell bug because the sandbox list should filter by namespace which it currently does not as of 0.0086

Docker driver works fine however because it correctly filters the namespice even if both gateways have access to containers 

Now if you want to continue with podman the workaround is to create a gateway that connects to the rootful socket. On mac since only one podman machine can be run at the same time it wont work. Maybe its possible to have docker container runtime running at the same time to create a gateway targetted to that socket but i havent tested this?

On linux just start the rootful socket

`sudo systemctl start podman.socket`

  Create a minimal development-auth configuration:

```
  cat > /tmp/openshell-rootful-demo.toml <<'EOF'
  [openshell]
  version = 1

  [openshell.gateway.auth]
  allow_unauthenticated_users = true
EOF
```

Start the gateway in a new terminal

```
  sudo -H env \
    OPENSHELL_LOCAL_TLS_DIR=/home/brian/.local/state/openshell/tls \
    OPENSHELL_PODMAN_SOCKET=/run/podman/podman.sock \
    OPENSHELL_DRIVERS=podman \
    /usr/bin/openshell-gateway \
      --config /tmp/openshell-rootful-demo.toml \
      --disable-tls \
      --bind-address 0.0.0.0 \
      --port 17675 \
      --db-url 'sqlite::memory:?cache=shared'

```

  Now create the sandbox again:

```
  openshell --gateway podman-rootful-demo sandbox create \
    --name rootful-demo-box \
    --no-tty \
    -- sh -lc 'echo "Created by the rootful gateway"'
```


`openshell --gateway openshell sandbox create     --name rootless-demo-box     --no-tty     -- sh -lc 'echo "Created by the rootless gateway"'`

So now that created a simple sandbox using both gateways

Start kaiden with this pr you should see both sandboxes with both gateways able to delete them and in the workspace creation now see a gateway category 

https://github.com/user-attachments/assets/4c5d2b96-6979-41b7-b6e5-4271fabd4fab

gateway selector will only show if multi gateways is detected









