### PR TITLE
feat(#2521): add gateway list UI in Settings under OpenShell section

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -216,15 +216,14 @@ test.skip('experimental configuration should be visible if one property has expe
   });
 });
 
-test('OpenShell nav entry is always visible with accordion', () => {
+test('Gateways nav entry is always visible', () => {
   render(PreferencesNavigation, {
     meta: {
       url: '/',
     } as unknown as TinroRouteMeta,
   });
 
-  const openshellLink = screen.getByRole('link', { name: 'OpenShell' });
-  expect(openshellLink).toBeVisible();
-
-  expect(screen.queryByRole('link', { name: 'Gateways' })).not.toBeInTheDocument();
+  const gatewaysLink = screen.getByRole('link', { name: 'Gateways' });
+  expect(gatewaysLink).toBeVisible();
+  expect(gatewaysLink).toHaveAttribute('href', '/preferences/openshell/gateways');
 });

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -215,3 +215,16 @@ test.skip('experimental configuration should be visible if one property has expe
     expect(experimental).toBeDefined();
   });
 });
+
+test('OpenShell nav entry is always visible with accordion', () => {
+  render(PreferencesNavigation, {
+    meta: {
+      url: '/',
+    } as unknown as TinroRouteMeta,
+  });
+
+  const openshellLink = screen.getByRole('link', { name: 'OpenShell' });
+  expect(openshellLink).toBeVisible();
+
+  expect(screen.queryByRole('link', { name: 'Gateways' })).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { faServer } from '@fortawesome/free-solid-svg-icons';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
@@ -23,14 +22,6 @@ let sectionExpanded: { [key: string]: boolean } = $state({});
 let experimentalSection: boolean = $state(false);
 
 let settingsNavigationItems: SettingsNavItemConfig[] = $state(settingsNavigationEntries);
-
-let openshellExpanded: boolean = $state(false);
-
-$effect(() => {
-  if (meta.url.startsWith('/preferences/openshell')) {
-    openshellExpanded = true;
-  }
-});
 
 function updateDockerCompatibility(): void {
   window
@@ -111,22 +102,6 @@ onMount(() => {
         />
       {/if}
     {/each}
-
-    <!-- OpenShell section -->
-    <SettingsNavItem
-      title="OpenShell"
-      href="/preferences/openshell/gateways"
-      icon={faServer}
-      section={true}
-      selected={meta.url.startsWith('/preferences/openshell') && !openshellExpanded}
-      bind:expanded={openshellExpanded} />
-    {#if openshellExpanded}
-      <SettingsNavItem
-        title="Gateways"
-        href="/preferences/openshell/gateways"
-        child={true}
-        selected={meta.url === '/preferences/openshell/gateways'} />
-    {/if}
 
     <!-- Default configuration properties start -->
     {#each configProperties as [configSection, configItems] (configSection)}

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { faServer } from '@fortawesome/free-solid-svg-icons';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
@@ -22,6 +23,8 @@ let sectionExpanded: { [key: string]: boolean } = $state({});
 let experimentalSection: boolean = $state(false);
 
 let settingsNavigationItems: SettingsNavItemConfig[] = $state(settingsNavigationEntries);
+
+let openshellExpanded: boolean = $state(false);
 
 function updateDockerCompatibility(): void {
   window
@@ -102,6 +105,22 @@ onMount(() => {
         />
       {/if}
     {/each}
+
+    <!-- OpenShell section -->
+    <SettingsNavItem
+      title="OpenShell"
+      href="/preferences/openshell/gateways"
+      icon={faServer}
+      section={true}
+      selected={meta.url.startsWith('/preferences/openshell') && !openshellExpanded}
+      bind:expanded={openshellExpanded} />
+    {#if openshellExpanded}
+      <SettingsNavItem
+        title="Gateways"
+        href="/preferences/openshell/gateways"
+        child={true}
+        selected={meta.url === '/preferences/openshell/gateways'} />
+    {/if}
 
     <!-- Default configuration properties start -->
     {#each configProperties as [configSection, configItems] (configSection)}

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -26,6 +26,12 @@ let settingsNavigationItems: SettingsNavItemConfig[] = $state(settingsNavigation
 
 let openshellExpanded: boolean = $state(false);
 
+$effect(() => {
+  if (meta.url.startsWith('/preferences/openshell')) {
+    openshellExpanded = true;
+  }
+});
+
 function updateDockerCompatibility(): void {
   window
     .getConfigurationValue<boolean>(`${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`)

--- a/packages/renderer/src/PreferencesNavigation.ts
+++ b/packages/renderer/src/PreferencesNavigation.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
+import { faServer } from '@fortawesome/free-solid-svg-icons';
 import type { Component } from 'svelte';
 
 import CLIToolsIcon from '/@/lib/images/CLIToolsIcon.svelte';
@@ -31,7 +33,7 @@ export interface SettingsNavItemConfig {
   title: string;
   href: string;
   visible?: boolean;
-  icon?: Component;
+  icon?: IconDefinition | Component | string;
 }
 
 // Static navigation entries for routes not in the main navigation registry
@@ -39,4 +41,5 @@ export const settingsNavigationEntries: SettingsNavItemConfig[] = [
   { title: 'Resources', href: '/preferences/resources', visible: true, icon: ResourcesIcon },
   { title: 'Proxy', href: '/preferences/proxies', visible: true, icon: ProxyIcon },
   { title: 'CLI Tools', href: '/preferences/cli-tools', visible: true, icon: CLIToolsIcon },
+  { title: 'Gateways', href: '/preferences/openshell/gateways', visible: true, icon: faServer },
 ];

--- a/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.spec.ts
@@ -1,0 +1,171 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { extensionInfos } from '/@/stores/extensions';
+import { openshellGateways } from '/@/stores/openshell-gateways';
+import type { GatewayInfo } from '/@api/openshell-gateway-info';
+
+import PreferencesOpenshellGatewaysRendering from './PreferencesOpenshellGatewaysRendering.svelte';
+
+function setOpenshellStarted(): void {
+  extensionInfos.set([
+    {
+      id: 'kaiden.openshell',
+      name: 'openshell',
+      description: '',
+      displayName: 'OpenShell',
+      publisher: 'kaiden',
+      removable: false,
+      devMode: false,
+      version: '0.4.0',
+      state: 'started',
+      path: '',
+      readme: '',
+    },
+  ]);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  extensionInfos.set([]);
+  openshellGateways.set([]);
+});
+
+test('shows not-running message when OpenShell extension is not started', () => {
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('OpenShell extension is not running')).toBeInTheDocument();
+});
+
+test('shows empty screen when extension is started but no gateways are registered', () => {
+  setOpenshellStarted();
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('No gateways found')).toBeInTheDocument();
+});
+
+test('displays active gateway in the Active Gateway section', () => {
+  setOpenshellStarted();
+  const activeGateway: GatewayInfo = {
+    name: 'kaiden-local',
+    endpoint: 'http://127.0.0.1:17670',
+    active: true,
+    type: 'local',
+  };
+  openshellGateways.set([activeGateway]);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('Active Gateway')).toBeInTheDocument();
+  expect(screen.getByText('kaiden-local')).toBeInTheDocument();
+  expect(screen.getByText('Managed')).toBeInTheDocument();
+  expect(screen.getByText('local · http://127.0.0.1:17670')).toBeInTheDocument();
+
+  const statusDot = screen.getAllByLabelText('Gateway status')[0];
+  expect(statusDot).toHaveClass('bg-(--pd-status-running)');
+
+  expect(screen.queryByText('Other Gateways')).not.toBeInTheDocument();
+});
+
+test('displays non-active gateways in Other Gateways section', () => {
+  setOpenshellStarted();
+  const gateways: GatewayInfo[] = [
+    {
+      name: 'kaiden-local',
+      endpoint: 'http://127.0.0.1:17670',
+      active: true,
+      type: 'local',
+    },
+    {
+      name: 'production',
+      endpoint: 'https://gateway.example.com',
+      active: false,
+      type: 'remote',
+      is_remote: true,
+      remote_host: 'user@gateway.example.com',
+    },
+  ];
+  openshellGateways.set(gateways);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('Active Gateway')).toBeInTheDocument();
+  expect(screen.getByText('Other Gateways')).toBeInTheDocument();
+  expect(screen.getByText('production')).toBeInTheDocument();
+  expect(screen.getByText('Referenced')).toBeInTheDocument();
+  expect(screen.getByText('remote · remote · https://gateway.example.com')).toBeInTheDocument();
+});
+
+test('shows Referenced badge for non-local gateways', () => {
+  setOpenshellStarted();
+  const gateways: GatewayInfo[] = [
+    {
+      name: 'remote-gw',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      type: 'remote',
+    },
+  ];
+  openshellGateways.set(gateways);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('Referenced')).toBeInTheDocument();
+});
+
+test('shows Managed badge for local gateways', () => {
+  setOpenshellStarted();
+  const gateways: GatewayInfo[] = [
+    {
+      name: 'local-gw',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      type: 'local',
+    },
+  ];
+  openshellGateways.set(gateways);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('Managed')).toBeInTheDocument();
+});
+
+test('hides empty screen when gateways exist', () => {
+  setOpenshellStarted();
+  openshellGateways.set([{ name: 'gw', endpoint: 'http://localhost:17670', active: true }]);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  const emptyTitle = screen.queryByText('No gateways found');
+  expect(emptyTitle).toBeInTheDocument();
+  expect(emptyTitle?.closest('[hidden]') ?? emptyTitle?.closest('.hidden')).toBeTruthy();
+});
+
+test('renders multiple non-active gateways', () => {
+  setOpenshellStarted();
+  const gateways: GatewayInfo[] = [
+    { name: 'active-gw', endpoint: 'http://localhost:17670', active: true, type: 'local' },
+    { name: 'team-shared', endpoint: 'https://team.example.com', active: false, type: 'remote', is_remote: true },
+    { name: 'dev-remote', endpoint: 'https://dev.example.com', active: false, type: 'remote' },
+  ];
+  openshellGateways.set(gateways);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('team-shared')).toBeInTheDocument();
+  expect(screen.getByText('dev-remote')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.spec.ts
@@ -111,7 +111,7 @@ test('displays non-active gateways in Other Gateways section', () => {
   expect(screen.getByText('Other Gateways')).toBeInTheDocument();
   expect(screen.getByText('production')).toBeInTheDocument();
   expect(screen.getByText('Referenced')).toBeInTheDocument();
-  expect(screen.getByText('remote · remote · https://gateway.example.com')).toBeInTheDocument();
+  expect(screen.getByText('remote · https://gateway.example.com')).toBeInTheDocument();
 });
 
 test('shows Referenced badge for non-local gateways', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+
+import EngineIcon from '/@/lib/ui/EngineIcon.svelte';
+import { extensionInfos } from '/@/stores/extensions';
+import { openshellGateways } from '/@/stores/openshell-gateways';
+import type { GatewayInfo } from '/@api/openshell-gateway-info';
+
+import SettingsPage from './SettingsPage.svelte';
+
+const OPENSHELL_EXTENSION_ID = 'kaiden.openshell';
+let openshellStarted: boolean = $derived(
+  $extensionInfos.some(ext => ext.id === OPENSHELL_EXTENSION_ID && ext.state === 'started'),
+);
+
+let activeGateway: GatewayInfo | undefined = $derived($openshellGateways.find(g => g.active));
+let otherGateways: GatewayInfo[] = $derived($openshellGateways.filter(g => !g.active));
+
+function getTypeBadge(gateway: GatewayInfo): string {
+  if (gateway.type === 'local') {
+    return 'Managed';
+  }
+  return 'Referenced';
+}
+
+function getDetails(gateway: GatewayInfo): string {
+  const parts: string[] = [];
+  if (gateway.type) {
+    parts.push(gateway.type);
+  }
+  if (gateway.is_remote) {
+    parts.push('remote');
+  }
+  parts.push(gateway.endpoint);
+  return parts.join(' · ');
+}
+</script>
+
+<SettingsPage title="Gateways">
+  {#snippet subtitle()}
+    <span>The runtime that provisions sandboxes, enforces policy, and routes inference traffic.</span>
+  {/snippet}
+
+  <div class="h-full" role="region" aria-label="Gateways">
+    {#if !openshellStarted}
+      <EmptyScreen
+        icon={EngineIcon}
+        title="OpenShell extension is not running"
+        message="Install and start the OpenShell extension to manage gateways" />
+    {:else}
+      <EmptyScreen
+        icon={EngineIcon}
+        title="No gateways found"
+        message="Start the OpenShell extension to register a gateway"
+        hidden={$openshellGateways.length > 0} />
+    {/if}
+
+    {#if openshellStarted && activeGateway}
+      <div class="mb-6">
+        <h3
+          class="text-xs font-semibold uppercase tracking-wide text-(--pd-content-card-text) opacity-70 mb-2"
+          aria-label="Active gateway section">
+          Active Gateway
+        </h3>
+        <div
+          class="bg-(--pd-content-card-bg) rounded-md p-4"
+          role="region"
+          aria-label="Active gateway {activeGateway.name}">
+          <div class="flex items-center gap-3">
+            <div class="w-2 h-2 rounded-full shrink-0 bg-(--pd-status-running)" aria-label="Gateway status"></div>
+            <span class="text-lg font-semibold text-(--pd-content-card-text)">{activeGateway.name}</span>
+            <span
+              class="text-xs font-medium px-2 py-0.5 rounded-full bg-(--pd-label-bg) text-(--pd-label-text)">
+              {getTypeBadge(activeGateway)}
+            </span>
+            <span class="text-sm text-(--pd-content-card-text) opacity-70">{getDetails(activeGateway)}</span>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    {#if openshellStarted && otherGateways.length > 0}
+      <div>
+        <h3
+          class="text-xs font-semibold uppercase tracking-wide text-(--pd-content-card-text) opacity-70 mb-2"
+          aria-label="Other gateways section">
+          Other Gateways
+        </h3>
+        <div class="flex flex-col gap-2">
+          {#each otherGateways as gateway (gateway.name)}
+            <div
+              class="bg-(--pd-content-card-bg) rounded-md p-4"
+              role="region"
+              aria-label="Gateway {gateway.name}">
+              <div class="flex items-center gap-3">
+                <div class="w-2 h-2 rounded-full shrink-0 bg-(--pd-status-running)" aria-label="Gateway status"></div>
+                <span class="font-semibold text-(--pd-content-card-text)">{gateway.name}</span>
+                <span
+                  class="text-xs font-medium px-2 py-0.5 rounded-full bg-(--pd-label-bg) text-(--pd-label-text)">
+                  {getTypeBadge(gateway)}
+                </span>
+                <span class="text-sm text-(--pd-content-card-text) opacity-70">{getDetails(gateway)}</span>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  </div>
+</SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.svelte
@@ -28,7 +28,7 @@ function getDetails(gateway: GatewayInfo): string {
   if (gateway.type) {
     parts.push(gateway.type);
   }
-  if (gateway.is_remote) {
+  if (gateway.is_remote && gateway.type !== 'remote') {
     parts.push('remote');
   }
   parts.push(gateway.endpoint);

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -14,6 +14,7 @@ import PreferencesCliToolsRendering from './PreferencesCliToolsRendering.svelte'
 import PreferencesContainerConnectionRendering from './PreferencesContainerConnectionRendering.svelte';
 import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
+import PreferencesOpenshellGatewaysRendering from './PreferencesOpenshellGatewaysRendering.svelte';
 import PreferencesProviderRendering from './PreferencesProviderRendering.svelte';
 import PreferencesProxiesRendering from './PreferencesProxiesRendering.svelte';
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
@@ -78,6 +79,9 @@ onMount(async () => {
   </Route>
   <Route path="/cli-tools" breadcrumb="CLI Tools">
     <PreferencesCliToolsRendering />
+  </Route>
+  <Route path="/openshell/gateways" breadcrumb="OpenShell Gateways">
+    <PreferencesOpenshellGatewaysRendering />
   </Route>
   <Route path="/kubernetes-contexts" breadcrumb="Kubernetes Contexts">
     <PreferencesKubernetesContextsRendering />


### PR DESCRIPTION
## Summary

- Add a new  **Gateways** section in the Settings sidebar
- The gateway view displays the active gateway prominently, with
  remaining gateways listed below — each showing a status dot, a
  type badge (Managed/Referenced), and endpoint details
- When the OpenShell extension is not installed or started, the view
  shows an empty state message instead of the gateway list
  
<img width="1052" height="711" alt="Captura de pantalla 2026-08-03 a las 15 06 16" src="https://github.com/user-attachments/assets/a4231a71-ee84-46db-ad0a-cac2503cdf57" />


## Test plan

- [ ] Open Settings and verify the **Gateways** entry appears
      in the sidebar
- [ ] With the OpenShell extension stopped/uninstalled, verify the
      "OpenShell extension is not running" empty state is shown
- [ ] With the extension running and one gateway, verify the
      **Active Gateway** section renders with status dot, name,
      badge, and endpoint
- [ ] With multiple gateways, verify inactive ones appear under
      **Other Gateways**

Closes #2619 