### PR TITLE
fix(ci): restore package.json before branch checkout in openshell workflow

### DIFF
--- a/.github/workflows/nightly-openshell-update.yaml
+++ b/.github/workflows/nightly-openshell-update.yaml
@@ -110,6 +110,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git fetch origin "$BRANCH_NAME"
+          git restore extensions/openshell/package.json
           git checkout "$BRANCH_NAME"
           git checkout main -- extensions/openshell/package.json
 


### PR DESCRIPTION
## Summary

- Fix the nightly OpenShell update workflow failing when an existing PR already exists for the `chore/bump-openshell` branch
- Add `git restore extensions/openshell/package.json` before `git checkout "$BRANCH_NAME"` to discard uncommitted changes from the shared "Update version" step

## Problem

The "Update version in package.json" step modifies `extensions/openshell/package.json` while still on `main`. When an existing PR exists, the subsequent `git checkout` of the bump branch fails with:

```
error: Your local changes to the following files would be overwritten by checkout:
    extensions/openshell/package.json
```

See failed run: https://github.com/openkaiden/kaiden/actions/runs/29894783803/job/88842527871

## Fix

Restore the file before switching branches. The "Update existing PR" step already resets `package.json` from main and applies the new version itself, so the shared step's modification is redundant for that code path.

## Test plan

- [x] Verify the "Create new PR" path is unaffected — `git checkout -B` tolerates dirty working trees
- [ ] Trigger a manual workflow dispatch when a `chore/bump-openshell` PR already exists to confirm the "Update existing PR" path succeeds