### PR TITLE
feat(acp): add optional command override to AcpConfiguration

### DIFF
--- a/packages/api/src/agent-info.ts
+++ b/packages/api/src/agent-info.ts
@@ -19,6 +19,7 @@
 import type { ModelType, ProviderImages } from '@openkaiden/api';
 
 export interface AcpConfigurationInfo {
+  command?: string;
   args: ReadonlyArray<string>;
 }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5572,6 +5572,7 @@ declare module '@openkaiden/api' {
   }
 
   export interface AcpConfiguration {
+    readonly command?: string;
     readonly args: ReadonlyArray<string>;
   }
 

--- a/packages/main/src/plugin/acp/acp-session-manager.spec.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.spec.ts
@@ -103,6 +103,22 @@ describe('AcpSessionManager', () => {
       expect(result.command).toEqual(['copilot', '--acp']);
     });
 
+    test('uses acp.command override when provided', async () => {
+      const agent = createAgentInfo({
+        id: 'claude',
+        command: 'claude',
+        acp: { command: 'claude-agent-acp', args: [] },
+      });
+      vi.mocked(agentRegistry.getAgent).mockResolvedValue(agent);
+
+      const options: AcpSessionCreateOptions = { sandboxName: 'sb', prompt: 'hello', agentId: 'claude' };
+      const sandbox = createSandbox();
+
+      const result = await manager.resolveAgentCommand(options, sandbox);
+
+      expect(result.command).toEqual(['claude-agent-acp']);
+    });
+
     test('options.agentId takes priority over sandbox label', async () => {
       const agent = createAgentInfo({ id: 'openclaw', command: 'openclaw' });
       vi.mocked(agentRegistry.getAgent).mockResolvedValue(agent);

--- a/packages/main/src/plugin/acp/acp-session-manager.ts
+++ b/packages/main/src/plugin/acp/acp-session-manager.ts
@@ -106,7 +106,7 @@ export class AcpSessionManager {
       throw new Error(`Agent "${agentInfo.name}" does not support ACP`);
     }
 
-    const command = [agentInfo.command, ...agentInfo.acp.args];
+    const command = [agentInfo.acp.command ?? agentInfo.command, ...agentInfo.acp.args];
     return { agentInfo, command };
   }
 


### PR DESCRIPTION
## Summary
- Add optional `command` field to `AcpConfiguration` (extension-api) and `AcpConfigurationInfo` (api)
- When set, the ACP session manager uses it instead of the agent's base command
- Needed for agents like Claude where the ACP adapter (`claude-agent-acp`) is a separate binary from the regular command (`claude`)

## Test plan
- [ ] Run `pnpm vitest run packages/main/src/plugin/acp/acp-session-manager.spec.ts` — all 16 tests pass (including new `uses acp.command override when provided` test)
