### PR TITLE
fix: configure npmjs access for fullsend

### DIFF
--- a/.fullsend/code.yaml
+++ b/.fullsend/code.yaml
@@ -1,2 +1,3 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/ca518d9353f5a8363c6ba499d7a2070a1b0e7c5d/harness/code.yaml#sha256=6ac2a3dc3e163e53137d6839b7f31f17a3942d9ca316741d21a041df6784fb1d
 image: ghcr.io/openkaiden/kaiden-fullsend-image@sha256:752de42626946c37a453a0b0ddd2effd7a2a4cecda86595586097d14b1c21635
+policy: .fullsend/policies/code.yaml

--- a/.fullsend/fix.yaml
+++ b/.fullsend/fix.yaml
@@ -1,2 +1,3 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/ca518d9353f5a8363c6ba499d7a2070a1b0e7c5d/harness/fix.yaml#sha256=5af5a1658ea36dd0982a475b08e51246224a52a3cdcfd805e837a16a286b6756
 image: ghcr.io/openkaiden/kaiden-fullsend-image@sha256:752de42626946c37a453a0b0ddd2effd7a2a4cecda86595586097d14b1c21635
+policy: .fullsend/policies/code.yaml

--- a/.fullsend/policies/code.yaml
+++ b/.fullsend/policies/code.yaml
@@ -1,0 +1,145 @@
+---
+version: 1
+
+# Sandbox policy for the code agent.
+#
+# Grants network access the code agent needs beyond the base sandbox:
+#   - Vertex AI (global inference + GCP auth token exchange)
+#   - GitHub API (gh/git only — curl excluded from the binary allowlist
+#     to prevent raw HTTP access with the injected GH_TOKEN)
+#   - gitleaks releases (fallback download if not pre-installed in image)
+#   - npm/yarn/pnpm/PyPI/Go registries (running tests may pull dev dependencies)
+#   - pre-commit binary needs github (clone hook repos), package registries
+#     (pip install hook deps), and GitHub releases (hook binaries like gitleaks)
+
+filesystem_policy:
+  include_workdir: true
+  read_only: [/usr, /lib, /proc, /dev/urandom, /app, /etc, /var/log]
+  read_write: [/sandbox, /tmp, /dev/null]
+landlock:
+  compatibility: best_effort
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  vertex_ai:
+    name: vertex-ai
+    endpoints:
+      - host: "api.anthropic.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      - host: "*.googleapis.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+    binaries:
+      - path: "**/claude"
+      - path: "**/node"
+
+  github_api:
+    name: github-api
+    endpoints:
+      - host: "api.github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      # gh CLI uses POST /graphql for reads; protocol: graphql allows
+      # queries but blocks mutations at the AST level
+      - host: "api.github.com"
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        access: read-only
+        path: "/graphql"
+      - host: "github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - path: "**/gh"
+      - path: "**/git"
+      - path: "**/node"
+      - path: "**/pre-commit"
+
+  gitleaks_releases:
+    name: gitleaks-releases
+    endpoints:
+      - host: "github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "objects.githubusercontent.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "release-assets.githubusercontent.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - path: "**/pre-commit"
+
+  package_registries:
+    name: package-registries
+    endpoints:
+      - host: "registry.npmjs.org"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+        allow_encoded_slash: true
+      - host: "registry.yarnpkg.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "pypi.org"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "files.pythonhosted.org"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "proxy.golang.org"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "sum.golang.org"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "storage.googleapis.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - path: "**/npm"
+      - path: "**/npx"
+      - path: "**/yarn"
+      - path: "**/yarnpkg"
+      - path: "**/pnpm"
+      - path: "**/node"
+      - path: "**/pip"
+      - path: "**/pip3"
+      - path: "**/python"
+      - path: "**/python3"
+      - path: "**/python3.*"
+      - path: "**/uv"
+      - path: "**/uvx"
+      - path: "**/go"
+      - path: "**/pre-commit"


### PR DESCRIPTION
The Fullsend code and fix agent have not been able to access npmjs to install packages. Based on an analysis of the agent logs the issue appears to be that packages like @podman-desktop/ui-svelte cause encoded slashes to be required, and that's blocked by default in OpenShell's network policy.

The solution is to add `allow_encoded_slash: true` to the agent's policy. This should be done in the fullsend agent repo, but to confirm it is the problem we'll try copying the policy here temporarily. The two policy files are ugly and long, but the only change from the default is line 99/95 where allow_encoded_slash is added. If this works, then this PR would be undone once the fix is released upstream.

Fixes #2609.