### PR TITLE
fix(secret-vault): remove unsupported other secret type

### DIFF
--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.spec.ts
@@ -53,32 +53,22 @@ beforeEach(() => {
   vi.mocked(window.listSecretServices).mockResolvedValue(MOCK_SERVICES);
 });
 
-test('renders type options from fetched services plus Other', async () => {
+test('renders fetched service types without Other and requires a service selection', async () => {
   render(SecretVaultCreate);
 
   await waitFor(() => {
     expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
   });
   expect(screen.getByLabelText('Gemini')).toBeInTheDocument();
-  expect(screen.getByLabelText('Other')).toBeInTheDocument();
-});
-
-test('defaults to Other type with full form fields', async () => {
-  render(SecretVaultCreate);
-
-  await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
-  });
-
-  expect(screen.getByText('Other Secret')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Other')).not.toBeInTheDocument();
+  expect(screen.getByLabelText('GitHub')).toHaveAttribute('aria-pressed', 'false');
+  expect(screen.getByText('Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
-  expect(screen.getByLabelText('Secret value')).toBeInTheDocument();
-  expect(screen.getByLabelText('Description')).toBeInTheDocument();
-  expect(screen.getByLabelText('Host pattern')).toBeInTheDocument();
-  expect(screen.getByText('Injection settings')).toBeInTheDocument();
-  expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
-  expect(screen.getByLabelText('Header name')).toBeInTheDocument();
-  expect(screen.getByLabelText('Value format')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Token')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Secret value')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Description')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Host pattern')).not.toBeInTheDocument();
+  expect(screen.queryByText('Injection settings')).not.toBeInTheDocument();
 });
 
 test('hides injection fields and shows credential fields when a predefined service type is selected', async () => {
@@ -117,21 +107,8 @@ test('Add Secret button is disabled when required fields are empty', async () =>
   render(SecretVaultCreate);
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
   });
-
-  expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
-});
-
-test('Add Secret button is disabled for Other type without host pattern', async () => {
-  render(SecretVaultCreate);
-
-  await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
-  });
-
-  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-secret' } });
-  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'secret-value' } });
 
   expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
 });
@@ -143,81 +120,6 @@ test('cancel navigates back to secret vault', async () => {
 
   const cancelButton = screen.getByRole('button', { name: 'Cancel' });
   await fireEvent.click(cancelButton);
-
-  expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
-});
-
-test('submits Other secret with injection settings', async () => {
-  const { handleNavigation } = await import('/@/navigation');
-
-  render(SecretVaultCreate);
-
-  await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
-  });
-
-  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-api-key' } });
-  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-123' } });
-  await fireEvent.input(screen.getByLabelText('Description'), { target: { value: 'Production API key' } });
-  await fireEvent.input(screen.getByLabelText('Host pattern'), { target: { value: 'api.example.com' } });
-  await fireEvent.input(screen.getByLabelText('Header name'), { target: { value: 'Authorization' } });
-  await fireEvent.input(screen.getByLabelText('Value format'), { target: { value: 'Bearer {value}' } });
-
-  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
-
-  expect(window.createSecret).toHaveBeenCalledWith({
-    name: 'my-api-key',
-    type: 'other',
-    value: 'sk-123',
-    description: 'Production API key',
-    hosts: ['api.example.com'],
-    header: 'Authorization',
-    headerTemplate: 'Bearer ${value}',
-  });
-
-  expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
-});
-
-test('does not double-prefix ${value} when user types it directly in value format', async () => {
-  render(SecretVaultCreate);
-
-  await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
-  });
-
-  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'my-api-key' } });
-  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-123' } });
-  await fireEvent.input(screen.getByLabelText('Host pattern'), { target: { value: 'api.example.com' } });
-  await fireEvent.input(screen.getByLabelText('Header name'), { target: { value: 'Authorization' } });
-  await fireEvent.input(screen.getByLabelText('Value format'), { target: { value: 'Bearer ${value}' } });
-
-  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
-
-  expect(window.createSecret).toHaveBeenCalledWith(expect.objectContaining({ headerTemplate: 'Bearer ${value}' }));
-});
-
-test('submits Other secret using default Authorization header when header name is not changed', async () => {
-  const { handleNavigation } = await import('/@/navigation');
-
-  render(SecretVaultCreate);
-
-  await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
-  });
-
-  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'custom-key' } });
-  await fireEvent.input(screen.getByLabelText('Secret value'), { target: { value: 'sk-abc' } });
-  await fireEvent.input(screen.getByLabelText('Host pattern'), { target: { value: 'api.custom.io' } });
-
-  await fireEvent.click(screen.getByRole('button', { name: 'Add Secret' }));
-
-  expect(window.createSecret).toHaveBeenCalledWith({
-    name: 'custom-key',
-    type: 'other',
-    value: 'sk-abc',
-    hosts: ['api.custom.io'],
-    header: 'Authorization',
-  });
 
   expect(handleNavigation).toHaveBeenCalledWith({ page: 'secret-vault' });
 });
