### PR TITLE
fix(workspaces): pin provider creation to selected gateway

### DIFF
--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -51,7 +51,7 @@ export interface SecretCreateOptions extends SecretInfo {
  * so that `SecretManager` can switch between them at runtime.
  */
 export interface SecretCliBackend {
-  createSecret(options: SecretCreateOptions): Promise<SecretName>;
+  createSecret(options: SecretCreateOptions, gateway?: string): Promise<SecretName>;
   listSecrets(gateway?: string): Promise<SecretInfo[]>;
   removeSecret(name: string): Promise<SecretName>;
   listServices(): Promise<OpenshellProfile[]>;

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -1024,6 +1024,7 @@ describe('ensureModelSecret', () => {
     await manager.ensureModelSecret(options);
 
     expect(options.secrets).toBeUndefined();
+    expect(secretManager.ensureSecretForModel).toHaveBeenCalledWith('unknown::model::', 'kaiden');
   });
 
   test('adds secret name to options.secrets when found', async () => {
@@ -1033,6 +1034,7 @@ describe('ensureModelSecret', () => {
     await manager.ensureModelSecret(options);
 
     expect(options.secrets).toContain('cursor-conn-123');
+    expect(secretManager.ensureSecretForModel).toHaveBeenCalledWith('cursor::gpt-4o::https://api.cursor.com', 'kaiden');
   });
 
   test('does not call setInference when secret type is not in SET_INFERENCE_TYPES', async () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -437,7 +437,7 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   private async ensureModelSecretFromConfig(options: AgentWorkspaceCreateOptions): Promise<string | undefined> {
-    const secret = await this.secretManager.ensureSecretForModel(options.model);
+    const secret = await this.secretManager.ensureSecretForModel(options.model, options.gateway);
     if (!secret) return undefined;
 
     options.secrets = [...new Set([...(options.secrets ?? []), secret.name])];

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -1151,6 +1151,30 @@ describe('deleteProvider', () => {
 });
 
 describe('createProvider', () => {
+  test('creates provider on the selected gateway', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));
+
+    await openshellCli.createProvider(
+      {
+        name: 'my-openai',
+        type: 'openai',
+        credentials: { apiKey: 'sk-123' },
+      },
+      'remote',
+    );
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['provider', 'create', '--name', 'my-openai', '--type', 'openai', '-g', 'remote', '--credential', 'apiKey'],
+      {
+        env: {
+          apiKey: 'sk-123',
+        },
+      },
+    );
+  });
+
   test('executes provider create with name, type, and credentials', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult(''));

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -413,11 +413,14 @@ export class OpenshellCli {
     await this.runCli(['provider', 'delete', name]);
   }
 
-  async createProvider(options: CreateProviderOptions): Promise<void> {
+  async createProvider(options: CreateProviderOptions, gateway?: string): Promise<void> {
     if (Object.keys(options.credentials).length === 0 && !options.flags?.length) {
       throw new Error('credentials must not be empty');
     }
     const args = ['provider', 'create', '--name', options.name, '--type', options.type];
+    if (gateway) {
+      args.push('-g', gateway);
+    }
     const env: Record<string, string> = options.env ?? {};
     for (const [key, value] of Object.entries(options.credentials)) {
       env[key] = value;

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.spec.ts
@@ -51,13 +51,16 @@ describe('createSecret', () => {
 
     const result = await adapter.createSecret(defaultOptions);
 
-    expect(openshellCli.createProvider).toHaveBeenCalledWith({
-      name: 'my-secret',
-      type: 'github',
-      credentials: { GH_TOKEN: 'ghp_abc123' },
-      config: undefined,
-      flags: undefined,
-    });
+    expect(openshellCli.createProvider).toHaveBeenCalledWith(
+      {
+        name: 'my-secret',
+        type: 'github',
+        credentials: { GH_TOKEN: 'ghp_abc123' },
+        config: undefined,
+        flags: undefined,
+      },
+      undefined,
+    );
     expect(result).toEqual({ name: 'my-secret' });
   });
 
@@ -65,6 +68,14 @@ describe('createSecret', () => {
     vi.mocked(openshellCli.createProvider).mockRejectedValue(new Error('provider type not supported'));
 
     await expect(adapter.createSecret(defaultOptions)).rejects.toThrow('provider type not supported');
+  });
+
+  test('creates secret on the selected gateway', async () => {
+    vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
+
+    await adapter.createSecret(defaultOptions, 'remote');
+
+    expect(openshellCli.createProvider).toHaveBeenCalledWith(expect.any(Object), 'remote');
   });
 
   test('passes config and flags through to createProvider', async () => {
@@ -82,13 +93,16 @@ describe('createSecret', () => {
 
     const result = await adapter.createSecret(options);
 
-    expect(openshellCli.createProvider).toHaveBeenCalledWith({
-      name: 'my-vertex',
-      type: 'google-vertex-ai',
-      credentials: { GOOGLE_APPLICATION_CREDENTIALS: '/path/to/creds.json' },
-      config: { GOOGLE_VERTEX_PROJECT: 'my-project', GOOGLE_VERTEX_LOCATION: 'us-east5' },
-      flags: ['--from-gcloud-adc'],
-    });
+    expect(openshellCli.createProvider).toHaveBeenCalledWith(
+      {
+        name: 'my-vertex',
+        type: 'google-vertex-ai',
+        credentials: { GOOGLE_APPLICATION_CREDENTIALS: '/path/to/creds.json' },
+        config: { GOOGLE_VERTEX_PROJECT: 'my-project', GOOGLE_VERTEX_LOCATION: 'us-east5' },
+        flags: ['--from-gcloud-adc'],
+      },
+      undefined,
+    );
     expect(result).toEqual({ name: 'my-vertex' });
   });
 });

--- a/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
+++ b/packages/main/src/plugin/secret-manager/openshell-secret-adapter.ts
@@ -40,18 +40,21 @@ export class OpenshellSecretAdapter implements SecretCliBackend {
     private readonly openshellCli: OpenshellCli,
   ) {}
 
-  async createSecret(options: SecretCreateOptions): Promise<SecretName> {
+  async createSecret(options: SecretCreateOptions, gateway?: string): Promise<SecretName> {
     if (typeof options.value === 'string') {
       throw new Error('options.value must be a record for Openshell');
     }
-    await this.openshellCli.createProvider({
-      name: options.name,
-      type: options.type,
-      credentials: options.value.credentials,
-      config: options.value.config,
-      flags: options.value.flags,
-      env: options.value.env,
-    });
+    await this.openshellCli.createProvider(
+      {
+        name: options.name,
+        type: options.type,
+        credentials: options.value.credentials,
+        config: options.value.config,
+        flags: options.value.flags,
+        env: options.value.env,
+      },
+      gateway,
+    );
     return { name: options.name };
   }
 

--- a/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { FileSystemWatcher, InferenceProviderConnection, RegisterInferenceConnectionEvent } from '@openkaiden/api';
+import type { FileSystemWatcher, InferenceProviderConnection } from '@openkaiden/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
@@ -48,15 +48,12 @@ const openshellCli = new OpenshellCli({} as Exec, {} as CliToolRegistry);
 const openshellAdapter = new OpenshellSecretAdapter(openshellCli);
 
 let gatewayStartCallback: (() => void) | undefined;
-let registerInferenceCallback: ((event: RegisterInferenceConnectionEvent) => void) | undefined;
 let unregisterInferenceCallback:
   | ((event: { providerId: string; connection: InferenceProviderConnection }) => void)
   | undefined;
 
 const providerRegistry = {
-  onDidRegisterInferenceConnection: vi.fn((cb: (event: RegisterInferenceConnectionEvent) => void) => {
-    registerInferenceCallback = cb;
-  }),
+  onDidRegisterInferenceConnection: vi.fn(),
   onDidUnregisterInferenceConnection: vi.fn(
     (cb: (event: { providerId: string; connection: InferenceProviderConnection }) => void) => {
       unregisterInferenceCallback = cb;
@@ -99,7 +96,6 @@ const filesystemMonitoring = {
 beforeEach(() => {
   vi.resetAllMocks();
   gatewayStartCallback = undefined;
-  registerInferenceCallback = undefined;
   unregisterInferenceCallback = undefined;
   vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
   vi.mocked(safeStorageRegistry.getExtensionStorage).mockReturnValue(extensionStorageMock);
@@ -128,8 +124,8 @@ describe('init', () => {
     expect(ipcHandle).toHaveBeenCalledWith('secret-manager:remove', expect.any(Function));
   });
 
-  test('subscribes to inference connection events', () => {
-    expect(providerRegistry.onDidRegisterInferenceConnection).toHaveBeenCalled();
+  test('subscribes only to inference connection unregister events', () => {
+    expect(providerRegistry.onDidRegisterInferenceConnection).not.toHaveBeenCalled();
     expect(providerRegistry.onDidUnregisterInferenceConnection).toHaveBeenCalled();
   });
 
@@ -157,7 +153,6 @@ describe('openshellAdapter', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     gatewayStartCallback = undefined;
-    registerInferenceCallback = undefined;
     unregisterInferenceCallback = undefined;
     vi.mocked(filesystemMonitoring.createFileSystemWatcher).mockReturnValue(mockWatcher);
     vi.mocked(safeStorageRegistry.getExtensionStorage).mockReturnValue(extensionStorageMock);
@@ -178,11 +173,14 @@ describe('openshellAdapter', () => {
 
     const result = await manager.create(defaultOptions);
 
-    expect(openshellCli.createProvider).toHaveBeenCalledWith({
-      name: 'my-secret',
-      type: 'github',
-      credentials: { GH_TOKEN: 'ghp_abc123' },
-    });
+    expect(openshellCli.createProvider).toHaveBeenCalledWith(
+      {
+        name: 'my-secret',
+        type: 'github',
+        credentials: { GH_TOKEN: 'ghp_abc123' },
+      },
+      undefined,
+    );
     expect(result).toEqual({ name: 'my-secret' });
   });
 
@@ -249,96 +247,7 @@ describe('inference connection lifecycle', () => {
     credentials: () => ({ token: 'secret-token' }),
   };
 
-  function setupConfigMocks(secretType: string, flags?: string): void {
-    const properties = {
-      'cursor.connection._type': {
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.cursor' },
-        title: 'Cursor',
-        parentId: 'cursor',
-      },
-      'cursor.connection.token': {
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.cursor' },
-        format: 'password',
-        title: 'Cursor',
-        parentId: 'cursor',
-      },
-    } as Record<string, Record<string, unknown>>;
-    if (flags) {
-      properties['cursor.connection._flags'] = {
-        scope: 'InferenceProviderConnection',
-        extension: { id: 'kaiden.cursor' },
-        title: 'Cursor',
-        parentId: 'cursor',
-      };
-    }
-
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(
-      properties as unknown as ReturnType<typeof configurationRegistry.getConfigurationProperties>,
-    );
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn((key: string) => {
-        if (key === 'cursor.connection._type') return secretType;
-        if (key === 'cursor.connection.token') return 'cursor:conn-123:token';
-        if (key === 'cursor.connection._flags') return flags;
-        return undefined;
-      }),
-      has: vi.fn(),
-      update: vi.fn(),
-    } as unknown as ReturnType<typeof configurationRegistry.getConfiguration>);
-
-    vi.mocked(extensionStorageMock.get).mockResolvedValue('actual-api-key');
-    vi.mocked(openshellCli.listProviders).mockResolvedValue([]);
-    vi.mocked(openshellCli.createProvider).mockResolvedValue(undefined);
-    vi.mocked(providerRegistry.getProvider).mockReturnValue({
-      extensionId: 'kaiden.cursor',
-    } as unknown as ProviderImpl);
-  }
-
-  test('creates openshell provider on inference connection register', async () => {
-    setupConfigMocks('cursor');
-
-    registerInferenceCallback!({
-      providerId: 'kaiden.cursor',
-      connection: mockConnection,
-    });
-
-    await vi.waitFor(() => {
-      expect(openshellCli.createProvider).toHaveBeenCalledWith({
-        name: 'kaiden.cursor-conn-123',
-        type: 'cursor',
-        credentials: { token: 'actual-api-key' },
-      });
-    });
-  });
-
-  test('skips creation when provider with same name already exists', async () => {
-    setupConfigMocks('cursor');
-
-    vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'kaiden.cursor-conn-123', type: 'cursor' }]);
-
-    registerInferenceCallback!({
-      providerId: 'kaiden.cursor',
-      connection: mockConnection,
-    });
-
-    await new Promise(resolve => setTimeout(resolve, 50));
-    expect(openshellCli.createProvider).not.toHaveBeenCalled();
-  });
-
   test('deletes openshell provider on inference connection unregister', async () => {
-    setupConfigMocks('cursor');
-
-    registerInferenceCallback!({
-      providerId: 'kaiden.cursor',
-      connection: mockConnection,
-    });
-
-    await vi.waitFor(() => {
-      expect(openshellCli.createProvider).toHaveBeenCalled();
-    });
-
     vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'kaiden.cursor-conn-123', type: 'cursor' }]);
     vi.mocked(openshellCli.deleteProvider).mockResolvedValue(undefined);
 
@@ -352,23 +261,6 @@ describe('inference connection lifecycle', () => {
     });
   });
 
-  test('skips creation when no _type config property exists', async () => {
-    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue({});
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn(() => undefined),
-      has: vi.fn(),
-      update: vi.fn(),
-    } as unknown as ReturnType<typeof configurationRegistry.getConfiguration>);
-
-    registerInferenceCallback!({
-      providerId: 'kaiden.ramalama',
-      connection: mockConnection,
-    });
-
-    await new Promise(resolve => setTimeout(resolve, 50));
-    expect(openshellCli.createProvider).not.toHaveBeenCalled();
-  });
-
   test('getSecretForModel returns SecretInfo matching by name', async () => {
     vi.mocked(providerRegistry.getInferenceConnection).mockReturnValue({
       connection: mockConnection,
@@ -379,8 +271,9 @@ describe('inference connection lifecycle', () => {
       { name: 'kaiden.cursor-conn-123', type: 'cursor' },
     ]);
 
-    const secret = await manager.getSecretForModel('cursor::model-1::');
+    const secret = await manager.getSecretForModel('cursor::model-1::', 'remote');
     expect(secret).toEqual({ name: 'kaiden.cursor-conn-123', type: 'cursor' });
+    expect(openshellCli.listProviders).toHaveBeenCalledWith('remote');
   });
 
   test('getSecretForModel returns undefined for unknown model', async () => {
@@ -454,13 +347,16 @@ describe('createSecretForConnection', () => {
   test('creates secret and returns SecretInfo when none exists', async () => {
     setupConfigMocksForCreate('cursor');
 
-    const result = await manager.createSecretForConnection('kaiden.cursor', mockConnection, false);
+    const result = await manager.createSecretForConnection('kaiden.cursor', mockConnection);
 
-    expect(openshellCli.createProvider).toHaveBeenCalledWith({
-      name: 'kaiden.cursor-conn-456',
-      type: 'cursor',
-      credentials: { token: 'actual-api-key' },
-    });
+    expect(openshellCli.createProvider).toHaveBeenCalledWith(
+      {
+        name: 'kaiden.cursor-conn-456',
+        type: 'cursor',
+        credentials: { token: 'actual-api-key' },
+      },
+      undefined,
+    );
     expect(result).toEqual({ name: 'kaiden.cursor-conn-456', type: 'cursor' });
   });
 
@@ -475,17 +371,7 @@ describe('createSecretForConnection', () => {
       extensionId: 'kaiden.cursor',
     } as unknown as ProviderImpl);
 
-    const result = await manager.createSecretForConnection('kaiden.cursor', mockConnection, false);
-
-    expect(result).toBeUndefined();
-    expect(openshellCli.createProvider).not.toHaveBeenCalled();
-  });
-
-  test('returns undefined when secret already exists', async () => {
-    setupConfigMocksForCreate('cursor');
-    vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'kaiden.cursor-conn-456', type: 'cursor' }]);
-
-    const result = await manager.createSecretForConnection('kaiden.cursor', mockConnection, true);
+    const result = await manager.createSecretForConnection('kaiden.cursor', mockConnection);
 
     expect(result).toBeUndefined();
     expect(openshellCli.createProvider).not.toHaveBeenCalled();
@@ -510,10 +396,11 @@ describe('ensureSecretForModel', () => {
     });
     vi.mocked(openshellCli.listProviders).mockResolvedValue([{ name: 'kaiden.cursor-conn-789', type: 'cursor' }]);
 
-    const result = await manager.ensureSecretForModel('cursor::model-1::');
+    const result = await manager.ensureSecretForModel('cursor::model-1::', 'remote');
 
     expect(result).toEqual({ name: 'kaiden.cursor-conn-789', type: 'cursor' });
     expect(openshellCli.createProvider).not.toHaveBeenCalled();
+    expect(openshellCli.listProviders).toHaveBeenCalledWith('remote');
   });
 
   test('creates and returns secret when missing but connection exists', async () => {
@@ -558,9 +445,16 @@ describe('ensureSecretForModel', () => {
     } as unknown as ReturnType<typeof configurationRegistry.getConfiguration>);
     vi.mocked(extensionStorageMock.get).mockResolvedValue('actual-api-key');
 
-    const result = await manager.ensureSecretForModel('cursor::model-1::');
+    const result = await manager.ensureSecretForModel('cursor::model-1::', 'remote');
 
-    expect(openshellCli.createProvider).toHaveBeenCalled();
+    expect(openshellCli.createProvider).toHaveBeenCalledWith(
+      {
+        name: 'kaiden.cursor-conn-789',
+        type: 'cursor',
+        credentials: { token: 'actual-api-key' },
+      },
+      'remote',
+    );
     expect(result).toEqual({ name: 'kaiden.cursor-conn-789', type: 'cursor' });
   });
 

--- a/packages/main/src/plugin/secret-manager/secret-manager.ts
+++ b/packages/main/src/plugin/secret-manager/secret-manager.ts
@@ -16,12 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type {
-  Configuration,
-  InferenceProviderConnection,
-  RegisterInferenceConnectionEvent,
-  UnregisterInferenceConnectionEvent,
-} from '@openkaiden/api';
+import type { Configuration, InferenceProviderConnection, UnregisterInferenceConnectionEvent } from '@openkaiden/api';
 import { inject, injectable } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
@@ -63,8 +58,8 @@ export class SecretManager {
     return this.openshellAdapter;
   }
 
-  async create(options: SecretCreateOptions): Promise<SecretName> {
-    const result = await this.cli.createSecret(options);
+  async create(options: SecretCreateOptions, gateway?: string): Promise<SecretName> {
+    const result = await this.cli.createSecret(options, gateway);
     this.apiSender.send('secret-manager-update');
     return result;
   }
@@ -83,29 +78,29 @@ export class SecretManager {
     return this.cli.listServices();
   }
 
-  async getSecretForModel(modelId: string): Promise<SecretInfo | undefined> {
+  async getSecretForModel(modelId: string, gateway?: string): Promise<SecretInfo | undefined> {
     const info = this.providerRegistry.getInferenceConnection(modelId);
     if (!info) return undefined;
 
     const expectedName = `${info.providerId}-${info.connection.id}`;
-    const secrets = await this.list();
+    const secrets = await this.list(gateway);
     return secrets.find(s => s.name === expectedName);
   }
 
-  async ensureSecretForModel(modelId: string): Promise<SecretInfo | undefined> {
-    const existing = await this.getSecretForModel(modelId);
+  async ensureSecretForModel(modelId: string, gateway?: string): Promise<SecretInfo | undefined> {
+    const existing = await this.getSecretForModel(modelId, gateway);
     if (existing) return existing;
 
     const info = this.providerRegistry.getInferenceConnection(modelId);
     if (!info) return undefined;
 
-    return this.createSecretForConnection(info.providerId, info.connection, false);
+    return this.createSecretForConnection(info.providerId, info.connection, gateway);
   }
 
   async createSecretForConnection(
     providerId: string,
     connection: InferenceProviderConnection,
-    checkDuplicates: boolean,
+    gateway?: string,
   ): Promise<SecretInfo | undefined> {
     const provider = this.providerRegistry.getProvider(providerId);
     const { config, connectionProperties } = this.getConnectionProperties(connection, provider);
@@ -158,22 +153,16 @@ export class SecretManager {
 
     const secretName = `${providerId}-${connection.id}`;
 
-    if (checkDuplicates) {
-      const existingSecrets = await this.list();
-      if (existingSecrets.some(s => s.name === secretName)) return undefined;
-    }
-
-    await this.create({
-      name: secretName,
-      type: secretType,
-      value: value,
-    });
+    await this.create(
+      {
+        name: secretName,
+        type: secretType,
+        value: value,
+      },
+      gateway,
+    );
 
     return { name: secretName, type: secretType };
-  }
-
-  private async onInferenceConnectionRegistered(event: RegisterInferenceConnectionEvent): Promise<void> {
-    await this.createSecretForConnection(event.providerId, event.connection, true);
   }
 
   public getConnectionProperties(
@@ -208,12 +197,6 @@ export class SecretManager {
   }
 
   init(): void {
-    this.providerRegistry.onDidRegisterInferenceConnection(event => {
-      this.onInferenceConnectionRegistered(event).catch((err: unknown) => {
-        console.error('Failed to create openshell provider for inference connection:', err);
-      });
-    });
-
     this.providerRegistry.onDidUnregisterInferenceConnection(event => {
       this.onInferenceConnectionUnregistered(event).catch((err: unknown) => {
         console.error('Failed to delete openshell provider for inference connection:', err);

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -498,18 +498,28 @@ test('Expect secrets listed from the selected gateway', async () => {
     { name: 'local', endpoint: 'http://localhost:17670', active: true },
     { name: 'remote', endpoint: 'https://remote.example.com', active: false },
   ]);
-  vi.mocked(window.listSecrets).mockResolvedValue([
-    {
-      name: 'github-token',
-      type: 'github',
-      description: 'Personal access token',
-    },
-    {
-      name: 'anthropic-key',
-      type: 'anthropic',
-      description: 'API key',
-    },
-  ]);
+  vi.mocked(window.listSecrets).mockImplementation(async gateway =>
+    gateway === 'remote'
+      ? [
+          {
+            name: 'github-token',
+            type: 'github',
+            description: 'Personal access token',
+          },
+          {
+            name: 'anthropic-key',
+            type: 'anthropic',
+            description: 'API key',
+          },
+        ]
+      : [
+          {
+            name: 'local-only-secret',
+            type: 'generic',
+            description: 'Only available on the local gateway',
+          },
+        ],
+  );
 
   render(AgentWorkspaceCreate);
 
@@ -519,9 +529,32 @@ test('Expect secrets listed from the selected gateway', async () => {
 
   expect(screen.getByText('github-token')).toBeInTheDocument();
   expect(screen.getByText('anthropic-key')).toBeInTheDocument();
+  expect(screen.queryByText('local-only-secret')).not.toBeInTheDocument();
   expect(window.listSecrets).toHaveBeenCalledWith('remote');
   expect(screen.getByText('Secret Vault')).toBeInTheDocument();
   expect(screen.queryByText('No secrets in your vault yet.')).not.toBeInTheDocument();
+});
+
+test('Expect stale secret selections cleared and Continue disabled while gateway secrets load', async () => {
+  let resolveSecrets: (secrets: { name: string; type: string; description: string }[]) => void;
+  vi.mocked(window.listSecrets).mockImplementation(
+    () =>
+      new Promise(resolve => {
+        resolveSecrets = resolve;
+      }),
+  );
+  wizard.draft.selectedSecretIds = ['local-only-secret'];
+
+  render(AgentWorkspaceCreate);
+
+  await navigateToToolsSecretsStep();
+
+  expect(wizard.draft.selectedSecretIds).toEqual([]);
+  expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+
+  resolveSecrets!([{ name: 'remote-secret', type: 'generic', description: 'Remote gateway secret' }]);
+
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled());
 });
 
 test('Expect Open Vault button navigates to secret vault', async () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -292,6 +292,7 @@ $effect(() => {
 // --- Wizard navigation ---
 let currentStepIndex = $derived(wizard.draft.currentStepIndex);
 let error = $state('');
+let secretsLoading = $state(false);
 
 let currentStepId = $derived(wizardSteps[wizard.draft.currentStepIndex]?.id ?? '');
 let isLastStep = $derived(wizard.draft.currentStepIndex === wizardSteps.length - 1);
@@ -320,6 +321,9 @@ let isCurrentStepComplete = $derived.by(() => {
   }
   if (currentStepId === 'agent-model') {
     return hasModel;
+  }
+  if (currentStepId === 'tools-secrets') {
+    return !secretsLoading;
   }
   return true;
 });
@@ -625,6 +629,7 @@ async function startWorkspace(): Promise<void> {
                 {mcpItems}
                 bind:selectedMcpIds={wizard.draft.selectedMcpIds}
                 bind:selectedSecretIds={wizard.draft.selectedSecretIds}
+                bind:secretsLoading
                 {knowledgeItems}
                 bind:selectedKnowledgeIds={wizard.draft.selectedKnowledgeIds} />
             {:else if currentStepId === 'filesystem'}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreateStepToolsSecrets.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faBook, faKey, faServer, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { Button, Expandable } from '@podman-desktop/ui-svelte';
+import { untrack } from 'svelte';
 import { router } from 'tinro';
 
 import type { ChecklistItem } from '/@/lib/ui/ChecklistPanel.svelte';
@@ -15,6 +16,7 @@ interface Props {
   mcpItems: ChecklistItem[];
   selectedMcpIds: string[];
   selectedSecretIds: string[];
+  secretsLoading: boolean;
   gateway: string;
   knowledgeItems: ChecklistItem[];
   selectedKnowledgeIds: string[];
@@ -26,6 +28,7 @@ let {
   mcpItems,
   selectedMcpIds = $bindable(),
   selectedSecretIds = $bindable(),
+  secretsLoading = $bindable(),
   gateway,
   knowledgeItems,
   selectedKnowledgeIds = $bindable(),
@@ -42,18 +45,22 @@ let secretItems: ChecklistItem[] = $derived(
 
 $effect(() => {
   let cancelled = false;
+  const requestedSecretIds = untrack(() => selectedSecretIds);
   secrets = [];
+  selectedSecretIds = [];
+  secretsLoading = true;
   window.listSecrets(gateway).then(
     items => {
       if (!cancelled) {
         secrets = items;
         const available = new Set(items.map(item => item.name));
-        selectedSecretIds = selectedSecretIds.filter(id => available.has(id));
+        selectedSecretIds = requestedSecretIds.filter(id => available.has(id));
+        secretsLoading = false;
       }
     },
     (error: unknown) => {
       if (!cancelled) {
-        selectedSecretIds = [];
+        secretsLoading = false;
         console.error('Failed to list secrets for gateway', error);
       }
     },


### PR DESCRIPTION
## Summary

- stop eagerly creating OpenShell providers when inference connections are registered
- create a missing model provider when a workspace is created, once the target gateway is known
- scope both the provider existence check and provider creation to the workspace's selected gateway
- preserve provider reuse for subsequent workspaces on the same gateway

Fixes #2559.

## Design

Inference connections are global to Kaiden and do not carry gateway context. Creating their OpenShell providers at registration time therefore targets whichever gateway happens to be active, or would require copying credentials to every gateway.

Workspace creation has both pieces of required context: the selected inference connection and selected gateway. It now checks that gateway for the connection-derived provider and creates it there only when missing.

Inference-connection unregister cleanup remains unchanged. Correct cross-gateway deletion belongs to the broader lifecycle work in #2525.

## Dependency

This PR is stacked on #2616, which adds gateway-scoped provider listing. Until #2616 merges, this PR contains both commits in its comparison against `main`.

### Local two-gateway verification

With gateways named `openshell` and `test-secondary`, inspect their initial providers:

```bash
openshell provider list -g openshell -o json | jq -r '.[].name'
openshell provider list -g test-secondary -o json | jq -r '.[].name'
```

Remove the provider associated with the inference connection/model used for testing:

```bash
openshell provider delete -g openshell <provider-name>
openshell provider delete -g test-secondary <provider-name>
```

Restart Kaiden. The provider remains absent because inference connection registration no longer creates it eagerly.

Create a workspace in Kaiden using that model and select `test-secondary`. Provider provisioning occurs before sandbox creation, so the placement can be verified even if a lightweight test gateway cannot complete sandbox startup:

```bash
openshell provider list -g test-secondary -o json | jq -r '.[].name'
openshell provider list -g openshell -o json | jq -r '.[].name'
```

The connection-derived provider appears only on `test-secondary`.

Create another workspace using the same model and gateway, then verify the provider was reused:

```bash
openshell provider list -g test-secondary -o json |
  jq '[.[] | select(.name == "<provider-name>")] | length'
```

The result is `1`.
