### PR TITLE
fix(acp): use absolute path for ACP session cwd

### DIFF
--- a/packages/main/src/plugin/acp/acp-session-manager.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.ts
@@ -303,7 +303,7 @@ export class AcpSessionManager {
 
     debugProtocol('creating new session...');
     const newSession = await session.connection.newSession({
-      cwd: '.',
+      cwd: '/sandbox',
       mcpServers: [],
     });
     debugProtocol(`session created: ${newSession.sessionId}, keys: ${Object.keys(newSession).join(',')}`);
@@ -712,7 +712,7 @@ export class AcpSessionManager {
     debugProtocol(`${session.info.sandboxName} reconnected: protocol v${initResult.protocolVersion}`);
 
     const newSession = await connection.newSession({
-      cwd: '.',
+      cwd: '/sandbox',
       mcpServers: [],
     });
     debugProtocol(`${session.info.sandboxName} new session: ${newSession.sessionId}`);


### PR DESCRIPTION
## Summary
- Change `cwd: '.'` to `cwd: '/sandbox'` in both `newSession` calls in the ACP session manager (initial connection and reconnect)
- The Claude ACP agent (`claude-agent-acp`) requires an absolute path for `cwd`; `.` causes `Invalid params: cwd must be an absolute path`
- `/sandbox` is the standard sources directory inside all sandboxes

## Test plan
- [ ] Run `pnpm vitest run packages/main/src/plugin/acp/acp-session-manager.spec.ts` — all 15 tests pass