@@ -271,35 +173,19 @@ test('displays error when createSecret fails', async () => {
   });
 });
 
-test('injection settings section can be collapsed and expanded', async () => {
-  render(SecretVaultCreate);
-
-  await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
-  });
-
-  expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
-
-  await fireEvent.click(screen.getByText('Injection settings'));
-
-  expect(screen.queryByLabelText('Path pattern')).not.toBeInTheDocument();
-
-  await fireEvent.click(screen.getByText('Injection settings'));
-
-  expect(screen.getByLabelText('Path pattern')).toBeInTheDocument();
-});
-
-test('still renders form when listSecretServices fails', async () => {
+test('does not offer an unsupported fallback type when listSecretServices fails', async () => {
   vi.mocked(window.listSecretServices).mockRejectedValueOnce(new Error('CLI not found'));
 
   render(SecretVaultCreate);
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Other')).toBeInTheDocument();
+    expect(screen.queryByText('Loading secret types…')).not.toBeInTheDocument();
   });
 
-  expect(screen.getByText('Other Secret')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Other')).not.toBeInTheDocument();
+  expect(screen.getByText('Secret')).toBeInTheDocument();
   expect(screen.getByLabelText('Name')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Add Secret' })).toBeDisabled();
 });
 
 test('Add Secret button is disabled when required credentials are empty for predefined type', async () => {
@@ -357,7 +243,7 @@ test('filters out profiles without credentials from type options', async () => {
 
   expect(screen.queryByLabelText('No Creds')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('Empty Creds')).not.toBeInTheDocument();
-  expect(screen.getByLabelText('Other')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Other')).not.toBeInTheDocument();
 });
 
 test('uses credential name as fallback key when env_vars is empty', async () => {

--- a/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultCreate.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-import { faChevronDown, faChevronUp, faGear, faKey } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
-import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
 
 import type { CardSelectorOption } from '/@/lib/ui/CardSelector.svelte';
@@ -11,50 +9,34 @@ import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
 import type { OpenshellProfile } from '/@api/openshell-gateway-info';
-import type { SecretCreateOptions, SecretValue } from '/@api/secret-info';
+import type { SecretCreateOptions } from '/@api/secret-info';
 
-import { getServiceIcon, OTHER_TYPE } from './secret-vault-utils';
+import { getServiceIcon } from './secret-vault-utils';
 
 let services = $state<OpenshellProfile[]>([]);
 let loading = $state(true);
 
-let type = $state(OTHER_TYPE);
+let type = $state('');
 let name = $state('');
-let secret = $state('');
-let description = $state('');
-let hostPattern = $state('');
-let pathPattern = $state('');
-let headerName = $state('Authorization');
-let valueFormat = $state('');
-let injectionOpen = $state(true);
 let saving = $state(false);
 let error = $state('');
 let credentialValues = $state<Record<string, string>>({});
 
 let serviceMap = $derived(new Map(services.map(s => [s.id, s])));
 
-let typeOptions = $derived<CardSelectorOption[]>([
-  ...services.map(s => ({
+let typeOptions = $derived<CardSelectorOption[]>(
+  services.map(s => ({
     title: s.display_name,
     badge: s.display_name,
     value: s.id,
     icon: getServiceIcon(s.id),
   })),
-  {
-    title: 'Other',
-    badge: 'Custom',
-    value: OTHER_TYPE,
-    icon: faKey,
-    description: 'Custom secret with configurable injection',
-  },
-]);
+);
 
-let effectiveType = $derived(type || OTHER_TYPE);
-let isOther = $derived(!serviceMap.has(effectiveType));
-let selectedProfile = $derived(serviceMap.get(effectiveType));
+let selectedProfile = $derived(serviceMap.get(type));
 
 $effect(() => {
-  effectiveType;
+  type;
   credentialValues = {};
 });
 
@@ -66,28 +48,15 @@ function formatCredentialPlaceholder(credName: string): string {
   return `Enter ${credName.replace(/_/g, ' ')}`;
 }
 
-let title = $derived.by(() => {
-  if (isOther) return 'Other Secret';
-  if (!selectedProfile) return 'Other Secret';
-  return `${selectedProfile.display_name} Secret`;
-});
-
-let subtitle = $derived.by(() => {
-  if (isOther) return 'Configure a custom secret to inject as a header into matching requests.';
-  return selectedProfile?.description ?? '';
-});
+let title = $derived(selectedProfile ? `${selectedProfile.display_name} Secret` : 'Secret');
+let subtitle = $derived(selectedProfile?.description ?? '');
 
 let canSave = $derived.by(() => {
   if (loading) return false;
   if (!name.trim()) return false;
-  if (isOther) {
-    if (!secret.trim() || !hostPattern.trim() || !headerName.trim()) return false;
-  } else {
-    const creds = selectedProfile?.credentials ?? [];
-    const requiredFilled = creds.filter(c => c.required).every(c => credentialValues[c.name]?.trim());
-    if (!requiredFilled) return false;
-  }
-  return true;
+  if (!selectedProfile) return false;
+  const creds = selectedProfile.credentials ?? [];
+  return creds.filter(c => c.required).every(c => credentialValues[c.name]?.trim());
 });
 
 onMount(async () => {
@@ -104,53 +73,29 @@ function cancel(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT });
 }
 
-function toggleInjection(): void {
-  injectionOpen = !injectionOpen;
-}
-
 async function addSecret(): Promise<void> {
   if (!canSave) return;
   saving = true;
   error = '';
   try {
-    let value: string | SecretValue;
-
-    if (isOther) {
-      value = secret;
-    } else {
-      const creds = selectedProfile?.credentials ?? [];
-      value = {
-        credentials: Object.fromEntries(
-          creds
-            .filter(c => credentialValues[c.name]?.trim())
-            .flatMap(c => {
-              const val = credentialValues[c.name]!.trim();
-              const keys = c.env_vars?.length ? c.env_vars : [c.name];
-              return keys.map(k => [k, val]);
-            }),
-        ),
-      };
-    }
+    const creds = selectedProfile?.credentials ?? [];
+    const value = {
+      credentials: Object.fromEntries(
+        creds
+          .filter(c => credentialValues[c.name]?.trim())
+          .flatMap(c => {
+            const val = credentialValues[c.name]!.trim();
+            const keys = c.env_vars?.length ? c.env_vars : [c.name];
+            return keys.map(k => [k, val]);
+          }),
+      ),
+    };
 
     const options: SecretCreateOptions = {
       name: name.trim(),
-      type: effectiveType,
+      type,
       value,
     };
-
-    if (isOther) {
-      if (description.trim()) {
-        options.description = description.trim();
-      }
-      options.hosts = [hostPattern.trim()];
-      options.header = headerName.trim();
-      if (pathPattern.trim()) {
-        options.path = pathPattern.trim();
-      }
-      if (valueFormat.trim()) {
-        options.headerTemplate = valueFormat.trim().replace(/(?<!\$)\{value\}/g, '${value}');
-      }
-    }
 
     await window.createSecret(options);
     handleNavigation({ page: NavigationPage.SECRET_VAULT });
@@ -175,6 +120,7 @@ async function addSecret(): Promise<void> {
               label="Secret type"
               options={typeOptions}
               bind:selected={type}
+              required
             />
           {/if}
 
@@ -188,27 +134,7 @@ async function addSecret(): Promise<void> {
             <Input bind:value={name} placeholder="e.g. GitHub Token" aria-label="Name" />
           </div>
 
-          {#if isOther}
-            <div>
-              <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Secret value</span>
-              <PasswordInput
-                bind:password={secret}
-                placeholder="Enter secret value"
-                aria-label="Secret value"
-              />
-              <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
-                Encrypted at rest. You won't be able to view this value again.
-              </p>
-            </div>
-
-            <div>
-              <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
-                Description
-                <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
-              </span>
-              <Input bind:value={description} placeholder="What this secret is used for" aria-label="Description" />
-            </div>
-          {:else if selectedProfile?.credentials}
+          {#if selectedProfile?.credentials}
             {#each selectedProfile.credentials as credential (credential.name)}
               <div>
                 <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
@@ -224,59 +150,6 @@ async function addSecret(): Promise<void> {
                 />
               </div>
             {/each}
-          {/if}
-
-          {#if isOther}
-            <div>
-              <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Host pattern</span>
-              <Input bind:value={hostPattern} placeholder="e.g. api.example.com or *.example.com" aria-label="Host pattern" />
-              <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
-                The host this secret applies to. Use *.example.com for wildcard subdomains.
-              </p>
-            </div>
-
-            <div class="rounded-lg border border-(--pd-content-card-border) overflow-hidden">
-              <button
-                type="button"
-                class="w-full flex items-center gap-3 px-4 py-3 bg-(--pd-content-card-inset-bg)
-                  hover:bg-(--pd-content-card-hover-inset-bg) cursor-pointer"
-                aria-expanded={injectionOpen}
-                aria-controls="injection-settings"
-                onclick={toggleInjection}
-              >
-                <Icon icon={faGear} size="sm" />
-                <span class="text-sm font-semibold text-(--pd-modal-text) flex-1 text-left">Injection settings</span>
-                <Icon icon={injectionOpen ? faChevronUp : faChevronDown} size="sm" />
-              </button>
-
-              {#if injectionOpen}
-                <div id="injection-settings" class="px-4 pb-4 pt-2 space-y-4 bg-(--pd-content-card-inset-bg)">
-                  <div>
-                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">Header name</span>
-                    <Input bind:value={headerName} placeholder="Authorization" aria-label="Header name" />
-                  </div>
-
-                  <div>
-                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
-                      Value format
-                      <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
-                    </span>
-                    <Input bind:value={valueFormat} placeholder="Bearer {'{value}'}" aria-label="Value format" />
-                    <p class="text-xs text-(--pd-content-card-text) opacity-60 mt-1.5">
-                      Use {'{value}'} as a placeholder for the secret. Defaults to the raw value.
-                    </p>
-                  </div>
-
-                  <div>
-                    <span class="block text-sm font-semibold text-(--pd-modal-text) mb-2">
-                      Path pattern
-                      <span class="font-normal text-(--pd-content-card-text) opacity-60">(optional)</span>
-                    </span>
-                    <Input bind:value={pathPattern} placeholder="e.g. /v1/*" aria-label="Path pattern" />
-                  </div>
-                </div>
-              {/if}
-            </div>
           {/if}
 
           {#if error}

--- a/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
+++ b/packages/renderer/src/lib/secret-vault/SecretVaultList.svelte
@@ -12,7 +12,6 @@ import SecretVaultAccount from './columns/SecretVaultAccount.svelte';
 import SecretVaultActions from './columns/SecretVaultActions.svelte';
 import SecretVaultIntegration from './columns/SecretVaultIntegration.svelte';
 import SecretVaultMaskedSecret from './columns/SecretVaultMaskedSecret.svelte';
-import { isKnownService, KNOWN_GROUP_LABEL, OTHER_GROUP_LABEL } from './secret-vault-utils';
 import SecretVaultEmptyScreen from './SecretVaultEmptyScreen.svelte';
 
 type SecretVaultSelectable = SecretVaultInfo & { selected: boolean };
@@ -55,12 +54,6 @@ const secrets: SecretVaultSelectable[] = $derived(
   $filteredSecretVaultInfos.map(secret => ({ ...secret, selected: false })),
 );
 
-const knownSecrets: SecretVaultSelectable[] = $derived(secrets.filter(s => isKnownService(s.type)));
-
-const otherSecrets: SecretVaultSelectable[] = $derived(secrets.filter(s => !isKnownService(s.type)));
-
-const hasBothGroups: boolean = $derived(knownSecrets.length > 0 && otherSecrets.length > 0);
-
 function addSecret(): void {
   handleNavigation({ page: NavigationPage.SECRET_VAULT_CREATE });
 }
@@ -81,7 +74,7 @@ function addSecret(): void {
         {:else}
           <SecretVaultEmptyScreen onclick={addSecret} />
         {/if}
-      {:else if !hasBothGroups}
+      {:else}
         <Table
           kind="secret-vault"
           data={secrets}
@@ -89,29 +82,6 @@ function addSecret(): void {
           row={row}
           defaultSortColumn="Integration"
         />
-      {:else}
-        <div class="flex flex-col w-full">
-          <div class="mx-5 pt-2 text-sm font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]">{KNOWN_GROUP_LABEL}</div>
-          <div class="flex min-w-full">
-            <Table
-              kind="secret-vault"
-              data={knownSecrets}
-              columns={columns}
-              row={row}
-              defaultSortColumn="Integration"
-            />
-          </div>
-          <div class="mx-5 pt-2 text-sm font-semibold uppercase tracking-wider text-[var(--pd-table-header-text)]">{OTHER_GROUP_LABEL}</div>
-          <div class="flex min-w-full">
-            <Table
-              kind="secret-vault"
-              data={otherSecrets}
-              columns={columns}
-              row={row}
-              defaultSortColumn="Integration"
-            />
-          </div>
-        </div>
       {/if}
     </div>
   {/snippet}

--- a/packages/renderer/src/lib/secret-vault/secret-vault-utils.spec.ts
+++ b/packages/renderer/src/lib/secret-vault/secret-vault-utils.spec.ts
@@ -16,53 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { faKey, faPlug } from '@fortawesome/free-solid-svg-icons';
 import { describe, expect, test } from 'vitest';
 
-import {
-  getSecretGroupLabel,
-  isKnownService,
-  KNOWN_GROUP_LABEL,
-  KNOWN_SERVICES,
-  OTHER_GROUP_LABEL,
-} from './secret-vault-utils';
+import { getSecretIcon } from './secret-vault-utils';
 
-describe('KNOWN_SERVICES', () => {
-  test('contains expected service names', () => {
-    expect(KNOWN_SERVICES.has('github')).toBeTruthy();
-    expect(KNOWN_SERVICES.has('gemini')).toBeTruthy();
-    expect(KNOWN_SERVICES.has('anthropic')).toBeTruthy();
+describe('getSecretIcon', () => {
+  test('returns the generic key icon when no type is available', () => {
+    expect(getSecretIcon()).toBe(faKey);
   });
 
-  test('does not contain other or unknown types', () => {
-    expect(KNOWN_SERVICES.has('other')).toBeFalsy();
-    expect(KNOWN_SERVICES.has('unknown')).toBeFalsy();
-  });
-});
-
-describe('isKnownService', () => {
-  test.each(['github', 'gemini', 'anthropic'])('returns true for known service %s', type => {
-    expect(isKnownService(type)).toBeTruthy();
+  test('treats unrecognized types like any other service', () => {
+    expect(getSecretIcon('other')).toBe(faPlug);
   });
 
-  test.each(['other', 'custom', 'unknown'])('returns false for non-known type %s', type => {
-    expect(isKnownService(type)).toBeFalsy();
-  });
-
-  test('returns false when called without argument', () => {
-    expect(isKnownService()).toBeFalsy();
-  });
-});
-
-describe('getSecretGroupLabel', () => {
-  test.each(['github', 'gemini', 'anthropic'])('returns known group label for %s', type => {
-    expect(getSecretGroupLabel(type)).toBe(KNOWN_GROUP_LABEL);
-  });
-
-  test.each(['other', 'custom'])('returns other group label for %s', type => {
-    expect(getSecretGroupLabel(type)).toBe(OTHER_GROUP_LABEL);
-  });
-
-  test('returns other group label when called without argument', () => {
-    expect(getSecretGroupLabel()).toBe(OTHER_GROUP_LABEL);
+  test('treats an empty type like any other service', () => {
+    expect(getSecretIcon('')).toBe(faPlug);
   });
 });

--- a/packages/renderer/src/lib/secret-vault/secret-vault-utils.ts
+++ b/packages/renderer/src/lib/secret-vault/secret-vault-utils.ts
@@ -32,20 +32,6 @@ const SERVICE_LABELS: Record<string, string> = {
   anthropic: 'Anthropic',
 };
 
-export const OTHER_TYPE = 'other';
-
-export const KNOWN_SERVICES = new Set(Object.keys(SERVICE_LABELS));
-export const KNOWN_GROUP_LABEL = 'Built-in integrations';
-export const OTHER_GROUP_LABEL = 'Other secrets';
-
-export function isKnownService(type?: string): boolean {
-  return !!type && KNOWN_SERVICES.has(type);
-}
-
-export function getSecretGroupLabel(type?: string): string {
-  return isKnownService(type) ? KNOWN_GROUP_LABEL : OTHER_GROUP_LABEL;
-}
-
 export function getServiceIcon(name: string): IconDefinition {
   return SERVICE_ICONS[name] ?? faPlug;
 }
@@ -55,6 +41,6 @@ export function getServiceLabel(name: string): string {
 }
 
 export function getSecretIcon(type?: string): IconDefinition {
-  if (!type || type === OTHER_TYPE) return faKey;
+  if (type === undefined) return faKey;
   return getServiceIcon(type);
 }


### PR DESCRIPTION
## Summary

- remove the unsupported Other secret option and its custom injection fields
- require users to select an available secret card before creating a secret
- remove obsolete secret grouping and Other-specific utilities
- update secret-vault tests for service-profile-only creation

## Tests

- `vitest run --project renderer packages/renderer/src/lib/secret-vault` (27 tests passed)
- ESLint on all changed files
- Svelte autofixer on changed Svelte components

Closes #2506