### PR TITLE
fix(openshell): allow Electron header downloads in sandbox policy

### DIFF
--- a/.fullsend/policies/code.yaml
+++ b/.fullsend/policies/code.yaml
@@ -23,6 +23,39 @@ process:
   run_as_group: sandbox
 
 network_policies:
+
+  # Required for Kaiden:
+  # added to be able to download node-gyp releases for pnpm install
+  nodegyp_releases:
+    name: nodegyp-releases
+    endpoints:
+      - host: codeload.github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: /electron/node-gyp/** }
+      - host: www.electronjs.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: /headers/** }
+      - host: artifacts.electronjs.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: /** }
+      - host: nodejs.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: /dist/** }
+    binaries:
+      - path: "**/node"
+
   vertex_ai:
     name: vertex-ai
     endpoints:
@@ -87,6 +120,8 @@ network_policies:
         access: read-only
     binaries:
       - path: "**/pre-commit"
+      # required by Kaiden for better-sqlite3 (during pnpm install)
+      - path: "**/node"
 
   package_registries:
     name: package-registries


### PR DESCRIPTION
## Summary
- Add `www.electronjs.org` and `artifacts.electronjs.org` to the `nodegyp_releases` network policy so `@electron/rebuild` can download Electron headers during `pnpm install`
- Add `nodejs.org` for node-gyp Node.js headers fallback
- Add `**/node` binary to `gitleaks_releases` policy for better-sqlite3 prebuild downloads

## Test plan
- [ ] Run `pnpm install` inside an OpenShell sandbox with the updated policy
- [ ] Verify no `DENIED` entries for `electronjs.org` or `nodejs.org` in sandbox logs
- [ ] Verify native modules (`cpu-features`, `better-sqlite3`) build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)