### PR TITLE
chore: skip Husky DCO when running workflow

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -30,7 +30,7 @@ if test ! -f "$1"; then
   exit 1
 fi
 
-pnpm commitlint --edit "$1"
+pnpm commitlint --edit "$1" || exit $?
 
 # skip DCO for agents
 if test "${GITHUB_ACTIONS:-}" = "true"; then

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -32,6 +32,11 @@ fi
 
 pnpm commitlint --edit "$1"
 
+# skip DCO for agents
+if test "${GITHUB_ACTIONS:-}" = "true"; then
+  exit 0
+fi
+
 SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
 grep -qs "^$SOB" "$1" || echo "$SOB" >>"$1"
 


### PR DESCRIPTION
The Fullsend code and fix agents are failing due to DCO:
- their instructions say not to use DCO, because agents are not human (the correct behaviour)
- the agent commits, which triggers Husky - which lints, checks commitlint ... and applies DCO
- agent postscript fails because DCO was applied

This change avoids Husky DCO when running in GitHub actions workflows.

Code agent: https://github.com/openkaiden/kaiden/actions/runs/30927076530/job/92052139133
Fix agent: https://github.com/openkaiden/kaiden/actions/runs/30576976374/job/90987636583