### PR TITLE
fix(ci): utilize GITHUB_TOKEN for binary downloads and CI workflows

### DIFF
--- a/.github/workflows/npmjs-publish.yaml
+++ b/.github/workflows/npmjs-publish.yaml
@@ -97,6 +97,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show publish parameters
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -182,6 +182,8 @@ jobs:
 
       - name: Execute pnpm
         run: pnpm install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run linter
         run: pnpm lint:check
@@ -216,6 +218,8 @@ jobs:
 
       - name: Execute pnpm
         run: pnpm install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run typecheck
         run: pnpm typecheck
@@ -246,6 +250,8 @@ jobs:
 
       - name: Execute pnpm
         run: pnpm install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         # run the unit tests with coverage on ubuntu
       - name: Run unit tests with coverage

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -245,7 +245,7 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: create the pnpm store from the dependencies
         run: |
-          podman run --platform linux/${{ matrix.arch }} -v $(pwd):/project --rm -i --entrypoint=sh node:24 -c "cd /project && npm install -g corepack@latest && corepack enable pnpm && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm install --frozen-lockfile  --store-dir pnpm-store"
+          podman run --platform linux/${{ matrix.arch }} -v $(pwd):/project --rm -i -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" --entrypoint=sh node:24 -c "cd /project && npm install -g corepack@latest && corepack enable pnpm && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm install --frozen-lockfile  --store-dir pnpm-store"
           # now the store is in the pnpm-store directory
           # create a tarball of the store
           echo "Creating the archive store-cache-pnpm-${{ matrix.arch }}.tgz"

--- a/extensions/openshell/src/openshell-download.spec.ts
+++ b/extensions/openshell/src/openshell-download.spec.ts
@@ -196,6 +196,36 @@ describe('downloadBinaries', () => {
 
     expect(mkdir).toHaveBeenCalledWith('/output', { recursive: true });
   });
+
+  test('sends Authorization header when GITHUB_TOKEN is set', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, body: new PassThrough() });
+    vi.stubGlobal('fetch', fetchMock);
+    stubOpenShellExtraction();
+    const digests = new Map([['openshell-image-builder-x86_64-unknown-linux-gnu', 'abc123']]);
+
+    await downloadBinaries(OPENSHELL_IMAGE_BUILDER_DOWNLOAD, '0.9.0', 'linux', 'x64', '/output', digests);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-token' }) }),
+    );
+  });
+
+  test('sends no Authorization header when GITHUB_TOKEN is unset', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, body: new PassThrough() });
+    vi.stubGlobal('fetch', fetchMock);
+    stubOpenShellExtraction();
+    const digests = new Map([['openshell-image-builder-x86_64-unknown-linux-gnu', 'abc123']]);
+
+    await downloadBinaries(OPENSHELL_IMAGE_BUILDER_DOWNLOAD, '0.9.0', 'linux', 'x64', '/output', digests);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: expect.not.objectContaining({ Authorization: expect.any(String) }) }),
+    );
+  });
 });
 
 describe('getRelease', () => {

--- a/extensions/openshell/src/openshell-download.ts
+++ b/extensions/openshell/src/openshell-download.ts
@@ -146,7 +146,12 @@ export async function getRelease(downloadConfig: GitHubArtifactDownload, version
 }
 
 async function download(url: string, dest: string): Promise<void> {
-  const res = await fetch(url, { redirect: 'follow' });
+  const headers: Record<string, string> = {};
+  const token = process.env['GITHUB_TOKEN'];
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(url, { headers, redirect: 'follow' });
   if (!res.ok || !res.body) {
     throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
   }


### PR DESCRIPTION
- Use GITHUB_TOKEN in openshell-download.ts when downloading binaries from GitHub
- Pass Authorization header with Bearer token to bypass rate limiting
- Add GITHUB_TOKEN env var to pr-check.yaml lint-format and typecheck jobs
- Add GITHUB_TOKEN env var to npmjs-publish.yaml workflow
- Ensures token is available during post-install script execution in CI

Fixes #2592