### PR TITLE
feat(claude): add baseImage and enable ACP mode

### DIFF
--- a/extensions/claude/src/claude-extension.spec.ts
+++ b/extensions/claude/src/claude-extension.spec.ts
@@ -60,6 +60,8 @@ describe('ClaudeExtension', () => {
         name: 'Claude Code',
         description: expect.any(String),
         icon: expect.objectContaining({ icon: './icon.png' }),
+        baseImage: 'ghcr.io/openkaiden/openshell-image-claude:fd194d5bde14bf758c82bb2aace23fea596dfbde',
+        acp: { command: 'claude-agent-acp', args: [] },
         tags: ['Cloud'],
         destinationSkillsFolder: '${HOME}/.claude/skills',
         isSupportedModelType: expect.any(Function),

--- a/extensions/claude/src/claude-extension.ts
+++ b/extensions/claude/src/claude-extension.ts
@@ -108,6 +108,8 @@ export class ClaudeExtension {
       description: 'Anthropic cloud agent — connect with an API key to access Claude models.',
       icon: providerImages,
       command: 'claude',
+      baseImage: 'ghcr.io/openkaiden/openshell-image-claude:fd194d5bde14bf758c82bb2aace23fea596dfbde',
+      acp: { command: 'claude-agent-acp', args: [] },
       tags: ['Cloud'],
       configurationFiles: [
         {


### PR DESCRIPTION
:warning: Depends on
- [x] #2635
- [x] #2636

## Summary
- Set `baseImage` to the dedicated Claude container image (`ghcr.io/openkaiden/openshell-image-claude:fd194d5bde14bf758c82bb2aace23fea596dfbde`)
- Enable ACP mode using `claude-agent-acp` as the ACP command

fixes https://github.com/openkaiden/kaiden/issues/2634

## Test plan
- [ ] Run `pnpm vitest run extensions/claude/src/claude-extension.spec.ts` (30 tests pass)
- [ ] Create a Claude workspace and verify it uses the dedicated container image
- [ ] Start an ACP session with Claude and verify it launches `claude-agent-acp`