### PR TITLE
feat(renderer): add dynamic gateway state to gateway list section

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.spec.ts
@@ -71,6 +71,7 @@ test('displays active gateway in the Active Gateway section', () => {
     endpoint: 'http://127.0.0.1:17670',
     active: true,
     type: 'local',
+    gatewayState: { reachable: true, health: 'healthy' },
   };
   openshellGateways.set([activeGateway]);
   render(PreferencesOpenshellGatewaysRendering);
@@ -78,9 +79,9 @@ test('displays active gateway in the Active Gateway section', () => {
   expect(screen.getByText('Active Gateway')).toBeInTheDocument();
   expect(screen.getByText('kaiden-local')).toBeInTheDocument();
   expect(screen.getByText('Managed')).toBeInTheDocument();
-  expect(screen.getByText('local · http://127.0.0.1:17670')).toBeInTheDocument();
+  expect(screen.getByText('local · http://127.0.0.1:17670 · Connected')).toBeInTheDocument();
 
-  const statusDot = screen.getAllByLabelText('Gateway status')[0];
+  const statusDot = screen.getAllByLabelText('Gateway state')[0];
   expect(statusDot).toHaveClass('bg-(--pd-status-running)');
 
   expect(screen.queryByText('Other Gateways')).not.toBeInTheDocument();
@@ -111,7 +112,7 @@ test('displays non-active gateways in Other Gateways section', () => {
   expect(screen.getByText('Other Gateways')).toBeInTheDocument();
   expect(screen.getByText('production')).toBeInTheDocument();
   expect(screen.getByText('Referenced')).toBeInTheDocument();
-  expect(screen.getByText('remote · https://gateway.example.com')).toBeInTheDocument();
+  expect(screen.getByText('remote · https://gateway.example.com · Unknown')).toBeInTheDocument();
 });
 
 test('shows Referenced badge for non-local gateways', () => {
@@ -168,4 +169,82 @@ test('renders multiple non-active gateways', () => {
 
   expect(screen.getByText('team-shared')).toBeInTheDocument();
   expect(screen.getByText('dev-remote')).toBeInTheDocument();
+});
+
+test('shows unknown state text and color when gatewayState is undefined', () => {
+  setOpenshellStarted();
+  openshellGateways.set([{ name: 'no-state-gw', endpoint: 'http://localhost:17670', active: true }]);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('http://localhost:17670 · Unknown')).toBeInTheDocument();
+  const statusDot = screen.getByLabelText('Gateway state');
+  expect(statusDot).toHaveClass('bg-(--pd-status-unknown)');
+});
+
+test('shows disconnected state text and stopped color when gateway is unreachable', () => {
+  setOpenshellStarted();
+  openshellGateways.set([
+    {
+      name: 'unreachable-gw',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: false, health: 'unknown' },
+    },
+  ]);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('http://localhost:17670 · Disconnected')).toBeInTheDocument();
+  const statusDot = screen.getByLabelText('Gateway state');
+  expect(statusDot).toHaveClass('bg-(--pd-status-stopped)');
+});
+
+test('shows degraded state text and color for degraded gateway', () => {
+  setOpenshellStarted();
+  openshellGateways.set([
+    {
+      name: 'degraded-gw',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'degraded' },
+    },
+  ]);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('http://localhost:17670 · Degraded')).toBeInTheDocument();
+  const statusDot = screen.getByLabelText('Gateway state');
+  expect(statusDot).toHaveClass('bg-(--pd-status-degraded)');
+});
+
+test('shows unhealthy state text and terminated color for unhealthy gateway', () => {
+  setOpenshellStarted();
+  openshellGateways.set([
+    {
+      name: 'unhealthy-gw',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'unhealthy' },
+    },
+  ]);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('http://localhost:17670 · Unhealthy')).toBeInTheDocument();
+  const statusDot = screen.getByLabelText('Gateway state');
+  expect(statusDot).toHaveClass('bg-(--pd-status-terminated)');
+});
+
+test('shows connected state text and running color for healthy gateway', () => {
+  setOpenshellStarted();
+  openshellGateways.set([
+    {
+      name: 'healthy-gw',
+      endpoint: 'http://localhost:17670',
+      active: true,
+      gatewayState: { reachable: true, health: 'healthy' },
+    },
+  ]);
+  render(PreferencesOpenshellGatewaysRendering);
+
+  expect(screen.getByText('http://localhost:17670 · Connected')).toBeInTheDocument();
+  const statusDot = screen.getByLabelText('Gateway state');
+  expect(statusDot).toHaveClass('bg-(--pd-status-running)');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesOpenshellGatewaysRendering.svelte
@@ -23,6 +23,25 @@ function getTypeBadge(gateway: GatewayInfo): string {
   return 'Referenced';
 }
 
+function getStatusColor(gateway: GatewayInfo): string {
+  if (!gateway.gatewayState) {
+    return 'bg-(--pd-status-unknown)';
+  }
+  if (!gateway.gatewayState.reachable) {
+    return 'bg-(--pd-status-stopped)';
+  }
+  switch (gateway.gatewayState.health) {
+    case 'healthy':
+      return 'bg-(--pd-status-running)';
+    case 'degraded':
+      return 'bg-(--pd-status-degraded)';
+    case 'unhealthy':
+      return 'bg-(--pd-status-terminated)';
+    default:
+      return 'bg-(--pd-status-unknown)';
+  }
+}
+
 function getDetails(gateway: GatewayInfo): string {
   const parts: string[] = [];
   if (gateway.type) {
@@ -32,6 +51,27 @@ function getDetails(gateway: GatewayInfo): string {
     parts.push('remote');
   }
   parts.push(gateway.endpoint);
+
+  if (!gateway.gatewayState) {
+    parts.push('Unknown');
+  } else if (!gateway.gatewayState.reachable) {
+    parts.push('Disconnected');
+  } else {
+    switch (gateway.gatewayState.health) {
+      case 'healthy':
+        parts.push('Connected');
+        break;
+      case 'degraded':
+        parts.push('Degraded');
+        break;
+      case 'unhealthy':
+        parts.push('Unhealthy');
+        break;
+      default:
+        parts.push('Unknown');
+    }
+  }
+
   return parts.join(' · ');
 }
 </script>
@@ -67,7 +107,7 @@ function getDetails(gateway: GatewayInfo): string {
           role="region"
           aria-label="Active gateway {activeGateway.name}">
           <div class="flex items-center gap-3">
-            <div class="w-2 h-2 rounded-full shrink-0 bg-(--pd-status-running)" aria-label="Gateway status"></div>
+            <div class="w-2 h-2 rounded-full shrink-0 {getStatusColor(activeGateway)}" aria-label="Gateway state"></div>
             <span class="text-lg font-semibold text-(--pd-content-card-text)">{activeGateway.name}</span>
             <span
               class="text-xs font-medium px-2 py-0.5 rounded-full bg-(--pd-label-bg) text-(--pd-label-text)">
@@ -93,7 +133,7 @@ function getDetails(gateway: GatewayInfo): string {
               role="region"
               aria-label="Gateway {gateway.name}">
               <div class="flex items-center gap-3">
-                <div class="w-2 h-2 rounded-full shrink-0 bg-(--pd-status-running)" aria-label="Gateway status"></div>
+                <div class="w-2 h-2 rounded-full shrink-0 {getStatusColor(gateway)}" aria-label="Gateway state"></div>
                 <span class="font-semibold text-(--pd-content-card-text)">{gateway.name}</span>
                 <span
                   class="text-xs font-medium px-2 py-0.5 rounded-full bg-(--pd-label-bg) text-(--pd-label-text)">


### PR DESCRIPTION
## Summary

- Replace the static green status dot in the gateway list with dynamic
  state logic driven by `gatewayState` (from #2515)
- Map `gatewayState.health` and `reachable` to the appropriate theme
  status colors (`--pd-status-running`, `--pd-status-degraded`,
  `--pd-status-terminated`, `--pd-status-stopped`, `--pd-status-unknown`)
- Append a human-readable state label (Connected, Disconnected, Degraded,
  Unhealthy, Unknown) to the gateway details line
  
<img width="1918" height="948" alt="Captura de pantalla 2026-08-04 a las 12 21 38" src="https://github.com/user-attachments/assets/f41adc7c-b130-4778-8256-66e440665040" />


## Test plan

### Unit tests

- [x] 13 unit tests covering all gateway state combinations pass

### Manual testing (store override)

Temporarily seed the store to visualize all states at once:

1. In `packages/renderer/src/stores/openshell-gateways.ts`, comment out
   `openshellGatewaysEventStore.setup();` and add:
   ```ts
   openshellGateways.set([
     { name: 'healthy-gw', endpoint: 'http://localhost:17670', active: true, type: 'local', gatewayState: { reachable: true, health: 'healthy' } },
     { name: 'degraded-gw', endpoint: 'http://remote:17670', active: false, type: 'remote', gatewayState: { reachable: true, health: 'degraded' } },
     { name: 'unhealthy-gw', endpoint: 'http://broken:17670', active: false, type: 'remote', gatewayState: { reachable: true, health: 'unhealthy' } },
     { name: 'unreachable-gw', endpoint: 'http://down:17670', active: false, type: 'remote', gatewayState: { reachable: false, health: 'unknown' } },
     { name: 'no-state-gw', endpoint: 'http://new:17670', active: false, type: 'remote' },
   ]);
   ```
2. Run the app and navigate to **Settings > Gateways**
3. Verify: green (Connected), amber (Degraded), red (Unhealthy),
   dark gray (Disconnected), and light gray (Unknown) dots with
   matching state labels

### Manual testing (real gateway)

To verify the unreachable state with a real gateway registration:

1. Register a gateway pointing to a dead endpoint:
   ```bash
   openshell gateway add --name fake-unreachable --endpoint https://10.255.255.1:17670
   ```
2. Open **Settings > Gateways** and verify `fake-unreachable` shows a
   gray dot with "Disconnected" in its details
3. Clean up:
   ```bash
   openshell gateway remove fake-unreachable
   ```

> **Note:** The Degraded and Unhealthy states depend on the gateway's
> internal health reporting and cannot be triggered manually with
> standard CLI commands.

Closes #2618