### PR TITLE
fix(opencode): avoid provider ID collision with OpenCode built-in loaders

### DIFF
--- a/extensions/opencode/src/extension.spec.ts
+++ b/extensions/opencode/src/extension.spec.ts
@@ -234,6 +234,32 @@ describe('activate', () => {
       expect(written.provider.anthropic.options.baseURL).toBe('https://custom.anthropic.example.com');
     });
 
+    test('renames openai provider ID to avoid OpenCode built-in loader collision', async () => {
+      await activate(extensionContextMock);
+      const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];
+
+      const configFile = createConfigFile();
+      await agent.preWorkspaceStart(
+        createContext([configFile], {
+          provider: 'openai',
+          modelLabel: 'Qwen3.6-35B-A3B',
+          endpoint: 'https://litellm.example.com/v1',
+        }),
+      );
+
+      const written = JSON.parse(configFile.updateMock.mock.calls[0]![0] as string);
+      expect(written.model).toBe('openai-compat/Qwen3.6-35B-A3B');
+      expect(written.provider['openai-compat']).toEqual({
+        name: 'openai',
+        npm: '@ai-sdk/openai-compatible',
+        options: { apiKey: '{env:OPENAI_API_KEY}', baseURL: 'https://litellm.example.com/v1' },
+        models: {
+          'Qwen3.6-35B-A3B': { _launch: true, name: 'Qwen3.6-35B-A3B' },
+        },
+      });
+      expect(written.provider).not.toHaveProperty('openai');
+    });
+
     test('does not add provider block for native provider with endpoint', async () => {
       await activate(extensionContextMock);
       const agent = vi.mocked(agents.registerAgent).mock.calls[0]![0];

--- a/extensions/opencode/src/extension.ts
+++ b/extensions/opencode/src/extension.ts
@@ -67,6 +67,11 @@ const PROVIDER_ALIASES: Record<string, string> = {
   vertexai: 'anthropic',
 };
 
+// OpenCode built-in provider IDs whose custom loaders call sdk.responses()
+// unconditionally. Using these IDs with @ai-sdk/openai-compatible causes
+// "sdk.responses is not a function". We suffix them to avoid the collision.
+const OPENCODE_RESPONSES_ONLY_LOADERS = new Set(['openai', 'azure', 'azure-cognitive-services']);
+
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   const disposable = agents.registerAgent({
     id: 'opencode',
@@ -122,21 +127,32 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       const endpoint = context.model.endpoint;
 
       if (provider) {
-        config.model = `${provider}/${modelName}`;
-
         if ((!NATIVE_PROVIDERS.has(provider) || provider in NATIVE_PROVIDER_SDKS) && endpoint) {
+          const npm = NATIVE_PROVIDER_SDKS[provider] ?? '@ai-sdk/openai-compatible';
+
+          // Avoid provider IDs that trigger OpenCode's built-in loaders which
+          // unconditionally call sdk.responses() (unsupported by openai-compatible).
+          const configId =
+            npm === '@ai-sdk/openai-compatible' && OPENCODE_RESPONSES_ONLY_LOADERS.has(provider)
+              ? `${provider}-compat`
+              : provider;
+
+          config.model = `${configId}/${modelName}`;
+
           const providers = config.provider ?? {};
-          const providerEntry = providers[provider] ?? {};
+          const providerEntry = providers[configId] ?? {};
 
           providerEntry.name = provider;
-          providerEntry.npm = NATIVE_PROVIDER_SDKS[provider] ?? '@ai-sdk/openai-compatible';
+          providerEntry.npm = npm;
           providerEntry.options = { apiKey: '{env:OPENAI_API_KEY}', ...providerEntry.options, baseURL: endpoint };
 
           providerEntry.models ??= {};
           providerEntry.models[modelName] ??= { _launch: true, name: modelName };
 
-          providers[provider] = providerEntry;
+          providers[configId] = providerEntry;
           config.provider = providers;
+        } else {
+          config.model = `${provider}/${modelName}`;
         }
       } else {
         config.model = modelName;


### PR DESCRIPTION
## Summary

- Fix `TypeError: sdk.responses is not a function` when using the OpenAI Compatible provider with OpenCode agent workspaces
- Suffix the provider ID to `"openai-compat"` when the configured npm package is `@ai-sdk/openai-compatible` and the ID would collide with OpenCode's built-in loaders (`openai`, `azure`, `azure-cognitive-services`)
- Add unit test covering the provider ID renaming

## Problem

OpenCode has built-in custom loaders for specific provider IDs (e.g. `"openai"`) that unconditionally call `sdk.responses(modelID)`. When a user connects via Kaiden's "OpenAI Compatible" extension (LiteMaaS, vLLM, etc.), `llmMetadata.name` is `"openai"`, which was used directly as the provider key in the generated `opencode.json`. Since the SDK package `@ai-sdk/openai-compatible` does not expose `.responses()`, the workspace crashes immediately on start.

## Fix

The extension now detects when the provider ID would collide with a built-in loader and suffixes it to `"openai-compat"`. This bypasses the built-in loader, causing OpenCode to use `sdk.languageModel()` instead — which works correctly with `@ai-sdk/openai-compatible`.

## Test plan

- [x] Unit tests pass (31/31)
- [ ] Create a workspace with OpenCode + OpenAI Compatible provider (e.g. LiteMaaS with Qwen3.6-35B-A3B) → no `sdk.responses` error
- [ ] Create a workspace with OpenCode + Anthropic (native) → still works as before
- [ ] Create a workspace with OpenCode + Ollama → still works as before
- [ ] Create a workspace with OpenCode + Vertex AI → still works as before

Closes #2519