### PR TITLE
chore(ci): add unit-tests flag to codecov upload

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -267,6 +267,8 @@ jobs:
       - name: publish codecov report
         if: ${{ matrix.os=='ubuntu-24.04' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          flags: unit-tests
 
   smoke-e2e-tests:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}


### PR DESCRIPTION
## Summary

- Add `flags: unit-tests` to the codecov upload step in `pr-check.yaml` so codecov can track unit test coverage separately in its dashboard

## Test plan

- [ ] Verify CI workflows run successfully
- [ ] Confirm codecov reports show the `unit-tests` flag on the uploaded coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)