### PR TITLE
fix(openshell): write gateway logs to file

### DIFF
--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -18,6 +18,7 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import type { WriteStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -35,16 +36,29 @@ import type { GatewayInfo } from '/@api/openshell-gateway-info.js';
 import { OpenshellGateway } from './openshell-gateway.js';
 
 vi.mock(import('node:child_process'));
+vi.mock(import('node:fs'));
 vi.mock(import('node:fs/promises'));
 vi.mock(import('/@/plugin/util/exec.js'));
 
 const { spawn } = await import('node:child_process');
+const { createWriteStream } = await import('node:fs');
 
 const GATEWAY_BINARY = '/usr/local/bin/openshell-gateway';
 const KAIDEN_DATA_DIRECTORY = '/home/user/.local/share/kaiden';
 const GATEWAY_STORAGE_DIRECTORY = join(KAIDEN_DATA_DIRECTORY, 'openshell-gateway');
 const GATEWAY_CONFIG_PATH = join(GATEWAY_STORAGE_DIRECTORY, 'gateway.toml');
 const GATEWAY_DB_URL = `sqlite:${join(GATEWAY_STORAGE_DIRECTORY, 'gateway.db')}?mode=rwc`;
+const GATEWAY_LOG_PATH = join(GATEWAY_STORAGE_DIRECTORY, 'gateway.log');
+
+type MockWriteStream = WriteStream & {
+  write: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+};
+
+const gatewayLogStream = Object.assign(new EventEmitter(), {
+  write: vi.fn(),
+  end: vi.fn(),
+}) as unknown as MockWriteStream;
 
 function createMockChildProcess(): ChildProcess & { _stdout: EventEmitter; _stderr: EventEmitter } {
   const proc = new EventEmitter() as ChildProcess & { _stdout: EventEmitter; _stderr: EventEmitter };
@@ -91,13 +105,14 @@ beforeEach(() => {
   vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
     { name: 'openshell-gateway', path: GATEWAY_BINARY },
   ] as unknown as CliToolInfo[]);
+  vi.mocked(createWriteStream).mockReturnValue(gatewayLogStream);
   vi.mocked(exec.exec).mockResolvedValue({ command: '', stdout: '', stderr: '' });
   gateway = new OpenshellGateway(cliToolRegistry, openshellCli, directories, exec, notificationRegistry);
 });
 
 describe('init', () => {
-  test('skips auto-start when existing gateway is healthy and already active', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  test('creates the gateway log and reuses a healthy active gateway', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const existingGateways: GatewayInfo[] = [
       { name: 'local-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
     ];
@@ -106,6 +121,15 @@ describe('init', () => {
 
     await gateway.init();
 
+    const message = '[openshell-gateway] gateway detected (https://127.0.0.1:8443) and is healthy';
+    expect(mkdir).toHaveBeenCalledWith(GATEWAY_STORAGE_DIRECTORY, { recursive: true });
+    expect(createWriteStream).toHaveBeenCalledWith(GATEWAY_LOG_PATH, { flags: 'w' });
+    expect(gatewayLogStream.write).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/^===== Kaiden gateway session started \d{4}-\d{2}-\d{2}T.*Z =====\n$/),
+    );
+    expect(consoleLog).toHaveBeenCalledWith(message);
+    expect(gatewayLogStream.write).toHaveBeenCalledWith(`${message}\n`);
     expect(openshellCli.listGateways).toHaveBeenCalled();
     expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
     expect(spawn).not.toHaveBeenCalled();
@@ -264,15 +288,15 @@ describe('getGatewayBinaryPath', () => {
 });
 
 describe('start', () => {
-  test('spawns the gateway process with default args including config', async () => {
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  test('spawns the gateway process and writes its output only to the log', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
     vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
 
     await gateway.start();
-
     expect(spawn).toHaveBeenCalledWith(
       GATEWAY_BINARY,
       [
@@ -288,6 +312,19 @@ describe('start', () => {
       ],
       expect.objectContaining({ detached: false }),
     );
+
+    consoleLog.mockClear();
+    consoleError.mockClear();
+    gatewayLogStream.write.mockClear();
+    const stdout = Buffer.from('routine gateway output\n');
+    const stderr = Buffer.from('routine gateway diagnostic\n');
+    proc._stdout.emit('data', stdout);
+    proc._stderr.emit('data', stderr);
+
+    expect(gatewayLogStream.write).toHaveBeenNthCalledWith(1, stdout);
+    expect(gatewayLogStream.write).toHaveBeenNthCalledWith(2, stderr);
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
   });
 
   test('spawns with custom port and address', async () => {
@@ -511,6 +548,26 @@ describe('stop', () => {
     expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
+  test('does not clear a newer process when the stopped process exits late', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const stoppedProcess = createMockChildProcess();
+    const currentProcess = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValueOnce(stoppedProcess).mockReturnValueOnce(currentProcess);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
+    vi.mocked(openshellCli.checkEndpointStatus).mockResolvedValue(true);
+    await gateway.start();
+    const stopPromise = gateway.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    await stopPromise;
+    await gateway.start();
+
+    stoppedProcess.emit('exit', 0, undefined);
+    expect(gateway.isRunning()).toBe(true);
+    vi.useRealTimers();
+  });
+
   test('is a no-op when not running', async () => {
     await gateway.stop();
   });
@@ -535,7 +592,7 @@ describe('isRunning', () => {
 });
 
 describe('dispose', () => {
-  test('stops the gateway process', async () => {
+  test('stops the gateway process and closes its log', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const proc = createMockChildProcess();
     vi.mocked(spawn).mockReturnValue(proc);
@@ -547,6 +604,8 @@ describe('dispose', () => {
     gateway.dispose();
 
     expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    proc.emit('exit', 0, undefined);
+    await vi.waitFor(() => expect(gatewayLogStream.end).toHaveBeenCalledOnce());
   });
 });
 

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ChildProcess } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import type { WriteStream } from 'node:fs';
+import { createWriteStream, type WriteStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -39,9 +39,6 @@ vi.mock(import('node:child_process'));
 vi.mock(import('node:fs'));
 vi.mock(import('node:fs/promises'));
 vi.mock(import('/@/plugin/util/exec.js'));
-
-const { spawn } = await import('node:child_process');
-const { createWriteStream } = await import('node:fs');
 
 const GATEWAY_BINARY = '/usr/local/bin/openshell-gateway';
 const KAIDEN_DATA_DIRECTORY = '/home/user/.local/share/kaiden';
@@ -101,6 +98,7 @@ const notificationRegistry = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  gatewayLogStream.removeAllListeners();
   vi.mocked(directories.getDataDirectory).mockReturnValue(KAIDEN_DATA_DIRECTORY);
   vi.mocked(cliToolRegistry.getCliToolInfos).mockReturnValue([
     { name: 'openshell-gateway', path: GATEWAY_BINARY },
@@ -111,8 +109,8 @@ beforeEach(() => {
 });
 
 describe('init', () => {
-  test('creates the gateway log and reuses a healthy active gateway', async () => {
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  test('skips auto-start when existing gateway is healthy and already active', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const existingGateways: GatewayInfo[] = [
       { name: 'local-gw', endpoint: 'https://127.0.0.1:8443', active: true, type: 'local' },
     ];
@@ -121,18 +119,10 @@ describe('init', () => {
 
     await gateway.init();
 
-    const message = '[openshell-gateway] gateway detected (https://127.0.0.1:8443) and is healthy';
-    expect(mkdir).toHaveBeenCalledWith(GATEWAY_STORAGE_DIRECTORY, { recursive: true });
-    expect(createWriteStream).toHaveBeenCalledWith(GATEWAY_LOG_PATH, { flags: 'w' });
-    expect(gatewayLogStream.write).toHaveBeenNthCalledWith(
-      1,
-      expect.stringMatching(/^===== Kaiden gateway session started \d{4}-\d{2}-\d{2}T.*Z =====\n$/),
-    );
-    expect(consoleLog).toHaveBeenCalledWith(message);
-    expect(gatewayLogStream.write).toHaveBeenCalledWith(`${message}\n`);
     expect(openshellCli.listGateways).toHaveBeenCalled();
     expect(openshellCli.checkEndpointStatus).toHaveBeenCalledWith('https://127.0.0.1:8443');
     expect(spawn).not.toHaveBeenCalled();
+    expect(createWriteStream).not.toHaveBeenCalled();
     expect(openshellCli.selectGateway).not.toHaveBeenCalled();
   });
 
@@ -312,10 +302,11 @@ describe('start', () => {
       ],
       expect.objectContaining({ detached: false }),
     );
+    expect(createWriteStream).toHaveBeenCalledWith(GATEWAY_LOG_PATH, { flags: 'w' });
+    expect(gatewayLogStream.write).not.toHaveBeenCalled();
 
     consoleLog.mockClear();
     consoleError.mockClear();
-    gatewayLogStream.write.mockClear();
     const stdout = Buffer.from('routine gateway output\n');
     const stderr = Buffer.from('routine gateway diagnostic\n');
     proc._stdout.emit('data', stdout);

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -22,7 +22,6 @@ import type { WriteStream } from 'node:fs';
 import { createWriteStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { format } from 'node:util';
 
 import type { Disposable } from '@openkaiden/api';
 import { inject, injectable, preDestroy } from 'inversify';
@@ -46,8 +45,6 @@ const MAX_HEALTH_CHECK_ATTEMPTS = 30;
 const STOP_TIMEOUT_MS = 5000;
 const SUPERVISOR_IMAGE_BASE = 'ghcr.io/nvidia/openshell/supervisor';
 const GATEWAY_LOG_FILENAME = 'gateway.log';
-
-type GatewayLogLevel = 'log' | 'warn' | 'error';
 
 /**
  * Manages the `openshell-gateway` server binary lifecycle.
@@ -84,7 +81,6 @@ export class OpenshellGateway implements Disposable {
   ) {}
 
   async init(): Promise<void> {
-    await this.initializeGatewayLog();
     try {
       const gateways = await this.openshellCli.listGateways();
       const localGateways = gateways.filter(gw => gw.type === 'local' || this.isLocalEndpoint(gw.endpoint));
@@ -94,41 +90,38 @@ export class OpenshellGateway implements Disposable {
             if (!gw.active) {
               await this.openshellCli.selectGateway(gw.name);
             }
-            this.logGatewayMessage('log', `[openshell-gateway] gateway detected (${gw.endpoint}) and is healthy`);
+            console.log(`[openshell-gateway] gateway detected (${gw.endpoint}) and is healthy`);
             this._onDidGatewayStart.fire();
             return;
           }
         }
-        this.logGatewayMessage('warn', '[openshell-gateway] local gateway(s) defined but none reachable');
+        console.warn('[openshell-gateway] local gateway(s) defined but none reachable');
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      this.logGatewayMessage('warn', `[openshell-gateway] failed to discover gateways: ${message}`);
+      console.warn(`[openshell-gateway] failed to discover gateways: ${message}`);
     }
 
     const binaryPath = this.getGatewayBinaryPath();
     if (!binaryPath) {
-      this.logGatewayMessage(
-        'warn',
-        '[openshell-gateway] no existing gateways and binary not registered, skipping auto-start',
-      );
+      console.warn('[openshell-gateway] no existing gateways and binary not registered, skipping auto-start');
       return;
     }
 
     if (await this.isEndpointHealthy()) {
-      this.logGatewayMessage('log', '[openshell-gateway] found healthy gateway on default port, registering');
+      console.log('[openshell-gateway] found healthy gateway on default port, registering');
       await this.registerWithCli();
       this._onDidGatewayStart.fire();
       return;
     }
 
-    this.logGatewayMessage('log', '[openshell-gateway] no existing gateways found, auto-starting local gateway');
+    console.log('[openshell-gateway] no existing gateways found, auto-starting local gateway');
     try {
       await this.start();
       this._onDidGatewayStart.fire();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      this.logGatewayMessage('error', `[openshell-gateway] auto-start failed: ${message}`);
+      console.error(`[openshell-gateway] auto-start failed: ${message}`);
       this._onDidGatewayInitFailed.fire(message);
       this.notificationRegistry.addNotification({
         title: 'OpenShell Gateway failed to start',
@@ -161,10 +154,8 @@ export class OpenshellGateway implements Disposable {
   }
 
   async start(options?: OpenshellGatewayStartOptions): Promise<void> {
-    await this.initializeGatewayLog();
-
     if (this.#gatewayProcess) {
-      this.logGatewayMessage('log', '[openshell-gateway] already running, skipping start');
+      console.log('[openshell-gateway] already running, skipping start');
       return;
     }
 
@@ -185,7 +176,8 @@ export class OpenshellGateway implements Disposable {
 
     const configPath = await this.createGatewayConfig(binaryPath, options?.supervisorImage);
     const args = this.buildArgs(options?.disableTls ?? true, configPath);
-    this.logGatewayMessage('log', `[openshell-gateway] starting: ${binaryPath} ${args.join(' ')}`);
+    console.log(`[openshell-gateway] starting: ${binaryPath} ${args.join(' ')}`);
+    await this.initializeGatewayLog();
 
     const gatewayProcess = spawn(binaryPath, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -194,28 +186,25 @@ export class OpenshellGateway implements Disposable {
     this.#gatewayProcess = gatewayProcess;
 
     gatewayProcess.stdout?.on('data', (data: Buffer) => {
-      this.logGatewayProcessOutput(data);
+      this.#gatewayLogStream?.write(data);
     });
 
     const stderrChunks: string[] = [];
     gatewayProcess.stderr?.on('data', (data: Buffer) => {
       const text = data.toString().trimEnd();
-      this.logGatewayProcessOutput(data);
+      this.#gatewayLogStream?.write(data);
       stderrChunks.push(text);
     });
 
     gatewayProcess.on('exit', (code, signal) => {
-      this.logGatewayMessage(
-        'log',
-        `[openshell-gateway] exited with code=${code ?? 'none'} signal=${signal ?? 'none'}`,
-      );
+      console.log(`[openshell-gateway] exited with code=${code ?? 'none'} signal=${signal ?? 'none'}`);
       if (this.#gatewayProcess === gatewayProcess) {
         this.#gatewayProcess = undefined;
       }
     });
 
     gatewayProcess.on('error', (err: Error) => {
-      this.logGatewayMessage('error', `[openshell-gateway] failed to start: ${err.message}`);
+      console.error(`[openshell-gateway] failed to start: ${err.message}`);
       if (this.#gatewayProcess === gatewayProcess) {
         this.#gatewayProcess = undefined;
       }
@@ -225,7 +214,7 @@ export class OpenshellGateway implements Disposable {
       await this.waitForReady();
     } catch (err: unknown) {
       await this.stop().catch((stopErr: unknown) => {
-        this.logGatewayMessage('warn', '[openshell-gateway] failed to stop after startup error:', stopErr);
+        console.warn('[openshell-gateway] failed to stop after startup error:', stopErr);
       });
       this.#port = previousPort;
       this.#bindAddress = previousBindAddress;
@@ -244,13 +233,13 @@ export class OpenshellGateway implements Disposable {
       return;
     }
 
-    this.logGatewayMessage('log', '[openshell-gateway] stopping');
+    console.log('[openshell-gateway] stopping');
     proc.kill('SIGTERM');
 
     await new Promise<void>(resolve => {
       const timeout = setTimeout(() => {
         if (typeof proc.exitCode !== 'number') {
-          this.logGatewayMessage('warn', '[openshell-gateway] did not exit after SIGTERM, sending SIGKILL');
+          console.warn('[openshell-gateway] did not exit after SIGTERM, sending SIGKILL');
           proc.kill('SIGKILL');
         }
         resolve();
@@ -272,7 +261,7 @@ export class OpenshellGateway implements Disposable {
   @preDestroy()
   dispose(): void {
     this.stop()
-      .catch((err: unknown) => this.logGatewayMessage('error', '[openshell-gateway] failed to stop: ', err))
+      .catch((err: unknown) => console.error('[openshell-gateway] failed to stop: ', err))
       .finally(() => this.closeGatewayLog());
     this._onDidGatewayStart.dispose();
     this._onDidGatewayInitFailed.dispose();
@@ -327,10 +316,7 @@ export class OpenshellGateway implements Disposable {
           image = `${SUPERVISOR_IMAGE_BASE}:${version}`;
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
-          this.logGatewayMessage(
-            'warn',
-            `[openshell-gateway] unable to detect version for supervisor pinning: ${message}`,
-          );
+          console.warn(`[openshell-gateway] unable to detect version for supervisor pinning: ${message}`);
         }
       }
 
@@ -346,20 +332,20 @@ export class OpenshellGateway implements Disposable {
       await mkdir(storageDirectory, { recursive: true });
       await writeFile(configPath, config, 'utf-8');
       if (image) {
-        this.logGatewayMessage('log', `[openshell-gateway] supervisor image pinned to ${image}`);
+        console.log(`[openshell-gateway] supervisor image pinned to ${image}`);
       }
-      this.logGatewayMessage('log', `[openshell-gateway] generated local gateway config at ${configPath}`);
+      console.log(`[openshell-gateway] generated local gateway config at ${configPath}`);
       return configPath;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      this.logGatewayMessage('warn', `[openshell-gateway] failed to generate gateway config: ${message}`);
+      console.warn(`[openshell-gateway] failed to generate gateway config: ${message}`);
       return undefined;
     }
   }
 
   private async waitForReady(): Promise<void> {
     const endpoint = `http://${this.#bindAddress}:${this.#port}`;
-    this.logGatewayMessage('log', `[openshell-gateway] waiting for server at ${endpoint}`);
+    console.log(`[openshell-gateway] waiting for server at ${endpoint}`);
 
     for (let attempt = 0; attempt < MAX_HEALTH_CHECK_ATTEMPTS; attempt++) {
       if (!this.isRunning()) {
@@ -367,7 +353,7 @@ export class OpenshellGateway implements Disposable {
       }
 
       if (await this.openshellCli.checkEndpointStatus(endpoint)) {
-        this.logGatewayMessage('log', '[openshell-gateway] server is ready');
+        console.log('[openshell-gateway] server is ready');
         return;
       }
 
@@ -381,10 +367,10 @@ export class OpenshellGateway implements Disposable {
     const endpoint = `http://${this.#bindAddress}:${this.#port}`;
     try {
       await this.openshellCli.addGateway({ endpoint, local: true, name: 'kaiden-local' });
-      this.logGatewayMessage('log', `[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
+      console.log(`[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      this.logGatewayMessage('warn', `[openshell-gateway] failed to register with CLI: ${message}`);
+      console.warn(`[openshell-gateway] failed to register with CLI: ${message}`);
     }
   }
 
@@ -405,20 +391,10 @@ export class OpenshellGateway implements Disposable {
         }
         console.error(`[openshell-gateway] unable to write log file ${logPath}: ${err.message}`);
       });
-      stream.write(`===== Kaiden gateway session started ${new Date().toISOString()} =====\n`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`[openshell-gateway] unable to open log file ${logPath}: ${message}`);
     }
-  }
-
-  private logGatewayMessage(level: GatewayLogLevel, ...args: unknown[]): void {
-    console[level](...args);
-    this.#gatewayLogStream?.write(`${format(...args)}\n`);
-  }
-
-  private logGatewayProcessOutput(data: Buffer): void {
-    this.#gatewayLogStream?.write(data);
   }
 
   private closeGatewayLog(): void {

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.ts
@@ -18,8 +18,11 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import type { WriteStream } from 'node:fs';
+import { createWriteStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { format } from 'node:util';
 
 import type { Disposable } from '@openkaiden/api';
 import { inject, injectable, preDestroy } from 'inversify';
@@ -42,6 +45,9 @@ const HEALTH_CHECK_INTERVAL_MS = 1000;
 const MAX_HEALTH_CHECK_ATTEMPTS = 30;
 const STOP_TIMEOUT_MS = 5000;
 const SUPERVISOR_IMAGE_BASE = 'ghcr.io/nvidia/openshell/supervisor';
+const GATEWAY_LOG_FILENAME = 'gateway.log';
+
+type GatewayLogLevel = 'log' | 'warn' | 'error';
 
 /**
  * Manages the `openshell-gateway` server binary lifecycle.
@@ -54,6 +60,7 @@ const SUPERVISOR_IMAGE_BASE = 'ghcr.io/nvidia/openshell/supervisor';
 @injectable()
 export class OpenshellGateway implements Disposable {
   #gatewayProcess: ChildProcess | undefined;
+  #gatewayLogStream: WriteStream | undefined;
   #port: number = DEFAULT_PORT;
   #bindAddress: string = DEFAULT_BIND_ADDRESS;
 
@@ -77,6 +84,7 @@ export class OpenshellGateway implements Disposable {
   ) {}
 
   async init(): Promise<void> {
+    await this.initializeGatewayLog();
     try {
       const gateways = await this.openshellCli.listGateways();
       const localGateways = gateways.filter(gw => gw.type === 'local' || this.isLocalEndpoint(gw.endpoint));
@@ -86,38 +94,41 @@ export class OpenshellGateway implements Disposable {
             if (!gw.active) {
               await this.openshellCli.selectGateway(gw.name);
             }
-            console.log(`[openshell-gateway] gateway detected (${gw.endpoint}) and is healthy`);
+            this.logGatewayMessage('log', `[openshell-gateway] gateway detected (${gw.endpoint}) and is healthy`);
             this._onDidGatewayStart.fire();
             return;
           }
         }
-        console.warn('[openshell-gateway] local gateway(s) defined but none reachable');
+        this.logGatewayMessage('warn', '[openshell-gateway] local gateway(s) defined but none reachable');
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[openshell-gateway] failed to discover gateways: ${message}`);
+      this.logGatewayMessage('warn', `[openshell-gateway] failed to discover gateways: ${message}`);
     }
 
     const binaryPath = this.getGatewayBinaryPath();
     if (!binaryPath) {
-      console.warn('[openshell-gateway] no existing gateways and binary not registered, skipping auto-start');
+      this.logGatewayMessage(
+        'warn',
+        '[openshell-gateway] no existing gateways and binary not registered, skipping auto-start',
+      );
       return;
     }
 
     if (await this.isEndpointHealthy()) {
-      console.log('[openshell-gateway] found healthy gateway on default port, registering');
+      this.logGatewayMessage('log', '[openshell-gateway] found healthy gateway on default port, registering');
       await this.registerWithCli();
       this._onDidGatewayStart.fire();
       return;
     }
 
-    console.log('[openshell-gateway] no existing gateways found, auto-starting local gateway');
+    this.logGatewayMessage('log', '[openshell-gateway] no existing gateways found, auto-starting local gateway');
     try {
       await this.start();
       this._onDidGatewayStart.fire();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error(`[openshell-gateway] auto-start failed: ${message}`);
+      this.logGatewayMessage('error', `[openshell-gateway] auto-start failed: ${message}`);
       this._onDidGatewayInitFailed.fire(message);
       this.notificationRegistry.addNotification({
         title: 'OpenShell Gateway failed to start',
@@ -150,8 +161,10 @@ export class OpenshellGateway implements Disposable {
   }
 
   async start(options?: OpenshellGatewayStartOptions): Promise<void> {
+    await this.initializeGatewayLog();
+
     if (this.#gatewayProcess) {
-      console.log('[openshell-gateway] already running, skipping start');
+      this.logGatewayMessage('log', '[openshell-gateway] already running, skipping start');
       return;
     }
 
@@ -172,39 +185,47 @@ export class OpenshellGateway implements Disposable {
 
     const configPath = await this.createGatewayConfig(binaryPath, options?.supervisorImage);
     const args = this.buildArgs(options?.disableTls ?? true, configPath);
-    console.log(`[openshell-gateway] starting: ${binaryPath} ${args.join(' ')}`);
+    this.logGatewayMessage('log', `[openshell-gateway] starting: ${binaryPath} ${args.join(' ')}`);
 
-    this.#gatewayProcess = spawn(binaryPath, args, {
+    const gatewayProcess = spawn(binaryPath, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,
     });
+    this.#gatewayProcess = gatewayProcess;
 
-    this.#gatewayProcess.stdout?.on('data', (data: Buffer) => {
-      console.log(`[openshell-gateway] ${data.toString().trimEnd()}`);
+    gatewayProcess.stdout?.on('data', (data: Buffer) => {
+      this.logGatewayProcessOutput(data);
     });
 
     const stderrChunks: string[] = [];
-    this.#gatewayProcess.stderr?.on('data', (data: Buffer) => {
+    gatewayProcess.stderr?.on('data', (data: Buffer) => {
       const text = data.toString().trimEnd();
-      console.error(`[openshell-gateway] ${text}`);
+      this.logGatewayProcessOutput(data);
       stderrChunks.push(text);
     });
 
-    this.#gatewayProcess.on('exit', (code, signal) => {
-      console.log(`[openshell-gateway] exited with code=${code ?? 'none'} signal=${signal ?? 'none'}`);
-      this.#gatewayProcess = undefined;
+    gatewayProcess.on('exit', (code, signal) => {
+      this.logGatewayMessage(
+        'log',
+        `[openshell-gateway] exited with code=${code ?? 'none'} signal=${signal ?? 'none'}`,
+      );
+      if (this.#gatewayProcess === gatewayProcess) {
+        this.#gatewayProcess = undefined;
+      }
     });
 
-    this.#gatewayProcess.on('error', (err: Error) => {
-      console.error(`[openshell-gateway] failed to start: ${err.message}`);
-      this.#gatewayProcess = undefined;
+    gatewayProcess.on('error', (err: Error) => {
+      this.logGatewayMessage('error', `[openshell-gateway] failed to start: ${err.message}`);
+      if (this.#gatewayProcess === gatewayProcess) {
+        this.#gatewayProcess = undefined;
+      }
     });
 
     try {
       await this.waitForReady();
     } catch (err: unknown) {
       await this.stop().catch((stopErr: unknown) => {
-        console.warn('[openshell-gateway] failed to stop after startup error:', stopErr);
+        this.logGatewayMessage('warn', '[openshell-gateway] failed to stop after startup error:', stopErr);
       });
       this.#port = previousPort;
       this.#bindAddress = previousBindAddress;
@@ -223,13 +244,13 @@ export class OpenshellGateway implements Disposable {
       return;
     }
 
-    console.log('[openshell-gateway] stopping');
+    this.logGatewayMessage('log', '[openshell-gateway] stopping');
     proc.kill('SIGTERM');
 
     await new Promise<void>(resolve => {
       const timeout = setTimeout(() => {
         if (typeof proc.exitCode !== 'number') {
-          console.warn('[openshell-gateway] did not exit after SIGTERM, sending SIGKILL');
+          this.logGatewayMessage('warn', '[openshell-gateway] did not exit after SIGTERM, sending SIGKILL');
           proc.kill('SIGKILL');
         }
         resolve();
@@ -250,7 +271,9 @@ export class OpenshellGateway implements Disposable {
 
   @preDestroy()
   dispose(): void {
-    this.stop().catch((err: unknown) => console.error('[openshell-gateway] failed to stop: ', err));
+    this.stop()
+      .catch((err: unknown) => this.logGatewayMessage('error', '[openshell-gateway] failed to stop: ', err))
+      .finally(() => this.closeGatewayLog());
     this._onDidGatewayStart.dispose();
     this._onDidGatewayInitFailed.dispose();
   }
@@ -304,7 +327,10 @@ export class OpenshellGateway implements Disposable {
           image = `${SUPERVISOR_IMAGE_BASE}:${version}`;
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
-          console.warn(`[openshell-gateway] unable to detect version for supervisor pinning: ${message}`);
+          this.logGatewayMessage(
+            'warn',
+            `[openshell-gateway] unable to detect version for supervisor pinning: ${message}`,
+          );
         }
       }
 
@@ -320,20 +346,20 @@ export class OpenshellGateway implements Disposable {
       await mkdir(storageDirectory, { recursive: true });
       await writeFile(configPath, config, 'utf-8');
       if (image) {
-        console.log(`[openshell-gateway] supervisor image pinned to ${image}`);
+        this.logGatewayMessage('log', `[openshell-gateway] supervisor image pinned to ${image}`);
       }
-      console.log(`[openshell-gateway] generated local gateway config at ${configPath}`);
+      this.logGatewayMessage('log', `[openshell-gateway] generated local gateway config at ${configPath}`);
       return configPath;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[openshell-gateway] failed to generate gateway config: ${message}`);
+      this.logGatewayMessage('warn', `[openshell-gateway] failed to generate gateway config: ${message}`);
       return undefined;
     }
   }
 
   private async waitForReady(): Promise<void> {
     const endpoint = `http://${this.#bindAddress}:${this.#port}`;
-    console.log(`[openshell-gateway] waiting for server at ${endpoint}`);
+    this.logGatewayMessage('log', `[openshell-gateway] waiting for server at ${endpoint}`);
 
     for (let attempt = 0; attempt < MAX_HEALTH_CHECK_ATTEMPTS; attempt++) {
       if (!this.isRunning()) {
@@ -341,7 +367,7 @@ export class OpenshellGateway implements Disposable {
       }
 
       if (await this.openshellCli.checkEndpointStatus(endpoint)) {
-        console.log('[openshell-gateway] server is ready');
+        this.logGatewayMessage('log', '[openshell-gateway] server is ready');
         return;
       }
 
@@ -355,10 +381,48 @@ export class OpenshellGateway implements Disposable {
     const endpoint = `http://${this.#bindAddress}:${this.#port}`;
     try {
       await this.openshellCli.addGateway({ endpoint, local: true, name: 'kaiden-local' });
-      console.log(`[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
+      this.logGatewayMessage('log', `[openshell-gateway] registered with CLI as kaiden-local at ${endpoint}`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[openshell-gateway] failed to register with CLI: ${message}`);
+      this.logGatewayMessage('warn', `[openshell-gateway] failed to register with CLI: ${message}`);
     }
+  }
+
+  private async initializeGatewayLog(): Promise<void> {
+    if (this.#gatewayLogStream) {
+      return;
+    }
+
+    const storageDirectory = join(this.directories.getDataDirectory(), 'openshell-gateway');
+    const logPath = join(storageDirectory, GATEWAY_LOG_FILENAME);
+    try {
+      await mkdir(storageDirectory, { recursive: true });
+      const stream = createWriteStream(logPath, { flags: 'w' });
+      this.#gatewayLogStream = stream;
+      stream.on('error', (err: Error) => {
+        if (this.#gatewayLogStream === stream) {
+          this.#gatewayLogStream = undefined;
+        }
+        console.error(`[openshell-gateway] unable to write log file ${logPath}: ${err.message}`);
+      });
+      stream.write(`===== Kaiden gateway session started ${new Date().toISOString()} =====\n`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[openshell-gateway] unable to open log file ${logPath}: ${message}`);
+    }
+  }
+
+  private logGatewayMessage(level: GatewayLogLevel, ...args: unknown[]): void {
+    console[level](...args);
+    this.#gatewayLogStream?.write(`${format(...args)}\n`);
+  }
+
+  private logGatewayProcessOutput(data: Buffer): void {
+    this.#gatewayLogStream?.write(data);
+  }
+
+  private closeGatewayLog(): void {
+    this.#gatewayLogStream?.end();
+    this.#gatewayLogStream = undefined;
   }
 }


### PR DESCRIPTION
## Summary

This pr pipes the gateway.process logs for the "kaiden-local" gateway to a logfile preserving the console clarity since those logs were verbose and made the console unreadable. 

https://github.com/user-attachments/assets/f8e78623-7741-48ed-aa9b-3f4a8e1a20ed

https://github.com/user-attachments/assets/8a257cd3-0274-4f53-99f8-32e7de41bc7a




## Local testing

1. Remove the registered default gateway:

   ```sh
   openshell gateway remove openshell
   ```

2. Stop any existing `openshell-gateway` process.

   Linux:

   ```sh
   ps aux | grep -i openshell-gateway | grep -v grep
   kill <PID>
   ```

   macOS:

   ```sh
   ps aux | grep -i "[o]penshell-gateway"
   kill <PID>
   ```

3. Start Kaiden and allow it to create a new gateway:

   ```sh
   pnpm watch
   ```

4. Inspect the gateway log.

   Linux:

   ```sh
   tail -f "${XDG_DATA_HOME:-$HOME/.local/share}/kaiden/openshell-gateway/gateway.log"
   ```

   macOS:

   ```sh
   tail -f "$HOME/.local/share/kaiden/openshell-gateway/gateway.log"
   ```

   If `KAIDEN_HOME_DIR` is set, inspect `$KAIDEN_HOME_DIR/openshell-gateway/gateway.log` instead.

5. Verify that:

the logfile was created and u see the log process

Fixes #2549