### PR TITLE
feat(vertex-ai): pre-fill factory form with environment defaults

### DIFF
--- a/extensions/vertex-ai/src/vertex-ai.spec.ts
+++ b/extensions/vertex-ai/src/vertex-ai.spec.ts
@@ -308,13 +308,25 @@ describe('applyEnvironmentDefaults', () => {
   });
 
   test('should set credentialsFile default to ADC path when file exists and no env var set', async () => {
+    if (process.platform === 'win32' && !process.env.APPDATA) {
+      const vertexAi = createVertexAi();
+      await vertexAi.init();
+      expect(UPDATE_PROPERTY_DEFAULT_MOCK).not.toHaveBeenCalledWith(
+        'vertex-ai.factory.credentialsFile',
+        expect.anything(),
+      );
+      return;
+    }
+
+    const expectedPath =
+      process.platform === 'win32'
+        ? join(process.env.APPDATA!, 'gcloud', 'application_default_credentials.json')
+        : join('/home/testuser', '.config/gcloud', 'application_default_credentials.json');
+
     const vertexAi = createVertexAi();
     await vertexAi.init();
 
-    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith(
-      'vertex-ai.factory.credentialsFile',
-      '~/.config/gcloud/application_default_credentials.json',
-    );
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith('vertex-ai.factory.credentialsFile', expectedPath);
   });
 
   test('should not set credentialsFile default when ADC file does not exist and no env var set', async () => {

--- a/extensions/vertex-ai/src/vertex-ai.spec.ts
+++ b/extensions/vertex-ai/src/vertex-ai.spec.ts
@@ -31,7 +31,7 @@ import type {
   provider as ProviderAPI,
   SecretStorage,
 } from '@openkaiden/api';
-import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   CONNECTIONS_KEY,
@@ -75,9 +75,12 @@ const CONFIGURATION_MOCK: Configuration = {
   update: CONFIG_UPDATE_MOCK,
 } as unknown as Configuration;
 
+const UPDATE_PROPERTY_DEFAULT_MOCK = vi.fn();
+
 const CONFIGURATION_API_MOCK: typeof ConfigurationAPI = {
   getConfiguration: vi.fn().mockReturnValue(CONFIGURATION_MOCK),
   onDidChangeConfiguration: vi.fn(),
+  updatePropertyDefault: UPDATE_PROPERTY_DEFAULT_MOCK,
 } as unknown as typeof ConfigurationAPI;
 
 const VALID_CREDENTIALS = JSON.stringify({
@@ -215,6 +218,124 @@ describe('init', () => {
     expect(PROVIDER_MOCK.registerInferenceProviderConnection).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'fake-uuid-1' }),
     );
+  });
+});
+
+describe('applyEnvironmentDefaults', () => {
+  const ENV_KEYS = [
+    'GOOGLE_VERTEX_PROJECT',
+    'ANTHROPIC_VERTEX_PROJECT_ID',
+    'GOOGLE_VERTEX_LOCATION',
+    'CLOUD_ML_REGION',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+  ] as const;
+
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  test('should set projectId default from GOOGLE_VERTEX_PROJECT', async () => {
+    process.env.GOOGLE_VERTEX_PROJECT = 'env-project';
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith('vertex-ai.factory.projectId', 'env-project');
+  });
+
+  test('should set projectId default from ANTHROPIC_VERTEX_PROJECT_ID when GOOGLE_VERTEX_PROJECT is unset', async () => {
+    process.env.ANTHROPIC_VERTEX_PROJECT_ID = 'anthropic-project';
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith('vertex-ai.factory.projectId', 'anthropic-project');
+  });
+
+  test('should prefer GOOGLE_VERTEX_PROJECT over ANTHROPIC_VERTEX_PROJECT_ID', async () => {
+    process.env.GOOGLE_VERTEX_PROJECT = 'google-project';
+    process.env.ANTHROPIC_VERTEX_PROJECT_ID = 'anthropic-project';
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith('vertex-ai.factory.projectId', 'google-project');
+  });
+
+  test('should set region default from GOOGLE_VERTEX_LOCATION', async () => {
+    process.env.GOOGLE_VERTEX_LOCATION = 'europe-west1';
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith('vertex-ai.factory.region', 'europe-west1');
+  });
+
+  test('should set region default from CLOUD_ML_REGION when GOOGLE_VERTEX_LOCATION is unset', async () => {
+    process.env.CLOUD_ML_REGION = 'asia-east1';
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith('vertex-ai.factory.region', 'asia-east1');
+  });
+
+  test('should set credentialsFile default from GOOGLE_APPLICATION_CREDENTIALS', async () => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = '/custom/path/creds.json';
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith(
+      'vertex-ai.factory.credentialsFile',
+      '/custom/path/creds.json',
+    );
+  });
+
+  test('should set credentialsFile default to ADC path when file exists and no env var set', async () => {
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).toHaveBeenCalledWith(
+      'vertex-ai.factory.credentialsFile',
+      '~/.config/gcloud/application_default_credentials.json',
+    );
+  });
+
+  test('should not set credentialsFile default when ADC file does not exist and no env var set', async () => {
+    vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).not.toHaveBeenCalledWith(
+      'vertex-ai.factory.credentialsFile',
+      expect.anything(),
+    );
+  });
+
+  test('should not call updatePropertyDefault for project or region when no env vars are set', async () => {
+    vi.mocked(access).mockRejectedValue(new Error('ENOENT'));
+
+    const vertexAi = createVertexAi();
+    await vertexAi.init();
+
+    expect(UPDATE_PROPERTY_DEFAULT_MOCK).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -37,7 +37,13 @@ export const CONNECTIONS_KEY = 'vertex-ai:connections';
 export const PROVIDER_ID = 'vertex-ai';
 const FETCH_TIMEOUT_MS = 30_000;
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
-const DEFAULT_ADC_PATH = '~/.config/gcloud/application_default_credentials.json';
+const ADC_FILENAME = 'application_default_credentials.json';
+const DEFAULT_ADC_PATH: string | undefined =
+  process.platform === 'win32'
+    ? process.env.APPDATA
+      ? join(process.env.APPDATA, 'gcloud', ADC_FILENAME)
+      : undefined
+    : `~/.config/gcloud/${ADC_FILENAME}`;
 export interface VertexAiConnectionConfig {
   projectId: string;
   region: string;
@@ -154,10 +160,14 @@ export class VertexAi implements Disposable {
       return process.env.GOOGLE_APPLICATION_CREDENTIALS;
     }
 
-    const defaultPath = this.resolveCredentialsPath(DEFAULT_ADC_PATH);
+    if (!DEFAULT_ADC_PATH) {
+      return undefined;
+    }
+
+    const resolvedPath = this.resolveCredentialsPath(DEFAULT_ADC_PATH);
     try {
-      await access(defaultPath);
-      return DEFAULT_ADC_PATH;
+      await access(resolvedPath);
+      return resolvedPath;
     } catch {
       return undefined;
     }

--- a/extensions/vertex-ai/src/vertex-ai.ts
+++ b/extensions/vertex-ai/src/vertex-ai.ts
@@ -37,6 +37,7 @@ export const CONNECTIONS_KEY = 'vertex-ai:connections';
 export const PROVIDER_ID = 'vertex-ai';
 const FETCH_TIMEOUT_MS = 30_000;
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+const DEFAULT_ADC_PATH = '~/.config/gcloud/application_default_credentials.json';
 export interface VertexAiConnectionConfig {
   projectId: string;
   region: string;
@@ -127,7 +128,39 @@ export class VertexAi implements Disposable {
       create: this.factory.bind(this),
     });
 
+    await this.applyEnvironmentDefaults();
     await this.restoreConnections();
+  }
+
+  private async applyEnvironmentDefaults(): Promise<void> {
+    const projectId = process.env.GOOGLE_VERTEX_PROJECT ?? process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+    if (projectId) {
+      this.configurationAPI.updatePropertyDefault('vertex-ai.factory.projectId', projectId);
+    }
+
+    const region = process.env.GOOGLE_VERTEX_LOCATION ?? process.env.CLOUD_ML_REGION;
+    if (region) {
+      this.configurationAPI.updatePropertyDefault('vertex-ai.factory.region', region);
+    }
+
+    const credentialsFile = await this.resolveDefaultCredentialsFile();
+    if (credentialsFile) {
+      this.configurationAPI.updatePropertyDefault('vertex-ai.factory.credentialsFile', credentialsFile);
+    }
+  }
+
+  private async resolveDefaultCredentialsFile(): Promise<string | undefined> {
+    if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+      return process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    }
+
+    const defaultPath = this.resolveCredentialsPath(DEFAULT_ADC_PATH);
+    try {
+      await access(defaultPath);
+      return DEFAULT_ADC_PATH;
+    } catch {
+      return undefined;
+    }
   }
 
   private async restoreConnections(): Promise<void> {

--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -119,4 +119,5 @@ export interface IConfigurationRegistry {
     value: unknown,
     scope?: PodmanDesktopApiConfigurationScope | PodmanDesktopApiConfigurationScope[],
   ): Promise<void>;
+  updatePropertyDefault(key: string, value: unknown): void;
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1664,6 +1664,17 @@ declare module '@openkaiden/api' {
      * An event that is emitted when the {@link Configuration configuration} changed.
      */
     export const onDidChangeConfiguration: Event<ConfigurationChangeEvent>;
+
+    /**
+     * Update the default value of a configuration property at runtime.
+     *
+     * Useful for pre-populating factory form fields with environment-derived values.
+     * The updated default is visible to the renderer without persisting to settings.
+     *
+     * @param key Full property key (e.g. `'my-ext.factory.field'`).
+     * @param value The new default value.
+     */
+    export function updatePropertyDefault(key: string, value: unknown): void;
   }
 
   /**

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -336,6 +336,37 @@ test('addConfigurationEnum with a previous default value', async () => {
   expect(val).toEqual('myValue1');
 });
 
+test('updatePropertyDefault should update the default field and notify', () => {
+  const node: IConfigurationNode = {
+    id: 'my.property',
+    title: 'Test Property',
+    type: 'object',
+    properties: {
+      ['my.factory.field']: {
+        description: 'A factory field',
+        type: 'string',
+        scope: 'InferenceProviderConnectionFactory',
+      },
+    },
+  };
+
+  configurationRegistry.registerConfigurations([node]);
+
+  configurationRegistry.updatePropertyDefault('my.factory.field', 'env-value');
+
+  const records = configurationRegistry.getConfigurationProperties();
+  expect(records['my.factory.field']?.default).toBe('env-value');
+  expect(apiSender.send).toHaveBeenCalledWith('configuration-changed');
+});
+
+test('updatePropertyDefault should be a no-op for unknown keys', () => {
+  vi.mocked(apiSender.send).mockClear();
+
+  configurationRegistry.updatePropertyDefault('unknown.key', 'value');
+
+  expect(apiSender.send).not.toHaveBeenCalledWith('configuration-changed');
+});
+
 test('check to be able to register a property with a group', async () => {
   const node: IConfigurationNode = {
     id: 'custom',

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -379,6 +379,14 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     return new ConfigurationImpl(this.apiSender, callback, this.configurationValues, section, scope);
   }
 
+  updatePropertyDefault(key: string, value: unknown): void {
+    const property = this.configurationProperties[key];
+    if (property) {
+      property.default = value;
+      this.apiSender.send('configuration-changed');
+    }
+  }
+
   addConfigurationEnum(key: string, values: string[], valueWhenRemoved: unknown): Disposable {
     const property = this.configurationProperties[key];
     if (property?.enum) {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1049,6 +1049,9 @@ export class ExtensionLoader implements IAsyncDisposable {
       onDidChangeConfiguration: (listener, thisArg, disposables) => {
         return configurationRegistry.onDidChangeConfigurationAPI(listener, thisArg, disposables);
       },
+      updatePropertyDefault(key: string, value: unknown): void {
+        configurationRegistry.updatePropertyDefault(key, value);
+      },
     };
 
     const imageRegistry = this.imageRegistry;


### PR DESCRIPTION
## Summary

- Add `updatePropertyDefault` to the configuration API, allowing extensions to dynamically set schema defaults at runtime without persisting to user settings
- Vertex AI extension now pre-fills the connection form with values from environment variables (`GOOGLE_VERTEX_PROJECT`, `ANTHROPIC_VERTEX_PROJECT_ID`, `GOOGLE_VERTEX_LOCATION`, `CLOUD_ML_REGION`, `GOOGLE_APPLICATION_CREDENTIALS`) during initialization
- The default ADC credentials path (`~/.config/gcloud/application_default_credentials.json`) is only pre-filled if the file exists on disk

## Test plan

- [ ] Unit tests for `updatePropertyDefault` in `ConfigurationRegistry` (update + no-op for unknown keys)
- [ ] Unit tests for `applyEnvironmentDefaults` covering env var priority, credentials file existence check, and no-op when nothing is set
- [ ] Manual: set `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION`, open the Vertex AI connection form — fields should be pre-filled
- [ ] Manual: unset all env vars, verify `~/.config/gcloud/application_default_credentials.json` is shown only if the file exists
- [ ] Manual: override a pre-filled value in the form, verify the override is used (not the env var)

Closes #2507