### PR TITLE
feat: allow creating empty workspaces without a project folder

### DIFF
--- a/packages/api/src/agent-workspace-info.ts
+++ b/packages/api/src/agent-workspace-info.ts
@@ -99,7 +99,7 @@ export function getSandboxNameValidationError(name: string): string | undefined 
  * Options for creating (initializing) a new workspace via `kdn init`.
  */
 export interface AgentWorkspaceCreateOptions {
-  sourcePath: string;
+  sourcePath?: string;
   agent: string;
   model: string;
   gateway: string;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -36,6 +36,7 @@ import type { AgentRegistry } from '/@/plugin/agent-registry.js';
 import * as configWriter from '/@/plugin/agent-workspace/workspace-config-writer.js';
 import type { IPCHandle } from '/@/plugin/api.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
+import type { Directories } from '/@/plugin/directories.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import type { ProviderImpl } from '/@/plugin/provider-impl.js';
@@ -149,6 +150,10 @@ const secretManager = {
   getConnectionProperties: vi.fn(),
 } as unknown as SecretManager;
 
+const directories = {
+  getAgentWorkspacesConfigDirectory: vi.fn().mockReturnValue('/mock/data/agent-workspaces'),
+} as unknown as Directories;
+
 function mockEnoent(): NodeJS.ErrnoException {
   const err: NodeJS.ErrnoException = new Error('ENOENT');
   err.code = 'ENOENT';
@@ -168,6 +173,7 @@ beforeEach(() => {
     get: vi.fn().mockReturnValue(undefined),
   } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
   vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({});
+  vi.mocked(directories.getAgentWorkspacesConfigDirectory).mockReturnValue('/mock/data/agent-workspaces');
   vi.mocked(lstat).mockImplementation(async path => {
     const value = String(path);
     const isDirectory =
@@ -205,6 +211,7 @@ beforeEach(() => {
     openshellCli,
     agentRegistry,
     openshellGateway,
+    directories,
   );
   manager.init();
 });
@@ -856,6 +863,114 @@ describe('create – OpenShell mode', () => {
   });
 });
 
+describe('create – no-folder workspace', () => {
+  const noFolderOptions: AgentWorkspaceCreateOptions = {
+    agent: 'claude',
+    name: 'empty-sandbox',
+    model: 'ramalama::granite-4.6::',
+    gateway: 'kaiden',
+  };
+
+  const mockAgent: Agent = {
+    id: 'claude',
+    name: 'Claude Code',
+    description: 'Test agent',
+    command: 'claude',
+    configurationFiles: [],
+    destinationSkillsFolder: '${HOME}/.claude/skills',
+    async preWorkspaceStart(): Promise<void> {},
+  };
+
+  beforeEach(() => {
+    vi.mocked(openshellCli.createSandbox).mockResolvedValue(undefined);
+    vi.mocked(agentRegistry.getAgentRegistration).mockReturnValue(mockAgent);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+    vi.mocked(realpath).mockImplementation(async (p: unknown) => p as string);
+  });
+
+  test('rejects workspace name containing path-traversal characters', async () => {
+    await expect(manager.create({ ...noFolderOptions, name: '../../etc' })).rejects.toThrow(
+      'Workspace name must contain only lowercase letters (a-z), digits (0-9), and hyphens (-)',
+    );
+    expect(openshellCli.createSandbox).not.toHaveBeenCalled();
+  });
+
+  test('throws when sourcePath is absent and name is not provided', async () => {
+    await expect(manager.create({ ...noFolderOptions, name: undefined })).rejects.toThrow(
+      'workspace name is required when no project folder is specified',
+    );
+    expect(openshellCli.createSandbox).not.toHaveBeenCalled();
+  });
+
+  test('creates sandbox without source file uploads when sourcePath is absent', async () => {
+    await manager.create(noFolderOptions);
+
+    expect(openshellCli.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'empty-sandbox',
+        gateway: 'kaiden',
+      }),
+    );
+    const callArg = vi.mocked(openshellCli.createSandbox).mock.calls[0]![0]!;
+    expect(callArg.uploads).toBeUndefined();
+  });
+
+  test('does not add WORKSPACE_LABEL when sourcePath is absent', async () => {
+    await manager.create(noFolderOptions);
+
+    const callArg = vi.mocked(openshellCli.createSandbox).mock.calls[0]![0]!;
+    expect(callArg.labels).toEqual({ [AGENT_LABEL]: 'claude' });
+  });
+
+  test('writes config to global directory scoped by gateway and name', async () => {
+    const spy = vi.spyOn(configWriter, 'writeWorkspaceConfig');
+    await manager.create(noFolderOptions);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'empty-sandbox', gateway: 'kaiden' }),
+      join('/mock/data/agent-workspaces', 'kaiden', 'empty-sandbox'),
+    );
+  });
+
+  test('replaceConfig removes config from global directory when sourcePath is absent', async () => {
+    await manager.create({ ...noFolderOptions, replaceConfig: true });
+
+    expect(rm).toHaveBeenCalledWith(join('/mock/data/agent-workspaces', 'kaiden', 'empty-sandbox', 'workspace.json'), {
+      force: true,
+    });
+  });
+
+  test('uploads mounts with absolute paths and warns about skipped $SOURCES mounts', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spy = vi.spyOn(configWriter, 'writeWorkspaceConfig').mockResolvedValue({
+      mounts: [
+        { host: '/Users/me/repos/lib', target: 'lib', ro: false },
+        { host: '$SOURCES/sub', target: 'sub', ro: true },
+      ],
+    } as AgentWorkspaceConfiguration);
+
+    await manager.create(noFolderOptions);
+
+    const callArg = vi.mocked(openshellCli.createSandbox).mock.calls[0]![0]!;
+    expect(callArg.uploads).toEqual([{ local: '/Users/me/repos/lib', remote: 'lib' }]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('skipping mount "$SOURCES/sub"'));
+    spy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  test('merges into existing config at global directory', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ skills: ['/existing/skill'] }));
+    const spy = vi.spyOn(configWriter, 'writeWorkspaceConfig');
+
+    await manager.create({ ...noFolderOptions, network: { mode: 'allow' } });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ network: { mode: 'allow' } }),
+      join('/mock/data/agent-workspaces', 'kaiden', 'empty-sandbox'),
+    );
+  });
+});
+
 describe('checkWorkspaceConfigExists', () => {
   test('returns true when workspace.json exists', async () => {
     vi.mocked(access).mockResolvedValue(undefined);
@@ -872,6 +987,13 @@ describe('checkWorkspaceConfigExists', () => {
     const result = await manager.checkWorkspaceConfigExists('/tmp/my-project');
 
     expect(result).toBe(false);
+  });
+
+  test('returns false for empty sourcePath', async () => {
+    const result = await manager.checkWorkspaceConfigExists('');
+
+    expect(result).toBe(false);
+    expect(access).not.toHaveBeenCalled();
   });
 });
 
@@ -1049,6 +1171,18 @@ describe('remove', () => {
 
     expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
   });
+
+  test('cleans up global config directory after sandbox deletion', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
+    vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
+
+    await manager.remove('ws-1', 'kaiden');
+
+    expect(rm).toHaveBeenCalledWith(join('/mock/data/agent-workspaces', 'kaiden', 'test-workspace-1'), {
+      recursive: true,
+      force: true,
+    });
+  });
 });
 
 describe('deleteOpenshellSandbox', () => {
@@ -1058,6 +1192,17 @@ describe('deleteOpenshellSandbox', () => {
     await manager.deleteOpenshellSandbox('shared-name', 'remote-gateway');
 
     expect(openshellCli.deleteSandbox).toHaveBeenCalledWith('shared-name', 'remote-gateway');
+  });
+
+  test('cleans up global config directory after sandbox deletion', async () => {
+    vi.mocked(openshellCli.deleteSandbox).mockResolvedValue(undefined);
+
+    await manager.deleteOpenshellSandbox('my-workspace', 'kaiden');
+
+    expect(rm).toHaveBeenCalledWith(join('/mock/data/agent-workspaces', 'kaiden', 'my-workspace'), {
+      recursive: true,
+      force: true,
+    });
   });
 });
 
