### PR TITLE
fix(#1287): move skill creation to full page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -64,6 +64,7 @@ export enum NavigationPage {
   AGENT_WORKSPACE_CREATE = 'agent-workspace-create',
   CODING_AGENTS = 'coding-agents',
   SKILLS = 'skills',
+  SKILL_CREATE = 'skill-create',
   SKILL_DETAILS = 'skill-details',
   RAG_ENVIRONMENTS = 'rag-environments',
   RAG_ENVIRONMENT_DETAILS = 'rag-environment-details',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -80,6 +80,7 @@ export interface NavigationParameters {
   [NavigationPage.AGENT_WORKSPACE_CREATE]: never;
   [NavigationPage.CODING_AGENTS]: never;
   [NavigationPage.SKILLS]: never;
+  [NavigationPage.SKILL_CREATE]: never;
   [NavigationPage.SKILL_DETAILS]: {
     name: string;
   };

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -97,6 +97,7 @@ import SecretVaultDetails from './lib/secret-vault/SecretVaultDetails.svelte';
 import SecretVaultList from './lib/secret-vault/SecretVaultList.svelte';
 import ServiceDetails from './lib/service/ServiceDetails.svelte';
 import ServicesList from './lib/service/ServicesList.svelte';
+import SkillCreate from './lib/skills/SkillCreate.svelte';
 import SkillDetails from './lib/skills/SkillDetails.svelte';
 import SkillsList from './lib/skills/SkillsList.svelte';
 import StatusBar from './lib/statusbar/StatusBar.svelte';
@@ -354,6 +355,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/skills/*" breadcrumb="Skills" navigationHint="root" firstmatch>
           <Route path="/" breadcrumb="Skills" navigationHint="root">
             <SkillsList />
+          </Route>
+          <Route path="/create" breadcrumb="Create Skill" navigationHint="details">
+            <SkillCreate />
           </Route>
           <Route path="/:name/*" let:meta breadcrumb="Skill Details" navigationHint="details">
             <SkillDetails name={decodeURIComponent(meta.params.name)} />

--- a/packages/renderer/src/lib/skills/SkillCreate.spec.ts
+++ b/packages/renderer/src/lib/skills/SkillCreate.spec.ts
@@ -22,9 +22,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
+
 import SkillCreate from './SkillCreate.svelte';
 
-const closeMock = vi.fn();
+vi.mock(import('/@/navigation'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -41,16 +44,17 @@ beforeEach(() => {
   });
 });
 
-test('should render the Create Skill dialog title', async () => {
-  render(SkillCreate, { onclose: closeMock });
+test('should render the Create Skill page title', async () => {
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByText('Create Skill')).toBeInTheDocument();
   });
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
 test('should render target cards after loading', async () => {
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByText('Kaiden Skills')).toBeInTheDocument();
@@ -59,7 +63,7 @@ test('should render target cards after loading', async () => {
 });
 
 test('should render name, description, and content fields', async () => {
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByLabelText('Skill name')).toBeInTheDocument();
@@ -69,7 +73,7 @@ test('should render name, description, and content fields', async () => {
 });
 
 test('should render the drag/drop zone', async () => {
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByLabelText('Drop or click to select a SKILL.md file')).toBeInTheDocument();
@@ -79,24 +83,24 @@ test('should render the drag/drop zone', async () => {
 });
 
 test('should have Create button disabled when fields are empty', async () => {
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
   });
 });
 
-test('should call onclose when Cancel is clicked', async () => {
-  render(SkillCreate, { onclose: closeMock });
+test('should navigate back to Skills when Cancel is clicked', async () => {
+  render(SkillCreate);
 
   const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
   await fireEvent.click(cancelButton);
 
-  expect(closeMock).toHaveBeenCalled();
+  expect(handleNavigation).toHaveBeenCalledWith({ page: NavigationPage.SKILLS });
 });
 
 test('should enable Create button when all fields are filled and target is auto-selected', async () => {
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByText('Kaiden Skills')).toBeInTheDocument();
@@ -114,8 +118,8 @@ test('should enable Create button when all fields are filled and target is auto-
   expect(createButton).toBeEnabled();
 });
 
-test('should call createSkill with correct parameters and close on success', async () => {
-  render(SkillCreate, { onclose: closeMock });
+test('should call createSkill with correct parameters and navigate back on success', async () => {
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByText('Kaiden Skills')).toBeInTheDocument();
@@ -136,11 +140,11 @@ test('should call createSkill with correct parameters and close on success', asy
     { name: 'test-skill', description: 'A test skill', content: 'Some content' },
     '/test/skills',
   );
-  expect(closeMock).toHaveBeenCalled();
+  expect(handleNavigation).toHaveBeenCalledWith({ page: NavigationPage.SKILLS });
 });
 
 test('should call createSkill with claude target when Claude card is selected', async () => {
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByText('Claude Skills')).toBeInTheDocument();
@@ -166,7 +170,7 @@ test('should call createSkill with claude target when Claude card is selected', 
 test('should display error when createSkill fails', async () => {
   vi.mocked(window.createSkill).mockRejectedValue(new Error('Skill already exists'));
 
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   await waitFor(() => {
     expect(screen.getByText('Kaiden Skills')).toBeInTheDocument();
@@ -184,11 +188,11 @@ test('should display error when createSkill fails', async () => {
   await fireEvent.click(createButton);
 
   expect(await screen.findByText(/Skill already exists/)).toBeInTheDocument();
-  expect(closeMock).not.toHaveBeenCalled();
+  expect(handleNavigation).not.toHaveBeenCalled();
 });
 
 test('should render drop zone with correct label', async () => {
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   const dropZone = await screen.findByRole('button', { name: 'Drop or click to select a SKILL.md file' });
   expect(dropZone).toBeInTheDocument();
@@ -202,7 +206,7 @@ test('should open file dialog when drop zone is clicked', async () => {
     content: '# Body',
   });
 
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   const dropZone = await screen.findByLabelText('Drop or click to select a SKILL.md file');
   await fireEvent.click(dropZone);
@@ -223,7 +227,7 @@ test('should prefill fields from parsed file when browsing', async () => {
     content: '# Body content',
   });
 
-  render(SkillCreate, { onclose: closeMock });
+  render(SkillCreate);
 
   const dropZone = await screen.findByLabelText('Drop or click to select a SKILL.md file');
   await fireEvent.click(dropZone);

--- a/packages/renderer/src/lib/skills/SkillCreate.svelte
+++ b/packages/renderer/src/lib/skills/SkillCreate.svelte
@@ -4,16 +4,12 @@ import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { load } from 'js-yaml';
 
-import Dialog from '/@/lib/dialogs/Dialog.svelte';
+import FormPage from '/@/lib/ui/FormPage.svelte';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 import type { SkillFileContent } from '/@api/skill/skill-info';
 
 import SkillFolderCards from './SkillFolderCards.svelte';
-
-interface Props {
-  onclose: () => void;
-}
-
-let { onclose }: Props = $props();
 
 let target = $state('');
 let name = $state('');
@@ -25,13 +21,6 @@ let error = $state<string | undefined>();
 let dragging = $state(false);
 let selectedFile = $state('');
 let sourceFilePath = $state('');
-let errorEl = $state<HTMLDivElement>();
-
-$effect(() => {
-  if (error && errorEl?.scrollIntoView) {
-    errorEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }
-});
 
 const isValid = $derived(
   target.length > 0 &&
@@ -56,7 +45,7 @@ async function create(): Promise<void> {
       },
       target,
     );
-    onclose();
+    handleNavigation({ page: NavigationPage.SKILLS });
   } catch (err: unknown) {
     error = String(err);
   } finally {
@@ -144,87 +133,109 @@ async function handleBrowse(): Promise<void> {
     error = `No metadata found in ${fileName}. The file must contain YAML frontmatter (---).`;
   }
 }
+
+function cancel(): void {
+  handleNavigation({ page: NavigationPage.SKILLS });
+}
 </script>
 
-<Dialog title="Create Skill" onclose={onclose}>
+<FormPage title="Create Skill">
   {#snippet content()}
-    <div class="w-full">
-      <SkillFolderCards bind:selected={target} />
+    <div class="px-5 pb-5 min-w-full">
+      <div class="bg-[var(--pd-content-card-bg)] py-6">
+        <div class="flex flex-col px-6 max-w-4xl mx-auto gap-5">
+          <div style:--card-selector-option-min-height="8rem">
+            <SkillFolderCards bind:selected={target} />
+          </div>
 
-      {#if !selectedFile}
-        <button
-          class="mt-2 w-full cursor-pointer flex flex-col items-center px-4 py-8 border-2 border-dashed rounded-md transition-colors
-            bg-[var(--pd-content-card-inset-bg)]
-            {dragging
-              ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
-              : 'border-gray-600 hover:border-[var(--pd-content-card-border-selected)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
-          aria-label="Drop or click to select a SKILL.md file"
-          onclick={handleBrowse}
-          ondragover={handleDragOver}
-          ondragleave={handleDragLeave}
-          ondrop={handleDrop}>
-          <Icon icon={faFileImport} class="text-[var(--pd-link)]" size="1.5x" />
-          <span class="text-[var(--pd-content-text)]">
-            Drag & Drop or <strong class="text-[var(--pd-link)]">Choose file</strong> to import
-          </span>
-          <span class="opacity-50 text-sm text-[var(--pd-content-text)]">Supported formats: .md</span>
-        </button>
+          {#if !selectedFile}
+            <div>
+              <button
+                class="w-full cursor-pointer flex flex-col items-center px-4 py-8 border-2 border-dashed rounded-md transition-colors
+                  bg-[var(--pd-content-card-inset-bg)]
+                  {dragging
+                    ? 'border-[var(--pd-content-card-border-selected)] bg-[var(--pd-content-card-hover-inset-bg)]'
+                    : 'border-[var(--pd-content-card-border)] hover:border-[var(--pd-content-card-border-selected)] hover:bg-[var(--pd-content-card-hover-inset-bg)]'}"
+                aria-label="Drop or click to select a SKILL.md file"
+                onclick={handleBrowse}
+                ondragover={handleDragOver}
+                ondragleave={handleDragLeave}
+                ondrop={handleDrop}>
+                <Icon icon={faFileImport} class="text-[var(--pd-link)]" size="1.5x" />
+                <span class="text-[var(--pd-content-text)]">
+                  Drag & Drop or <strong class="text-[var(--pd-link)]">Choose file</strong> to import
+                </span>
+                <span class="opacity-50 text-sm text-[var(--pd-content-text)]">Supported formats: .md</span>
+              </button>
 
-        <div class="flex items-center gap-3 my-3">
-          <div class="flex-1 h-px bg-[var(--pd-content-divider)]"></div>
-          <span class="text-sm text-[var(--pd-content-text)] opacity-60">or create manually</span>
-          <div class="flex-1 h-px bg-[var(--pd-content-divider)]"></div>
-        </div>
-      {:else}
-        <div class="mt-2">
-          <label for="skill-file-path" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">File</label>
-          <div class="flex flex-row gap-2 items-center">
-            <Input id="skill-file-path" value={selectedFile} aria-label="Selected file" readonly class="grow" />
-            <Button type="link" onclick={handleBrowse} aria-label="Change file">Change</Button>
+              <div class="flex items-center gap-3 mt-5">
+                <div class="flex-1 h-px bg-[var(--pd-content-divider)]"></div>
+                <span class="text-sm text-[var(--pd-content-text)] opacity-60">or create manually</span>
+                <div class="flex-1 h-px bg-[var(--pd-content-divider)]"></div>
+              </div>
+            </div>
+          {:else}
+            <div>
+              <label for="skill-file-path" class="block mb-2 text-sm font-semibold text-[var(--pd-modal-text)]">
+                File
+              </label>
+              <div class="flex flex-row gap-2 items-center">
+                <Input id="skill-file-path" value={selectedFile} aria-label="Selected file" readonly class="grow" />
+                <Button type="link" onclick={handleBrowse} aria-label="Change file">Change</Button>
+              </div>
+            </div>
+          {/if}
+
+          <div>
+            <label for="skill-name" class="block mb-2 text-sm font-semibold text-[var(--pd-modal-text)]">Name</label>
+            <Input
+              id="skill-name"
+              bind:value={name}
+              placeholder="my-skill-name"
+              aria-label="Skill name"
+              required
+              disabled={creating} />
+          </div>
+
+          <div>
+            <label for="skill-description" class="block mb-2 text-sm font-semibold text-[var(--pd-modal-text)]">
+              Description
+            </label>
+            <Input
+              id="skill-description"
+              bind:value={description}
+              placeholder="A short description of the skill"
+              aria-label="Skill description"
+              required
+              disabled={creating} />
+          </div>
+
+          <div>
+            <label for="skill-content" class="block mb-2 text-sm font-semibold text-[var(--pd-modal-text)]">
+              Content
+            </label>
+            <textarea
+              id="skill-content"
+              bind:value={skillContent}
+              placeholder="Skill instructions in markdown..."
+              aria-label="Skill content"
+              class="w-full min-h-32 rounded-md border border-[var(--pd-content-card-border)] bg-[var(--pd-input-field-bg)]
+                focus:bg-[var(--pd-input-field-focused-bg)] text-[var(--pd-content-text)] px-3 py-2 text-sm outline-none resize-y"
+              disabled={creating}></textarea>
+          </div>
+
+          {#if error}
+            <ErrorMessage {error} />
+          {/if}
+
+          <div class="flex items-center justify-end gap-3 pt-4 border-t border-[var(--pd-content-card-border)]">
+            <Button type="link" onclick={cancel} disabled={creating}>Cancel</Button>
+            <Button type="primary" inProgress={creating} disabled={!isValid || creating} onclick={create}>
+              Create
+            </Button>
           </div>
         </div>
-      {/if}
-
-      <label for="skill-name" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Name</label>
-      <Input
-        id="skill-name"
-        bind:value={name}
-        placeholder="my-skill-name"
-        aria-label="Skill name"
-        required
-        disabled={creating} />
-
-      <label for="skill-description" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Description</label>
-      <Input
-        id="skill-description"
-        bind:value={description}
-        placeholder="A short description of the skill"
-        aria-label="Skill description"
-        required
-        disabled={creating} />
-
-      <label for="skill-content" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Content</label>
-      <textarea
-        id="skill-content"
-        bind:value={skillContent}
-        placeholder="Skill instructions in markdown..."
-        aria-label="Skill content"
-        class="w-full min-h-[80px] rounded-md border border-[var(--pd-content-card-border)] bg-[var(--pd-input-field-bg)]
-          focus:bg-[var(--pd-input-field-focused-bg)] text-[var(--pd-content-text)] px-3 py-2 text-sm outline-none resize-y"
-        rows="4"
-        disabled={creating}></textarea>
-      {#if error}
-        <div bind:this={errorEl}>
-          <ErrorMessage {error} />
-        </div>
-      {/if}
+      </div>
     </div>
   {/snippet}
-
-  {#snippet buttons()}
-    <Button type="link" onclick={onclose} disabled={creating}>Cancel</Button>
-    <Button type="primary" inProgress={creating} disabled={!isValid || creating} onclick={create}>
-      Create
-    </Button>
-  {/snippet}
-</Dialog>
+</FormPage>

--- a/packages/renderer/src/lib/skills/SkillCreate.svelte
+++ b/packages/renderer/src/lib/skills/SkillCreate.svelte
@@ -21,6 +21,13 @@ let error = $state<string | undefined>();
 let dragging = $state(false);
 let selectedFile = $state('');
 let sourceFilePath = $state('');
+let errorEl = $state<HTMLDivElement>();
+
+$effect(() => {
+  if (error && errorEl?.scrollIntoView) {
+    errorEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+});
 
 const isValid = $derived(
   target.length > 0 &&
@@ -225,7 +232,9 @@ function cancel(): void {
           </div>
 
           {#if error}
-            <ErrorMessage {error} />
+            <div bind:this={errorEl}>
+              <ErrorMessage {error} />
+            </div>
           {/if}
 
           <div class="flex items-center justify-end gap-3 pt-4 border-t border-[var(--pd-content-card-border)]">

--- a/packages/renderer/src/lib/skills/SkillsList.spec.ts
+++ b/packages/renderer/src/lib/skills/SkillsList.spec.ts
@@ -22,12 +22,15 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { handleNavigation } from '/@/navigation';
 import * as skillsStore from '/@/stores/skills';
+import { NavigationPage } from '/@api/navigation-page';
 import type { SkillInfo } from '/@api/skill/skill-info';
 
 import SkillsList from './SkillsList.svelte';
 
 vi.mock(import('/@/stores/skills'));
+vi.mock(import('/@/navigation'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -64,11 +67,11 @@ test('should show table when skills exist', () => {
   expect(screen.getByText('skill-b')).toBeInTheDocument();
 });
 
-test('should open the create dialog when "New skill" is clicked', async () => {
+test('should navigate to the create page when "New skill" is clicked', async () => {
   render(SkillsList);
 
   const buttons = screen.getAllByText('New skill');
   await fireEvent.click(buttons[0]);
 
-  expect(screen.getByText('Create Skill')).toBeInTheDocument();
+  expect(handleNavigation).toHaveBeenCalledWith({ page: NavigationPage.SKILL_CREATE });
 });

--- a/packages/renderer/src/lib/skills/SkillsList.spec.ts
+++ b/packages/renderer/src/lib/skills/SkillsList.spec.ts
@@ -34,6 +34,7 @@ vi.mock(import('/@/navigation'));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.mocked(skillsStore).filteredSkillInfos = writable<SkillInfo[]>([]);
   vi.mocked(skillsStore).skillSearchPattern = writable('');
   vi.mocked(window.listSkillFolders).mockResolvedValue([

--- a/packages/renderer/src/lib/skills/SkillsList.svelte
+++ b/packages/renderer/src/lib/skills/SkillsList.svelte
@@ -5,18 +5,18 @@ import { Button, FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } fr
 import SkillEnabledColumn from '/@/lib/skills/columns/SkillEnabledColumn.svelte';
 import SkillNameColumn from '/@/lib/skills/columns/SkillNameColumn.svelte';
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { handleNavigation } from '/@/navigation';
 import { filteredSkillInfos, skillSearchPattern } from '/@/stores/skills';
+import { NavigationPage } from '/@api/navigation-page';
 import type { SkillInfo } from '/@api/skill/skill-info';
 
 import { SkillDescriptionColumn } from './columns/skill-columns';
 import SkillActions from './SkillActions.svelte';
-import SkillCreate from './SkillCreate.svelte';
 import SkillEmptyScreen from './SkillEmptyScreen.svelte';
 
 type SkillSelectable = SkillInfo & { selected: boolean };
 
 let searchTerm = $state('');
-let showCreateDialog = $state(false);
 
 $effect(() => {
   skillSearchPattern.set(searchTerm);
@@ -47,18 +47,14 @@ const columns = [nameColumn, new SkillDescriptionColumn(), enabledColumn, action
 
 const skills: SkillSelectable[] = $derived($filteredSkillInfos.map(skill => ({ ...skill, selected: false })));
 
-function openCreateDialog(): void {
-  showCreateDialog = true;
-}
-
-function closeCreateDialog(): void {
-  showCreateDialog = false;
+function openCreatePage(): void {
+  handleNavigation({ page: NavigationPage.SKILL_CREATE });
 }
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="Skills">
   {#snippet additionalActions()}
-    <Button icon={faPlus} onclick={openCreateDialog}>
+    <Button icon={faPlus} onclick={openCreatePage}>
       New skill
     </Button>
   {/snippet}
@@ -69,7 +65,7 @@ function closeCreateDialog(): void {
         {#if searchTerm}
           <FilteredEmptyScreen icon={NoLogIcon} kind="skills" bind:searchTerm={searchTerm} />
         {:else}
-          <SkillEmptyScreen onclick={openCreateDialog} />
+          <SkillEmptyScreen onclick={openCreatePage} />
         {/if}
       {:else}
         <Table
@@ -83,7 +79,3 @@ function closeCreateDialog(): void {
     </div>
   {/snippet}
 </NavPage>
-
-{#if showCreateDialog}
-  <SkillCreate onclose={closeCreateDialog} />
-{/if}

--- a/packages/renderer/src/lib/ui/CardSelector.svelte
+++ b/packages/renderer/src/lib/ui/CardSelector.svelte
@@ -31,7 +31,7 @@ function handleClick(value: string): void {
   <div class="grid gap-2 w-full grid-cols-[repeat(auto-fill,minmax(12rem,1fr))]">
     {#each options as option (option.value)}
       <button
-        class="rounded-md bg-[var(--pd-content-card-inset-bg)] p-3 min-w-0 min-h-24 cursor-pointer
+        class="rounded-md bg-[var(--pd-content-card-inset-bg)] p-3 min-w-0 min-h-[var(--card-selector-option-min-height,6rem)] cursor-pointer
           hover:bg-[var(--pd-content-card-hover-inset-bg)]
           {selected === option.value ? 'border-[var(--pd-content-card-border-selected)]' : 'border-[var(--pd-content-card-border)]'}
           border-2 flex flex-col overflow-hidden"

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -326,3 +326,9 @@ test(`Test navigationHandle for ${NavigationPage.SEMANTIC_ROUTERS}`, () => {
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/models/semantic-routers');
 });
+
+test(`Test navigationHandle for ${NavigationPage.SKILL_CREATE}`, () => {
+  handleNavigation({ page: NavigationPage.SKILL_CREATE });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/skills/create');
+});

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -197,6 +197,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.SKILLS:
       router.goto('/skills');
       break;
+    case NavigationPage.SKILL_CREATE:
+      router.goto('/skills/create');
+      break;
     case NavigationPage.SECRET_VAULT:
       router.goto('/secret-vault');
       break;

--- a/tests/playwright/src/model/pages/skills-create-page.ts
+++ b/tests/playwright/src/model/pages/skills-create-page.ts
@@ -24,8 +24,7 @@ import { withMockedFileDialog } from '/@/utils/app-ready';
 import { BasePage } from './base-page';
 
 export class SkillsCreatePage extends BasePage {
-  readonly dialog: Locator;
-  readonly dialogHeading: Locator;
+  readonly heading: Locator;
   readonly nameInput: Locator;
   readonly descriptionInput: Locator;
   readonly contentTextarea: Locator;
@@ -35,25 +34,23 @@ export class SkillsCreatePage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    this.dialog = this.page.getByRole('dialog', { name: 'Create Skill' });
-    this.dialogHeading = this.dialog.getByRole('heading', { name: 'Create Skill' });
-    this.nameInput = this.dialog.getByLabel('Skill name');
-    this.descriptionInput = this.dialog.getByLabel('Skill description');
-    this.contentTextarea = this.dialog.getByLabel('Skill content');
-    this.cancelButton = this.dialog.getByRole('button', { name: 'Cancel' });
-    this.createButton = this.dialog.getByRole('button', { name: 'Create' });
-    this.fileDropZone = this.dialog.getByLabel('Drop or click to select a SKILL.md file');
+    this.heading = this.page.getByRole('heading', { name: 'Create Skill' });
+    this.nameInput = this.page.getByLabel('Skill name');
+    this.descriptionInput = this.page.getByLabel('Skill description');
+    this.contentTextarea = this.page.getByLabel('Skill content');
+    this.cancelButton = this.page.getByRole('button', { name: 'Cancel' });
+    this.createButton = this.page.getByRole('button', { name: 'Create' });
+    this.fileDropZone = this.page.getByLabel('Drop or click to select a SKILL.md file');
   }
 
   async waitForLoad(): Promise<void> {
-    await expect(this.dialog).toBeVisible({ timeout: TIMEOUTS.SHORT });
-    await expect(this.dialogHeading).toBeVisible();
+    await expect(this.heading).toBeVisible({ timeout: TIMEOUTS.SHORT });
   }
 
   async cancel(): Promise<void> {
     await expect(this.cancelButton).toBeEnabled();
     await this.cancelButton.click();
-    await expect(this.dialog).toBeHidden();
+    await expect(this.heading).toBeHidden({ timeout: TIMEOUTS.SHORT });
   }
 
   async selectFile(absoluteFilePath: string, electronApp: ElectronApplication): Promise<void> {
@@ -73,6 +70,6 @@ export class SkillsCreatePage extends BasePage {
   async create(): Promise<void> {
     await expect(this.createButton).toBeEnabled({ timeout: TIMEOUTS.SHORT });
     await this.createButton.click();
-    await expect(this.dialog).toBeHidden({ timeout: TIMEOUTS.SHORT });
+    await expect(this.heading).toBeHidden({ timeout: TIMEOUTS.SHORT });
   }
 }

--- a/tests/playwright/src/model/pages/skills-page.ts
+++ b/tests/playwright/src/model/pages/skills-page.ts
@@ -58,7 +58,7 @@ export class SkillsPage extends BaseTablePage {
     return (await this.noSkillsMessage.count()) > 0;
   }
 
-  async openCreateDialog(): Promise<SkillsCreatePage> {
+  async openCreatePage(): Promise<SkillsCreatePage> {
     await this.waitForLoad();
     await expect(this.newSkillButton).toBeEnabled();
     await this.newSkillButton.click();
@@ -67,7 +67,7 @@ export class SkillsPage extends BaseTablePage {
     return createPage;
   }
 
-  async openCreateDialogFromContentRegion(): Promise<SkillsCreatePage> {
+  async openCreatePageFromContentRegion(): Promise<SkillsCreatePage> {
     await this.waitForLoad();
     await expect(this.newSkillButtonFromContentRegion).toBeEnabled();
     await this.newSkillButtonFromContentRegion.click();
@@ -77,13 +77,13 @@ export class SkillsPage extends BaseTablePage {
   }
 
   async createSkill(name: string, description: string, content: string): Promise<void> {
-    const createPage = await this.openCreateDialog();
+    const createPage = await this.openCreatePage();
     await createPage.fillForm(name, description, content);
     await createPage.create();
   }
 
   async importSkill(absoluteFilePath: string, electronApp: ElectronApplication): Promise<void> {
-    const createPage = await this.openCreateDialog();
+    const createPage = await this.openCreatePage();
     await createPage.selectFile(absoluteFilePath, electronApp);
     await createPage.create();
   }

--- a/tests/playwright/src/specs/skills-smoke.spec.ts
+++ b/tests/playwright/src/specs/skills-smoke.spec.ts
@@ -51,12 +51,12 @@ test.describe('Skills page - initial state', { tag: '@smoke' }, () => {
     await expect(skillsPage.table).not.toBeVisible();
   });
 
-  test('[SKL-INIT-02] Create Skill dialog can be opened from either entry point and cancelled', async ({
+  test('[SKL-INIT-02] Create Skill page can be opened from either entry point and cancelled', async ({
     skillsPage,
   }) => {
     const entryPoints: Array<{ label: string; open: () => Promise<SkillsCreatePage> }> = [
-      { label: 'header New Skill button', open: () => skillsPage.openCreateDialog() },
-      { label: 'empty state New Skill button', open: () => skillsPage.openCreateDialogFromContentRegion() },
+      { label: 'header New Skill button', open: () => skillsPage.openCreatePage() },
+      { label: 'empty state New Skill button', open: () => skillsPage.openCreatePageFromContentRegion() },
     ];
 
     for (const { label, open } of entryPoints) {
@@ -64,7 +64,7 @@ test.describe('Skills page - initial state', { tag: '@smoke' }, () => {
         await skillsPage.waitForLoad();
         const createPage = await open();
 
-        await expect(createPage.dialogHeading).toBeVisible();
+        await expect(createPage.heading).toBeVisible();
         await expect(createPage.nameInput).toBeVisible();
         await expect(createPage.descriptionInput).toBeVisible();
         await expect(createPage.contentTextarea).toBeVisible();


### PR DESCRIPTION
## Summary

- replace the Create Skill modal with a routed full-page form matching the Add Secret UI pattern
- preserve target selection, drag-and-drop import, file browsing, manual entry, validation, and error handling
- give target cards more room while keeping the skill content editor compact and vertically resizable
- add typed navigation for the new create route and update focused tests

<img width="1911" height="1328" alt="Screenshot From 2026-07-23 20-51-57" src="https://github.com/user-attachments/assets/5490d0a0-a133-4ab5-bb2d-8a2e1771166f" />

Fixes #1287