### PR TITLE
chore(openshell): bump default version to v0.0.88

### DIFF
--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenShell",
   "description": "Registers the openshell CLI binary for managing sandboxed workspaces.",
   "version": "0.4.0-next",
-  "openshellVersion": "0.0.69",
+  "openshellVersion": "0.0.88",
   "openshellImageBuilderVersion": "0.9.0",
   "icon": "icon.png",
   "publisher": "kaiden",


### PR DESCRIPTION
## Summary

Bump the pinned OpenShell version from v0.0.69 to v0.0.88.

## Why

The bundled version is significantly behind upstream. Older binaries
have incompatible protocol changes that cause sandbox creation
failures and terminal connection errors against current gateways.

Tested locally with OpenShell v0.0.88 gateway (Podman driver, macOS
arm64) - sandbox creation, source upload, terminal connect, and
network policy all working.

## Test plan

- Verified Kaiden downloads v0.0.88 binaries on extension activation
- Verified workspace creation and terminal access against a v0.0.88
  gateway