### PR TITLE
fix: correct fullsend custom image configuration

### DIFF
--- a/.fullsend/code.yaml
+++ b/.fullsend/code.yaml
@@ -1,0 +1,2 @@
+base: https://raw.githubusercontent.com/fullsend-ai/agents/ca518d9353f5a8363c6ba499d7a2070a1b0e7c5d/harness/code.yaml#sha256=6ac2a3dc3e163e53137d6839b7f31f17a3942d9ca316741d21a041df6784fb1d
+image: ghcr.io/openkaiden/kaiden-fullsend-image@sha256:752de42626946c37a453a0b0ddd2effd7a2a4cecda86595586097d14b1c21635

--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -16,3 +16,8 @@ create_issues:
         repos:
             - openkaiden/kaiden
             - fullsend-ai/fullsend
+agents:
+    - name: code
+      source: code.yaml
+    - name: fix
+      source: fix.yaml

--- a/.fullsend/customized/harness/code.yaml
+++ b/.fullsend/customized/harness/code.yaml
@@ -1,1 +1,0 @@
-image: ghcr.io/openkaiden/kaiden-fullsend-image@sha256:752de42626946c37a453a0b0ddd2effd7a2a4cecda86595586097d14b1c21635

--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -1,1 +1,0 @@
-image: ghcr.io/openkaiden/kaiden-fullsend-image@sha256:752de42626946c37a453a0b0ddd2effd7a2a4cecda86595586097d14b1c21635

--- a/.fullsend/fix.yaml
+++ b/.fullsend/fix.yaml
@@ -1,0 +1,2 @@
+base: https://raw.githubusercontent.com/fullsend-ai/agents/ca518d9353f5a8363c6ba499d7a2070a1b0e7c5d/harness/fix.yaml#sha256=5af5a1658ea36dd0982a475b08e51246224a52a3cdcfd805e837a16a286b6756
+image: ghcr.io/openkaiden/kaiden-fullsend-image@sha256:752de42626946c37a453a0b0ddd2effd7a2a4cecda86595586097d14b1c21635


### PR DESCRIPTION
## Summary

- Moves fullsend harness overrides from `.fullsend/customized/harness/` to `.fullsend/` and adds the required `base:` field referencing the upstream harness at the v0.32.0 tag, per [fullsend-ai/agents#498](https://github.com/fullsend-ai/agents/pull/498/changes)
- Adds `agents:` section to `.fullsend/config.yaml` to wire up the custom code and fix harnesses
- Removes the old `.fullsend/customized/harness/code.yaml` and `fix.yaml` files

Closes #2599

## Test plan

- [ ] Verify fullsend code agent picks up the custom image on next PR run
- [ ] Verify fullsend fix agent picks up the custom image on next PR run

🤖 Generated with [Claude Code](https://claude.com/claude-code)