@@ -1098,6 +1243,28 @@ describe('getConfiguration', () => {
 
     await expect(manager.getConfiguration('ws-1')).rejects.toThrow('EACCES: permission denied');
   });
+
+  test('reads from global directory for no-folder workspaces', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
+    vi.mocked(readFile).mockResolvedValue('{"network":{"mode":"allow"}}');
+
+    const result = await manager.getConfiguration('ws-2');
+
+    expect(readFile).toHaveBeenCalledWith(
+      join('/mock/data/agent-workspaces', 'kaiden', 'test-workspace-2', 'workspace.json'),
+      'utf-8',
+    );
+    expect(result).toEqual({ network: { mode: 'allow' } });
+  });
+
+  test('returns empty config when global directory file does not exist for no-folder workspace', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
+    vi.mocked(readFile).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+    const result = await manager.getConfiguration('ws-2');
+
+    expect(result).toEqual({});
+  });
 });
 
 describe('updateConfiguration', () => {
@@ -1131,6 +1298,18 @@ describe('updateConfiguration', () => {
     vi.mocked(configWriter.updateWorkspaceConfig).mockRejectedValue(new Error('permission denied'));
 
     await expect(manager.updateConfiguration('ws-1', {})).rejects.toThrow('permission denied');
+  });
+
+  test('writes to global directory for no-folder workspaces', async () => {
+    vi.mocked(openshellCli.listSandboxesPerGateway).mockResolvedValue(TEST_SUMMARIES);
+    const spy = vi.spyOn(configWriter, 'updateWorkspaceConfig');
+
+    await manager.updateConfiguration('ws-2', { skills: ['/new/skill'] });
+
+    expect(spy).toHaveBeenCalledWith(join('/mock/data/agent-workspaces', 'kaiden', 'test-workspace-2'), {
+      skills: ['/new/skill'],
+    });
+    expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
   });
 });
 

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -30,6 +30,7 @@ import { AgentRegistry } from '/@/plugin/agent-registry.js';
 import { updateWorkspaceConfig, writeWorkspaceConfig } from '/@/plugin/agent-workspace/workspace-config-writer.js';
 import { WritableConfigurationFile } from '/@/plugin/agent-workspace/writable-configuration-file.js';
 import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
