### PR TITLE
fix(workspaces): scope secrets to selected gateway

### DIFF
--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -52,7 +52,7 @@ export interface SecretCreateOptions extends SecretInfo {
  */
 export interface SecretCliBackend {
   createSecret(options: SecretCreateOptions): Promise<SecretName>;
-  listSecrets(): Promise<SecretInfo[]>;
+  listSecrets(gateway?: string): Promise<SecretInfo[]>;
   removeSecret(name: string): Promise<SecretName>;
   listServices(): Promise<OpenshellProfile[]>;
 }

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -1072,6 +1072,18 @@ describe('listProviders', () => {
     expect(result).toEqual([]);
   });
 
+  test('lists providers from the selected gateway', async () => {
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify([])));
+
+    await openshellCli.listProviders('remote');
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['provider', 'list', '-g', 'remote', '-o', 'json'],
+      undefined,
+    );
+  });
+
   test('rejects when CLI fails', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockRejectedValue(new Error('no gateway configured'));

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -395,8 +395,12 @@ export class OpenshellCli {
 
   // ── provider commands ──────────────────────────────────────────────
 
-  async listProviders(): Promise<OpenshellProviderInfo[]> {
-    const data = await this.execCLI<unknown>(['provider', 'list']);
+  async listProviders(gateway?: string): Promise<OpenshellProviderInfo[]> {
+    const args = ['provider', 'list'];
+    if (gateway) {
+      args.push('-g', gateway);
+    }
+    const data = await this.execCLI<unknown>(args);
     return z.array(OpenshellProviderInfoSchema).parse(data);
   }
 

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
@@ -117,6 +117,14 @@ describe('listSecrets', () => {
     expect(result).toEqual([]);
   });
 
+  test('lists secrets from the selected gateway', async () => {
+    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
+
+    await adapter.listSecrets('remote');
+
+    expect(openshellCli.listProviders).toHaveBeenCalledWith('remote');
+  });
+
   test('rejects when openshellCli.listProviders fails', async () => {
     vi.mocked(openshellCli.listProviders).mockRejectedValue(new Error('no gateway configured'));
 

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -55,8 +55,8 @@ export class OpenshellSecretAdapter implements SecretCliBackend {
     return { name: options.name };
   }
 
-  async listSecrets(): Promise<SecretInfo[]> {
-    return await this.openshellCli.listProviders();
+  async listSecrets(gateway?: string): Promise<SecretInfo[]> {
+    return await this.openshellCli.listProviders(gateway);
   }
 
   async removeSecret(name: string): Promise<SecretName> {

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -69,8 +69,8 @@ export class SecretManager {
     return result;
   }
 
-  async list(): Promise<SecretInfo[]> {
-    return this.cli.listSecrets();
+  async list(gateway?: string): Promise<SecretInfo[]> {
+    return this.cli.listSecrets(gateway);
   }
 
   async remove(name: string): Promise<SecretName> {
@@ -231,8 +231,8 @@ export class SecretManager {
       },
     );
 
-    this.ipcHandle('secret-manager:list', async (): Promise<SecretInfo[]> => {
-      return this.list();
+    this.ipcHandle('secret-manager:list', async (_listener: unknown, gateway?: string): Promise<SecretInfo[]> => {
+      return this.list(gateway);
     });
 
     this.ipcHandle('secret-manager:remove', async (_listener: unknown, name: string): Promise<SecretName> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -532,8 +532,8 @@ export function initExposure(): void {
     return ipcInvoke('secret-manager:create', options);
   });
 
-  contextBridge.exposeInMainWorld('listSecrets', async (): Promise<SecretInfo[]> => {
-    return ipcInvoke('secret-manager:list');
+  contextBridge.exposeInMainWorld('listSecrets', async (gateway?: string): Promise<SecretInfo[]> => {
+    return ipcInvoke('secret-manager:list', gateway);
   });
 
   contextBridge.exposeInMainWorld('removeSecret', async (name: string): Promise<SecretName> => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -125,6 +125,7 @@ const mockOllamaProvider: ProviderInfo = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.listSecrets).mockResolvedValue([]);
   vi.useFakeTimers({ shouldAdvanceTime: true });
   HTMLElement.prototype.animate = vi.fn().mockReturnValue({
     finished: Promise.resolve(),
@@ -492,17 +493,19 @@ test('Expect secrets empty state shown when vault is empty', async () => {
   expect(screen.getByRole('button', { name: 'Open Vault' })).toBeInTheDocument();
 });
 
-test('Expect secrets listed when vault has entries', async () => {
-  vi.mocked(secretVaultStore).secretVaultInfos = writable<readonly SecretVaultInfo[]>([
+test('Expect secrets listed from the selected gateway', async () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    { name: 'local', endpoint: 'http://localhost:17670', active: true },
+    { name: 'remote', endpoint: 'https://remote.example.com', active: false },
+  ]);
+  vi.mocked(window.listSecrets).mockResolvedValue([
     {
-      id: 'github-token',
-      name: 'GitHub Token',
+      name: 'github-token',
       type: 'github',
       description: 'Personal access token',
     },
     {
-      id: 'anthropic-key',
-      name: 'Anthropic Key',
+      name: 'anthropic-key',
       type: 'anthropic',
       description: 'API key',
     },
@@ -510,11 +513,13 @@ test('Expect secrets listed when vault has entries', async () => {
 
   render(AgentWorkspaceCreate);
 
+  await fireEvent.change(screen.getByRole('combobox'), { target: { value: 'remote' } });
   await navigateToToolsSecretsStep();
   await expandCustomize();
 
-  expect(screen.getByText('GitHub Token')).toBeInTheDocument();
-  expect(screen.getByText('Anthropic Key')).toBeInTheDocument();
+  expect(screen.getByText('github-token')).toBeInTheDocument();
+  expect(screen.getByText('anthropic-key')).toBeInTheDocument();
+  expect(window.listSecrets).toHaveBeenCalledWith('remote');
   expect(screen.getByText('Secret Vault')).toBeInTheDocument();
   expect(screen.queryByText('No secrets in your vault yet.')).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -620,6 +620,7 @@ async function startWorkspace(): Promise<void> {
             {:else if currentStepId === 'tools-secrets'}
               <AgentWorkspaceCreateStepToolsSecrets
                 {skillItems}
+                gateway={wizard.draft.selectedGateway}
                 bind:selectedSkillIds={wizard.draft.selectedSkillIds}
                 {mcpItems}
                 bind:selectedMcpIds={wizard.draft.selectedMcpIds}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
@@ -42,6 +42,7 @@ let secretItems: ChecklistItem[] = $derived(
 
 $effect(() => {
   let cancelled = false;
+  secrets = [];
   window.listSecrets(gateway).then(
     items => {
       if (!cancelled) {
@@ -50,7 +51,12 @@ $effect(() => {
         selectedSecretIds = selectedSecretIds.filter(id => available.has(id));
       }
     },
-    (error: unknown) => console.error('Failed to list secrets for gateway', error),
+    (error: unknown) => {
+      if (!cancelled) {
+        selectedSecretIds = [];
+        console.error('Failed to list secrets for gateway', error);
+      }
+    },
   );
   return (): void => {
     cancelled = true;

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
@@ -6,8 +6,8 @@ import { router } from 'tinro';
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
 import ChecklistPanel from '/@/lib/ui/ChecklistPanel.svelte';
 import { handleNavigation } from '/@/navigation';
-import { secretVaultInfos } from '/@/stores/secret-vault';
 import { NavigationPage } from '/@api/navigation-page';
+import type { SecretInfo } from '/@api/secret-info';
 
 interface Props {
   skillItems: ChecklistItem[];
@@ -15,6 +15,7 @@ interface Props {
   mcpItems: ChecklistItem[];
   selectedMcpIds: string[];
   selectedSecretIds: string[];
+  gateway: string;
   knowledgeItems: ChecklistItem[];
   selectedKnowledgeIds: string[];
 }
@@ -25,17 +26,36 @@ let {
   mcpItems,
   selectedMcpIds = $bindable(),
   selectedSecretIds = $bindable(),
+  gateway,
   knowledgeItems,
   selectedKnowledgeIds = $bindable(),
 }: Props = $props();
 
+let secrets = $state.raw<SecretInfo[]>([]);
 let secretItems: ChecklistItem[] = $derived(
-  $secretVaultInfos.map(s => ({
-    id: s.id,
+  secrets.map(s => ({
+    id: s.name,
     name: s.name,
     description: [s.type, s.description].filter(Boolean).join(' · '),
   })),
 );
+
+$effect(() => {
+  let cancelled = false;
+  window.listSecrets(gateway).then(
+    items => {
+      if (!cancelled) {
+        secrets = items;
+        const available = new Set(items.map(item => item.name));
+        selectedSecretIds = selectedSecretIds.filter(id => available.has(id));
+      }
+    },
+    (error: unknown) => console.error('Failed to list secrets for gateway', error),
+  );
+  return (): void => {
+    cancelled = true;
+  };
+});
 
 let allIncluded: boolean = $derived(
   selectedSkillIds.length === skillItems.length &&


### PR DESCRIPTION
## Summary

- scope the secrets displayed during workspace creation to the selected OpenShell gateway
- pass the optional gateway through the existing secret list IPC and backend path
- remove selected secrets that are not available on the selected gateway
- leave secret creation and removal unchanged so #2559 remains independently scoped

Fixes #2556.

## Testing

- `pnpm exec vitest run packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts packages/main/src/plugin/secret-manager/secret-manager.spec.ts packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts`
- `pnpm run typecheck:main`
- `pnpm run typecheck:renderer`
- pre-commit ESLint and Biome checks

### Local two-gateway verification

Start a second temporary gateway with its own database. Binding to loopback avoids exposing the gateway and avoids rootless Podman issues associated with `0.0.0.0`:

```bash
mkdir -p /tmp/kaiden-secondary-gateway

openshell-gateway \
  --port 17671 \
  --bind-address 127.0.0.1 \
  --disable-tls \
  --db-url 'sqlite:/tmp/kaiden-secondary-gateway/gateway.db?mode=rwc'

openshell gateway add \
  http://127.0.0.1:17671 \
  --local \
  --name test-secondary
```

This lightweight secondary gateway is sufficient for exercising provider create/list. Full sandbox creation may require the normal TLS/JWT and Podman driver configuration used by Kaiden.

Create dummy providers using the built-in `github` profile. The placeholder value is intentionally not a real token:

```bash
openshell provider create \
  -g openshell \
  --name kaiden-filter-test-primary \
  --type github \
  --credential api_token=kaiden-filter-test-placeholder

openshell provider create \
  -g test-secondary \
  --name kaiden-filter-test-secondary \
  --type github \
  --credential api_token=kaiden-filter-test-placeholder
```

Verify isolation at the CLI level:

```bash
openshell provider list -g openshell -o json
openshell provider list -g test-secondary -o json
```

The first result contains `kaiden-filter-test-primary`, while the second contains `kaiden-filter-test-secondary`.

In Kaiden, open workspace creation and select each gateway in turn. The **Tools & Secrets** step displays only the provider associated with the selected gateway.

Cleanup:

```bash
openshell provider delete -g openshell kaiden-filter-test-primary
openshell provider delete -g test-secondary kaiden-filter-test-secondary
openshell gateway remove test-secondary
```
