### PR TITLE
feat(openshell): track gateway lifecycle state

### DIFF
--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -58,6 +58,7 @@
           "scope": "DEFAULT",
           "default": 5,
           "minimum": 1,
+          "maximum": 3600,
           "description": "Interval in seconds between OpenShell gateway state checks."
         }
       }

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -52,6 +52,13 @@
           "when": "!isWindows",
           "default": "",
           "description": "Custom path to openshell-gateway binary (Default is blank)"
+        },
+        "openshell.gateway.pollInterval": {
+          "type": "number",
+          "scope": "DEFAULT",
+          "default": 5,
+          "minimum": 1,
+          "description": "Interval in seconds between OpenShell gateway state checks."
         }
       }
     }

--- a/packages/api/src/openshell-gateway-info.ts
+++ b/packages/api/src/openshell-gateway-info.ts
@@ -18,6 +18,17 @@
 
 import z from 'zod';
 
+export const GatewayHealthSchema = z.enum(['healthy', 'degraded', 'unhealthy', 'unknown']);
+
+export type GatewayHealth = z.output<typeof GatewayHealthSchema>;
+
+export const GatewayStateSchema = z.object({
+  reachable: z.boolean(),
+  health: GatewayHealthSchema,
+});
+
+export type GatewayState = z.output<typeof GatewayStateSchema>;
+
 export const GatewayInfoSchema = z.object({
   name: z.string(),
   endpoint: z.string(),
@@ -28,6 +39,7 @@ export const GatewayInfoSchema = z.object({
   is_remote: z.boolean().optional(),
   remote_host: z.string().nullable().optional(),
   resolved_host: z.string().nullable().optional(),
+  gatewayState: GatewayStateSchema.optional(),
 });
 
 export type GatewayInfo = z.output<typeof GatewayInfoSchema>;
@@ -126,6 +138,7 @@ export interface OpenshellGatewayStartOptions {
 }
 
 export const GatewayRuntimeInfoSchema = z.looseObject({
+  status: GatewayHealthSchema,
   compute_drivers: z.array(
     z.looseObject({
       capabilities: z.looseObject({

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -149,6 +149,7 @@ const openshellGateway = {
 const openshellGatewayStateManager = {
   listGateways: vi.fn(),
   refresh: vi.fn(),
+  whenReady: vi.fn(),
   onDidUpdateGateways: vi.fn((cb: () => void) => {
     gatewayStateUpdateCallback = cb;
     return { dispose: vi.fn() };
@@ -182,6 +183,14 @@ beforeEach(() => {
   vi.mocked(writeFile).mockResolvedValue(undefined);
   vi.mocked(rm).mockResolvedValue(undefined);
   vi.mocked(openshellGatewayStateManager.refresh).mockResolvedValue(undefined);
+  vi.mocked(openshellGatewayStateManager.whenReady).mockResolvedValue(undefined);
+  vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue([
+    {
+      name: 'kaiden',
+      endpoint: 'http://127.0.0.1:17670',
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
   vi.mocked(readFile).mockResolvedValue('{}');
   vi.mocked(realpath).mockImplementation(async (p: unknown) => p as string);
   vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
@@ -351,6 +360,37 @@ describe('create – OpenShell mode', () => {
         command: ['true'],
       }),
     );
+  });
+
+  test('rejects an unreachable gateway before creating a sandbox', async () => {
+    vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue([
+      {
+        name: 'kaiden',
+        endpoint: 'http://127.0.0.1:17670',
+        gatewayState: { reachable: false, health: 'unknown' },
+      },
+    ]);
+
+    await expect(manager.create(defaultOptions)).rejects.toThrow('gateway "kaiden" is unreachable');
+
+    expect(openshellCli.createSandbox).not.toHaveBeenCalled();
+  });
+
+  test('waits for the gateway cache before checking reachability', async () => {
+    let resolveReady: () => void;
+    vi.mocked(openshellGatewayStateManager.whenReady).mockReturnValue(
+      new Promise(resolve => {
+        resolveReady = resolve;
+      }),
+    );
+
+    const createPromise = manager.create(defaultOptions);
+    await Promise.resolve();
+    expect(openshellGatewayStateManager.listGateways).not.toHaveBeenCalled();
+
+    resolveReady!();
+    await createPromise;
+    expect(openshellGatewayStateManager.listGateways).toHaveBeenCalledOnce();
   });
 
   test('returns { id: sandboxName }', async () => {

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.spec.ts
@@ -40,6 +40,7 @@ import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { Directories } from '/@/plugin/directories.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import type { OpenshellGatewayStateManager } from '/@/plugin/openshell-cli/openshell-gateway-state-manager.js';
 import type { ProviderImpl } from '/@/plugin/provider-impl.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { SecretManager } from '/@/plugin/secret-manager/secret-manager.js';
@@ -131,6 +132,7 @@ const providerRegistry = {
 
 let gatewayStartCallback: (() => void) | undefined;
 let gatewayInitFailedCallback: ((message: string) => void) | undefined;
+let gatewayStateUpdateCallback: (() => void) | undefined;
 let sandboxListChangeCallback: (() => void) | undefined;
 
 const openshellGateway = {
@@ -143,6 +145,15 @@ const openshellGateway = {
     return { dispose: vi.fn() };
   }),
 } as unknown as OpenshellGateway;
+
+const openshellGatewayStateManager = {
+  listGateways: vi.fn(),
+  refresh: vi.fn(),
+  onDidUpdateGateways: vi.fn((cb: () => void) => {
+    gatewayStateUpdateCallback = cb;
+    return { dispose: vi.fn() };
+  }),
+} as unknown as OpenshellGatewayStateManager;
 
 const secretManager = {
   create: vi.fn(),
@@ -170,6 +181,7 @@ beforeEach(() => {
   mockTask.error = '';
   vi.mocked(writeFile).mockResolvedValue(undefined);
   vi.mocked(rm).mockResolvedValue(undefined);
+  vi.mocked(openshellGatewayStateManager.refresh).mockResolvedValue(undefined);
   vi.mocked(readFile).mockResolvedValue('{}');
   vi.mocked(realpath).mockImplementation(async (p: unknown) => p as string);
   vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
@@ -196,6 +208,7 @@ beforeEach(() => {
   vi.mocked(tmpdir).mockReturnValue('/tmp');
   gatewayStartCallback = undefined;
   gatewayInitFailedCallback = undefined;
+  gatewayStateUpdateCallback = undefined;
   sandboxListChangeCallback = undefined;
   Object.defineProperty(openshellCli, 'onDidSandboxListChange', {
     value: vi.fn((cb: () => void) => {
@@ -216,6 +229,7 @@ beforeEach(() => {
     openshellCli,
     agentRegistry,
     openshellGateway,
+    openshellGatewayStateManager,
     directories,
   );
   manager.init();
@@ -263,9 +277,9 @@ describe('init', () => {
     expect(openshellGateway.onDidGatewayStart).toHaveBeenCalled();
   });
 
-  test('sends gateway and workspace update events when gateway starts', () => {
+  test('refreshes gateway state and sends a workspace update when gateway starts', () => {
     gatewayStartCallback!();
-    expect(apiSender.send).toHaveBeenCalledWith('agent-gateway-update');
+    expect(openshellGatewayStateManager.refresh).toHaveBeenCalled();
     expect(apiSender.send).toHaveBeenCalledWith('agent-workspace-update');
   });
 
@@ -273,8 +287,13 @@ describe('init', () => {
     expect(openshellGateway.onDidGatewayInitFailed).toHaveBeenCalled();
   });
 
-  test('sends gateway update event when gateway init fails', () => {
+  test('refreshes gateway state when gateway init fails', () => {
     gatewayInitFailedCallback!('Socket not found');
+    expect(openshellGatewayStateManager.refresh).toHaveBeenCalled();
+  });
+
+  test('sends gateway update event when monitored gateway state changes', () => {
+    gatewayStateUpdateCallback!();
     expect(apiSender.send).toHaveBeenCalledWith('agent-gateway-update');
   });
 
@@ -1152,6 +1171,7 @@ describe('listOpenshellGateways', () => {
       auth: 'plaintext',
       type: 'local',
       source: 'user',
+      gatewayState: { reachable: true, health: 'healthy' },
     },
     {
       name: 'remote-vm',
@@ -1163,26 +1183,22 @@ describe('listOpenshellGateways', () => {
       is_remote: true,
       remote_host: 'user@gateway-alias',
       resolved_host: '10.0.0.5',
+      gatewayState: { reachable: false, health: 'unknown' },
     },
   ];
 
-  test('delegates to openshellCli.listGateways and returns registered gateways', async () => {
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(TEST_GATEWAYS);
+  test('returns the cached gateway-state snapshot', async () => {
+    vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue(TEST_GATEWAYS);
 
     const result = await manager.listOpenshellGateways();
 
-    expect(openshellCli.listGateways).toHaveBeenCalled();
+    expect(openshellGatewayStateManager.listGateways).toHaveBeenCalled();
     expect(result).toEqual(TEST_GATEWAYS);
-  });
-
-  test('rejects when openshellCli.listGateways fails', async () => {
-    vi.mocked(openshellCli.listGateways).mockRejectedValue(new Error('command not found'));
-
-    await expect(manager.listOpenshellGateways()).rejects.toThrow('command not found');
+    expect(result).not.toBe(TEST_GATEWAYS);
   });
 
   test('IPC handler returns OpenShell gateways', async () => {
-    vi.mocked(openshellCli.listGateways).mockResolvedValue(TEST_GATEWAYS);
+    vi.mocked(openshellGatewayStateManager.listGateways).mockReturnValue(TEST_GATEWAYS);
     const handler = vi
       .mocked(ipcHandle)
       .mock.calls.find(([channel]) => channel === 'agent-workspace:listOpenshellGateways')?.[1];

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -140,6 +140,14 @@ export class AgentWorkspaceManager implements Disposable {
         throw new Error('model is required to create a workspace');
       }
 
+      await this.openshellGatewayStateManager.whenReady();
+      const gateway = this.openshellGatewayStateManager
+        .listGateways()
+        .find(candidate => candidate.name === options.gateway);
+      if (!gateway?.gatewayState?.reachable) {
+        throw new Error(`gateway "${options.gateway}" is unreachable`);
+      }
+
       if (options.replaceConfig) {
         if (options.sourcePath) {
           await rm(join(options.sourcePath, '.kaiden', 'workspace.json'), { force: true });

--- a/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
+++ b/packages/main/src/plugin/agent-workspace/agent-workspace-manager.ts
@@ -33,6 +33,7 @@ import { IPCHandle, WebContentsType } from '/@/plugin/api.js';
 import { Directories } from '/@/plugin/directories.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import { OpenshellGatewayStateManager } from '/@/plugin/openshell-cli/openshell-gateway-state-manager.js';
 import {
   buildPolicyObject,
   collectBinaryFlags,
@@ -113,6 +114,8 @@ export class AgentWorkspaceManager implements Disposable {
     private readonly agentRegistry: AgentRegistry,
     @inject(OpenshellGateway)
     private readonly openshellGateway: OpenshellGateway,
+    @inject(OpenshellGatewayStateManager)
+    private readonly openshellGatewayStateManager: OpenshellGatewayStateManager,
     @inject(Directories)
     private readonly directories: Directories,
   ) {}
@@ -559,7 +562,7 @@ export class AgentWorkspaceManager implements Disposable {
   }
 
   async listOpenshellGateways(): Promise<GatewayInfo[]> {
-    return this.openshellCli.listGateways();
+    return [...this.openshellGatewayStateManager.listGateways()];
   }
 
   async deleteOpenshellSandbox(name: string, gateway: string): Promise<void> {
@@ -828,13 +831,31 @@ export class AgentWorkspaceManager implements Disposable {
 
     this.disposables.push(
       this.openshellGateway.onDidGatewayStart(() => {
-        this.apiSender.send('agent-gateway-update');
+        this.openshellGatewayStateManager.refresh().catch((err: unknown) => {
+          console.warn(
+            `[AgentWorkspaceManager] unable to refresh gateways after startup: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        });
         this.apiSender.send('agent-workspace-update');
       }),
     );
 
     this.disposables.push(
       this.openshellGateway.onDidGatewayInitFailed(() => {
+        this.openshellGatewayStateManager.refresh().catch((err: unknown) => {
+          console.warn(
+            `[AgentWorkspaceManager] unable to refresh gateways after startup failure: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        });
+      }),
+    );
+
+    this.disposables.push(
+      this.openshellGatewayStateManager.onDidUpdateGateways(() => {
         this.apiSender.send('agent-gateway-update');
       }),
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -73,6 +73,7 @@ import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { OpenshellGateway } from '/@/plugin/openshell-cli/openshell-gateway.js';
+import { OpenshellGatewayStateManager } from '/@/plugin/openshell-cli/openshell-gateway-state-manager.js';
 import { OpenshellImageBuilder } from '/@/plugin/openshell-cli/openshell-image-builder.js';
 import { OpenShellRegistry } from '/@/plugin/openshell-registry.js';
 import { RagEnvironmentRegistry } from '/@/plugin/rag-environment-registry.js';
@@ -603,6 +604,7 @@ export class PluginSystem {
     container.bind<OpenShellRegistry>(OpenShellRegistry).toSelf().inSingletonScope();
     container.bind<OpenshellCli>(OpenshellCli).toSelf().inSingletonScope();
     container.bind<OpenshellGateway>(OpenshellGateway).toSelf().inSingletonScope();
+    container.bind<OpenshellGatewayStateManager>(OpenshellGatewayStateManager).toSelf().inSingletonScope();
     container.bind<OpenshellImageBuilder>(OpenshellImageBuilder).toSelf().inSingletonScope();
     container.bind<AgentWorkspaceManager>(AgentWorkspaceManager).toSelf().inSingletonScope();
     container.bind<OpenshellSecretAdapter>(OpenshellSecretAdapter).toSelf().inSingletonScope();
@@ -705,6 +707,8 @@ export class PluginSystem {
 
     const agentWorkspaceManager = container.get<AgentWorkspaceManager>(AgentWorkspaceManager);
     agentWorkspaceManager.init();
+    const openshellGatewayStateManager = container.get<OpenshellGatewayStateManager>(OpenshellGatewayStateManager);
+    openshellGatewayStateManager.init();
 
     const secretManager = container.get<SecretManager>(SecretManager);
     secretManager.init();

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.spec.ts
@@ -744,6 +744,19 @@ describe('getGatewayInfo', () => {
     expect(exec.exec).toHaveBeenCalledWith(OPENSHELL_CLI_PATH, ['gateway', 'info', '-o', 'json'], undefined);
     expect(result).toEqual(payload);
   });
+
+  test('gets runtime information for a named gateway', async () => {
+    const payload = { compute_drivers: [], status: 'degraded' };
+    vi.mocked(exec.exec).mockResolvedValue(mockExecResult(JSON.stringify(payload)));
+
+    await expect(openshellCli.getGatewayInfo('remote')).resolves.toEqual(payload);
+
+    expect(exec.exec).toHaveBeenCalledWith(
+      OPENSHELL_CLI_PATH,
+      ['gateway', 'info', '-g', 'remote', '-o', 'json'],
+      undefined,
+    );
+  });
 });
 
 describe('listSandboxesForGateway', () => {

--- a/packages/main/src/plugin/openshell-cli/openshell-cli.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-cli.ts
@@ -418,8 +418,12 @@ export class OpenshellCli {
     return z.array(GatewayInfoSchema).parse(data);
   }
 
-  async getGatewayInfo(): Promise<GatewayRuntimeInfo> {
-    const data = await this.execCLI<unknown>(['gateway', 'info']);
+  async getGatewayInfo(gatewayName?: string): Promise<GatewayRuntimeInfo> {
+    const args = ['gateway', 'info'];
+    if (gatewayName) {
+      args.push('-g', gatewayName);
+    }
+    const data = await this.execCLI<unknown>(args);
     return GatewayRuntimeInfoSchema.parse(data);
   }
 

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.spec.ts
@@ -1,0 +1,191 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import type { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import type { IConfigurationRegistry } from '/@api/configuration/models.js';
+
+import { OpenshellGatewayStateManager } from './openshell-gateway-state-manager.js';
+
+const openshellCli = {
+  listGateways: vi.fn(),
+  getGatewayInfo: vi.fn(),
+} as unknown as OpenshellCli;
+let pollInterval = 5;
+let configurationChangeCallback: ((event: { key: string }) => void) | undefined;
+const configurationRegistry = {
+  getConfiguration: vi.fn(() => ({ get: vi.fn(() => pollInterval) })),
+  onDidChangeConfiguration: vi.fn((callback: (event: { key: string }) => void) => {
+    configurationChangeCallback = callback;
+    return { dispose: vi.fn() };
+  }),
+} as unknown as IConfigurationRegistry;
+
+let manager: OpenshellGatewayStateManager;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  pollInterval = 5;
+  configurationChangeCallback = undefined;
+  vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+    get: vi.fn(() => pollInterval),
+  } as unknown as ReturnType<IConfigurationRegistry['getConfiguration']>);
+  vi.mocked(configurationRegistry.onDidChangeConfiguration).mockImplementation(callback => {
+    configurationChangeCallback = callback as (event: { key: string }) => void;
+    return { dispose: vi.fn() };
+  });
+  manager = new OpenshellGatewayStateManager(openshellCli, configurationRegistry);
+});
+
+afterEach(() => {
+  manager.dispose();
+  vi.useRealTimers();
+});
+
+test('builds a cached snapshot from registrations and runtime information', async () => {
+  vi.mocked(openshellCli.listGateways).mockResolvedValue([
+    { name: 'local', endpoint: 'http://127.0.0.1:17670', active: true },
+    { name: 'remote', endpoint: 'https://gateway.example.com', active: false },
+  ]);
+  vi.mocked(openshellCli.getGatewayInfo)
+    .mockResolvedValueOnce({ status: 'healthy', compute_drivers: [] })
+    .mockResolvedValueOnce({ status: 'degraded', compute_drivers: [] });
+
+  await manager.refresh();
+
+  expect(openshellCli.getGatewayInfo).toHaveBeenCalledWith('local');
+  expect(openshellCli.getGatewayInfo).toHaveBeenCalledWith('remote');
+  expect(manager.listGateways()).toEqual([
+    {
+      name: 'local',
+      endpoint: 'http://127.0.0.1:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://gateway.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'degraded' },
+    },
+  ]);
+});
+
+test('marks a gateway unreachable when runtime information cannot be retrieved', async () => {
+  vi.mocked(openshellCli.listGateways).mockResolvedValue([{ name: 'stopped', endpoint: 'http://127.0.0.1:17671' }]);
+  vi.mocked(openshellCli.getGatewayInfo).mockRejectedValue(new Error('connection refused'));
+
+  await manager.refresh();
+
+  expect(manager.listGateways()).toEqual([
+    {
+      name: 'stopped',
+      endpoint: 'http://127.0.0.1:17671',
+      gatewayState: { reachable: false, health: 'unknown' },
+    },
+  ]);
+});
+
+test('fires an update when a registration is removed by the CLI', async () => {
+  const listener = vi.fn();
+  manager.onDidUpdateGateways(listener);
+  vi.mocked(openshellCli.listGateways)
+    .mockResolvedValueOnce([{ name: 'local', endpoint: 'http://127.0.0.1:17670' }])
+    .mockResolvedValueOnce([]);
+  vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({ status: 'healthy', compute_drivers: [] });
+
+  await manager.refresh();
+  listener.mockClear();
+  await manager.refresh();
+
+  expect(listener).toHaveBeenCalledOnce();
+  expect(listener).toHaveBeenCalledWith([]);
+  expect(manager.listGateways()).toEqual([]);
+});
+
+test('does not fire an update when the gateway snapshot is unchanged', async () => {
+  const listener = vi.fn();
+  manager.onDidUpdateGateways(listener);
+  vi.mocked(openshellCli.listGateways).mockResolvedValue([
+    { name: 'local', endpoint: 'http://127.0.0.1:17670', active: true },
+  ]);
+  vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({ status: 'healthy', compute_drivers: [] });
+
+  await manager.refresh();
+  listener.mockClear();
+  await manager.refresh();
+
+  expect(listener).not.toHaveBeenCalled();
+});
+
+test('fires an update when active selection or gateway state changes', async () => {
+  const listener = vi.fn();
+  manager.onDidUpdateGateways(listener);
+  vi.mocked(openshellCli.listGateways)
+    .mockResolvedValueOnce([{ name: 'local', endpoint: 'http://127.0.0.1:17670', active: false }])
+    .mockResolvedValueOnce([{ name: 'local', endpoint: 'http://127.0.0.1:17670', active: true }]);
+  vi.mocked(openshellCli.getGatewayInfo)
+    .mockResolvedValueOnce({ status: 'healthy', compute_drivers: [] })
+    .mockResolvedValueOnce({ status: 'unhealthy', compute_drivers: [] });
+
+  await manager.refresh();
+  listener.mockClear();
+  await manager.refresh();
+
+  expect(listener).toHaveBeenCalledOnce();
+  expect(manager.listGateways()[0]).toEqual(
+    expect.objectContaining({
+      active: true,
+      gatewayState: { reachable: true, health: 'unhealthy' },
+    }),
+  );
+});
+
+test('polls gateways and stops polling when disposed', async () => {
+  vi.useFakeTimers();
+  vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+
+  manager.init();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(openshellCli.listGateways).toHaveBeenCalledOnce();
+
+  await vi.advanceTimersByTimeAsync(5000);
+  expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
+
+  manager.dispose();
+  await vi.advanceTimersByTimeAsync(5000);
+  expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
+});
+
+test('reschedules polling when the configured interval changes', async () => {
+  vi.useFakeTimers();
+  vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+
+  manager.init();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(openshellCli.listGateways).toHaveBeenCalledOnce();
+
+  pollInterval = 1;
+  configurationChangeCallback?.({ key: 'openshell.gateway.pollInterval' });
+
+  await vi.advanceTimersByTimeAsync(999);
+  expect(openshellCli.listGateways).toHaveBeenCalledOnce();
+  await vi.advanceTimersByTimeAsync(1);
+  expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
+});

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.spec.ts
@@ -134,6 +134,33 @@ test('does not fire an update when the gateway snapshot is unchanged', async () 
   expect(listener).not.toHaveBeenCalled();
 });
 
+test('runs a trailing refresh when another refresh is requested while one is active', async () => {
+  let resolveFirstRefresh: (gateways: [{ name: string; endpoint: string }]) => void;
+  vi.mocked(openshellCli.listGateways)
+    .mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveFirstRefresh = resolve;
+      }),
+    )
+    .mockResolvedValueOnce([{ name: 'new', endpoint: 'http://127.0.0.1:17671' }]);
+  vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({ status: 'healthy', compute_drivers: [] });
+
+  const activeRefresh = manager.refresh();
+  const queuedRefresh = manager.refresh();
+  resolveFirstRefresh!([{ name: 'old', endpoint: 'http://127.0.0.1:17670' }]);
+
+  await Promise.all([activeRefresh, queuedRefresh]);
+
+  expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
+  expect(manager.listGateways()).toEqual([
+    {
+      name: 'new',
+      endpoint: 'http://127.0.0.1:17671',
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+});
+
 test('fires an update when active selection or gateway state changes', async () => {
   const listener = vi.fn();
   manager.onDidUpdateGateways(listener);
@@ -190,6 +217,19 @@ test('waits for the initial refresh before becoming ready', async () => {
   expect(openshellCli.listGateways).toHaveBeenCalledOnce();
 });
 
+test('becomes ready after the initial refresh fails and a later refresh succeeds', async () => {
+  vi.mocked(openshellCli.listGateways)
+    .mockRejectedValueOnce(new Error('temporary startup failure'))
+    .mockResolvedValue([]);
+
+  manager.init();
+
+  await expect(manager.whenReady()).rejects.toThrow('temporary startup failure');
+  await manager.refresh();
+  await expect(manager.whenReady()).resolves.toBeUndefined();
+  expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
+});
+
 test('reschedules polling when the configured interval changes', async () => {
   vi.useFakeTimers();
   vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
@@ -214,6 +254,18 @@ test('clamps polling intervals below one second', async () => {
 
   manager.init();
   await vi.advanceTimersByTimeAsync(999);
+  expect(openshellCli.listGateways).toHaveBeenCalledOnce();
+  await vi.advanceTimersByTimeAsync(1);
+  expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
+});
+
+test('clamps polling intervals above one hour', async () => {
+  vi.useFakeTimers();
+  pollInterval = 3601;
+  vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+
+  manager.init();
+  await vi.advanceTimersByTimeAsync(3_599_999);
   expect(openshellCli.listGateways).toHaveBeenCalledOnce();
   await vi.advanceTimersByTimeAsync(1);
   expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.spec.ts
@@ -18,9 +18,9 @@
 
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
-import type { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import type { IConfigurationRegistry } from '/@api/configuration/models.js';
 
+import type { OpenshellCli } from './openshell-cli.js';
 import { OpenshellGatewayStateManager } from './openshell-gateway-state-manager.js';
 
 const openshellCli = {
@@ -173,6 +173,23 @@ test('polls gateways and stops polling when disposed', async () => {
   expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
 });
 
+test('waits for the initial refresh before becoming ready', async () => {
+  let resolveListGateways: (gateways: []) => void;
+  vi.mocked(openshellCli.listGateways).mockReturnValue(
+    new Promise(resolve => {
+      resolveListGateways = resolve;
+    }),
+  );
+
+  manager.init();
+  const ready = manager.whenReady();
+
+  expect(manager.listGateways()).toEqual([]);
+  resolveListGateways!([]);
+  await ready;
+  expect(openshellCli.listGateways).toHaveBeenCalledOnce();
+});
+
 test('reschedules polling when the configured interval changes', async () => {
   vi.useFakeTimers();
   vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
@@ -184,6 +201,18 @@ test('reschedules polling when the configured interval changes', async () => {
   pollInterval = 1;
   configurationChangeCallback?.({ key: 'openshell.gateway.pollInterval' });
 
+  await vi.advanceTimersByTimeAsync(999);
+  expect(openshellCli.listGateways).toHaveBeenCalledOnce();
+  await vi.advanceTimersByTimeAsync(1);
+  expect(openshellCli.listGateways).toHaveBeenCalledTimes(2);
+});
+
+test('clamps polling intervals below one second', async () => {
+  vi.useFakeTimers();
+  pollInterval = 0;
+  vi.mocked(openshellCli.listGateways).mockResolvedValue([]);
+
+  manager.init();
   await vi.advanceTimersByTimeAsync(999);
   expect(openshellCli.listGateways).toHaveBeenCalledOnce();
   await vi.advanceTimersByTimeAsync(1);

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.ts
@@ -22,16 +22,18 @@ import type { Disposable } from '@openkaiden/api';
 import { inject, injectable, preDestroy } from 'inversify';
 
 import { Emitter } from '/@/plugin/events/emitter.js';
-import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
 import { IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { IDisposable } from '/@api/disposable.js';
 import type { Event } from '/@api/event.js';
 import type { GatewayInfo } from '/@api/openshell-gateway-info.js';
 
+import { OpenshellCli } from './openshell-cli.js';
+
 const OPENSHELL_CONFIGURATION_SECTION = 'openshell';
 const GATEWAY_POLL_INTERVAL_CONFIGURATION = 'gateway.pollInterval';
 const GATEWAY_POLL_INTERVAL_CONFIGURATION_KEY = `${OPENSHELL_CONFIGURATION_SECTION}.${GATEWAY_POLL_INTERVAL_CONFIGURATION}`;
 const DEFAULT_GATEWAY_POLL_INTERVAL_SECONDS = 5;
+const MIN_GATEWAY_POLL_INTERVAL_SECONDS = 1;
 
 @injectable()
 export class OpenshellGatewayStateManager implements Disposable {
@@ -39,6 +41,7 @@ export class OpenshellGatewayStateManager implements Disposable {
   #initialized = false;
   #pollInterval: NodeJS.Timeout | undefined;
   #refreshPromise: Promise<void> | undefined;
+  #initialRefreshPromise: Promise<void> | undefined;
   #configurationChangeDisposable: IDisposable | undefined;
 
   readonly #onDidUpdateGateways = new Emitter<readonly GatewayInfo[]>();
@@ -56,7 +59,8 @@ export class OpenshellGatewayStateManager implements Disposable {
       return;
     }
     this.#initialized = true;
-    this.refresh().catch((err: unknown) => this.logRefreshError(err));
+    this.#initialRefreshPromise = this.refresh();
+    this.#initialRefreshPromise.catch((err: unknown) => this.logRefreshError(err));
     this.schedulePolling();
     this.#configurationChangeDisposable = this.configurationRegistry.onDidChangeConfiguration(event => {
       if (event.key === GATEWAY_POLL_INTERVAL_CONFIGURATION_KEY) {
@@ -69,9 +73,10 @@ export class OpenshellGatewayStateManager implements Disposable {
     if (this.#pollInterval) {
       clearInterval(this.#pollInterval);
     }
-    const pollIntervalSeconds = this.configurationRegistry
+    const configuredPollIntervalSeconds = this.configurationRegistry
       .getConfiguration(OPENSHELL_CONFIGURATION_SECTION)
       .get<number>(GATEWAY_POLL_INTERVAL_CONFIGURATION, DEFAULT_GATEWAY_POLL_INTERVAL_SECONDS);
+    const pollIntervalSeconds = Math.max(MIN_GATEWAY_POLL_INTERVAL_SECONDS, configuredPollIntervalSeconds);
     this.#pollInterval = setInterval(() => {
       this.refresh().catch((err: unknown) => this.logRefreshError(err));
     }, pollIntervalSeconds * 1000);
@@ -79,6 +84,11 @@ export class OpenshellGatewayStateManager implements Disposable {
 
   listGateways(): readonly GatewayInfo[] {
     return Array.from(this.#gateways.values());
+  }
+
+  /** Waits until the initial gateway snapshot has been populated. */
+  whenReady(): Promise<void> {
+    return this.#initialRefreshPromise ?? this.refresh();
   }
 
   refresh(): Promise<void> {

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.ts
@@ -34,14 +34,16 @@ const GATEWAY_POLL_INTERVAL_CONFIGURATION = 'gateway.pollInterval';
 const GATEWAY_POLL_INTERVAL_CONFIGURATION_KEY = `${OPENSHELL_CONFIGURATION_SECTION}.${GATEWAY_POLL_INTERVAL_CONFIGURATION}`;
 const DEFAULT_GATEWAY_POLL_INTERVAL_SECONDS = 5;
 const MIN_GATEWAY_POLL_INTERVAL_SECONDS = 1;
+const MAX_GATEWAY_POLL_INTERVAL_SECONDS = 60 * 60;
 
 @injectable()
 export class OpenshellGatewayStateManager implements Disposable {
   #gateways = new Map<string, GatewayInfo>();
   #initialized = false;
+  #ready = false;
   #pollInterval: NodeJS.Timeout | undefined;
   #refreshPromise: Promise<void> | undefined;
-  #initialRefreshPromise: Promise<void> | undefined;
+  #refreshQueued = false;
   #configurationChangeDisposable: IDisposable | undefined;
 
   readonly #onDidUpdateGateways = new Emitter<readonly GatewayInfo[]>();
@@ -59,8 +61,7 @@ export class OpenshellGatewayStateManager implements Disposable {
       return;
     }
     this.#initialized = true;
-    this.#initialRefreshPromise = this.refresh();
-    this.#initialRefreshPromise.catch((err: unknown) => this.logRefreshError(err));
+    this.refresh().catch((err: unknown) => this.logRefreshError(err));
     this.schedulePolling();
     this.#configurationChangeDisposable = this.configurationRegistry.onDidChangeConfiguration(event => {
       if (event.key === GATEWAY_POLL_INTERVAL_CONFIGURATION_KEY) {
@@ -76,7 +77,10 @@ export class OpenshellGatewayStateManager implements Disposable {
     const configuredPollIntervalSeconds = this.configurationRegistry
       .getConfiguration(OPENSHELL_CONFIGURATION_SECTION)
       .get<number>(GATEWAY_POLL_INTERVAL_CONFIGURATION, DEFAULT_GATEWAY_POLL_INTERVAL_SECONDS);
-    const pollIntervalSeconds = Math.max(MIN_GATEWAY_POLL_INTERVAL_SECONDS, configuredPollIntervalSeconds);
+    const pollIntervalSeconds = Math.min(
+      MAX_GATEWAY_POLL_INTERVAL_SECONDS,
+      Math.max(MIN_GATEWAY_POLL_INTERVAL_SECONDS, configuredPollIntervalSeconds),
+    );
     this.#pollInterval = setInterval(() => {
       this.refresh().catch((err: unknown) => this.logRefreshError(err));
     }, pollIntervalSeconds * 1000);
@@ -88,16 +92,40 @@ export class OpenshellGatewayStateManager implements Disposable {
 
   /** Waits until the initial gateway snapshot has been populated. */
   whenReady(): Promise<void> {
-    return this.#initialRefreshPromise ?? this.refresh();
+    if (this.#ready) {
+      return Promise.resolve();
+    }
+    return this.#refreshPromise ?? this.refresh();
   }
 
   refresh(): Promise<void> {
-    if (!this.#refreshPromise) {
-      this.#refreshPromise = this.doRefresh().finally(() => {
-        this.#refreshPromise = undefined;
-      });
+    if (this.#refreshPromise) {
+      this.#refreshQueued = true;
+      return this.#refreshPromise;
     }
+    this.#refreshPromise = this.runRefreshes().finally(() => {
+      this.#refreshPromise = undefined;
+    });
     return this.#refreshPromise;
+  }
+
+  private async runRefreshes(): Promise<void> {
+    let lastError: unknown;
+    let failed = false;
+    do {
+      this.#refreshQueued = false;
+      try {
+        await this.doRefresh();
+        this.#ready = true;
+        failed = false;
+      } catch (err: unknown) {
+        lastError = err;
+        failed = true;
+      }
+    } while (this.#refreshQueued);
+    if (failed) {
+      throw lastError;
+    }
   }
 
   private async doRefresh(): Promise<void> {

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway-state-manager.ts
@@ -1,0 +1,150 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { isDeepStrictEqual } from 'node:util';
+
+import type { Disposable } from '@openkaiden/api';
+import { inject, injectable, preDestroy } from 'inversify';
+
+import { Emitter } from '/@/plugin/events/emitter.js';
+import { OpenshellCli } from '/@/plugin/openshell-cli/openshell-cli.js';
+import { IConfigurationRegistry } from '/@api/configuration/models.js';
+import type { IDisposable } from '/@api/disposable.js';
+import type { Event } from '/@api/event.js';
+import type { GatewayInfo } from '/@api/openshell-gateway-info.js';
+
+const OPENSHELL_CONFIGURATION_SECTION = 'openshell';
+const GATEWAY_POLL_INTERVAL_CONFIGURATION = 'gateway.pollInterval';
+const GATEWAY_POLL_INTERVAL_CONFIGURATION_KEY = `${OPENSHELL_CONFIGURATION_SECTION}.${GATEWAY_POLL_INTERVAL_CONFIGURATION}`;
+const DEFAULT_GATEWAY_POLL_INTERVAL_SECONDS = 5;
+
+@injectable()
+export class OpenshellGatewayStateManager implements Disposable {
+  #gateways = new Map<string, GatewayInfo>();
+  #initialized = false;
+  #pollInterval: NodeJS.Timeout | undefined;
+  #refreshPromise: Promise<void> | undefined;
+  #configurationChangeDisposable: IDisposable | undefined;
+
+  readonly #onDidUpdateGateways = new Emitter<readonly GatewayInfo[]>();
+  readonly onDidUpdateGateways: Event<readonly GatewayInfo[]> = this.#onDidUpdateGateways.event;
+
+  constructor(
+    @inject(OpenshellCli)
+    private readonly openshellCli: OpenshellCli,
+    @inject(IConfigurationRegistry)
+    private readonly configurationRegistry: IConfigurationRegistry,
+  ) {}
+
+  init(): void {
+    if (this.#initialized) {
+      return;
+    }
+    this.#initialized = true;
+    this.refresh().catch((err: unknown) => this.logRefreshError(err));
+    this.schedulePolling();
+    this.#configurationChangeDisposable = this.configurationRegistry.onDidChangeConfiguration(event => {
+      if (event.key === GATEWAY_POLL_INTERVAL_CONFIGURATION_KEY) {
+        this.schedulePolling();
+      }
+    });
+  }
+
+  private schedulePolling(): void {
+    if (this.#pollInterval) {
+      clearInterval(this.#pollInterval);
+    }
+    const pollIntervalSeconds = this.configurationRegistry
+      .getConfiguration(OPENSHELL_CONFIGURATION_SECTION)
+      .get<number>(GATEWAY_POLL_INTERVAL_CONFIGURATION, DEFAULT_GATEWAY_POLL_INTERVAL_SECONDS);
+    this.#pollInterval = setInterval(() => {
+      this.refresh().catch((err: unknown) => this.logRefreshError(err));
+    }, pollIntervalSeconds * 1000);
+  }
+
+  listGateways(): readonly GatewayInfo[] {
+    return Array.from(this.#gateways.values());
+  }
+
+  refresh(): Promise<void> {
+    if (!this.#refreshPromise) {
+      this.#refreshPromise = this.doRefresh().finally(() => {
+        this.#refreshPromise = undefined;
+      });
+    }
+    return this.#refreshPromise;
+  }
+
+  private async doRefresh(): Promise<void> {
+    const registrations = await this.openshellCli.listGateways();
+    const gateways = await Promise.all(
+      registrations.map(async gateway => {
+        try {
+          const runtimeInfo = await this.openshellCli.getGatewayInfo(gateway.name);
+          return {
+            ...gateway,
+            gatewayState: {
+              reachable: true,
+              health: runtimeInfo.status,
+            },
+          };
+        } catch {
+          return {
+            ...gateway,
+            gatewayState: {
+              reachable: false,
+              health: 'unknown' as const,
+            },
+          };
+        }
+      }),
+    );
+    const nextGateways = new Map(gateways.map(gateway => [gateway.name, gateway]));
+    if (this.hasChanged(nextGateways)) {
+      this.#gateways = nextGateways;
+      this.#onDidUpdateGateways.fire(this.listGateways());
+    }
+  }
+
+  private hasChanged(nextGateways: ReadonlyMap<string, GatewayInfo>): boolean {
+    if (this.#gateways.size !== nextGateways.size) {
+      return true;
+    }
+    for (const [name, gateway] of nextGateways) {
+      if (!isDeepStrictEqual(this.#gateways.get(name), gateway)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private logRefreshError(err: unknown): void {
+    console.warn(`[openshell-gateway-state] refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  @preDestroy()
+  dispose(): void {
+    if (this.#pollInterval) {
+      clearInterval(this.#pollInterval);
+      this.#pollInterval = undefined;
+    }
+    this.#configurationChangeDisposable?.dispose();
+    this.#configurationChangeDisposable = undefined;
+    this.#onDidUpdateGateways.dispose();
+  }
+}

--- a/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
+++ b/packages/main/src/plugin/openshell-cli/openshell-gateway.spec.ts
@@ -973,6 +973,7 @@ describe('gateway config generation', () => {
   test('enables bind mounts when a local compute driver is detected', async () => {
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
     vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({
+      status: 'healthy',
       compute_drivers: [{ capabilities: { driver_name: 'podman' }, name: 'podman' }],
     });
 
@@ -984,7 +985,7 @@ describe('gateway config generation', () => {
 
   test('generates config without bind mounts when no driver is available', async () => {
     vi.mocked(exec.exec).mockResolvedValue(mockExecResult('openshell-gateway 0.0.69'));
-    vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({ compute_drivers: [] });
+    vi.mocked(openshellCli.getGatewayInfo).mockResolvedValue({ status: 'healthy', compute_drivers: [] });
 
     await gateway.start();
 

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -177,7 +177,12 @@ beforeEach(() => {
   );
   vi.mocked(workspaceProjectsStore).workspaceProjectInfos = writable<readonly WorkspaceProjectInfo[]>([]);
   vi.mocked(openshellGatewaysStore).openshellGateways = writable([
-    { name: 'kaiden', endpoint: 'http://localhost:17670', active: true },
+    {
+      name: 'kaiden',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
   ]);
   vi.mocked(openshellSandboxesStore).allOpenshellSandboxes = writable<(SandboxInfo & { gatewayName: string })[]>([]);
   vi.mocked(window.checkAgentWorkspaceConfigExists).mockResolvedValue(false);
@@ -255,8 +260,18 @@ test('Expect gateway selector hidden when only one gateway is available', () => 
 
 test('Expect gateway selector defaults to the active OpenShell gateway when multiple gateways are available', async () => {
   vi.mocked(openshellGatewaysStore).openshellGateways.set([
-    { name: 'local', endpoint: 'http://localhost:17670', active: false },
-    { name: 'remote', endpoint: 'https://remote.example.com', active: true },
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
   ]);
   render(AgentWorkspaceCreate);
 
@@ -277,8 +292,18 @@ test('Expect gateway selector defaults to the active OpenShell gateway when mult
 
 test('Expect selected gateway included when creating a workspace', async () => {
   vi.mocked(openshellGatewaysStore).openshellGateways.set([
-    { name: 'local', endpoint: 'http://localhost:17670', active: true },
-    { name: 'remote', endpoint: 'https://remote.example.com', active: false },
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
   ]);
   render(AgentWorkspaceCreate);
 
@@ -289,6 +314,35 @@ test('Expect selected gateway included when creating a workspace', async () => {
   await fireEvent.click(screen.getByRole('button', { name: 'Use all defaults and create workspace' }));
 
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(expect.objectContaining({ gateway: 'remote' }));
+});
+
+test('does not offer unreachable gateways for workspace creation', () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    {
+      name: 'local',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+    {
+      name: 'stopped',
+      endpoint: 'http://localhost:17671',
+      active: false,
+      gatewayState: { reachable: false, health: 'unknown' },
+    },
+    {
+      name: 'remote',
+      endpoint: 'https://remote.example.com',
+      active: false,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  expect(screen.getByRole('option', { name: /local/ })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: /remote/ })).toBeInTheDocument();
+  expect(screen.queryByRole('option', { name: /stopped/ })).not.toBeInTheDocument();
 });
 
 test('Expect Continue button rendered on step 1', () => {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.spec.ts
@@ -316,6 +316,18 @@ test('Expect selected gateway included when creating a workspace', async () => {
   expect(window.createAgentWorkspace).toHaveBeenCalledWith(expect.objectContaining({ gateway: 'remote' }));
 });
 
+test('offers gateways while their reachability state is unavailable', () => {
+  vi.mocked(openshellGatewaysStore).openshellGateways.set([
+    { name: 'local', endpoint: 'http://localhost:17670', active: true },
+    { name: 'remote', endpoint: 'https://remote.example.com', active: false },
+  ]);
+
+  render(AgentWorkspaceCreate);
+
+  expect(screen.getByRole('option', { name: /local/ })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: /remote/ })).toBeInTheDocument();
+});
+
 test('does not offer unreachable gateways for workspace creation', () => {
   vi.mocked(openshellGatewaysStore).openshellGateways.set([
     {

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -211,13 +211,14 @@ onMount(async () => {
   }
 });
 let customHosts = $derived(wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? []);
+let reachableGateways = $derived($openshellGateways.filter(gateway => gateway.gatewayState?.reachable));
 
 $effect.pre(() => {
-  const selectedGatewayExists = $openshellGateways.some(gateway => gateway.name === wizard.draft.selectedGateway);
+  const selectedGatewayExists = reachableGateways.some(gateway => gateway.name === wizard.draft.selectedGateway);
   if (!selectedGatewayExists) {
-    const activeGateway = $openshellGateways.find(gateway => gateway.active);
+    const activeGateway = reachableGateways.find(gateway => gateway.active);
     wizard.draft.selectedGateway =
-      activeGateway?.name ?? ($openshellGateways.length === 1 ? ($openshellGateways[0]?.name ?? '') : '');
+      activeGateway?.name ?? (reachableGateways.length === 1 ? (reachableGateways[0]?.name ?? '') : '');
   }
 });
 
@@ -605,7 +606,7 @@ function startWorkspace(): void {
               <AgentWorkspaceCreateStepWorkspace
                 bind:sourcePath={wizard.draft.sourcePath}
                 bind:sessionName={wizard.draft.sessionName}
-                gateways={[...$openshellGateways]}
+                gateways={[...reachableGateways]}
                 bind:selectedGateway={wizard.draft.selectedGateway}
                 bind:description={wizard.draft.description}
                 bind:nameManuallyEdited={wizard.draft.nameManuallyEdited}

--- a/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
+++ b/packages/renderer/src/lib/agent-workspaces/AgentWorkspaceCreate.svelte
@@ -211,7 +211,7 @@ onMount(async () => {
   }
 });
 let customHosts = $derived(wizard.draft.hostsByMode[wizard.draft.selectedNetwork] ?? []);
-let reachableGateways = $derived($openshellGateways.filter(gateway => gateway.gatewayState?.reachable));
+let reachableGateways = $derived($openshellGateways.filter(gateway => gateway.gatewayState?.reachable !== false));
 
 $effect.pre(() => {
   const selectedGatewayExists = reachableGateways.some(gateway => gateway.name === wizard.draft.selectedGateway);

--- a/packages/renderer/src/stores/openshell-gateways.spec.ts
+++ b/packages/renderer/src/stores/openshell-gateways.spec.ts
@@ -62,6 +62,7 @@ test('populates gateways when extensions are started', async () => {
       auth: 'plaintext',
       type: 'local',
       source: 'user',
+      gatewayState: { reachable: true, health: 'healthy' },
     },
   ];
   vi.mocked(window.listOpenshellGateways).mockResolvedValue(gateways);
@@ -76,7 +77,14 @@ test('populates gateways when extensions are started', async () => {
 
 test('refreshes gateways on OpenShell registry gateway updates after startup', async () => {
   const { openshellGateways } = await import('./openshell-gateways');
-  const initialGateways: GatewayInfo[] = [{ name: 'local', endpoint: 'http://127.0.0.1:17670', active: true }];
+  const initialGateways: GatewayInfo[] = [
+    {
+      name: 'local',
+      endpoint: 'http://127.0.0.1:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ];
   const updatedGateways: GatewayInfo[] = [
     ...initialGateways,
     {
@@ -89,6 +97,7 @@ test('refreshes gateways on OpenShell registry gateway updates after startup', a
       is_remote: true,
       remote_host: 'user@gateway.example.com',
       resolved_host: '10.0.0.5',
+      gatewayState: { reachable: true, health: 'healthy' },
     },
   ];
   vi.mocked(window.listOpenshellGateways).mockResolvedValueOnce(initialGateways).mockResolvedValueOnce(updatedGateways);
@@ -106,9 +115,23 @@ test('refreshes gateways on OpenShell registry gateway updates after startup', a
 
 test('refreshes gateways on agent gateway updates after startup', async () => {
   const { openshellGateways } = await import('./openshell-gateways');
-  const initialGateways: GatewayInfo[] = [{ name: 'local', endpoint: 'http://127.0.0.1:17670', active: true }];
+  const initialGateways: GatewayInfo[] = [
+    {
+      name: 'local',
+      endpoint: 'http://127.0.0.1:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ];
   const updatedGateways: GatewayInfo[] = [
-    { name: 'local', endpoint: 'http://127.0.0.1:17670', active: true, auth: 'plaintext', type: 'local' },
+    {
+      name: 'local',
+      endpoint: 'http://127.0.0.1:17670',
+      active: true,
+      auth: 'plaintext',
+      type: 'local',
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
   ];
   vi.mocked(window.listOpenshellGateways).mockResolvedValueOnce(initialGateways).mockResolvedValueOnce(updatedGateways);
 


### PR DESCRIPTION
Fixes #2515

## Summary

- Add reachability and health state to `GatewayInfo`.
- Monitor OpenShell gateways in the main process and notify the renderer when gateway information changes.
- Exclude unreachable gateways from workspace creation.
- Make the monitoring interval configurable through `openshell.gateway.pollInterval` in seconds (default: 5, minimum: 1).

The implementation follows the state-monitor pattern used by Podman Desktop for Kubernetes: a dedicated backend manager owns polling and cached gateway information, emits an invalidation event when its snapshot changes, and the renderer refetches through the existing IPC and store path. Polling is required because OpenShell does not currently expose gateway lifecycle notifications; see NVIDIA/OpenShell#2569.

`GatewayInfo` remains the single gateway object returned through the existing `GatewayInfo[]` IPC contract. The monitor enriches each gateway with `gatewayState`:

```ts
gatewayState: {
  reachable: boolean;
  health: 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
}
```

Reachability is determined by whether `openshell gateway info -g <name>` succeeds. When it succeeds, health comes from the command's `status` field. When it cannot connect, the gateway is reported as unreachable with unknown health.

Existing gateway startup checks continue to use `openshell status`.

## Manual testing

1. Add a secondary gateway whose endpoint is not running:

```sh
openshell gateway add \
  http://127.0.0.1:17671 \
  --local \
  --name test-secondary
```

2. Start Kaiden:

```sh
pnpm watch
```

3. In the renderer DevTools console, inspect the cached gateway information:

```js
await window.listOpenshellGateways()
```

The secondary gateway should contain:

```js
gatewayState: { reachable: false, health: 'unknown' }
```

A running gateway should report `reachable: true` and its OpenShell health status. This call reads Kaiden's cache; it does not invoke the OpenShell CLI directly.

4. Confirm that the unreachable secondary gateway is not offered during workspace creation.

5. Change the polling interval from the DevTools console:

```js
await window.updateConfigurationValue('openshell.gateway.pollInterval', 60)
await window.getConfigurationValue('openshell.gateway.pollInterval')
```

The second command should return `60`, and the monitor reschedules immediately without restarting Kaiden.

6. Remove or otherwise change a gateway with the OpenShell CLI. After the configured polling interval, run:

```js
await window.listOpenshellGateways()
```

The cached gateway information should reflect the CLI change.