+import { Directories } from '/@/plugin/directories.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
 import {
@@ -111,7 +112,16 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly agentRegistry: AgentRegistry,
     @inject(OpenshellGateway)
     private readonly openshellGateway: OpenshellGateway,
+    @inject(Directories)
+    private readonly directories: Directories,
   ) {}
+
+  private getGlobalConfigDir(gateway: string, sandboxName: string): string {
+    if (/[\\/]|\.\./.test(gateway) || /[\\/]|\.\./.test(sandboxName)) {
+      throw new Error(`Invalid workspace identifier: "${gateway}/${sandboxName}"`);
+    }
+    return join(this.directories.getAgentWorkspacesConfigDirectory(), gateway, sandboxName);
+  }
 
   async create(options: AgentWorkspaceCreateOptions): Promise<AgentWorkspaceId> {
     const suffix = options.name ? ` "${options.name}"` : '';
@@ -124,8 +134,11 @@ export class AgentWorkspaceManager implements Disposable {
       }
 
       if (options.replaceConfig) {
-        const configPath = join(options.sourcePath, '.kaiden', 'workspace.json');
-        await rm(configPath, { force: true });
+        if (options.sourcePath) {
+          await rm(join(options.sourcePath, '.kaiden', 'workspace.json'), { force: true });
+        } else if (options.name) {
+          await rm(join(this.getGlobalConfigDir(options.gateway, options.name), 'workspace.json'), { force: true });
+        }
       }
 
       const secretName = await this.ensureModelSecret(options);
@@ -150,7 +163,17 @@ export class AgentWorkspaceManager implements Disposable {
     const rawEndpoint = connectionInfo?.endpoint ?? options.model.split('::')[2] ?? undefined;
     const endpoint = rawEndpoint ? rewriteLocalhostUrl(rawEndpoint) : undefined;
 
-    const workspace = await writeWorkspaceConfig(options);
+    const sandboxName = options.name ?? (options.sourcePath ? basename(options.sourcePath) : undefined);
+    if (!sandboxName) {
+      throw new Error('workspace name is required when no project folder is specified');
+    }
+    const sandboxNameError = getSandboxNameValidationError(sandboxName);
+    if (sandboxNameError) {
+      throw new Error(sandboxNameError);
+    }
+
+    const configDir = options.sourcePath ? undefined : this.getGlobalConfigDir(options.gateway, sandboxName);
+    const workspace = await writeWorkspaceConfig(options, configDir);
     const agent = this.agentRegistry.getAgentRegistration(options.agent);
     const uploads: OpenshellUpload[] = [];
 
@@ -200,11 +223,6 @@ export class AgentWorkspaceManager implements Disposable {
 
     uploads.push(...(await this.buildOpenshellFilesystemUploads(options.sourcePath, workspace)));
 
-    const sandboxName = options.name ?? basename(options.sourcePath);
-    const sandboxNameError = getSandboxNameValidationError(sandboxName);
-    if (sandboxNameError) {
-      throw new Error(sandboxNameError);
-    }
     const env = workspace.environment
       ?.filter(entry => typeof entry.value === 'string' && entry.value !== '')
       .reduce<Record<string, string>>((acc, entry) => {
@@ -229,7 +247,10 @@ export class AgentWorkspaceManager implements Disposable {
       from: agent.baseImage,
       providers: options.secrets,
       env: env && Object.keys(env).length > 0 ? env : undefined,
-      labels: { ...encodeWorkspaceLabels(options.sourcePath), [AGENT_LABEL]: options.agent },
+      labels: {
+        ...(options.sourcePath ? encodeWorkspaceLabels(options.sourcePath) : {}),
+        [AGENT_LABEL]: options.agent,
+      },
       uploads: dedupedUploads.length > 0 ? dedupedUploads : undefined,
       noTty: true,
       command: ['true'],
@@ -259,8 +280,19 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   async checkWorkspaceConfigExists(sourcePath: string): Promise<boolean> {
+    if (!sourcePath) return false;
     try {
       await access(join(sourcePath, '.kaiden', 'workspace.json'));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async checkGlobalWorkspaceConfigExists(gateway: string, name: string): Promise<boolean> {
+    if (!gateway || getSandboxNameValidationError(name)) return false;
+    try {
+      await access(join(this.getGlobalConfigDir(gateway, name), 'workspace.json'));
       return true;
     } catch {
       return false;
@@ -281,15 +313,21 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   private async buildOpenshellFilesystemUploads(
-    sourcePath: string,
+    sourcePath: string | undefined,
     workspace: AgentWorkspaceConfiguration,
   ): Promise<OpenshellUpload[]> {
-    const uploads: OpenshellUpload[] = [{ local: sourcePath, remote: '.' }];
+    const uploads: OpenshellUpload[] = [];
+    if (sourcePath) {
+      uploads.push({ local: sourcePath, remote: '.' });
+    }
 
     for (const mount of workspace.mounts ?? []) {
       const local = this.resolveHostPath(mount.host, sourcePath);
       const remote = this.resolveOpenshellSandboxPath(mount.target, sourcePath);
       if (!local || !remote) {
+        console.warn(
+          `[AgentWorkspaceManager] skipping mount "${mount.host}" → "${mount.target}": cannot resolve without a project folder`,
+        );
         continue;
       }
       const resolvedRemote = await this.resolveUploadRemotePath(local, remote);
@@ -313,12 +351,12 @@ export class AgentWorkspaceManager implements Disposable {
     return remote;
   }
 
-  private resolveHostPath(path: string, sourcePath: string): string | undefined {
+  private resolveHostPath(path: string, sourcePath: string | undefined): string | undefined {
     if (path === SOURCES_VARIABLE) {
       return sourcePath;
     }
     if (path.startsWith(`${SOURCES_VARIABLE}/`)) {
-      return resolve(sourcePath, path.slice(SOURCES_VARIABLE.length + 1));
+      return sourcePath ? resolve(sourcePath, path.slice(SOURCES_VARIABLE.length + 1)) : undefined;
     }
     if (path === MOUNT_HOME_PREFIX) {
       return homedir();
@@ -335,7 +373,7 @@ export class AgentWorkspaceManager implements Disposable {
     return undefined;
   }
 
-  private resolveOpenshellSandboxPath(path: string, _sourcePath: string): string | undefined {
+  private resolveOpenshellSandboxPath(path: string, _sourcePath: string | undefined): string | undefined {
     if (path === SOURCES_VARIABLE) {
       return '.';
     }
@@ -420,6 +458,7 @@ export class AgentWorkspaceManager implements Disposable {
     try {
       await this.openshellCli.deleteSandbox(workspaceName, gateway);
       this.closeWorkspaceTerminal(id);
+      await rm(this.getGlobalConfigDir(gateway, workspaceName), { recursive: true, force: true });
       this.apiSender.send('agent-workspace-update');
       task.status = 'success';
       return { id };
@@ -433,37 +472,51 @@ export class AgentWorkspaceManager implements Disposable {
     }
   }
 
+  private findSandboxWithGateway(
+    workspaces: GatewaySandboxes[],
+    id: string,
+  ): { sandbox: GatewaySandboxes['sandboxes'][number]; gatewayName: string } | undefined {
+    for (const gw of workspaces) {
+      const sandbox = gw.sandboxes.find(ws => ws.id === id);
+      if (sandbox) {
+        return { sandbox, gatewayName: gw.gateway.name };
+      }
+    }
+    return undefined;
+  }
+
+  private resolveConfigDir(sandbox: { sourcePath?: string; name: string }, gatewayName: string): string {
+    return sandbox.sourcePath
+      ? join(sandbox.sourcePath, '.kaiden')
+      : this.getGlobalConfigDir(gatewayName, sandbox.name);
+  }
+
   async getConfiguration(id: string): Promise<AgentWorkspaceConfiguration> {
     const workspaces = await this.listOpenshellSandboxes();
-    const workspace = workspaces.flatMap(gw => gw.sandboxes).find(ws => ws.id === id);
-    if (!workspace) {
+    const match = this.findSandboxWithGateway(workspaces, id);
+    if (!match) {
       throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
     }
-    if (workspace.sourcePath) {
-      try {
-        const content = await readFile(join(workspace.sourcePath, '.kaiden', 'workspace.json'), 'utf-8');
-        return JSON.parse(content) as AgentWorkspaceConfiguration;
-      } catch (error: unknown) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-          return {} as AgentWorkspaceConfiguration;
-        }
-        throw error;
+    const configPath = join(this.resolveConfigDir(match.sandbox, match.gatewayName), 'workspace.json');
+    try {
+      const content = await readFile(configPath, 'utf-8');
+      return JSON.parse(content) as AgentWorkspaceConfiguration;
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {} as AgentWorkspaceConfiguration;
       }
-    } else {
-      return {};
+      throw error;
     }
   }
 
   async updateConfiguration(id: string, config: Partial<AgentWorkspaceConfiguration>): Promise<void> {
     const workspaces = await this.listOpenshellSandboxes();
-    const workspace = workspaces.flatMap(gw => gw.sandboxes).find(ws => ws.id === id);
-    if (!workspace) {
+    const match = this.findSandboxWithGateway(workspaces, id);
+    if (!match) {
       throw new Error(`workspace "${id}" not found. Use "workspace list" to see available workspaces.`);
     }
-    if (workspace.sourcePath) {
-      await updateWorkspaceConfig(join(workspace.sourcePath, '.kaiden'), config);
-      this.apiSender.send('agent-workspace-update');
-    }
+    await updateWorkspaceConfig(this.resolveConfigDir(match.sandbox, match.gatewayName), config);
+    this.apiSender.send('agent-workspace-update');
   }
 
   async updateSummary(id: string, update: Pick<AgentWorkspaceSummary, 'name'>): Promise<void> {
@@ -505,6 +558,7 @@ export class AgentWorkspaceManager implements Disposable {
     task.status = 'in-progress';
     try {
       await this.openshellCli.deleteSandbox(name, gateway);
+      await rm(this.getGlobalConfigDir(gateway, name), { recursive: true, force: true });
       this.apiSender.send('agent-workspace-update');
       task.status = 'success';
     } catch (err: unknown) {
@@ -596,6 +650,13 @@ export class AgentWorkspaceManager implements Disposable {
       'agent-workspace:checkConfigExists',
       async (_listener: unknown, sourcePath: string): Promise<boolean> => {
         return this.checkWorkspaceConfigExists(sourcePath);
+      },
+    );
+
+    this.ipcHandle(
+      'agent-workspace:checkGlobalConfigExists',
+      async (_listener: unknown, gateway: string, name: string): Promise<boolean> => {
+        return this.checkGlobalWorkspaceConfigExists(gateway, name);
       },
     );
 

--- a/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/workspace-config-writer.spec.ts
@@ -441,6 +441,53 @@ describe('writeWorkspaceConfig', () => {
     ]);
   });
 
+  test('writes workspace.json to overrideConfigDir when provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+
+    await writeWorkspaceConfig(
+      { ...defaultOptions, sourcePath: undefined, skills: ['/path/to/skill'] },
+      '/global/agent-workspaces/gw/my-sandbox',
+    );
+
+    expect(mkdir).toHaveBeenCalledWith('/global/agent-workspaces/gw/my-sandbox', { recursive: true });
+    expect(writeFile).toHaveBeenCalledWith(
+      join('/global/agent-workspaces/gw/my-sandbox', 'workspace.json'),
+      expect.any(String),
+      'utf-8',
+    );
+    const parsed = JSON.parse(vi.mocked(writeFile).mock.calls[0]![1] as string);
+    expect(parsed.skills).toEqual(['/path/to/skill']);
+  });
+
+  test('falls back to sourcePath/.kaiden when overrideConfigDir is not provided', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockRejectedValue(mockEnoent());
+
+    await writeWorkspaceConfig(defaultOptions);
+
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/my-project', '.kaiden'), { recursive: true });
+    expect(writeFile).toHaveBeenCalledWith(
+      join('/tmp/my-project', '.kaiden', 'workspace.json'),
+      expect.any(String),
+      'utf-8',
+    );
+  });
+
+  test('merges into existing config at overrideConfigDir', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ skills: ['/existing/skill'] }));
+
+    await writeWorkspaceConfig(
+      { ...defaultOptions, sourcePath: undefined, network: { mode: 'allow' } },
+      '/global/agent-workspaces/gw/my-sandbox',
+    );
+
+    const parsed = JSON.parse(vi.mocked(writeFile).mock.calls[0]![1] as string);
+    expect(parsed.skills).toEqual(['/existing/skill']);
+    expect(parsed.network).toEqual({ mode: 'allow' });
+  });
+
   test('preserves existing workspace.json secrets when no secrets provided', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(readFile).mockResolvedValue(

--- a/packages/main/src/plugin/agent-workspace/workspace-config-writer.ts
+++ b/packages/main/src/plugin/agent-workspace/workspace-config-writer.ts
@@ -27,7 +27,10 @@ import type { AgentWorkspaceCreateOptions } from '/@api/agent-workspace-info.js'
 
 export type WorkspaceConfiguration = workspaceComponents['schemas']['WorkspaceConfiguration'];
 
-export async function writeWorkspaceConfig(options: AgentWorkspaceCreateOptions): Promise<WorkspaceConfiguration> {
+export async function writeWorkspaceConfig(
+  options: AgentWorkspaceCreateOptions,
+  overrideConfigDir?: string,
+): Promise<WorkspaceConfiguration> {
   const mcpServers = options.mcp?.servers;
   const mcpCommands = options.mcp?.commands;
   const hasSkills = !!options.skills?.length;
@@ -35,7 +38,10 @@ export async function writeWorkspaceConfig(options: AgentWorkspaceCreateOptions)
   const hasWsConfig = !!options.workspaceConfiguration;
   const hasMounts = !!options.mounts?.length;
 
-  const configDir = join(options.sourcePath, '.kaiden');
+  if (!overrideConfigDir && !options.sourcePath) {
+    throw new Error('writeWorkspaceConfig requires either options.sourcePath or overrideConfigDir');
+  }
+  const configDir = overrideConfigDir ?? join(options.sourcePath!, '.kaiden');
   const configPath = join(configDir, 'workspace.json');
   await mkdir(configDir, { recursive: true });
 

--- a/packages/main/src/plugin/directories-legacy.ts
+++ b/packages/main/src/plugin/directories-legacy.ts
@@ -49,6 +49,7 @@ export class LegacyDirectories implements Directories {
   private readonly skillsDirectory: string;
   private readonly workspaceProjectsDirectory: string;
   private readonly semanticRoutersDirectory: string;
+  private readonly agentWorkspacesConfigDirectory: string;
 
   constructor() {
     // Check for custom directory override
@@ -73,6 +74,7 @@ export class LegacyDirectories implements Directories {
     this.skillsDirectory = path.resolve(this.desktopAppHomeDir, 'skills');
     this.workspaceProjectsDirectory = path.resolve(this.desktopAppHomeDir, 'workspace-projects');
     this.semanticRoutersDirectory = path.resolve(this.desktopAppHomeDir, 'semantic-routers');
+    this.agentWorkspacesConfigDirectory = path.resolve(this.desktopAppHomeDir, 'agent-workspaces');
   }
 
   getConfigurationDirectory(): string {
@@ -135,5 +137,9 @@ export class LegacyDirectories implements Directories {
 
   getSemanticRoutersDirectory(): string {
     return this.semanticRoutersDirectory;
+  }
+
+  getAgentWorkspacesConfigDirectory(): string {
+    return this.agentWorkspacesConfigDirectory;
   }
 }

--- a/packages/main/src/plugin/directories-linux-xdg.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.ts
@@ -42,6 +42,7 @@ export class LinuxXDGDirectories implements Directories {
   private readonly skillsDirectory: string;
   private readonly workspaceProjectsDirectory: string;
   private readonly semanticRoutersDirectory: string;
+  private readonly agentWorkspacesConfigDirectory: string;
 
   constructor() {
     // XDG_CONFIG_HOME: user-specific configuration files
@@ -64,6 +65,7 @@ export class LinuxXDGDirectories implements Directories {
     this.skillsDirectory = path.resolve(this.dataDirectory, 'skills');
     this.workspaceProjectsDirectory = path.resolve(this.dataDirectory, 'workspace-projects');
     this.semanticRoutersDirectory = path.resolve(this.dataDirectory, 'semantic-routers');
+    this.agentWorkspacesConfigDirectory = path.resolve(this.dataDirectory, 'agent-workspaces');
   }
 
   getConfigurationDirectory(): string {
@@ -116,5 +118,9 @@ export class LinuxXDGDirectories implements Directories {
 
   getSemanticRoutersDirectory(): string {
     return this.semanticRoutersDirectory;
+  }
+
+  getAgentWorkspacesConfigDirectory(): string {
+    return this.agentWorkspacesConfigDirectory;
   }
 }

--- a/packages/main/src/plugin/directories.ts
+++ b/packages/main/src/plugin/directories.ts
@@ -30,4 +30,5 @@ export interface Directories {
   getSkillsDirectory(): string;
   getWorkspaceProjectsDirectory(): string;
   getSemanticRoutersDirectory(): string;
+  getAgentWorkspacesConfigDirectory(): string;
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -341,6 +341,13 @@ export function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
+    'checkAgentWorkspaceGlobalConfigExists',
+    async (gateway: string, name: string): Promise<boolean> => {
+      return ipcInvoke('agent-workspace:checkGlobalConfigExists', gateway, name);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'createAgentWorkspace',
     async (options: AgentWorkspaceCreateOptions): Promise<AgentWorkspaceId> => {
       return ipcInvoke('agent-workspace:create', options);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -180,6 +180,7 @@ beforeEach(() => {
   ]);
   vi.mocked(openshellSandboxesStore).allOpenshellSandboxes = writable<(SandboxInfo & { gatewayName: string })[]>([]);
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
+  vi.mocked(window.checkAgentWorkspaceGlobalConfigExists).mockResolvedValue(false);
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   resetDraft();
 });
@@ -308,6 +309,36 @@ test('Expect Continue button enabled when name and source are filled', async () 
   });
 
   expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
+});
+
+test('Expect Continue button enabled when sourcePath is empty but workspace name is filled', async () => {
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('e.g., front-refactor'), {
+    target: { value: 'my-sandbox' },
+  });
+
+  expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
+});
+
+test('Expect whitespace-only sourcePath sent as undefined to createAgentWorkspace', async () => {
+  render(AgentWorkspaceCreate);
+
+  await fireEvent.input(screen.getByPlaceholderText('/path/to/project'), {
+    target: { value: '   ' },
+  });
+  await fireEvent.input(screen.getByPlaceholderText('e.g., front-refactor'), {
+    target: { value: 'my-sandbox' },
+  });
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
+
+  expect(window.createAgentWorkspace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sourcePath: undefined,
+      name: 'my-sandbox',
+    }),
+  );
 });
 
 test('Expect Continue button disabled when workspace name exceeds hostname limit', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -268,7 +268,24 @@ $effect(() => {
         }
       });
   } else {
-    wizard.draft.configExists = false;
+    const name = getEffectiveWorkspaceName();
+    const gateway = wizard.draft.selectedGateway;
+    if (name && gateway && !getSandboxNameValidationError(name)) {
+      window
+        .checkAgentWorkspaceGlobalConfigExists(gateway, name)
+        .then(exists => {
+          if (token === configCheckToken) {
+            wizard.draft.configExists = exists;
+          }
+        })
+        .catch(() => {
+          if (token === configCheckToken) {
+            wizard.draft.configExists = false;
+          }
+        });
+    } else {
+      wizard.draft.configExists = false;
+    }
   }
 });
 
@@ -297,7 +314,6 @@ let isCurrentStepComplete = $derived.by(() => {
     return (
       wizard.draft.selectedGateway !== '' &&
       getEffectiveWorkspaceName() !== '' &&
-      wizard.draft.sourcePath.trim() !== '' &&
       isWorkspaceNameValid() &&
       !validationErrors.name
     );
@@ -450,7 +466,6 @@ function buildMountsFrom(fileAccess: string, mounts: CustomMount[]): AgentWorksp
 async function startAsIs(): Promise<void> {
   if (
     !wizard.draft.selectedGateway ||
-    !wizard.draft.sourcePath.trim() ||
     !wizard.draft.selectedModel ||
     !isWorkspaceNameValid() ||
     validationErrors.name
@@ -462,7 +477,7 @@ async function startAsIs(): Promise<void> {
 
   try {
     await window.createAgentWorkspace({
-      sourcePath: draftSnapshot.sourcePath,
+      sourcePath: draftSnapshot.sourcePath.trim() || undefined,
       agent: draftSnapshot.selectedAgent,
       model: getModelId(draftSnapshot.selectedModel!),
       gateway: draftSnapshot.selectedGateway,
@@ -489,7 +504,6 @@ async function startWorkspace(): Promise<void> {
   if (
     !wizard.draft.selectedGateway ||
     !getEffectiveWorkspaceName() ||
-    !wizard.draft.sourcePath.trim() ||
     !wizard.draft.selectedModel ||
     !isWorkspaceNameValid() ||
     validationErrors.name
@@ -524,7 +538,7 @@ async function startWorkspace(): Promise<void> {
     const hasMcp = remoteServers.length > 0 || commandServers.length > 0;
 
     await window.createAgentWorkspace({
-      sourcePath: draftSnapshot.sourcePath,
+      sourcePath: draftSnapshot.sourcePath.trim() || undefined,
       agent: draftSnapshot.selectedAgent,
       model: getModelId(draftSnapshot.selectedModel!),
       gateway: draftSnapshot.selectedGateway,
@@ -573,7 +587,7 @@ async function startWorkspace(): Promise<void> {
             </span>
             <h1 class="text-2xl font-bold text-[var(--pd-modal-text)] mb-1">Create Coding Agent Workspace</h1>
             <p class="text-sm text-[var(--pd-content-card-text)] opacity-70 max-w-2xl leading-relaxed">
-              Add your code location first, then agent, tools, and sandbox filesystem & networking.
+              Choose a code location or start empty, then configure agent, tools, and sandbox settings.
             </p>
           </div>
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.spec.ts
@@ -52,7 +52,7 @@ test('Expect step description is displayed', () => {
 test('Expect project folder label and input are rendered', () => {
   render(AgentWorkspaceCreateStepWorkspace, defaultProps);
 
-  expect(screen.getByText('Project folder')).toBeInTheDocument();
+  expect(screen.getByText(/Project folder/)).toBeInTheDocument();
   expect(screen.getByPlaceholderText('/path/to/project')).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepWorkspace.svelte
@@ -79,7 +79,7 @@ let nameInputError = $derived(sessionNameError ?? errors?.name ?? '');
 
 <h2 class="text-lg font-semibold text-[var(--pd-modal-text)] mb-1">Workspace</h2>
 <p class="text-sm text-[var(--pd-content-card-text)] opacity-60 mb-5">
-  Point to a local project folder to set up your workspace.
+  Point to a local project folder, or leave it empty for a sandbox-only workspace.
 </p>
 
 <div class="space-y-4">
@@ -101,7 +101,7 @@ let nameInputError = $derived(sessionNameError ?? errors?.name ?? '');
 
   <div>
     <label for="workspace-source" class="block text-sm font-semibold text-[var(--pd-modal-text)] mb-2">
-      Project folder
+      Project folder <span class="text-xs font-normal opacity-50">(optional)</span>
     </label>
     <div class="flex gap-2 items-stretch">
       <Input
@@ -113,7 +113,7 @@ let nameInputError = $derived(sessionNameError ?? errors?.name ?? '');
       <Button onclick={onBrowseSource} aria-label="Browse for folder" icon={faFolderOpen} />
     </div>
     <p class="text-xs text-[var(--pd-content-card-text)] opacity-50 mt-1.5">
-      Select a local directory to use as the workspace source.
+      Select a local directory, or leave empty for a sandbox-only workspace.
     </p>
   </div>
 


### PR DESCRIPTION
Make sourcePath optional in AgentWorkspaceCreateOptions so users can
create sandbox-only workspaces. For no-folder workspaces, store the
workspace.json config under the global state directory scoped by
gateway and workspace name (<dataDir>/agent-workspaces/<gateway>/<name>/).

- Add getAgentWorkspacesConfigDirectory() to Directories interface
- Support optional overrideConfigDir in writeWorkspaceConfig()
- Update AgentWorkspaceManager to handle no-folder creation, config
  read/write, and cleanup on deletion
- Process mounts (absolute//Users/fbricon paths) even without sourcePath;
  warn when $SOURCES-relative mounts are skipped
- Update UI wizard to make project folder optional
- Add tests for all new paths

<img width="1420" height="1077" alt="Screenshot 2026-07-23 at 14 29 47" src="https://github.com/user-attachments/assets/0ae95eaa-2954-4718-8aab-e543cb448c96" />


fixes #2518 
